### PR TITLE
chore: reduce visibility of test classes/methods

### DIFF
--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/analytics/QueryKeyTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/analytics/QueryKeyTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Lars Helge Overland
  */
-public class QueryKeyTest
+class QueryKeyTest
 {
     @Test
     public void testAsPlainKey()

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/analytics/QueryKeyTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/analytics/QueryKeyTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 class QueryKeyTest
 {
     @Test
-    public void testAsPlainKey()
+    void testAsPlainKey()
     {
         String key = new QueryKey()
             .add( "dimension", "dx" )
@@ -62,7 +62,7 @@ class QueryKeyTest
     }
 
     @Test
-    public void testAsPlainKeyIgnoreNull()
+    void testAsPlainKeyIgnoreNull()
     {
         String key = new QueryKey()
             .add( "dimension", "dx" )
@@ -74,7 +74,7 @@ class QueryKeyTest
     }
 
     @Test
-    public void testNoCollision()
+    void testNoCollision()
     {
         String keyA = new QueryKey()
             .add( "dimension", "dx" )

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -320,8 +320,10 @@ class DataIntegrityServiceTest
     // Tests
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testGetDataElementsWithoutDataSet()
+    void testGetDataElementsWithoutDataSet()
     {
         subject.getDataElementsWithoutDataSet();
         verify( dataElementService ).getDataElementsWithoutDataSets();
@@ -329,7 +331,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetDataElementsWithoutGroups()
+    void testGetDataElementsWithoutGroups()
     {
         subject.getDataElementsWithoutGroups();
         verify( dataElementService ).getDataElementsWithoutGroups();
@@ -337,7 +339,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetDataElementsAssignedToDataSetsWithDifferentPeriodType()
+    void testGetDataElementsAssignedToDataSetsWithDifferentPeriodType()
     {
         String seed = "abcde";
         Map<String, DataElement> dataElements = createRandomDataElements( 6, seed );
@@ -372,7 +374,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetDataElementsAssignedToDataSetsWithDifferentPeriodTypeNoResult()
+    void testGetDataElementsAssignedToDataSetsWithDifferentPeriodTypeNoResult()
     {
 
         String seed = "abcde";
@@ -397,7 +399,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetDataSetsNotAssignedToOrganisationUnits()
+    void testGetDataSetsNotAssignedToOrganisationUnits()
     {
         clearInvocations( dataSetService );
         subject.getDataSetsNotAssignedToOrganisationUnits();
@@ -406,7 +408,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetIndicatorsWithIdenticalFormulas()
+    void testGetIndicatorsWithIdenticalFormulas()
     {
         when( indicatorService.getAllIndicators() ).thenReturn( List.of( indicatorA, indicatorB, indicatorC ) );
         List<DataIntegrityIssue> issues = subject.getIndicatorsWithIdenticalFormulas();
@@ -417,7 +419,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetIndicatorsWithoutGroups()
+    void testGetIndicatorsWithoutGroups()
     {
         subject.getIndicatorsWithoutGroups();
         verify( indicatorService ).getIndicatorsWithoutGroups();
@@ -425,7 +427,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetOrganisationUnitsWithCyclicReferences()
+    void testGetOrganisationUnitsWithCyclicReferences()
     {
         subject.getOrganisationUnitsWithCyclicReferences();
         verify( organisationUnitService ).getOrganisationUnitsWithCyclicReferences();
@@ -433,7 +435,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetOrphanedOrganisationUnits()
+    void testGetOrphanedOrganisationUnits()
     {
         subject.getOrphanedOrganisationUnits();
         verify( organisationUnitService ).getOrphanedOrganisationUnits();
@@ -441,7 +443,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetOrganisationUnitsWithoutGroups()
+    void testGetOrganisationUnitsWithoutGroups()
     {
         subject.getOrganisationUnitsWithoutGroups();
         verify( organisationUnitService ).getOrganisationUnitsWithoutGroups();
@@ -449,7 +451,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetProgramRulesWithNoExpression()
+    void testGetProgramRulesWithNoExpression()
     {
         programRuleB.setCondition( null );
         when( programRuleService.getProgramRulesWithNoCondition() ).thenReturn( List.of( programRuleB ) );
@@ -466,7 +468,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetProgramRulesVariableWithNoDataElement()
+    void testGetProgramRulesVariableWithNoDataElement()
     {
         programRuleVariableA.setProgram( programA );
 
@@ -485,7 +487,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testGetProgramRuleActionsWithNoDataObject()
+    void testGetProgramRuleActionsWithNoDataObject()
     {
         programRuleActionA.setProgramRule( programRuleA );
 
@@ -504,7 +506,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testInvalidProgramIndicatorExpression()
+    void testInvalidProgramIndicatorExpression()
     {
         ProgramIndicator programIndicator = new ProgramIndicator();
         programIndicator.setName( "Test-PI" );
@@ -526,7 +528,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testInvalidProgramIndicatorFilter()
+    void testInvalidProgramIndicatorFilter()
     {
         ProgramIndicator programIndicator = new ProgramIndicator();
         programIndicator.setName( "Test-PI" );
@@ -547,7 +549,7 @@ class DataIntegrityServiceTest
     }
 
     @Test
-    public void testValidProgramIndicatorFilter()
+    void testValidProgramIndicatorFilter()
     {
         ProgramIndicator programIndicator = new ProgramIndicator();
         programIndicator.setName( "Test-PI" );

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -106,7 +106,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class DataIntegrityServiceTest
+class DataIntegrityServiceTest
 {
 
     private static final String INVALID_EXPRESSION = "INVALID_EXPRESSION";

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/merge/orgunit/handler/MetadataOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/merge/orgunit/handler/MetadataOrgUnitMergeHandlerTest.java
@@ -73,7 +73,7 @@ class MetadataOrgUnitMergeHandlerTest
     }
 
     @Test
-    public void testMergeDataSets()
+    void testMergeDataSets()
     {
         DataSet dsA = createDataSet( 'A' );
         dsA.addOrganisationUnit( ouA );
@@ -100,7 +100,7 @@ class MetadataOrgUnitMergeHandlerTest
     }
 
     @Test
-    public void testMergePrograms()
+    void testMergePrograms()
     {
         Program prA = createProgram( 'A' );
         prA.addOrganisationUnit( ouA );
@@ -127,7 +127,7 @@ class MetadataOrgUnitMergeHandlerTest
     }
 
     @Test
-    public void testMergeOrgUnitGroups()
+    void testMergeOrgUnitGroups()
     {
         OrganisationUnitGroup ougA = createOrganisationUnitGroup( 'A' );
         ougA.addOrganisationUnit( ouA );

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/merge/orgunit/handler/MetadataOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/merge/orgunit/handler/MetadataOrgUnitMergeHandlerTest.java
@@ -50,7 +50,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataOrgUnitMergeHandlerTest
+class MetadataOrgUnitMergeHandlerTest
 {
 
     private MetadataOrgUnitMergeHandler handler;

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandlerTest.java
@@ -48,7 +48,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataOrgUnitSplitHandlerTest
+class MetadataOrgUnitSplitHandlerTest
 {
 
     private MetadataOrgUnitSplitHandler handler;

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandlerTest.java
@@ -71,7 +71,7 @@ class MetadataOrgUnitSplitHandlerTest
     }
 
     @Test
-    public void testSplitDataSets()
+    void testSplitDataSets()
     {
         DataSet dsA = createDataSet( 'A' );
         dsA.addOrganisationUnit( ouA );
@@ -98,7 +98,7 @@ class MetadataOrgUnitSplitHandlerTest
     }
 
     @Test
-    public void testSplitPrograms()
+    void testSplitPrograms()
     {
         Program prA = createProgram( 'A' );
         prA.addOrganisationUnit( ouA );

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -54,7 +54,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Dang Duy Hieu
  */
 @ExtendWith( MockitoExtension.class )
-public class SqlViewServiceTest extends DhisSpringTest
+class SqlViewServiceTest extends DhisSpringTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/sqlview/SqlViewServiceTest.java
@@ -101,8 +101,10 @@ class SqlViewServiceTest extends DhisSpringTest
     // SqlView
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testAddSqlView()
+    void testAddSqlView()
     {
         SqlView sqlViewA = createSqlView( 'A', sqlA );
         SqlView sqlViewB = createSqlView( 'B', sqlB );
@@ -127,7 +129,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testUpdateSqlView()
+    void testUpdateSqlView()
     {
         SqlView sqlView = createSqlView( 'A', sqlA );
 
@@ -143,7 +145,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetAndDeleteSqlView()
+    void testGetAndDeleteSqlView()
     {
         SqlView sqlViewA = createSqlView( 'A', sqlC );
         SqlView sqlViewB = createSqlView( 'B', sqlD );
@@ -166,7 +168,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetSqlViewByName()
+    void testGetSqlViewByName()
     {
         SqlView sqlViewA = createSqlView( 'A', sqlA );
         SqlView sqlViewB = createSqlView( 'B', sqlB );
@@ -180,7 +182,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testSetUpViewTableName()
+    void testSetUpViewTableName()
     {
         SqlView sqlViewC = createSqlView( 'C', sqlC );
         SqlView sqlViewD = createSqlView( 'D', sqlD );
@@ -190,14 +192,14 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateIllegalKeywords()
+    void testValidateIllegalKeywords()
     {
         assertThrows( IllegalQueryException.class,
             () -> sqlViewService.validateSqlView( getSqlView( "delete * from dataelement" ), null, null ) );
     }
 
     @Test
-    public void testValidateIllegalKeywordsCTE()
+    void testValidateIllegalKeywordsCTE()
     {
         SqlView sqlView = getSqlView( "WITH foo as (delete FROM dataelement returning *) SELECT * FROM foo;" );
 
@@ -207,7 +209,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateIllegalKeywordsAtEnd()
+    void testValidateIllegalKeywordsAtEnd()
     {
         SqlView sqlView = getSqlView( "WITH foo as (SELECT * FROM organisationunit) commit" );
 
@@ -217,7 +219,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateIllegalKeywordsAfterSemicolon()
+    void testValidateIllegalKeywordsAfterSemicolon()
     {
         SqlView sqlView = getSqlView( "select * from dataelement; delete from dataelement" );
 
@@ -227,7 +229,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateProtectedTables()
+    void testValidateProtectedTables()
     {
         SqlView sqlView = getSqlView( "select * from userinfo where userinfoid=1" );
 
@@ -237,7 +239,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateProtectedTables2()
+    void testValidateProtectedTables2()
     {
         SqlView sqlView = getSqlView( "select * from \"userinfo\" where userinfoid=1" );
 
@@ -247,7 +249,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateProtectedTables3()
+    void testValidateProtectedTables3()
     {
         SqlView sqlView = getSqlView( "select users.username \n FROM \"public\".users;" );
 
@@ -257,7 +259,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateMissingVariables()
+    void testValidateMissingVariables()
     {
         SqlView sqlView = getSqlView(
             "select * from dataelement where valueType = '${valueType}' and aggregationtype = '${aggregationType}'" );
@@ -272,7 +274,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateNotSelectQuery()
+    void testValidateNotSelectQuery()
     {
         assertIllegalQueryEx(
             assertThrows( IllegalQueryException.class,
@@ -281,7 +283,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateTableList()
+    void testValidateTableList()
     {
         SqlView sqlView = getSqlView( "select username,password from users,dataapprovallevel" );
 
@@ -291,7 +293,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetGridValidationFailure()
+    void testGetGridValidationFailure()
     {
         // this is the easiest way to be allowed to read SQL view data
         createAndInjectAdminUser();
@@ -306,7 +308,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetGridRequiresDataReadSharing()
+    void testGetGridRequiresDataReadSharing()
     {
         createAndInjectAdminUser( "F_SQLVIEW_PUBLIC_ADD" );
 
@@ -322,14 +324,14 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateSuccess_NonAsciiLetterVariableValues()
+    void testValidateSuccess_NonAsciiLetterVariableValues()
     {
         sqlViewService.validateSqlView( getSqlView( "select * from dataelement where valueType = '${valueType}'" ),
             null, singletonMap( "valueType", "å" ) );
     }
 
     @Test
-    public void testValidateSuccessA()
+    void testValidateSuccessA()
     {
         SqlView sqlView = getSqlView( "select * from dataelement where valueType = '${valueType}'" );
 
@@ -340,7 +342,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateSuccessB()
+    void testValidateSuccessB()
     {
         SqlView sqlView = getSqlView(
             "select ug.name from usergroup ug where ug.name ~* '^OU\\s(\\w.*)\\sAgency\\s(\\w.*)\\susers$'" );
@@ -349,7 +351,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateSuccessC()
+    void testValidateSuccessC()
     {
         SqlView sqlView = getSqlView(
             "SELECT a.dataelementid as dsd_id,a.name as dsd_name,b.dataelementid as ta_id,b.ta_name FROM dataelement a" );
@@ -358,7 +360,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateSuccessD()
+    void testValidateSuccessD()
     {
         SqlView sqlView = getSqlView( "SELECT name, created, lastupdated FROM dataelement" );
 
@@ -366,7 +368,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateSuccessE()
+    void testValidateSuccessE()
     {
         SqlView sqlView = getSqlView( "select * from datavalue where storedby = '${_current_username}'" );
 
@@ -374,7 +376,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateSuccessF()
+    void testValidateSuccessF()
     {
         SqlView sqlView = getSqlView(
             "select * from dataset where timelydays = ${timelyDays} and userid = ${_current_user_id}" );
@@ -386,7 +388,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidate_InvalidVarName()
+    void testValidate_InvalidVarName()
     {
         SqlView sqlView = getSqlView(
             "select * from dataelement where valueType = '${typö}' and aggregationtype = '${aggregationType}'" );
@@ -398,7 +400,7 @@ class SqlViewServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetSqlViewGrid()
+    void testGetSqlViewGrid()
     {
         User admin = createAndInjectAdminUser(); // makes admin current user
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
@@ -59,7 +59,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class AnalyticsCacheSettingsTest
+class AnalyticsCacheSettingsTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
@@ -74,7 +74,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testWhenProgressiveCachingIsEnabled()
+    void testWhenProgressiveCachingIsEnabled()
     {
         given( PROGRESSIVE, CACHE_1_MINUTE );
 
@@ -82,7 +82,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testWhenFixedCachingIsEnabled()
+    void testWhenFixedCachingIsEnabled()
     {
         given( FIXED, CACHE_1_MINUTE );
 
@@ -90,7 +90,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testWhenProgressiveCachingIsEnabledButStrategyIsNoCache()
+    void testWhenProgressiveCachingIsEnabledButStrategyIsNoCache()
     {
         given( PROGRESSIVE, NO_CACHE );
 
@@ -98,7 +98,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testWhenFixedCachingIsEnabledButStrategyIsNoCache()
+    void testWhenFixedCachingIsEnabledButStrategyIsNoCache()
     {
         given( FIXED, NO_CACHE );
 
@@ -106,7 +106,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testProgressiveExpirationTimeOrDefaultWhenTheTtlFactorIsSet()
+    void testProgressiveExpirationTimeOrDefaultWhenTheTtlFactorIsSet()
     {
         // Given
         final int aTtlFactor = 20;
@@ -125,7 +125,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testProgressiveExpirationTimeOrDefaultWhenTheTtlFactorIsNotSet()
+    void testProgressiveExpirationTimeOrDefaultWhenTheTtlFactorIsNotSet()
     {
         // Given
         final int theDefaultTtlFactor = (Integer) ANALYTICS_CACHE_PROGRESSIVE_TTL_FACTOR.getDefaultValue();
@@ -144,7 +144,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testProgressiveExpirationTimeOrDefaultWhenTheTtlFactorIsSetWithNegativeNumber()
+    void testProgressiveExpirationTimeOrDefaultWhenTheTtlFactorIsSetWithNegativeNumber()
     {
         // Given
         final int aTtlFactor = -20;
@@ -160,7 +160,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testWhenFixedExpirationTimeOrDefaultIsSet()
+    void testWhenFixedExpirationTimeOrDefaultIsSet()
     {
         given( CACHE_10_MINUTES );
 
@@ -168,7 +168,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testWhenFixedExpirationTimeOrDefaultIsNotCache()
+    void testWhenFixedExpirationTimeOrDefaultIsNotCache()
     {
         given( NO_CACHE );
 
@@ -177,7 +177,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testIsCachingEnabledWhenFixedExpirationTimeIsSet()
+    void testIsCachingEnabledWhenFixedExpirationTimeIsSet()
     {
         given( FIXED, CACHE_10_MINUTES );
 
@@ -185,7 +185,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testIsCachingEnabledWhenProgressiveExpirationTimeIsSet()
+    void testIsCachingEnabledWhenProgressiveExpirationTimeIsSet()
     {
         given( PROGRESSIVE, CACHE_10_MINUTES );
 
@@ -193,7 +193,7 @@ class AnalyticsCacheSettingsTest
     }
 
     @Test
-    public void testIsCachingEnabledWhenFixedExpirationTimeIsSetAndStrategyIsNoCache()
+    void testIsCachingEnabledWhenFixedExpirationTimeIsSetAndStrategyIsNoCache()
     {
         given( FIXED, NO_CACHE );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
@@ -49,7 +49,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class TimeToLiveTest
+class TimeToLiveTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
@@ -56,7 +56,7 @@ class TimeToLiveTest
     private DefaultSystemSettingManager systemSettingManager;
 
     @Test
-    public void testComputeForCurrentDayWhenCacheFactorIsNegative()
+    void testComputeForCurrentDayWhenCacheFactorIsNegative()
     {
         // Given
         final int aNegativeCachingFactor = -1;
@@ -66,7 +66,7 @@ class TimeToLiveTest
     }
 
     @Test
-    public void testComputeForZeroDayDiffWhenCacheFactorIsPositive()
+    void testComputeForZeroDayDiffWhenCacheFactorIsPositive()
     {
         // Given
 
@@ -83,7 +83,7 @@ class TimeToLiveTest
     }
 
     @Test
-    public void testComputeForOneDayBeforeWhenCacheFactorIsPositive()
+    void testComputeForOneDayBeforeWhenCacheFactorIsPositive()
     {
         // Given
         final int oneDayDiff = 1;
@@ -99,7 +99,7 @@ class TimeToLiveTest
     }
 
     @Test
-    public void testComputeEndingDateIsAheadOfNowAndCacheFactorIsPositive()
+    void testComputeEndingDateIsAheadOfNowAndCacheFactorIsPositive()
     {
         // Given
         final int tenDaysAhead = 10;
@@ -117,7 +117,7 @@ class TimeToLiveTest
     }
 
     @Test
-    public void testComputeEndingDateIsTenDaysBeforeNowAndCacheFactorIsPositive()
+    void testComputeEndingDateIsTenDaysBeforeNowAndCacheFactorIsPositive()
     {
         // Given
         final int tenDays = 10;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsManagerTest.java
@@ -62,8 +62,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class AnalyticsManagerTest
-    extends DhisConvenienceTest
+class AnalyticsManagerTest extends DhisConvenienceTest
 {
     @Mock
     private QueryPlanner queryPlanner;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsManagerTest.java
@@ -114,7 +114,7 @@ class AnalyticsManagerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testReplaceDataPeriodsWithAggregationPeriods()
+    void testReplaceDataPeriodsWithAggregationPeriods()
     {
         AnalyticsManager analyticsManager = new JdbcAnalyticsManager( queryPlanner, jdbcTemplate );
         Period y2012 = createPeriod( "2012" );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceBaseTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceBaseTest.java
@@ -67,7 +67,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( { MockitoExtension.class } )
-public abstract class AnalyticsServiceBaseTest
+abstract class AnalyticsServiceBaseTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceMetadataTest.java
@@ -76,7 +76,7 @@ import com.google.common.collect.Lists;
 /**
  * @author Luciano Fiandesio
  */
-public class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
+class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
 {
 
     @BeforeEach

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceMetadataTest.java
@@ -88,9 +88,9 @@ class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
                 .thenReturn( CompletableFuture.completedFuture( aggregatedValues ) );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void metadataContainsOuLevelData()
+    @Test
+    void metadataContainsOuLevelData()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             // PERIOD
@@ -126,9 +126,9 @@ class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
             hasProperty( "code", is( "OU_12345" ) ) ) );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void metadataContainsIndicatorGroupMetadata()
+    @Test
+    void metadataContainsIndicatorGroupMetadata()
     {
         List<DimensionalItemObject> periods = new ArrayList<>();
         periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
@@ -164,9 +164,9 @@ class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
                 hasProperty( "code", is( indicatorGroup.getCode() ) ) ) );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void metadataContainsOuGroupData()
+    @Test
+    void metadataContainsOuGroupData()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             // PERIOD
@@ -191,9 +191,9 @@ class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
             hasProperty( "uid", is( "tTUf91fCytl" ) ), hasProperty( "code", is( "OU_12345" ) ) ) );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void metadataContainsDataElementGroupMetadata()
+    @Test
+    void metadataContainsDataElementGroupMetadata()
     {
         List<DimensionalItemObject> periods = new ArrayList<>();
         periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
@@ -229,9 +229,9 @@ class AnalyticsServiceMetadataTest extends AnalyticsServiceBaseTest
                 hasProperty( "code", is( dataElementGroup.getCode() ) ) ) );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void metadataContainsRelativePeriodItem()
+    @Test
+    void metadataContainsRelativePeriodItem()
     {
 
         List<DimensionalItemObject> periods = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
@@ -65,8 +65,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * @author Luciano Fiandesio
  */
-public class AnalyticsServiceProgramDataElementTest
-    extends
+class AnalyticsServiceProgramDataElementTest extends
     AnalyticsServiceBaseTest
 {
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceProgramDataElementTest.java
@@ -74,7 +74,7 @@ class AnalyticsServiceProgramDataElementTest extends
      * Analytics Service
      */
     @Test
-    public void verifyProgramDataElementInQueryCallsEventsAnalytics()
+    void verifyProgramDataElementInQueryCallsEventsAnalytics()
     {
         ArgumentCaptor<EventQueryParams> capturedParams = ArgumentCaptor.forClass( EventQueryParams.class );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
@@ -70,7 +70,7 @@ import org.junit.jupiter.api.Test;
 class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 {
     @Test
-    public void verifyReportingRatesValueWhenPeriodIsFilter()
+    void verifyReportingRatesValueWhenPeriodIsFilter()
     {
         int timeUnit = 10;
         double expectedReports = 100D;
@@ -125,7 +125,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
     }
 
     @Test
-    public void verifyNullValueIsZeroForReportingRate()
+    void verifyNullValueIsZeroForReportingRate()
     {
         double expectedReports = 100D;
         DataSet dataSetA = createDataSet( 'A' );
@@ -164,7 +164,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
     }
 
     @Test
-    public void verifyNullTargetIsNullForReportingRate()
+    void verifyNullTargetIsNullForReportingRate()
     {
         DataSet dataSetA = createDataSet( 'A' );
         ReportingRate reportingRateA = new ReportingRate( dataSetA );
@@ -204,7 +204,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
     }
 
     @Test
-    public void verifyReportingRatesForMonthsWithLessThen30DaysAreComputedCorrectly()
+    void verifyReportingRatesForMonthsWithLessThen30DaysAreComputedCorrectly()
     {
         // Create a Dataset with a Daily period type
         DataSet dataSetA = createDataSet( 'A' );
@@ -252,7 +252,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
     }
 
     @Test
-    public void verifyReportingRatesForMonthsWithMoreThen30DaysAreComputedCorrectly()
+    void verifyReportingRatesForMonthsWithMoreThen30DaysAreComputedCorrectly()
     {
         // Create a Dataset with a Daily period type
         DataSet dataSetA = createDataSet( 'A' );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
@@ -67,8 +67,7 @@ import org.junit.jupiter.api.Test;
 /**
  * @author Luciano Fiandesio
  */
-public class AnalyticsServiceReportingRateTest
-    extends AnalyticsServiceBaseTest
+class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 {
     @Test
     public void verifyReportingRatesValueWhenPeriodIsFilter()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -160,7 +160,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithOuLevelToDataQueryParam()
+    void convertAnalyticsRequestWithOuLevelToDataQueryParam()
     {
         mockDimensionService();
 
@@ -190,7 +190,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithMultipleOuLevelToDataQueryParam()
+    void convertAnalyticsRequestWithMultipleOuLevelToDataQueryParam()
     {
         mockDimensionService();
 
@@ -230,7 +230,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithIndicatorGroup()
+    void convertAnalyticsRequestWithIndicatorGroup()
     {
         final String INDICATOR_GROUP_UID = "oehv9EO3vP7";
 
@@ -265,7 +265,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithOrgUnitGroup()
+    void convertAnalyticsRequestWithOrgUnitGroup()
     {
         mockDimensionService();
 
@@ -285,7 +285,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithOrgUnitGroupAsFilter()
+    void convertAnalyticsRequestWithOrgUnitGroupAsFilter()
     {
         mockDimensionService();
 
@@ -305,7 +305,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithOrgUnitLevelAsFilter()
+    void convertAnalyticsRequestWithOrgUnitLevelAsFilter()
     {
         OrganisationUnit level2OuA = new OrganisationUnit( "Bo" );
         OrganisationUnit level2OuB = new OrganisationUnit( "Bombali" );
@@ -345,7 +345,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithOrgUnitLevelAndOrgUnitGroupAsFilter()
+    void convertAnalyticsRequestWithOrgUnitLevelAndOrgUnitGroupAsFilter()
     {
         OrganisationUnit level2OuA = new OrganisationUnit( "Bo" );
         OrganisationUnit level2OuB = new OrganisationUnit( "Bombali" );
@@ -399,7 +399,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithDataElementGroup()
+    void convertAnalyticsRequestWithDataElementGroup()
     {
         when( dimensionService.getDataDimensionalItemObject( UID, DATA_ELEMENT_2.getUid() ) )
             .thenReturn( DATA_ELEMENT_2 );
@@ -436,7 +436,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithDataElementGroupAndIndicatorGroup()
+    void convertAnalyticsRequestWithDataElementGroupAndIndicatorGroup()
     {
         final String DATA_ELEMENT_GROUP_UID = "oehv9EO3vP7";
         final String INDICATOR_GROUP_UID = "iezv4GO4vD9";
@@ -486,7 +486,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithRelativePeriod()
+    void convertAnalyticsRequestWithRelativePeriod()
     {
         mockDimensionService();
         when( i18n.getString( "LAST_12_MONTHS" ) ).thenReturn( "Last 12 months" );
@@ -513,7 +513,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void convertAnalyticsRequestWithRelativePeriodAsFilter()
+    void convertAnalyticsRequestWithRelativePeriodAsFilter()
     {
         mockDimensionService();
         when( i18n.getString( "LAST_12_MONTHS" ) ).thenReturn( "Last 12 months" );
@@ -541,7 +541,7 @@ class DataQueryServiceDimensionItemKeywordTest
     }
 
     @Test
-    public void verifyGetOrgUnitsBasedOnUserOrgUnitType()
+    void verifyGetOrgUnitsBasedOnUserOrgUnitType()
     {
         testGetUserOrgUnits( UserOrgUnitType.DATA_CAPTURE );
         testGetUserOrgUnits( UserOrgUnitType.TEI_SEARCH );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceDimensionItemKeywordTest.java
@@ -85,7 +85,7 @@ import com.google.common.collect.Sets;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class DataQueryServiceDimensionItemKeywordTest
+class DataQueryServiceDimensionItemKeywordTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
@@ -66,7 +66,7 @@ import org.springframework.jdbc.support.rowset.SqlRowSet;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class JdbcAnalyticsManagerTest
+class JdbcAnalyticsManagerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
@@ -104,7 +104,7 @@ class JdbcAnalyticsManagerTest
     }
 
     @Test
-    public void verifyQueryGeneratedWhenDataElementHasLastAggregationType()
+    void verifyQueryGeneratedWhenDataElementHasLastAggregationType()
     {
         DataQueryParams params = createParams( AggregationType.LAST );
 
@@ -114,7 +114,7 @@ class JdbcAnalyticsManagerTest
     }
 
     @Test
-    public void verifyQueryGeneratedWhenDataElementHasLastAvgOrgUnitAggregationType()
+    void verifyQueryGeneratedWhenDataElementHasLastAvgOrgUnitAggregationType()
     {
         DataQueryParams params = createParams( AggregationType.LAST_AVERAGE_ORG_UNIT );
 
@@ -124,7 +124,7 @@ class JdbcAnalyticsManagerTest
     }
 
     @Test
-    public void verifyQueryGeneratedWhenDataElementHasLastInPeriodAggregationType()
+    void verifyQueryGeneratedWhenDataElementHasLastInPeriodAggregationType()
     {
         DataQueryParams params = createParams( AggregationType.LAST_IN_PERIOD );
 
@@ -134,7 +134,7 @@ class JdbcAnalyticsManagerTest
     }
 
     @Test
-    public void verifyQueryGeneratedWhenDataElementHasLastInPeriodAvgOrgUnitAggregationType()
+    void verifyQueryGeneratedWhenDataElementHasLastInPeriodAvgOrgUnitAggregationType()
     {
         DataQueryParams params = createParams( AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
@@ -76,7 +76,7 @@ import com.google.common.collect.Lists;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class QueryPlannerGroupByAggregationTypeTest
+class QueryPlannerGroupByAggregationTypeTest
 {
 
     private QueryPlanner subject;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerGroupByAggregationTypeTest.java
@@ -94,7 +94,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifyMultipleDataElementIsAggregatedWithTwoQueryGroupWhenDataTypeIsDifferent()
+    void verifyMultipleDataElementIsAggregatedWithTwoQueryGroupWhenDataTypeIsDifferent()
     {
         List<DimensionalItemObject> periods = new ArrayList<>();
         periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
@@ -128,7 +128,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifySingleNonDataElementRetainAggregationTypeButNullDataType()
+    void verifySingleNonDataElementRetainAggregationTypeButNullDataType()
     {
         List<DimensionalItemObject> periods = new ArrayList<>();
         periods.add( new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() ) );
@@ -155,7 +155,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifyASingleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
+    void verifyASingleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
     {
         // DataQueryParams with **one** DataElement as filter
         DataQueryParams queryParams = createDataQueryParams(
@@ -180,7 +180,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifyMultipleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
+    void verifyMultipleDataElementAsFilterRetainAggregationTypeAndAggregationDataType()
     {
         // DataQueryParams with **two** DataElement as filter
         // Both have DataType NUMERIC and AggregationType SUM
@@ -202,7 +202,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifyMultipleDataElementAsFilterHavingDifferentAggTypeDoNotRetainAggregationType()
+    void verifyMultipleDataElementAsFilterHavingDifferentAggTypeDoNotRetainAggregationType()
     {
         // DataQueryParams with **two** DataElement as filter
         // Both have DataType NUMERIC but different AggregationType
@@ -224,7 +224,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifyMultipleDataElementAsFilterHavingDifferentAggTypeRetainAggregationType()
+    void verifyMultipleDataElementAsFilterHavingDifferentAggTypeRetainAggregationType()
     {
         // DataQueryParams with **two** DataElement as filter
         // Both have DataType NUMERIC but different AggregationType
@@ -249,7 +249,7 @@ class QueryPlannerGroupByAggregationTypeTest
     }
 
     @Test
-    public void verifyMultipleDataElementAsFilterHavingDifferentDataTypeDoNotRetainAggregationType()
+    void verifyMultipleDataElementAsFilterHavingDifferentDataTypeDoNotRetainAggregationType()
     {
         // DataQueryParams with **two** DataElement as filter
         // One Data Element has Type Numeric

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryValidatorTest.java
@@ -77,7 +77,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class QueryValidatorTest
+class QueryValidatorTest
 {
 
     private DefaultQueryValidator queryValidator;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryValidatorTest.java
@@ -153,7 +153,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateSuccessA()
+    void validateSuccessA()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -166,7 +166,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateSuccessB()
+    void validateSuccessB()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -180,7 +180,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateSuccessSingleIndicatorFilter()
+    void validateSuccessSingleIndicatorFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -192,7 +192,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateSuccessSingleProgramIndicatorFilter()
+    void validateSuccessSingleProgramIndicatorFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -205,7 +205,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureSingleIndicatorAsFilter()
+    void validateFailureSingleIndicatorAsFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -217,7 +217,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureSingleProgramIndicatorAsFilter()
+    void validateFailureSingleProgramIndicatorAsFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -231,7 +231,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateErrorSingleIndicatorAsFilter()
+    void validateErrorSingleIndicatorAsFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -245,7 +245,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureMultipleIndicatorsFilter()
+    void validateFailureMultipleIndicatorsFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -257,7 +257,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateErrorMultipleIndicatorsFilter()
+    void validateErrorMultipleIndicatorsFilter()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -271,7 +271,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureReportingRatesAndDataElementGroupSetAsDimensions()
+    void validateFailureReportingRatesAndDataElementGroupSetAsDimensions()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -286,7 +286,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateErrorReportingRatesAndDataElementGroupSetAsDimensions()
+    void validateErrorReportingRatesAndDataElementGroupSetAsDimensions()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -303,7 +303,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureReportingRatesAndStartEndDates()
+    void validateFailureReportingRatesAndStartEndDates()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(
@@ -316,7 +316,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureValueType()
+    void validateFailureValueType()
     {
         deB.setValueType( ValueType.FILE_RESOURCE );
 
@@ -331,7 +331,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureAggregationType()
+    void validateFailureAggregationType()
     {
         deB.setAggregationType( AggregationType.CUSTOM );
 
@@ -346,7 +346,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateFailureOptionCombosWithIndicators()
+    void validateFailureOptionCombosWithIndicators()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension( new BaseDimensionalObject( DATA_X_DIM_ID, DimensionType.DATA_X, getList( deA, inA ) ) )
@@ -360,7 +360,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateMissingOrgUnitDimensionOutputFormatDataValueSet()
+    void validateMissingOrgUnitDimensionOutputFormatDataValueSet()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension( new BaseDimensionalObject( DATA_X_DIM_ID, DimensionType.DATA_X, getList( deA, deB ) ) )
@@ -371,7 +371,7 @@ class QueryValidatorTest
     }
 
     @Test
-    public void validateSuccessWithSkipDataDimensionCheck()
+    void validateSuccessWithSkipDataDimensionCheck()
     {
         DataQueryParams params = DataQueryParams.newBuilder()
             .addDimension(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapperTest.java
@@ -80,7 +80,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToName()
+    void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToName()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -108,7 +108,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToCode()
+    void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToCode()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -136,7 +136,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToUuid()
+    void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToUuid()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -164,7 +164,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToUid()
+    void testGetSchemeIdResponseMapWhenOutputIdSchemeIsSetToUid()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -192,7 +192,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToNameForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToNameForDataValueSet()
     {
         // Given
         final List<DataElement> dataElementsStub = stubDataElements();
@@ -218,7 +218,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToCodeForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToCodeForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -247,7 +247,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUuidForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUuidForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -276,7 +276,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUidForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeIsSetToUidForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -305,7 +305,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToNameForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToNameForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -334,7 +334,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToCodeForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToCodeForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -363,7 +363,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUuidForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUuidForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -392,7 +392,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUidForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeIsSetToUidForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -421,7 +421,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeOverridesOutputOrgUnitIdSchemeForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputOrgUnitIdSchemeOverridesOutputOrgUnitIdSchemeForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -453,7 +453,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeOverridesOutputOrgUnitIdSchemeForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputDataElementIdSchemeOverridesOutputOrgUnitIdSchemeForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();
@@ -486,7 +486,7 @@ class SchemaIdResponseMapperTest
     }
 
     @Test
-    public void testGetSchemeIdResponseMapWhenOutputDataElementAndOrgUnitIdSchemeOverrideOutputOrgUnitIdSchemeForDataValueSet()
+    void testGetSchemeIdResponseMapWhenOutputDataElementAndOrgUnitIdSchemeOverrideOutputOrgUnitIdSchemeForDataValueSet()
     {
         // Given
         final List<DataElementOperand> dataElementOperandsStub = stubDataElementOperands();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapperTest.java
@@ -68,7 +68,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author maikel arabori
  */
 @ExtendWith( MockitoExtension.class )
-public class SchemaIdResponseMapperTest
+class SchemaIdResponseMapperTest
 {
 
     private SchemaIdResponseMapper schemaIdResponseMapper;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
@@ -106,7 +106,7 @@ class AbstractAnalyticsServiceTest
     }
 
     @Test
-    public void verifyHeaderCreationBasedOnQueryItemsAndDimensions()
+    void verifyHeaderCreationBasedOnQueryItemsAndDimensions()
     {
         // Given
         DimensionalObject periods = new BaseDimensionalObject( DimensionalObject.PERIOD_DIM_ID, DimensionType.PERIOD,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
@@ -71,7 +71,7 @@ import com.google.common.collect.Lists;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class AbstractAnalyticsServiceTest
+class AbstractAnalyticsServiceTest
 {
 
     private Period peA;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -77,7 +77,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class AbstractJdbcEventAnalyticsManagerTest extends
+class AbstractJdbcEventAnalyticsManagerTest extends
     EventAnalyticsTest
 {
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -115,7 +115,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetSelectSqlWithProgramIndicator()
+    void verifyGetSelectSqlWithProgramIndicator()
     {
         ProgramIndicator programIndicator = createProgramIndicator( 'A', programA, "9.0", null );
         QueryItem item = new QueryItem( programIndicator );
@@ -127,7 +127,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetSelectSqlWithTextDataElement()
+    void verifyGetSelectSqlWithTextDataElement()
     {
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
 
@@ -140,7 +140,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetSelectSqlWithNonTextDataElement()
+    void verifyGetSelectSqlWithNonTextDataElement()
     {
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
 
@@ -153,7 +153,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetCoordinateColumn()
+    void verifyGetCoordinateColumn()
     {
         // Given
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
@@ -172,7 +172,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetColumn()
+    void verifyGetColumn()
     {
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
 
@@ -190,7 +190,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetAggregateClauseWithValue()
+    void verifyGetAggregateClauseWithValue()
     {
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
 
@@ -205,7 +205,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetAggregateClauseWithValueFails()
+    void verifyGetAggregateClauseWithValueFails()
     {
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
 
@@ -217,7 +217,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetAggregateClauseWithProgramIndicator()
+    void verifyGetAggregateClauseWithProgramIndicator()
     {
         ProgramIndicator programIndicator = createProgramIndicator( 'A', programA, "9.0", null );
         EventQueryParams params = new EventQueryParams.Builder( createRequestParams() )
@@ -234,7 +234,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetAggregateClauseWithProgramIndicatorAndCustomAggregationType()
+    void verifyGetAggregateClauseWithProgramIndicatorAndCustomAggregationType()
     {
         ProgramIndicator programIndicator = createProgramIndicator( 'A', programA, "9.0", null );
         programIndicator.setAggregationType( AggregationType.CUSTOM );
@@ -252,7 +252,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetAggregateClauseWithEnrollmentDimension()
+    void verifyGetAggregateClauseWithEnrollmentDimension()
     {
         ProgramIndicator programIndicator = createProgramIndicator( 'A', programA, "9.0", null );
         programIndicator.setAnalyticsType( AnalyticsType.ENROLLMENT );
@@ -270,7 +270,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetColumnsWithAttributeOrgUnitTypeAndCoordinatesReturnsFetchesCoordinatesFromOrgUnite()
+    void verifyGetColumnsWithAttributeOrgUnitTypeAndCoordinatesReturnsFetchesCoordinatesFromOrgUnite()
     {
         // Given
 
@@ -305,7 +305,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetWhereClauseWithAttributeOrgUnitTypeAndCoordinatesReturnsFetchesCoordinatesFromOrgUnite()
+    void verifyGetWhereClauseWithAttributeOrgUnitTypeAndCoordinatesReturnsFetchesCoordinatesFromOrgUnite()
     {
         // Given
 
@@ -340,7 +340,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
     }
 
     @Test
-    public void testGetWhereClauseWithMultipleOrgUnitDescendantsAtSameLevel()
+    void testGetWhereClauseWithMultipleOrgUnitDescendantsAtSameLevel()
     {
         // Given
         final DimensionalObject periods = new BaseDimensionalObject( DimensionalObject.PERIOD_DIM_ID,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
@@ -115,7 +115,7 @@ class DefaultEventAnalyticsServiceTest
     }
 
     @Test
-    public void testOutputSchemeWhenSchemeIsSet()
+    void testOutputSchemeWhenSchemeIsSet()
     {
         // Given mock variables
         final IdScheme codeScheme = IdScheme.CODE;
@@ -137,7 +137,7 @@ class DefaultEventAnalyticsServiceTest
     }
 
     @Test
-    public void testOutputSchemeWhenNoSchemeIsSet()
+    void testOutputSchemeWhenNoSchemeIsSet()
     {
         // Given mock variables
         final IdScheme noScheme = null;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsServiceTest.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Sets;
  * @author maikel arabori
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultEventAnalyticsServiceTest
+class DefaultEventAnalyticsServiceTest
 {
 
     private DefaultEventAnalyticsService defaultEventAnalyticsService;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -126,7 +126,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramAndStartEndDate()
+    void verifyWithProgramAndStartEndDate()
     {
         EventQueryParams params = new EventQueryParams.Builder( createRequestParams() )
             .withStartDate( getDate( 2017, 1, 1 ) ).withEndDate( getDate( 2017, 12, 31 ) ).build();
@@ -143,7 +143,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithLastUpdatedTimeField()
+    void verifyWithLastUpdatedTimeField()
     {
         EventQueryParams params = new EventQueryParams.Builder( createRequestParams() )
             .withStartDate( getDate( 2017, 1, 1 ) ).withEndDate( getDate( 2017, 12, 31 ) )
@@ -162,13 +162,13 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramStageAndNumericDataElement()
+    void verifyWithProgramStageAndNumericDataElement()
     {
         verifyWithProgramStageAndNumericDataElement( ValueType.NUMBER );
     }
 
     @Test
-    public void verifyWithProgramStageAndTextDataElement()
+    void verifyWithProgramStageAndTextDataElement()
     {
         verifyWithProgramStageAndNumericDataElement( ValueType.TEXT );
     }
@@ -198,7 +198,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramStageAndTextualDataElementAndFilter()
+    void verifyWithProgramStageAndTextualDataElementAndFilter()
     {
 
         EventQueryParams params = createRequestParamsWithFilter( programStage, ValueType.TEXT );
@@ -220,7 +220,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramStageAndNumericDataElementAndFilter2()
+    void verifyWithProgramStageAndNumericDataElementAndFilter2()
     {
 
         EventQueryParams params = createRequestParamsWithFilter( programStage, ValueType.NUMBER );
@@ -243,7 +243,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetEnrollmentsWithMissingValueEqFilter()
+    void verifyGetEnrollmentsWithMissingValueEqFilter()
     {
         String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
             + " where analytics_event_"
@@ -257,7 +257,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetEnrollmentsWithMissingValueNeFilter()
+    void verifyGetEnrollmentsWithMissingValueNeFilter()
     {
         String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
             + " where analytics_event_"
@@ -270,7 +270,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetEnrollmentsWithMissingValueAndNumericValuesInFilter()
+    void verifyGetEnrollmentsWithMissingValueAndNumericValuesInFilter()
     {
         String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
             + " where analytics_event_"
@@ -286,7 +286,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetEnrollmentsWithoutMissingValueAndNumericValuesInFilter()
+    void verifyGetEnrollmentsWithoutMissingValueAndNumericValuesInFilter()
     {
         String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
             + " where analytics_event_"
@@ -301,7 +301,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetEnrollmentsWithOnlyMissingValueInFilter()
+    void verifyGetEnrollmentsWithOnlyMissingValueInFilter()
     {
         String subSelect = "(select \"fWIAEtYVEGk\" from analytics_event_" + programA.getUid()
             + " where analytics_event_"
@@ -329,7 +329,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTei()
+    void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTei()
     {
         Date startDate = getDate( 2015, 1, 1 );
         Date endDate = getDate( 2017, 4, 8 );
@@ -368,7 +368,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramIndicatorAndRelationshipTypeDifferentConstraint()
+    void verifyWithProgramIndicatorAndRelationshipTypeDifferentConstraint()
     {
         Date startDate = getDate( 2015, 1, 1 );
         Date endDate = getDate( 2017, 4, 8 );
@@ -440,7 +440,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTei2()
+    void verifyWithProgramIndicatorAndRelationshipTypeBothSidesTei2()
     {
         Date startDate = getDate( 2015, 1, 1 );
         Date endDate = getDate( 2017, 4, 8 );
@@ -479,7 +479,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetColumnOfTypeCoordinateAndNoProgramStages()
+    void verifyGetColumnOfTypeCoordinateAndNoProgramStages()
     {
         // Given
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
@@ -495,7 +495,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetColumnOfTypeCoordinateAndWithProgramStages()
+    void verifyGetColumnOfTypeCoordinateAndWithProgramStages()
     {
         // Given
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
@@ -517,7 +517,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetCoordinateColumnAndNoProgramStage()
+    void verifyGetCoordinateColumnAndNoProgramStage()
     {
         // Given
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
@@ -544,7 +544,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetCoordinateColumnWithProgramStage()
+    void verifyGetCoordinateColumnWithProgramStage()
     {
         // Given
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );
@@ -571,7 +571,7 @@ class EnrollmentAnalyticsManagerTest extends
     }
 
     @Test
-    public void verifyGetCoordinateColumnWithNoProgram()
+    void verifyGetCoordinateColumnWithNoProgram()
     {
         // Given
         DimensionalItemObject dio = new BaseDimensionalItemObject( dataElementA.getUid() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -88,7 +88,7 @@ import com.google.common.collect.ImmutableList;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentAnalyticsManagerTest extends
+class EnrollmentAnalyticsManagerTest extends
     EventAnalyticsTest
 {
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
@@ -56,7 +56,7 @@ import org.springframework.jdbc.support.rowset.SqlRowSet;
 /**
  * @author Luciano Fiandesio
  */
-public abstract class EventAnalyticsTest
+abstract class EventAnalyticsTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
@@ -67,7 +67,7 @@ import com.google.common.collect.Lists;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class EventQueryValidatorTest extends DhisSpringTest
+class EventQueryValidatorTest extends DhisSpringTest
 {
 
     private Program prA;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventQueryValidatorTest.java
@@ -161,7 +161,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateSuccesA()
+    void validateSuccesA()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -173,7 +173,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateValidTimeField()
+    void validateValidTimeField()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -186,7 +186,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateSingleDataElementMultipleProgramsQueryItemSuccess()
+    void validateSingleDataElementMultipleProgramsQueryItemSuccess()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -201,7 +201,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateDuplicateQueryItems()
+    void validateDuplicateQueryItems()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -218,7 +218,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateFailureNoStartEndDatePeriods()
+    void validateFailureNoStartEndDatePeriods()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -228,7 +228,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateErrorNoStartEndDatePeriods()
+    void validateErrorNoStartEndDatePeriods()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -240,7 +240,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateInvalidQueryItemBothLegendSetAndOptionSet()
+    void validateInvalidQueryItemBothLegendSetAndOptionSet()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -253,7 +253,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateInvalidTimeField()
+    void validateInvalidTimeField()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -266,7 +266,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateInvalidOrgUnitField()
+    void validateInvalidOrgUnitField()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -279,7 +279,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateErrorPage()
+    void validateErrorPage()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -294,7 +294,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateErrorPageSize()
+    void validateErrorPageSize()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -309,7 +309,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateErrorMaxLimit()
+    void validateErrorMaxLimit()
     {
         when( systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT ) )
             .thenReturn( 100 );
@@ -327,7 +327,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateErrorFallbackCoordinateField()
+    void validateErrorFallbackCoordinateField()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )
@@ -344,7 +344,7 @@ class EventQueryValidatorTest extends DhisSpringTest
     }
 
     @Test
-    public void validateErrorClusterSize()
+    void validateErrorClusterSize()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( prA )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -98,7 +98,7 @@ import com.google.common.collect.ImmutableList;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventsAnalyticsManagerTest extends EventAnalyticsTest
+class EventsAnalyticsManagerTest extends EventAnalyticsTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -129,7 +129,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventSqlWithProgramWithNoRegistration()
+    void verifyGetEventSqlWithProgramWithNoRegistration()
     {
         mockEmptyRowSet();
 
@@ -147,7 +147,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventSqlWithOrgUnitTypeDataElement()
+    void verifyGetEventSqlWithOrgUnitTypeDataElement()
     {
         mockEmptyRowSet();
 
@@ -170,7 +170,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventSqlWithProgram()
+    void verifyGetEventSqlWithProgram()
     {
         mockEmptyRowSet();
 
@@ -185,7 +185,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsSqlWithProgramAndProgramStage()
+    void verifyGetEventsSqlWithProgramAndProgramStage()
     {
         mockEmptyRowSet();
 
@@ -202,7 +202,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithProgramStageAndNumericDataElement()
+    void verifyGetEventsWithProgramStageAndNumericDataElement()
     {
         mockEmptyRowSet();
 
@@ -219,7 +219,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithProgramStageAndNumericDataElementAndFilter()
+    void verifyGetEventsWithProgramStageAndNumericDataElementAndFilter()
     {
         mockEmptyRowSet();
 
@@ -236,7 +236,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithMissingValueEqFilter()
+    void verifyGetEventsWithMissingValueEqFilter()
     {
         String expected = "ax.\"fWIAEtYVEGk\" is null";
         testIt( EQ, NV, Collections.singleton(
@@ -244,7 +244,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithMissingValueNeFilter()
+    void verifyGetEventsWithMissingValueNeFilter()
     {
         String expected = "ax.\"fWIAEtYVEGk\" is not null";
         testIt( NE, NV, Collections.singleton(
@@ -252,7 +252,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithMissingValueAndNumericValuesInFilter()
+    void verifyGetEventsWithMissingValueAndNumericValuesInFilter()
     {
         String numericValues = String.join( OPTION_SEP, "10", "11", "12" );
         String expected = "(ax.\"fWIAEtYVEGk\" in (" + String.join( ",", numericValues.split( OPTION_SEP ) )
@@ -263,7 +263,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithoutMissingValueAndNumericValuesInFilter()
+    void verifyGetEventsWithoutMissingValueAndNumericValuesInFilter()
     {
         String numericValues = String.join( OPTION_SEP, "10", "11", "12" );
         String expected = "ax.\"fWIAEtYVEGk\" in (" + String.join( ",", numericValues.split( OPTION_SEP ) ) + ")";
@@ -273,7 +273,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithOnlyMissingValueInFilter()
+    void verifyGetEventsWithOnlyMissingValueInFilter()
     {
         String expected = "ax.\"fWIAEtYVEGk\" is null";
         String unexpected = "(ax.\"fWIAEtYVEGk\" in (";
@@ -298,7 +298,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithProgramStageAndTextDataElement()
+    void verifyGetEventsWithProgramStageAndTextDataElement()
     {
         mockEmptyRowSet();
 
@@ -315,7 +315,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetEventsWithProgramStageAndTextDataElementAndFilter()
+    void verifyGetEventsWithProgramStageAndTextDataElementAndFilter()
     {
         mockEmptyRowSet();
 
@@ -331,7 +331,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetAggregatedEventQuery()
+    void verifyGetAggregatedEventQuery()
     {
         mockRowSet();
 
@@ -359,7 +359,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyGetAggregatedEventQueryWithFilter()
+    void verifyGetAggregatedEventQueryWithFilter()
     {
 
         when( rowSet.getString( "fWIAEtYVEGk" ) ).thenReturn( "2000" );
@@ -387,19 +387,19 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     }
 
     @Test
-    public void verifyFirstAggregationTypeSubquery()
+    void verifyFirstAggregationTypeSubquery()
     {
         verifyFirstOrLastAggregationTypeSubquery( AnalyticsAggregationType.FIRST );
     }
 
     @Test
-    public void verifyLastAggregationTypeSubquery()
+    void verifyLastAggregationTypeSubquery()
     {
         verifyFirstOrLastAggregationTypeSubquery( AnalyticsAggregationType.LAST );
     }
 
     @Test
-    public void verifySortClauseHandlesProgramIndicators()
+    void verifySortClauseHandlesProgramIndicators()
     {
         Program program = createProgram( 'P' );
         ProgramIndicator piA = createProgramIndicator( 'A', program, ".", "." );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class ProgramIndicatorSubqueryBuilderTest
+class ProgramIndicatorSubqueryBuilderTest
 {
 
     private final static String DUMMY_EXPRESSION = "#{1234567}";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -83,7 +83,7 @@ class ProgramIndicatorSubqueryBuilderTest
     }
 
     @Test
-    public void verifyProgramIndicatorSubQueryWithAliasTable()
+    void verifyProgramIndicatorSubQueryWithAliasTable()
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
 
@@ -101,7 +101,7 @@ class ProgramIndicatorSubqueryBuilderTest
      * join is type EVENT
      */
     @Test
-    public void verifyProgramIndicatorWithoutAggregationTypeReturnsAvg()
+    void verifyProgramIndicatorWithoutAggregationTypeReturnsAvg()
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
         pi.setAggregationType( null );
@@ -116,7 +116,7 @@ class ProgramIndicatorSubqueryBuilderTest
     }
 
     @Test
-    public void verifyJoinWhenOuterQueryIsEnrollment()
+    void verifyJoinWhenOuterQueryIsEnrollment()
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
 
@@ -130,7 +130,7 @@ class ProgramIndicatorSubqueryBuilderTest
     }
 
     @Test
-    public void verifyJoinWhenRelationshipTypeIsPresent()
+    void verifyJoinWhenRelationshipTypeIsPresent()
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
 
@@ -156,7 +156,7 @@ class ProgramIndicatorSubqueryBuilderTest
     }
 
     @Test
-    public void verifyProgramIndicatorWithFilter()
+    void verifyProgramIndicatorWithFilter()
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
         pi.setFilter( DUMMY_FILTER_EXPRESSION );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
@@ -80,7 +80,7 @@ import com.google.common.collect.Sets;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class QueryItemLocatorTest
+class QueryItemLocatorTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
@@ -122,7 +122,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyExceptionOnEmptyDimension()
+    void verifyExceptionOnEmptyDimension()
     {
         assertThrows( IllegalQueryException.class,
             () -> subject.getQueryItemFromDimension( "", programA, EventOutputType.ENROLLMENT ),
@@ -130,7 +130,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyExceptionOnEmptyProgram()
+    void verifyExceptionOnEmptyProgram()
     {
         assertThrows( NullPointerException.class,
             () -> subject.getQueryItemFromDimension( dimension, null, EventOutputType.ENROLLMENT ),
@@ -138,7 +138,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionReturnsDataElementForEventQuery()
+    void verifyDimensionReturnsDataElementForEventQuery()
     {
         DataElement dataElementA = createDataElement( 'A' );
 
@@ -161,7 +161,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void getQueryItemFromDimensionThrowsRightExceptionWhenElementDoesNotBelongToProgram()
+    void getQueryItemFromDimensionThrowsRightExceptionWhenElementDoesNotBelongToProgram()
     {
         // Arrange
         DataElement iBelongDataElement = createDataElement( 'A' );
@@ -180,7 +180,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionFailsWhenProgramStageIsMissingForEnrollmentQuery()
+    void verifyDimensionFailsWhenProgramStageIsMissingForEnrollmentQuery()
     {
         DataElement dataElementA = createDataElement( 'A' );
 
@@ -199,7 +199,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionReturnsDataElementForEnrollmentQuery()
+    void verifyDimensionReturnsDataElementForEnrollmentQuery()
     {
         DataElement dataElementA = createDataElement( 'A' );
 
@@ -223,7 +223,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionWithLegendSetReturnsDataElement()
+    void verifyDimensionWithLegendSetReturnsDataElement()
     {
         String legendSetUid = CodeGenerator.generateUid();
 
@@ -252,7 +252,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionWithLegendSetAndProgramStageReturnsDataElement()
+    void verifyDimensionWithLegendSetAndProgramStageReturnsDataElement()
     {
         String legendSetUid = CodeGenerator.generateUid();
 
@@ -287,7 +287,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionReturnsTrackedEntityAttribute()
+    void verifyDimensionReturnsTrackedEntityAttribute()
     {
         OptionSet optionSetA = createOptionSet( 'A' );
 
@@ -314,7 +314,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionReturnsProgramIndicator()
+    void verifyDimensionReturnsProgramIndicator()
     {
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', programA, "", "" );
         programIndicatorA.setUid( dimension );
@@ -333,7 +333,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyDimensionReturnsProgramIndicatorWithRelationship()
+    void verifyDimensionReturnsProgramIndicatorWithRelationship()
     {
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', programA, "", "" );
         programIndicatorA.setUid( dimension );
@@ -357,7 +357,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyForeignProgramIndicatorWithoutRelationshipIsNotAccepted()
+    void verifyForeignProgramIndicatorWithoutRelationshipIsNotAccepted()
     {
 
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', programA, "", "" );
@@ -372,7 +372,7 @@ class QueryItemLocatorTest
     }
 
     @Test
-    public void verifyForeignProgramIndicatorWithRelationshipIsAccepted()
+    void verifyForeignProgramIndicatorWithRelationshipIsAccepted()
     {
 
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', programA, "", "" );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
@@ -125,7 +125,7 @@ class CategoryOptionGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsResolvedProperly()
+    void verifyExpressionIsResolvedProperly()
     {
         // arrange
 
@@ -148,7 +148,7 @@ class CategoryOptionGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
+    void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
     {
         // arrange
 
@@ -170,7 +170,7 @@ class CategoryOptionGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenCoPrefixNotInUid1()
+    void verifyExpressionIsNotResolvedWhenCoPrefixNotInUid1()
     {
         // arrange
 
@@ -192,7 +192,7 @@ class CategoryOptionGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
+    void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
     {
         // arrange
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
@@ -61,7 +61,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class CategoryOptionGroupResolverTest
+class CategoryOptionGroupResolverTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
@@ -56,7 +56,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class CategoryOptionResolverTest
+class CategoryOptionResolverTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionResolverTest.java
@@ -112,7 +112,7 @@ class CategoryOptionResolverTest
     }
 
     @Test
-    public void verifyExpressionIsResolvedProperly()
+    void verifyExpressionIsResolvedProperly()
     {
         // arrange
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
@@ -134,7 +134,7 @@ class CategoryOptionResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
+    void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
     {
         // arrange
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
@@ -156,7 +156,7 @@ class CategoryOptionResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenCoPrefixNotInUid1()
+    void verifyExpressionIsNotResolvedWhenCoPrefixNotInUid1()
     {
         // arrange
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,
@@ -177,7 +177,7 @@ class CategoryOptionResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
+    void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
     {
         // arrange
         dimensionalItemId = new DimensionalItemId( DimensionItemType.DATA_ELEMENT_OPERAND, uid1,

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolverTest.java
@@ -118,7 +118,7 @@ class DataElementGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsResolvedProperly()
+    void verifyExpressionIsResolvedProperly()
     {
         // arrange
 
@@ -142,7 +142,7 @@ class DataElementGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
+    void verifyExpressionIsNotResolvedWhenDimensionalItemIdHasNoItem()
     {
         // arrange
 
@@ -165,7 +165,7 @@ class DataElementGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenDeGroupPrefixNotInUid0()
+    void verifyExpressionIsNotResolvedWhenDeGroupPrefixNotInUid0()
     {
         // arrange
 
@@ -187,7 +187,7 @@ class DataElementGroupResolverTest
     }
 
     @Test
-    public void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
+    void verifyExpressionIsNotResolvedWhenExpressionIsNotValid()
     {
         // arrange
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/DataElementGroupResolverTest.java
@@ -56,7 +56,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class DataElementGroupResolverTest
+class DataElementGroupResolverTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
@@ -73,7 +73,7 @@ import com.google.common.collect.Lists;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class JdbcAnalyticsTableManagerTest
+class JdbcAnalyticsTableManagerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
@@ -95,7 +95,7 @@ class JdbcAnalyticsTableManagerTest
     }
 
     @Test
-    public void testGetRegularAnalyticsTable()
+    void testGetRegularAnalyticsTable()
     {
         Date startTime = new DateTime( 2019, 3, 1, 10, 0 ).toDate();
         List<Integer> dataYears = Lists.newArrayList( 2018, 2019 );
@@ -132,7 +132,7 @@ class JdbcAnalyticsTableManagerTest
     }
 
     @Test
-    public void testGetLatestAnalyticsTable()
+    void testGetLatestAnalyticsTable()
     {
         Date lastFullTableUpdate = new DateTime( 2019, 3, 1, 2, 0 ).toDate();
         Date lastLatestPartitionUpdate = new DateTime( 2019, 3, 1, 9, 0 ).toDate();
@@ -171,7 +171,7 @@ class JdbcAnalyticsTableManagerTest
     }
 
     @Test
-    public void testGetLatestAnalyticsTableNoFullTableUpdate()
+    void testGetLatestAnalyticsTableNoFullTableUpdate()
     {
         Date lastLatestPartitionUpdate = new DateTime( 2019, 3, 1, 9, 0 ).toDate();
         Date startTime = new DateTime( 2019, 3, 1, 10, 0 ).toDate();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -94,7 +94,7 @@ class JdbcEnrollmentAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyTeiTypeOrgUnitFetchesOuUidWhenPopulatingEventAnalyticsTable()
+    void verifyTeiTypeOrgUnitFetchesOuUidWhenPopulatingEventAnalyticsTable()
     {
         ArgumentCaptor<String> sql = ArgumentCaptor.forClass( String.class );
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Lists;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class JdbcEnrollmentAnalyticsTableManagerTest
+class JdbcEnrollmentAnalyticsTableManagerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -170,13 +170,13 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyTableType()
+    void verifyTableType()
     {
         assertThat( subject.getAnalyticsTableType(), is( AnalyticsTableType.EVENT ) );
     }
 
     @Test
-    public void verifyGetLatestAnalyticsTables()
+    void verifyGetLatestAnalyticsTables()
     {
         Program prA = createProgram( 'A' );
         Program prB = createProgram( 'B' );
@@ -229,7 +229,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyGetTableWithCategoryCombo()
+    void verifyGetTableWithCategoryCombo()
     {
         Program program = createProgram( 'A' );
 
@@ -265,7 +265,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyGetTableWithDataElements()
+    void verifyGetTableWithDataElements()
     {
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );
         Program program = createProgram( 'A' );
@@ -335,7 +335,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyGetTableWithTrackedEntityAttribute()
+    void verifyGetTableWithTrackedEntityAttribute()
     {
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );
         Program program = createProgram( 'A' );
@@ -386,7 +386,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyDataElementTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
+    void verifyDataElementTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
     {
         ArgumentCaptor<String> sql = ArgumentCaptor.forClass( String.class );
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );
@@ -421,7 +421,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyTeiTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
+    void verifyTeiTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
     {
         ArgumentCaptor<String> sql = ArgumentCaptor.forClass( String.class );
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );
@@ -458,7 +458,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyGetAnalyticsTableWithOuLevels()
+    void verifyGetAnalyticsTableWithOuLevels()
     {
         List<OrganisationUnitLevel> ouLevels = rnd.objects( OrganisationUnitLevel.class, 2 )
             .collect( Collectors.toList() );
@@ -488,7 +488,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyGetAnalyticsTableWithOuGroupSet()
+    void verifyGetAnalyticsTableWithOuGroupSet()
     {
         List<OrganisationUnitGroupSet> ouGroupSet = rnd.objects( OrganisationUnitGroupSet.class, 2 )
             .collect( Collectors.toList() );
@@ -517,7 +517,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyGetAnalyticsTableWithOptionGroupSets()
+    void verifyGetAnalyticsTableWithOptionGroupSets()
     {
         List<CategoryOptionGroupSet> cogs = rnd.objects( CategoryOptionGroupSet.class, 2 )
             .collect( Collectors.toList() );
@@ -583,7 +583,7 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
-    public void verifyTeaTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
+    void verifyTeaTypeOrgUnitFetchesOuNameWhenPopulatingEventAnalyticsTable()
     {
         ArgumentCaptor<String> sql = ArgumentCaptor.forClass( String.class );
         when( databaseInfo.isSpatialSupport() ).thenReturn( true );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -116,7 +116,7 @@ import com.google.common.collect.Sets;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class JdbcEventAnalyticsTableManagerTest
+class JdbcEventAnalyticsTableManagerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
@@ -77,7 +77,7 @@ import com.google.common.collect.Sets;
  * @author Jim Grace
  */
 @ExtendWith( MockitoExtension.class )
-public class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
+class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
 {
 
     private HibernateDataApprovalStore dataApprovalStore;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
@@ -264,7 +264,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testGetDataApprovalStatusesWithOpenPeriodsAfterCoEndDate()
+    void testGetDataApprovalStatusesWithOpenPeriodsAfterCoEndDate()
     {
         transactionTemplate.execute( status -> {
 
@@ -332,7 +332,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testApprovalStatusWithNoAccess()
+    void testApprovalStatusWithNoAccess()
     {
         transactionTemplate.execute( status -> {
 
@@ -343,7 +343,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testApprovalStatusWithOtherUserAccess()
+    void testApprovalStatusWithOtherUserAccess()
     {
         transactionTemplate.execute( status -> {
 
@@ -363,7 +363,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testApprovalStatusWithPublic()
+    void testApprovalStatusWithPublic()
     {
         transactionTemplate.execute( status -> {
 
@@ -377,7 +377,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testApprovalStatusWithOwner()
+    void testApprovalStatusWithOwner()
     {
         transactionTemplate.execute( status -> {
 
@@ -391,7 +391,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testApprovalStatusWithUserSharing()
+    void testApprovalStatusWithUserSharing()
     {
         transactionTemplate.execute( status -> {
 
@@ -405,7 +405,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testApprovalStatusWithUserGroupSharing()
+    void testApprovalStatusWithUserGroupSharing()
     {
         transactionTemplate.execute( status -> {
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
@@ -76,7 +76,7 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class DataSetNotificationServiceTest extends DhisConvenienceTest
+class DataSetNotificationServiceTest extends DhisConvenienceTest
 {
     public static final String TEMPALTE_A_UID = "smsTemplateA";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
@@ -214,7 +214,7 @@ class DataSetNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testShouldReturnNullIfRegistrationIsNull()
+    void testShouldReturnNullIfRegistrationIsNull()
     {
         subject.sendCompleteDataSetNotifications( null );
 
@@ -222,7 +222,7 @@ class DataSetNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfNotTemplateFoundForDataSet()
+    void testIfNotTemplateFoundForDataSet()
     {
         when( dsntService.getCompleteNotifications( any( DataSet.class ) ) ).thenReturn( null );
 
@@ -234,7 +234,7 @@ class DataSetNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendCompletionSMSNotification()
+    void testSendCompletionSMSNotification()
     {
         when( renderer.render( any( CompleteDataSetRegistration.class ), any( DataSetNotificationTemplate.class ) ) )
             .thenReturn( notificationMessage );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
@@ -144,7 +144,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldHasUserAccess()
+    void shouldHasUserAccess()
     {
         String hasUserAccess = deduplicationHelper.getUserAccessErrors(
             getTeiA(), getTeiB(),
@@ -154,7 +154,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserIsNull()
+    void shouldNotHasUserAccessWhenUserIsNull()
     {
         when( currentUserService.getCurrentUser() ).thenReturn( null );
 
@@ -167,7 +167,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoMergeRoles()
+    void shouldNotHasUserAccessWhenUserHasNoMergeRoles()
     {
         when( currentUserService.getCurrentUser() ).thenReturn( getNoMergeAuthsUser() );
 
@@ -180,7 +180,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoAccessToOriginalTEIType()
+    void shouldNotHasUserAccessWhenUserHasNoAccessToOriginalTEIType()
     {
         when( aclService.canDataWrite( user, trackedEntityTypeA ) ).thenReturn( false );
 
@@ -193,7 +193,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoAccessToDuplicateTEIType()
+    void shouldNotHasUserAccessWhenUserHasNoAccessToDuplicateTEIType()
     {
         when( aclService.canDataWrite( user, trackedEntityTypeB ) ).thenReturn( false );
 
@@ -206,7 +206,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoAccessToRelationshipType()
+    void shouldNotHasUserAccessWhenUserHasNoAccessToRelationshipType()
     {
         when( aclService.canDataWrite( user, relationshipType ) ).thenReturn( false );
 
@@ -219,7 +219,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoAccessToProgramInstance()
+    void shouldNotHasUserAccessWhenUserHasNoAccessToProgramInstance()
     {
         when( aclService.canDataWrite( user, programInstance.getProgram() ) ).thenReturn( false );
 
@@ -232,7 +232,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoCaptureScopeAccessToOriginalOrgUnit()
+    void shouldNotHasUserAccessWhenUserHasNoCaptureScopeAccessToOriginalOrgUnit()
     {
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnitA ) ).thenReturn( false );
 
@@ -245,7 +245,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotHasUserAccessWhenUserHasNoCaptureScopeAccessToDuplicateOrgUnit()
+    void shouldNotHasUserAccessWhenUserHasNoCaptureScopeAccessToDuplicateOrgUnit()
     {
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnitB ) ).thenReturn( false );
 
@@ -258,14 +258,14 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldFailGenerateMergeObjectDifferentTrackedEntityType()
+    void shouldFailGenerateMergeObjectDifferentTrackedEntityType()
     {
         assertThrows( PotentialDuplicateForbiddenException.class,
             () -> deduplicationHelper.generateMergeObject( getTeiA(), getTeiB() ) );
     }
 
     @Test
-    public void shouldFailGenerateMergeObjectConflictingValue()
+    void shouldFailGenerateMergeObjectConflictingValue()
     {
         TrackedEntityInstance original = getTeiA();
 
@@ -290,7 +290,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shoudGenerateMergeObjectForAttribute()
+    void shoudGenerateMergeObjectForAttribute()
         throws PotentialDuplicateConflictException,
         PotentialDuplicateForbiddenException
     {
@@ -321,7 +321,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMergeObjectRelationship()
+    void testMergeObjectRelationship()
         throws PotentialDuplicateConflictException,
         PotentialDuplicateForbiddenException
     {
@@ -366,7 +366,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldGenerateMergeObjectWIthEnrollments()
+    void shouldGenerateMergeObjectWIthEnrollments()
         throws PotentialDuplicateConflictException,
         PotentialDuplicateForbiddenException
     {
@@ -388,7 +388,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldFailGenerateMergeObjectEnrollmentsSameProgram()
+    void shouldFailGenerateMergeObjectEnrollmentsSameProgram()
     {
         TrackedEntityInstance original = getTeiA();
 
@@ -405,7 +405,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldFailGetDuplicateRelationshipErrorWithDuplicateRelationshipsWithTeis()
+    void shouldFailGetDuplicateRelationshipErrorWithDuplicateRelationshipsWithTeis()
     {
         TrackedEntityInstance teiA = getTeiA();
         TrackedEntityInstance teiB = getTeiB();
@@ -451,7 +451,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldFailGetDuplicateRelationshipErrorWithDuplicateRelationshipsWithTeisBidirectional()
+    void shouldFailGetDuplicateRelationshipErrorWithDuplicateRelationshipsWithTeisBidirectional()
     {
         TrackedEntityInstance teiA = getTeiA();
         TrackedEntityInstance teiB = getTeiB();
@@ -497,7 +497,7 @@ class DeduplicationHelperTest extends DhisConvenienceTest
     }
 
     @Test
-    public void shouldNotFailGetDuplicateRelationshipError()
+    void shouldNotFailGetDuplicateRelationshipError()
     {
         TrackedEntityInstance teiA = getTeiA();
         TrackedEntityInstance teiB = getTeiB();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/deduplication/DeduplicationHelperTest.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Lists;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( { MockitoExtension.class } )
-public class DeduplicationHelperTest extends DhisConvenienceTest
+class DeduplicationHelperTest extends DhisConvenienceTest
 {
     @InjectMocks
     private DeduplicationHelper deduplicationHelper;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -109,7 +109,7 @@ import com.google.common.collect.Sets;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class ExpressionService2Test extends DhisSpringTest
+class ExpressionService2Test extends DhisSpringTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -405,7 +405,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionElementAndOptionComboIds()
+    void testGetExpressionElementAndOptionComboIds()
     {
         Set<String> ids = target.getExpressionElementAndOptionComboIds( expressionC, VALIDATION_RULE_EXPRESSION );
 
@@ -415,7 +415,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDimensionalItemIdsNullOrEmpty()
+    void testGetExpressionDimensionalItemIdsNullOrEmpty()
     {
         Set<DimensionalItemId> itemIds = target.getExpressionDimensionalItemIds( null, INDICATOR_EXPRESSION );
         assertEquals( 0, itemIds.size() );
@@ -425,7 +425,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDimensionalItemIds()
+    void testGetExpressionDimensionalItemIds()
     {
         when( constantService.getConstantMap() ).thenReturn(
             ImmutableMap.<String, Constant> builder()
@@ -444,7 +444,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDimensionalItemMapsNullOrEmpty()
+    void testGetExpressionDimensionalItemMapsNullOrEmpty()
     {
         Map<DimensionalItemId, DimensionalItemObject> itemMap = new HashMap<>();
         Map<DimensionalItemId, DimensionalItemObject> sampleItemMap = new HashMap<>();
@@ -459,7 +459,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDimensionalItemMaps()
+    void testGetExpressionDimensionalItemMaps()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet(
             getId( opA ), getId( opB ), getId( opC ), getId( opD ) );
@@ -497,7 +497,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetIndicatorDimensionalItemMap()
+    void testGetIndicatorDimensionalItemMap()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet(
             getId( opA ), getId( opB ), getId( deB ), getId( pdeA ), getId( pteaA ), getId( piA ) );
@@ -532,7 +532,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDataElements()
+    void testGetExpressionDataElements()
     {
         when( dataElementService.getDataElement( opA.getDimensionItem().split( "\\." )[0] ) )
             .thenReturn( opA.getDataElement() );
@@ -560,7 +560,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testExpressionDimensionalItemMapsReportingRates()
+    void testExpressionDimensionalItemMapsReportingRates()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet( getId( reportingRate ), getId( opB ) );
 
@@ -581,7 +581,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionOptionComboIds()
+    void testGetExpressionOptionComboIds()
     {
         Set<String> comboIds = target.getExpressionOptionComboIds( expressionG, INDICATOR_EXPRESSION );
 
@@ -591,7 +591,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testExpressionIsValid()
+    void testExpressionIsValid()
     {
         when( constantService.getConstantMap() ).thenReturn(
             ImmutableMap.<String, Constant> builder()
@@ -661,7 +661,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDescription()
+    void testGetExpressionDescription()
     {
         when( constantService.getConstantMap() ).thenReturn(
             ImmutableMap.<String, Constant> builder()
@@ -695,7 +695,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionValue()
+    void testGetExpressionValue()
     {
         Map<DimensionalItemId, DimensionalItemObject> itemMap = ImmutableMap
             .<DimensionalItemId, DimensionalItemObject> builder()
@@ -725,7 +725,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetIndicatorDimensionalItemMap2()
+    void testGetIndicatorDimensionalItemMap2()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet( getId( opA ) );
 
@@ -767,7 +767,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetIndicatorDimensionalItemMap3()
+    void testGetIndicatorDimensionalItemMap3()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet( getId( opA ), getId( opE ), getId( opF ) );
 
@@ -815,7 +815,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testSubstituteIndicatorExpressions()
+    void testSubstituteIndicatorExpressions()
     {
         String expressionZ = "if(\"A\" < 'B' and true,0,0)";
 
@@ -855,8 +855,10 @@ class ExpressionService2Test extends DhisSpringTest
     // CRUD tests
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void verifyExpressionIsUpdated()
+    void verifyExpressionIsUpdated()
     {
         Expression expression = rnd.nextObject( Expression.class );
         target.updateExpression( expression );
@@ -864,7 +866,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void verifyExpressionIsDeleted()
+    void verifyExpressionIsDeleted()
     {
         Expression expression = rnd.nextObject( Expression.class );
         target.deleteExpression( expression );
@@ -872,7 +874,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void verifyExpressionIsAdded()
+    void verifyExpressionIsAdded()
     {
         Expression expression = rnd.nextObject( Expression.class );
         long id = target.addExpression( expression );
@@ -881,7 +883,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void verifyAllExpressionsCanBeFetched()
+    void verifyAllExpressionsCanBeFetched()
     {
         when( hibernateGenericStore.getAll() ).thenReturn( Lists.newArrayList( rnd.nextObject( Expression.class ) ) );
         List<Expression> expressions = target.getAllExpressions();
@@ -890,7 +892,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionOrgUnitGroups()
+    void testGetExpressionOrgUnitGroups()
     {
         when( organisationUnitGroupService.getOrganisationUnitGroup( groupA.getUid() ) ).thenReturn( groupA );
         Set<OrganisationUnitGroup> groups = target.getExpressionOrgUnitGroups( expressionH, INDICATOR_EXPRESSION );
@@ -904,7 +906,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testAnnualizedIndicatorValueWhenHavingMultiplePeriods()
+    void testAnnualizedIndicatorValueWhenHavingMultiplePeriods()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet( getId( opA ) );
 
@@ -958,7 +960,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testAnnualizedIndicatorValueWhenHavingNullPeriods()
+    void testAnnualizedIndicatorValueWhenHavingNullPeriods()
     {
         Set<DimensionalItemId> itemIds = Sets.newHashSet( getId( opA ) );
 
@@ -1003,7 +1005,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetNullWithoutNumeratorDataWithDenominatorData()
+    void testGetNullWithoutNumeratorDataWithDenominatorData()
     {
         IndicatorType indicatorType = new IndicatorType( "A", 100, false );
 
@@ -1026,7 +1028,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetNullWithNumeratorDataWithZeroDenominatorData()
+    void testGetNullWithNumeratorDataWithZeroDenominatorData()
     {
         IndicatorType indicatorType = new IndicatorType( "A", 100, false );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -73,7 +73,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class FileResourceCleanUpJobTest extends IntegrationTestBase
+class FileResourceCleanUpJobTest extends IntegrationTestBase
 {
 
     private FileResourceCleanUpJob cleanUpJob;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -135,7 +135,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase
     }
 
     @Test
-    public void testNoRetention()
+    void testNoRetention()
     {
         when( fileResourceContentStore.fileResourceContentExists( any( String.class ) ) ).thenReturn( true );
 
@@ -154,7 +154,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase
     }
 
     @Test
-    public void testRetention()
+    void testRetention()
     {
         when( fileResourceContentStore.fileResourceContentExists( any( String.class ) ) ).thenReturn( true );
 
@@ -189,7 +189,7 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase
     }
 
     @Test
-    public void testOrphan()
+    void testOrphan()
     {
         when( fileResourceContentStore.fileResourceContentExists( any( String.class ) ) ).thenReturn( false );
 
@@ -226,9 +226,9 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase
         userService.updateUser( userB );
     }
 
-    @Test
     @Disabled
-    public void testFalsePositive()
+    @Test
+    void testFalsePositive()
     {
         systemSettingManager.saveSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY,
             FileResourceRetentionStrategy.THREE_MONTHS );
@@ -247,9 +247,9 @@ class FileResourceCleanUpJobTest extends IntegrationTestBase
         assertTrue( fileResourceService.getFileResource( uid ).isAssigned() );
     }
 
-    @Test
     @Disabled
-    public void testFailedUpload()
+    @Test
+    void testFailedUpload()
     {
         systemSettingManager.saveSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY,
             FileResourceRetentionStrategy.THREE_MONTHS );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
@@ -62,7 +62,7 @@ import com.google.common.collect.ImmutableMap;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class FileResourceServiceTest
+class FileResourceServiceTest
 {
     @Mock
     private FileResourceStore fileResourceStore;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceServiceTest.java
@@ -101,7 +101,7 @@ class FileResourceServiceTest
     }
 
     @Test
-    public void verifySaveFile()
+    void verifySaveFile()
     {
         FileResource fileResource = new FileResource( "mycat.pdf", "application/pdf", 1000, "md5",
             FileResourceDomain.PUSH_ANALYSIS );
@@ -126,7 +126,7 @@ class FileResourceServiceTest
     }
 
     @Test
-    public void verifySaveIllegalFileTypeResourceA()
+    void verifySaveIllegalFileTypeResourceA()
     {
         FileResource fileResource = new FileResource( "very_evil_script.html", "text/html", 1024, "md5",
             FileResourceDomain.USER_AVATAR );
@@ -136,7 +136,7 @@ class FileResourceServiceTest
     }
 
     @Test
-    public void verifySaveIllegalFileTypeResourceB()
+    void verifySaveIllegalFileTypeResourceB()
     {
         FileResource fileResource = new FileResource( "suspicious_program.rpm", "application/x-rpm", 2048, "md5",
             FileResourceDomain.MESSAGE_ATTACHMENT );
@@ -146,7 +146,7 @@ class FileResourceServiceTest
     }
 
     @Test
-    public void verifySaveImageFile()
+    void verifySaveImageFile()
     {
         FileResource fileResource = new FileResource( "test.jpeg", MimeTypeUtils.IMAGE_JPEG.toString(), 1000, "md5",
             FileResourceDomain.DATA_VALUE );
@@ -177,7 +177,7 @@ class FileResourceServiceTest
     }
 
     @Test
-    public void verifyDeleteFile()
+    void verifyDeleteFile()
     {
         FileResource fileResource = new FileResource( "test.pdf", "application/pdf", 1000, "md5",
             FileResourceDomain.DOCUMENT );
@@ -199,7 +199,7 @@ class FileResourceServiceTest
     }
 
     @Test
-    public void verifySaveOrgUnitImageFile()
+    void verifySaveOrgUnitImageFile()
     {
         FileResource fileResource = new FileResource( "test.jpeg", MimeTypeUtils.IMAGE_JPEG.toString(), 1000, "md5",
             FileResourceDomain.ORG_UNIT );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/ImageProcessingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/ImageProcessingServiceTest.java
@@ -65,7 +65,7 @@ class ImageProcessingServiceTest
     }
 
     @Test
-    public void test_create_images_with_null_values()
+    void test_create_images_with_null_values()
     {
         Map<ImageFileDimension, File> images = subject.createImages( new FileResource(), null );
 
@@ -73,7 +73,7 @@ class ImageProcessingServiceTest
     }
 
     @Test
-    public void test_create_images_with_wrong_file_content_type()
+    void test_create_images_with_wrong_file_content_type()
         throws IOException
     {
         FileResource fileResource = new FileResource();
@@ -90,7 +90,7 @@ class ImageProcessingServiceTest
     }
 
     @Test
-    public void test_create_image()
+    void test_create_image()
         throws IOException
     {
         FileResource fileResource = new FileResource();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/ImageProcessingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/ImageProcessingServiceTest.java
@@ -48,7 +48,7 @@ import org.springframework.core.io.ClassPathResource;
  * @Author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class ImageProcessingServiceTest
+class ImageProcessingServiceTest
 {
     private static final int SMALL_IMAGE_WIDTH = 256;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Lists;
 @SuppressWarnings( "unchecked" )
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class SchemaToDataFetcherTest extends DhisConvenienceTest
+class SchemaToDataFetcherTest extends DhisConvenienceTest
 {
 
     private SchemaToDataFetcher subject;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/preheat/SchemaToDataFetcherTest.java
@@ -90,13 +90,13 @@ class SchemaToDataFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyInput()
+    void verifyInput()
     {
         assertThat( subject.fetch( null ), hasSize( 0 ) );
     }
 
     @Test
-    public void verifyUniqueFieldsAreMappedToHibernateObject()
+    void verifyUniqueFieldsAreMappedToHibernateObject()
     {
         Schema schema = createSchema( DataElement.class, "dataElement",
             Stream.of(
@@ -134,7 +134,7 @@ class SchemaToDataFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyUniqueFieldsAreSkippedOnReflectionError()
+    void verifyUniqueFieldsAreSkippedOnReflectionError()
     {
         Schema schema = createSchema( DummyDataElement.class, "dummyDataElement",
             Stream.of(
@@ -165,7 +165,7 @@ class SchemaToDataFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyUniqueFieldsAre()
+    void verifyUniqueFieldsAre()
     {
         Schema schema = createSchema( DummyDataElement.class, "dummyDataElement",
             Stream.of(
@@ -198,7 +198,7 @@ class SchemaToDataFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyNoSqlWhenUniquePropertiesListIsEmpty()
+    void verifyNoSqlWhenUniquePropertiesListIsEmpty()
     {
         Schema schema = createSchema( SMSCommand.class, "smsCommand", Lists.newArrayList() );
 
@@ -208,7 +208,7 @@ class SchemaToDataFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyNoSqlWhenNoUniquePropertyExist()
+    void verifyNoSqlWhenNoUniquePropertyExist()
     {
         Schema schema = createSchema( SMSCommand.class, "smsCommand",
             Stream.of(

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -177,7 +177,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCondition()
+    void testCondition()
     {
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
@@ -190,7 +190,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCount()
+    void testCount()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -204,7 +204,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCountWithStartEventBoundary()
+    void testCountWithStartEventBoundary()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -221,7 +221,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCountWithEndEventBoundary()
+    void testCountWithEndEventBoundary()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -238,7 +238,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCountWithStartAndEndEventBoundary()
+    void testCountWithStartAndEndEventBoundary()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -255,7 +255,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCountIfCondition()
+    void testCountIfCondition()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -271,7 +271,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCountIfValueNumeric()
+    void testCountIfValueNumeric()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -285,7 +285,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCountIfValueString()
+    void testCountIfValueString()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -301,7 +301,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDaysBetween()
+    void testDaysBetween()
     {
         when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
         when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
@@ -313,7 +313,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testHasValueDataElement()
+    void testHasValueDataElement()
     {
 
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -324,7 +324,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testHasValueAttribute()
+    void testHasValueAttribute()
     {
         when( attributeService.getTrackedEntityAttribute( attributeA.getUid() ) ).thenReturn( attributeA );
 
@@ -333,7 +333,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMinutesBetween()
+    void testMinutesBetween()
     {
         when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
         when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
@@ -346,7 +346,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMonthsBetween()
+    void testMonthsBetween()
     {
         when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
         when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
@@ -361,7 +361,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testOizp()
+    void testOizp()
     {
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
@@ -371,7 +371,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testRelationshipCountWithNoRelationshipId()
+    void testRelationshipCountWithNoRelationshipId()
     {
         String sql = test( "d2:relationshipCount()" );
         assertThat( sql, is( "(select count(*) from relationship r " +
@@ -380,7 +380,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testRelationshipCountWithRelationshipId()
+    void testRelationshipCountWithRelationshipId()
     {
         when( relationshipTypeService.getRelationshipType( relTypeA.getUid() ) ).thenReturn( relTypeA );
 
@@ -392,7 +392,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWeeksBetween()
+    void testWeeksBetween()
     {
         when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
         when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
@@ -404,14 +404,14 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testYearsBetween()
+    void testYearsBetween()
     {
         String sql = test( "d2:yearsBetween(V{enrollment_date}, V{analytics_period_start})" );
         assertThat( sql, is( "(date_part('year',age(cast('2020-01-01' as date), cast(enrollmentdate as date))))" ) );
     }
 
     @Test
-    public void testYearsBetweenWithProgramStage()
+    void testYearsBetweenWithProgramStage()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
 
@@ -425,7 +425,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testYearsBetweenWithProgramStageAndBoundaries()
+    void testYearsBetweenWithProgramStageAndBoundaries()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
 
@@ -440,7 +440,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testZing()
+    void testZing()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -450,7 +450,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testZpvcOneArg()
+    void testZpvcOneArg()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -462,7 +462,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testZpvcTwoArgs()
+    void testZpvcTwoArgs()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -476,7 +476,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testLog()
+    void testLog()
     {
         String sql = test( "log(V{enrollment_count})" );
         assertThat( sql, is( "ln(distinct pi)" ) );
@@ -486,21 +486,21 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testLog10()
+    void testLog10()
     {
         String sql = test( "log10(V{org_unit_count})" );
         assertThat( sql, is( "log(distinct ou)" ) );
     }
 
     @Test
-    public void testIllegalFunction()
+    void testIllegalFunction()
     {
         assertThrows( ParserException.class,
             () -> test( "d2:zztop(#{ProgrmStagA.DataElmentA})" ) );
     }
 
     @Test
-    public void testVectorAvg()
+    void testVectorAvg()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -510,7 +510,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testVectorCount()
+    void testVectorCount()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -520,7 +520,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testVectorMax()
+    void testVectorMax()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -530,7 +530,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testVectorMin()
+    void testVectorMin()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -540,7 +540,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testVectorStddev()
+    void testVectorStddev()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -550,7 +550,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testVectorSum()
+    void testVectorSum()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -560,7 +560,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testVectorVariance()
+    void testVectorVariance()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
@@ -570,7 +570,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCompareStrings()
+    void testCompareStrings()
     {
         String sql = test( "'a' < \"b\"" );
         assertThat( sql, is( "'a' < 'b'" ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -153,7 +153,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDataElement()
+    void testDataElement()
     {
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
@@ -163,7 +163,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDataElementAllowingNulls()
+    void testDataElementAllowingNulls()
     {
         when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
@@ -173,7 +173,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDataElementNotFound()
+    void testDataElementNotFound()
     {
         when( attributeService.getTrackedEntityAttribute( attributeA.getUid() ) ).thenReturn( attributeA );
         when( constantService.getConstant( constantA.getUid() ) ).thenReturn( constantA );
@@ -183,7 +183,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAttribute()
+    void testAttribute()
     {
         when( attributeService.getTrackedEntityAttribute( attributeA.getUid() ) ).thenReturn( attributeA );
 
@@ -192,7 +192,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAttributeAllowingNulls()
+    void testAttributeAllowingNulls()
     {
         when( attributeService.getTrackedEntityAttribute( attributeA.getUid() ) ).thenReturn( attributeA );
 
@@ -201,26 +201,26 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAttributeNotFound()
+    void testAttributeNotFound()
     {
         assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "A{NoAttribute}" ) );
     }
 
     @Test
-    public void testConstant()
+    void testConstant()
     {
         String sql = test( "C{constant00A}" );
         assertThat( sql, is( "123.456" ) );
     }
 
     @Test
-    public void testConstantNotFound()
+    void testConstantNotFound()
     {
         assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "C{notConstant}" ) );
     }
 
     @Test
-    public void testInvalidItemType()
+    void testInvalidItemType()
     {
         assertThrows( org.hisp.dhis.antlr.ParserException.class, () -> test( "I{notValidItm}" ) );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -112,21 +112,21 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAnalyticsPeriodEndVariable()
+    void testAnalyticsPeriodEndVariable()
     {
         String sql = castString( test( "V{analytics_period_end}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "'2018-12-31'" ) );
     }
 
     @Test
-    public void testAnalyticsPeriodStartVariable()
+    void testAnalyticsPeriodStartVariable()
     {
         String sql = castString( test( "V{analytics_period_start}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "'2018-01-01'" ) );
     }
 
     @Test
-    public void testCreationDateForEnrollment()
+    void testCreationDateForEnrollment()
     {
         String sql = castString( test( "V{creation_date}", new DefaultLiteral(), enrollmentIndicator ) );
         assertThat( sql,
@@ -137,28 +137,28 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCreationDateForEvent()
+    void testCreationDateForEvent()
     {
         String sql = castString( test( "V{creation_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "created" ) );
     }
 
     @Test
-    public void testCompletedDateForEnrollment()
+    void testCompletedDateForEnrollment()
     {
         String sql = castString( test( "V{completed_date}", new DefaultLiteral(), enrollmentIndicator ) );
         assertThat( sql, is( "completeddate" ) );
     }
 
     @Test
-    public void testCompletedDateForEvent()
+    void testCompletedDateForEvent()
     {
         String sql = castString( test( "V{completed_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "completeddate" ) );
     }
 
     @Test
-    public void testCurrentDateForEvent()
+    void testCurrentDateForEvent()
     {
         String sql = castString( test( "V{current_date}", new DefaultLiteral(), eventIndicator ) );
         String date = DateUtils.getLongDateString();
@@ -167,112 +167,112 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDueDate()
+    void testDueDate()
     {
         String sql = castString( test( "V{due_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "duedate" ) );
     }
 
     @Test
-    public void testEnrollmentCount()
+    void testEnrollmentCount()
     {
         String sql = castString( test( "V{enrollment_count}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "distinct pi" ) );
     }
 
     @Test
-    public void testEnrollmentDate()
+    void testEnrollmentDate()
     {
         String sql = castString( test( "V{enrollment_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "enrollmentdate" ) );
     }
 
     @Test
-    public void testEnrollmentStatus()
+    void testEnrollmentStatus()
     {
         String sql = castString( test( "V{enrollment_status}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "pistatus" ) );
     }
 
     @Test
-    public void testEventCount()
+    void testEventCount()
     {
         String sql = castString( test( "V{event_count}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "psi" ) );
     }
 
     @Test
-    public void testExecutionDate()
+    void testExecutionDate()
     {
         String sql = castString( test( "V{execution_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "executiondate" ) );
     }
 
     @Test
-    public void testEventDate()
+    void testEventDate()
     {
         String sql = castString( test( "V{event_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "executiondate" ) );
     }
 
     @Test
-    public void testIncidentDate()
+    void testIncidentDate()
     {
         String sql = castString( test( "V{incident_date}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "incidentdate" ) );
     }
 
     @Test
-    public void testProgramStageId()
+    void testProgramStageId()
     {
         String sql = castString( test( "V{program_stage_id}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "ps" ) );
     }
 
     @Test
-    public void testProgramStageIdForEnrollment()
+    void testProgramStageIdForEnrollment()
     {
         String sql = castString( test( "V{program_stage_id}", new DefaultLiteral(), enrollmentIndicator ) );
         assertThat( sql, is( "''" ) );
     }
 
     @Test
-    public void testProgramStageName()
+    void testProgramStageName()
     {
         String sql = castString( test( "V{program_stage_name}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "(select name from programstage where uid = ps)" ) );
     }
 
     @Test
-    public void testProgramStageNameForEnrollment()
+    void testProgramStageNameForEnrollment()
     {
         String sql = castString( test( "V{program_stage_name}", new DefaultLiteral(), enrollmentIndicator ) );
         assertThat( sql, is( "''" ) );
     }
 
     @Test
-    public void testSyncDate()
+    void testSyncDate()
     {
         String sql = castString( test( "V{sync_date}", new DefaultLiteral(), enrollmentIndicator ) );
         assertThat( sql, is( "lastupdated" ) );
     }
 
     @Test
-    public void testOrgUnitCount()
+    void testOrgUnitCount()
     {
         String sql = castString( test( "V{org_unit_count}", new DefaultLiteral(), enrollmentIndicator ) );
         assertThat( sql, is( "distinct ou" ) );
     }
 
     @Test
-    public void testTeiCount()
+    void testTeiCount()
     {
         String sql = castString( test( "V{tei_count}", new DefaultLiteral(), eventIndicator ) );
         assertThat( sql, is( "distinct tei" ) );
     }
 
     @Test
-    public void testValueCount()
+    void testValueCount()
     {
         String sql = castString( test( "V{value_count}", new DefaultLiteral(), eventIndicator ) );
 
@@ -283,7 +283,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testZeroPosValueCount()
+    void testZeroPosValueCount()
     {
         String sql = castString( test( "V{zero_pos_value_count}", new DefaultLiteral(), eventIndicator ) );
 
@@ -294,7 +294,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testInvalidVariable()
+    void testInvalidVariable()
     {
         assertThrows( ParserException.class,
             () -> test( "V{undefined_variable}", new DefaultLiteral(), eventIndicator ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -65,8 +65,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class ProgramSqlGeneratorVariablesTest
-    extends DhisConvenienceTest
+class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
 {
     private final String SQL_CASE_NOT_NULL = "case when \"%s\" is not null then 1 else 0 end";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -85,7 +85,7 @@ import com.google.common.collect.Sets;
  */
 @SuppressWarnings( "unchecked" )
 @ExtendWith( MockitoExtension.class )
-public class ProgramNotificationServiceTest extends DhisConvenienceTest
+class ProgramNotificationServiceTest extends DhisConvenienceTest
 {
 
     private static final String SUBJECT = "subject";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/ProgramNotificationServiceTest.java
@@ -214,8 +214,10 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     // Tests
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testIfProgramInstanceIsNull()
+    void testIfProgramInstanceIsNull()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( null );
 
@@ -225,7 +227,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfProgramStageInstanceIsNull()
+    void testIfProgramStageInstanceIsNull()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( null );
 
@@ -235,7 +237,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendCompletionNotification()
+    void testSendCompletionNotification()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( programInstances.iterator().next() );
 
@@ -260,7 +262,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendEnrollmentNotification()
+    void testSendEnrollmentNotification()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( programInstances.iterator().next() );
 
@@ -286,7 +288,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testUserGroupRecipient()
+    void testUserGroupRecipient()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( programInstances.iterator().next() );
 
@@ -312,7 +314,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testOuContactRecipient()
+    void testOuContactRecipient()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( programInstances.iterator().next() );
 
@@ -338,7 +340,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testProgramAttributeRecipientWithSMS()
+    void testProgramAttributeRecipientWithSMS()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( programInstances.iterator().next() );
 
@@ -366,7 +368,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testProgramAttributeRecipientWithEMAIL()
+    void testProgramAttributeRecipientWithEMAIL()
     {
         when( programInstanceStore.get( anyLong() ) ).thenReturn( programInstances.iterator().next() );
 
@@ -394,7 +396,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDataElementRecipientWithSMS()
+    void testDataElementRecipientWithSMS()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( programStageInstances.iterator().next() );
 
@@ -427,7 +429,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDataElementRecipientWithEmail()
+    void testDataElementRecipientWithEmail()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( programStageInstances.iterator().next() );
 
@@ -459,7 +461,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDataElementRecipientWithInternalRecipients()
+    void testDataElementRecipientWithInternalRecipients()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( programStageInstances.iterator().next() );
 
@@ -493,7 +495,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendToParent()
+    void testSendToParent()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( programStageInstances.iterator().next() );
 
@@ -524,7 +526,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendToHierarchy()
+    void testSendToHierarchy()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( programStageInstances.iterator().next() );
 
@@ -561,7 +563,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendToUsersAtOu()
+    void testSendToUsersAtOu()
     {
         when( programStageInstanceStore.get( anyLong() ) ).thenReturn( programStageInstances.iterator().next() );
 
@@ -593,7 +595,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testScheduledNotifications()
+    void testScheduledNotifications()
     {
         sentProgramMessages.clear();
 
@@ -614,7 +616,7 @@ class ProgramNotificationServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testScheduledNotificationsWithDateInPast()
+    void testScheduledNotificationsWithDateInPast()
     {
         sentInternalMessages.clear();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
@@ -157,7 +157,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTrackerEnrollmentNotificationWebHook()
+    void testTrackerEnrollmentNotificationWebHook()
     {
         when( programInstanceService.getProgramInstance( anyString() ) ).thenReturn( programInstance );
         when( templateService.isProgramLinkedToWebHookNotification( any( Program.class ) ) ).thenReturn( true );
@@ -186,7 +186,7 @@ class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTrackerEventNotificationWebHook()
+    void testTrackerEventNotificationWebHook()
     {
         when( programStageInstanceService.getProgramStageInstance( anyString() ) ).thenReturn( programStageInstance );
         when( templateService.isProgramStageLinkedToWebHookNotification( any( ProgramStage.class ) ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/notification/TrackerNotificationWebHookServiceTest.java
@@ -74,7 +74,7 @@ import com.google.common.collect.Sets;
  */
 
 @ExtendWith( MockitoExtension.class )
-public class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
+class TrackerNotificationWebHookServiceTest extends DhisConvenienceTest
 {
 
     private static final String URL = "https://www.google.com";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -79,7 +79,7 @@ class DefaultQueryServiceTest
     }
 
     @Test
-    public void verifyQueryEngineUsesPaginationInformation()
+    void verifyQueryEngineUsesPaginationInformation()
     {
         Query query = Query.from( new OrganisationUnitSchemaDescriptor().getSchema() );
         query.setFirstResult( 100 );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/DefaultQueryServiceTest.java
@@ -54,7 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultQueryServiceTest
+class DefaultQueryServiceTest
 {
 
     private DefaultQueryService subject;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
@@ -68,7 +68,7 @@ class DefaultQueryPlannerTest
     }
 
     @Test
-    public void verifyPlanQueryReturnsPersistedAndNotPersistedQueries()
+    void verifyPlanQueryReturnsPersistedAndNotPersistedQueries()
         throws Exception
     {
         // Create schema with attributes
@@ -107,7 +107,7 @@ class DefaultQueryPlannerTest
      * the target table
      */
     @Test
-    public void verifyPlanQueryReturnsNonPersistedQueryWithCriterion()
+    void verifyPlanQueryReturnsNonPersistedQueryWithCriterion()
         throws Exception
     {
         // Create schema with attributes
@@ -144,7 +144,7 @@ class DefaultQueryPlannerTest
     }
 
     @Test
-    public void verifyPlanQueryReturnsNonPersistedQueryWithCriterion2()
+    void verifyPlanQueryReturnsNonPersistedQueryWithCriterion2()
         throws Exception
     {
         // Create schema with attributes

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/planner/DefaultQueryPlannerTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultQueryPlannerTest
+class DefaultQueryPlannerTest
 {
 
     private DefaultQueryPlanner subject;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java
@@ -49,7 +49,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class RelationshipDeletionHandlerTest
+class RelationshipDeletionHandlerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/relationship/RelationshipDeletionHandlerTest.java
@@ -66,7 +66,7 @@ class RelationshipDeletionHandlerTest
     }
 
     @Test
-    public void allowDeleteRelationshipTypeWithData()
+    void allowDeleteRelationshipTypeWithData()
     {
         when( relationshipService.getRelationshipsByRelationshipType( any() ) )
             .thenReturn( singletonList( new Relationship() ) );
@@ -79,7 +79,7 @@ class RelationshipDeletionHandlerTest
     }
 
     @Test
-    public void allowDeleteRelationshipTypeWithoutData()
+    void allowDeleteRelationshipTypeWithoutData()
     {
         when( relationshipService.getRelationshipsByRelationshipType( any() ) )
             .thenReturn( emptyList() );
@@ -91,7 +91,7 @@ class RelationshipDeletionHandlerTest
     }
 
     @Test
-    public void deleteTrackedEntityInstance()
+    void deleteTrackedEntityInstance()
     {
         when( relationshipService.getRelationshipsByTrackedEntityInstance( any(), anyBoolean() ) )
             .thenReturn( singletonList( new Relationship() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/render/DeserializeTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/render/DeserializeTest.java
@@ -35,7 +35,7 @@ import com.google.common.base.MoreObjects;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class DeserializeTest
+class DeserializeTest
 {
     private String a;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
@@ -123,7 +123,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAccept()
+    void testAccept()
     {
         boolean result = bulkSmsGateway.accept( smsGatewayConfig );
 
@@ -136,7 +136,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSuccessful()
+    void testSuccessful()
     {
         ResponseEntity<String> successResponse = new ResponseEntity<>( SUCCESS_RESPONSE_STRING, HttpStatus.OK );
 
@@ -151,7 +151,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testBulkSend()
+    void testBulkSend()
     {
         ResponseEntity<String> successResponse = new ResponseEntity<>( SUCCESS_RESPONSE_STRING, HttpStatus.OK );
 
@@ -166,7 +166,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testFailureCode()
+    void testFailureCode()
     {
         ResponseEntity<String> errorResponse = new ResponseEntity<>( ERROR_RESPONSE_STRING, HttpStatus.CONFLICT );
 
@@ -182,7 +182,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWhenServerResponseIsNull()
+    void testWhenServerResponseIsNull()
     {
         when( restTemplate.exchange( any( String.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )
@@ -196,7 +196,7 @@ class BulkSmsGatewayTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testException()
+    void testException()
     {
         when( restTemplate.exchange( any( String.class ), any( HttpMethod.class ), any( HttpEntity.class ),
             eq( String.class ) ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/BulkSmsGatewayTest.java
@@ -73,7 +73,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class BulkSmsGatewayTest extends DhisConvenienceTest
+class BulkSmsGatewayTest extends DhisConvenienceTest
 {
 
     private static final String MESSAGE = "text-MESSAGE";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
@@ -148,7 +148,7 @@ class GenericSmsGatewayTest
     }
 
     @Test
-    public void testSendSms_Json()
+    void testSendSms_Json()
     {
         strSubstitutor = new StringSubstitutor( valueStore );
         body = strSubstitutor.replace( CONFIG_TEMPLATE_JSON );
@@ -191,7 +191,7 @@ class GenericSmsGatewayTest
     }
 
     @Test
-    public void testSendSms_Url()
+    void testSendSms_Url()
     {
         username.setHeader( false );
         password.setHeader( false );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/GenericSmsGatewayTest.java
@@ -74,7 +74,7 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class GenericSmsGatewayTest
+class GenericSmsGatewayTest
 {
 
     private static final String GATEWAY_URL = "http://gateway.com/messages";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SMPPClientTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SMPPClientTest.java
@@ -83,7 +83,7 @@ class SMPPClientTest
     }
 
     @Test
-    public void testSuccessMessage()
+    void testSuccessMessage()
     {
         SMPPGatewayConfig config = getSMPPConfigurations();
 
@@ -95,7 +95,7 @@ class SMPPClientTest
     }
 
     @Test
-    public void testFailedMessage()
+    void testFailedMessage()
     {
         SMPPGatewayConfig config = getSMPPConfigurations();
         config.setPassword( "123" );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SMPPClientTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SMPPClientTest.java
@@ -58,7 +58,7 @@ import com.google.common.collect.Sets;
 
 @Disabled( "Test to run manually" )
 @ExtendWith( MockitoExtension.class )
-public class SMPPClientTest
+class SMPPClientTest
 {
     private static final String SYSTEM_ID = "smppclient1";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
@@ -79,7 +79,7 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class SmsMessageSenderTest
+class SmsMessageSenderTest
 {
     private static final Integer MAX_ALLOWED_RECIPIENTS = 200;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
@@ -156,7 +156,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageWithGatewayConfig()
+    void testSendMessageWithGatewayConfig()
     {
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -173,7 +173,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageWithOutGatewayConfig()
+    void testSendMessageWithOutGatewayConfig()
     {
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( null );
 
@@ -189,7 +189,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testIsConfiguredWithOutGatewayConfig()
+    void testIsConfiguredWithOutGatewayConfig()
     {
         when( gatewayAdministrationService.hasGateways() ).thenReturn( false );
 
@@ -199,7 +199,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testIsConfiguredWithGatewayConfig()
+    void testIsConfiguredWithGatewayConfig()
     {
         when( gatewayAdministrationService.hasGateways() ).thenReturn( true );
 
@@ -209,7 +209,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageWithListOfUsers()
+    void testSendMessageWithListOfUsers()
     {
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         when( userSettingService.getUserSetting( any(), any() ) ).thenReturn( Boolean.TRUE );
@@ -225,7 +225,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageWithEmptyUserList()
+    void testSendMessageWithEmptyUserList()
     {
         OutboundMessageResponse status = smsMessageSender.sendMessage( subject, text, footer, sender, new HashSet<>(),
             false );
@@ -236,7 +236,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageWithUserSMSSettingsDisabled()
+    void testSendMessageWithUserSMSSettingsDisabled()
     {
         when( userSettingService.getUserSetting( any(), any() ) ).thenReturn( Boolean.FALSE );
 
@@ -248,7 +248,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageWithSingleRecipient()
+    void testSendMessageWithSingleRecipient()
     {
         when( bulkSmsGateway.accept( any() ) ).thenReturn( true );
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -262,7 +262,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageFailed()
+    void testSendMessageFailed()
     {
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -278,9 +278,9 @@ class SmsMessageSenderTest
         assertFalse( status.isOk() );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void testNumberNormalization()
+    @Test
+    void testNumberNormalization()
     {
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -306,9 +306,9 @@ class SmsMessageSenderTest
         assertEquals( 0, setDifference.size() );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void testSendMessageWithMaxRecipients()
+    @Test
+    void testSendMessageWithMaxRecipients()
     {
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
@@ -332,7 +332,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageBatchCompleted()
+    void testSendMessageBatchCompleted()
     {
         mockGateway();
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -359,7 +359,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageBatchFailed()
+    void testSendMessageBatchFailed()
     {
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
@@ -386,7 +386,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageBatchWithMaxRecipients()
+    void testSendMessageBatchWithMaxRecipients()
     {
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -426,7 +426,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageBatchWithOutMaxRecipients()
+    void testSendMessageBatchWithOutMaxRecipients()
     {
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
@@ -452,7 +452,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testSendMessageBatchWithOutGatewayConfiguration()
+    void testSendMessageBatchWithOutGatewayConfiguration()
     {
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( null );
 
@@ -468,7 +468,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testIfNoRecipient()
+    void testIfNoRecipient()
     {
         OutboundMessageResponse status = smsMessageSender.sendMessage( subject, text, StringUtils.EMPTY );
 
@@ -478,7 +478,7 @@ class SmsMessageSenderTest
     }
 
     @Test
-    public void testIfBatchIsNull()
+    void testIfBatchIsNull()
     {
         OutboundMessageResponseSummary summary = smsMessageSender.sendMessageBatch( null );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class GatewayAdministrationServiceTest
+class GatewayAdministrationServiceTest
 {
     private static final String BULKSMS = BulkSmsGatewayConfig.class.getName();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/config/GatewayAdministrationServiceTest.java
@@ -103,7 +103,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testGetByUid()
+    void testGetByUid()
     {
         subject.addGateway( bulkConfig );
         String uid = subject.getDefaultGateway().getUid();
@@ -115,14 +115,14 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testShouldReturnNullWhenUidIsNull()
+    void testShouldReturnNullWhenUidIsNull()
     {
         assertNull( subject.getByUid( "" ) );
         assertNull( subject.getByUid( null ) );
     }
 
     @Test
-    public void testSetDefaultGateway()
+    void testSetDefaultGateway()
     {
         subject.addGateway( bulkConfig );
         subject.addGateway( clickatellConfig );
@@ -136,7 +136,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testAddGateway()
+    void testAddGateway()
     {
         boolean isAdded = subject.addGateway( bulkConfig );
 
@@ -157,7 +157,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testUpdateDefaultGatewaySuccess()
+    void testUpdateDefaultGatewaySuccess()
     {
         assertTrue( subject.addGateway( bulkConfig ) );
         assertEquals( bulkConfig, subject.getDefaultGateway() );
@@ -174,7 +174,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testUpdateGatewaySuccess()
+    void testUpdateGatewaySuccess()
     {
         assertTrue( subject.addGateway( bulkConfig ) );
         assertEquals( bulkConfig, subject.getDefaultGateway() );
@@ -197,7 +197,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testNothingShouldBeUpdatedIfNullIsPassed()
+    void testNothingShouldBeUpdatedIfNullIsPassed()
     {
         bulkConfig.setName( BULKSMS );
         assertTrue( subject.addGateway( bulkConfig ) );
@@ -207,13 +207,13 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testWhenNoDefaultGateway()
+    void testWhenNoDefaultGateway()
     {
         assertNull( subject.getDefaultGateway() );
     }
 
     @Test
-    public void testSecondGatewayIsSetToFalse()
+    void testSecondGatewayIsSetToFalse()
     {
         when( smsConfigurationManager.getSmsConfiguration() ).thenReturn( spyConfiguration );
 
@@ -231,7 +231,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testRemoveDefaultGateway()
+    void testRemoveDefaultGateway()
     {
         subject.addGateway( bulkConfig );
         subject.addGateway( clickatellConfig );
@@ -250,7 +250,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testRemoveGateway()
+    void testRemoveGateway()
     {
         subject.addGateway( bulkConfig );
         subject.addGateway( clickatellConfig );
@@ -267,7 +267,7 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testRemoveSingleGateway()
+    void testRemoveSingleGateway()
     {
         subject.addGateway( bulkConfig );
 
@@ -280,13 +280,13 @@ class GatewayAdministrationServiceTest
     }
 
     @Test
-    public void testReturnFalseIfConfigIsNull()
+    void testReturnFalseIfConfigIsNull()
     {
         assertFalse( subject.addGateway( null ) );
     }
 
     @Test
-    public void testUpdateGateway()
+    void testUpdateGateway()
     {
         assertTrue( subject.addGateway( bulkConfig ) );
         assertEquals( bulkConfig, subject.getDefaultGateway() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
@@ -180,7 +180,7 @@ class AggregateDataSetSMSListenerTest extends
     }
 
     @Test
-    public void testAggregateDatasetListener()
+    void testAggregateDatasetListener()
     {
         subject.receive( incomingSmsAggregate );
 
@@ -192,7 +192,7 @@ class AggregateDataSetSMSListenerTest extends
     }
 
     @Test
-    public void testAggregateDatasetListenerRepeat()
+    void testAggregateDatasetListenerRepeat()
     {
         subject.receive( incomingSmsAggregate );
         subject.receive( incomingSmsAggregate );
@@ -205,7 +205,7 @@ class AggregateDataSetSMSListenerTest extends
     }
 
     @Test
-    public void testAggregateDatasetListenerNoValues()
+    void testAggregateDatasetListenerNoValues()
     {
         subject.receive( incomingSmsAggregateNoValues );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/AggregateDataSetSMSListenerTest.java
@@ -75,11 +75,9 @@ import com.google.common.collect.Sets;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class AggregateDataSetSMSListenerTest
-    extends
+class AggregateDataSetSMSListenerTest extends
     CompressionSMSListenerTest
 {
-    // Needed for parent
 
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/CompressionSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/CompressionSMSListenerTest.java
@@ -38,8 +38,7 @@ import org.hisp.dhis.smscompression.models.SmsMetadata;
 import org.hisp.dhis.smscompression.models.SmsSubmission;
 import org.hisp.dhis.user.User;
 
-public abstract class CompressionSMSListenerTest
-    extends
+abstract class CompressionSMSListenerTest extends
     DhisConvenienceTest
 {
     protected static final String SUCCESS_MESSAGE = "1:0::Submission has been processed successfully";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
@@ -277,7 +277,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAccept()
+    void testAccept()
     {
         // Mock for smsCommandService
         when( smsCommandService.getSMSCommand( anyString(), any() ) ).thenReturn( keyValueCommand );
@@ -294,7 +294,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testReceive()
+    void testReceive()
     {
         mockServices();
         incomingSms.setCreatedBy( user );
@@ -306,7 +306,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfDataSetIsLocked()
+    void testIfDataSetIsLocked()
     {
         ArgumentCaptor<IncomingSms> incomingSmsCaptor = ArgumentCaptor.forClass( IncomingSms.class );
 
@@ -333,7 +333,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfUserHasNoOu()
+    void testIfUserHasNoOu()
     {
         mockSmsSender();
 
@@ -354,7 +354,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfUserHasMultipleOUs()
+    void testIfUserHasMultipleOUs()
     {
         mockSmsSender();
 
@@ -385,7 +385,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfDiffUsersHasSameOU()
+    void testIfDiffUsersHasSameOU()
     {
         mockSmsSender();
         mockServices();
@@ -408,7 +408,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfCommandHasCorrectFormat()
+    void testIfCommandHasCorrectFormat()
     {
         mockSmsSender();
 
@@ -429,7 +429,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfMandatoryParameterMissing()
+    void testIfMandatoryParameterMissing()
     {
         mockSmsSender();
         mockServices();
@@ -456,7 +456,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDefaultSeparator()
+    void testDefaultSeparator()
     {
         mockServices();
         keyValueCommand.setSeparator( null );
@@ -471,7 +471,7 @@ class DataValueListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testCustomSeparator()
+    void testCustomSeparator()
     {
         mockSmsSender();
         mockServices();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DataValueListenerTest.java
@@ -89,7 +89,7 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class DataValueListenerTest extends DhisConvenienceTest
+class DataValueListenerTest extends DhisConvenienceTest
 {
     private static final String FETCHED_DATA_VALUE = "fetchedDataValue";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
@@ -61,11 +61,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class DeleteEventSMSListenerTest
-    extends
+class DeleteEventSMSListenerTest extends
     CompressionSMSListenerTest
 {
-    // Needed for all
 
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/DeleteEventSMSListenerTest.java
@@ -139,7 +139,7 @@ class DeleteEventSMSListenerTest extends
     }
 
     @Test
-    public void testDeleteEvent()
+    void testDeleteEvent()
     {
         subject.receive( incomingSmsDelete );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -89,11 +89,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.google.common.collect.Sets;
 
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentSMSListenerTest
-    extends
+class EnrollmentSMSListenerTest extends
     CompressionSMSListenerTest
 {
-    // Needed for parent
 
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/EnrollmentSMSListenerTest.java
@@ -220,7 +220,7 @@ class EnrollmentSMSListenerTest extends
     }
 
     @Test
-    public void testEnrollmentNoEvents()
+    void testEnrollmentNoEvents()
     {
         when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
             .thenReturn( trackedEntityAttribute );
@@ -235,7 +235,7 @@ class EnrollmentSMSListenerTest extends
     }
 
     @Test
-    public void testEnrollmentWithEvents()
+    void testEnrollmentWithEvents()
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
         when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
@@ -253,7 +253,7 @@ class EnrollmentSMSListenerTest extends
     }
 
     @Test
-    public void testEnrollmentWithEventsRepeat()
+    void testEnrollmentWithEventsRepeat()
     {
         when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
@@ -272,7 +272,7 @@ class EnrollmentSMSListenerTest extends
     }
 
     @Test
-    public void testEnrollmentWithNulls()
+    void testEnrollmentWithNulls()
     {
         when( trackedEntityAttributeService.getTrackedEntityAttribute( anyString() ) )
             .thenReturn( trackedEntityAttribute );
@@ -287,7 +287,7 @@ class EnrollmentSMSListenerTest extends
     }
 
     @Test
-    public void testEnrollmentNoAttribs()
+    void testEnrollmentNoAttribs()
     {
         subject.receive( incomingSmsEnrollmentNoAttribs );
 
@@ -299,7 +299,7 @@ class EnrollmentSMSListenerTest extends
     }
 
     @Test
-    public void testEnrollmentEventWithNulls()
+    void testEnrollmentEventWithNulls()
     {
         when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
@@ -319,7 +319,7 @@ class EnrollmentSMSListenerTest extends
     // For now there's no warning if an event within the event
     // list has no values. This might be changed in the future.
     @Test
-    public void testEnrollmentEventNoValues()
+    void testEnrollmentEventNoValues()
     {
         when( categoryService.getCategoryOptionCombo( anyString() ) ).thenReturn( categoryOptionCombo );
         when( programStageService.getProgramStage( anyString() ) ).thenReturn( programStage );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
@@ -68,11 +68,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class RelationshipSMSListenerTest
-    extends
+class RelationshipSMSListenerTest extends
     CompressionSMSListenerTest
 {
-    // Needed for parent
 
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/RelationshipSMSListenerTest.java
@@ -163,7 +163,7 @@ class RelationshipSMSListenerTest extends
     }
 
     @Test
-    public void testRelationship()
+    void testRelationship()
     {
         subject.receive( incomingSmsRelationship );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -79,11 +79,9 @@ import com.google.common.collect.Sets;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class SimpleEventSMSListenerTest
-    extends
+class SimpleEventSMSListenerTest extends
     CompressionSMSListenerTest
 {
-    // Needed for parent
 
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/SimpleEventSMSListenerTest.java
@@ -180,7 +180,7 @@ class SimpleEventSMSListenerTest extends
     }
 
     @Test
-    public void testSimpleEvent()
+    void testSimpleEvent()
     {
         subject.receive( incomingSmsSimpleEvent );
 
@@ -192,7 +192,7 @@ class SimpleEventSMSListenerTest extends
     }
 
     @Test
-    public void testSimpleEventRepeat()
+    void testSimpleEventRepeat()
     {
         subject.receive( incomingSmsSimpleEvent );
         subject.receive( incomingSmsSimpleEvent );
@@ -205,7 +205,7 @@ class SimpleEventSMSListenerTest extends
     }
 
     @Test
-    public void testSimpleEventWithNulls()
+    void testSimpleEventWithNulls()
     {
         subject.receive( incomingSmsSimpleEventWithNulls );
 
@@ -217,7 +217,7 @@ class SimpleEventSMSListenerTest extends
     }
 
     @Test
-    public void testSimpleEventNoValues()
+    void testSimpleEventNoValues()
     {
         subject.receive( incomingSmsSimpleEventNoValues );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -183,7 +183,7 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTeiRegistration()
+    void testTeiRegistration()
     {
         // Mock for trackedEntityInstanceService
         when( trackedEntityInstanceService.createTrackedEntityInstance( any(), any() ) ).thenReturn( 1L );
@@ -206,7 +206,7 @@ class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testIfProgramHasNoOu()
+    void testIfProgramHasNoOu()
     {
         Program programA = createProgram( 'P' );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackedEntityRegistrationListenerTest.java
@@ -79,7 +79,7 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
+class TrackedEntityRegistrationListenerTest extends DhisConvenienceTest
 {
     private static final String TEI_REGISTRATION_COMMAND = "tei";
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
@@ -186,7 +186,7 @@ class TrackerEventSMSListenerTest extends
     }
 
     @Test
-    public void testTrackerEvent()
+    void testTrackerEvent()
     {
         subject.receive( incomingSmsTrackerEvent );
 
@@ -198,7 +198,7 @@ class TrackerEventSMSListenerTest extends
     }
 
     @Test
-    public void testTrackerEventRepeat()
+    void testTrackerEventRepeat()
     {
         subject.receive( incomingSmsTrackerEvent );
         subject.receive( incomingSmsTrackerEvent );
@@ -211,7 +211,7 @@ class TrackerEventSMSListenerTest extends
     }
 
     @Test
-    public void testTrackerEventWithNulls()
+    void testTrackerEventWithNulls()
     {
         subject.receive( incomingSmsTrackerEventWithNulls );
 
@@ -223,7 +223,7 @@ class TrackerEventSMSListenerTest extends
     }
 
     @Test
-    public void testTrackerEventNoValues()
+    void testTrackerEventNoValues()
     {
         subject.receive( incomingSmsTrackerEventNoValues );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/listener/TrackerEventSMSListenerTest.java
@@ -81,11 +81,9 @@ import com.google.common.collect.Sets;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class TrackerEventSMSListenerTest
-    extends
+class TrackerEventSMSListenerTest extends
     CompressionSMSListenerTest
 {
-    // Needed for parent
 
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeServiceTest.java
@@ -122,14 +122,14 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void shouldThrowWhenTeaIsNull()
+    void shouldThrowWhenTeaIsNull()
     {
         assertThrows( IllegalArgumentException.class,
             () -> trackedEntityAttributeService.validateValueType( null, "" ) );
     }
 
     @Test
-    public void identicalTeiWithTheSameUniqueAttributeExistsInSystem()
+    void identicalTeiWithTheSameUniqueAttributeExistsInSystem()
     {
         when( trackedEntityAttributeStore
             .getTrackedEntityInstanceUidWithUniqueAttributeValue( any( TrackedEntityInstanceQueryParams.class ) ) )
@@ -143,7 +143,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void differentTeiWithTheSameUniqueAttributeExistsInSystem()
+    void differentTeiWithTheSameUniqueAttributeExistsInSystem()
     {
         when( trackedEntityAttributeStore
             .getTrackedEntityInstanceUidWithUniqueAttributeValue( any( TrackedEntityInstanceQueryParams.class ) ) )
@@ -157,7 +157,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void attributeIsUniqueWithinTheSystem()
+    void attributeIsUniqueWithinTheSystem()
     {
         when( trackedEntityAttributeStore
             .getTrackedEntityInstanceUidWithUniqueAttributeValue( any( TrackedEntityInstanceQueryParams.class ) ) )
@@ -171,7 +171,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void wrongValueToValueType()
+    void wrongValueToValueType()
     {
         tea.setValueType( ValueType.NUMBER );
         String teaValue = "Firstname";
@@ -185,7 +185,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void wrongValueToDateValueType()
+    void wrongValueToDateValueType()
     {
         tea.setValueType( ValueType.DATE );
         String teaValue = "Firstname";
@@ -194,7 +194,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void correctValueToValueType()
+    void correctValueToValueType()
     {
         String teaValue = "Firstname";
         tea.setValueType( ValueType.TEXT );
@@ -219,7 +219,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void successWhenTeaOptionValueIsValid()
+    void successWhenTeaOptionValueIsValid()
     {
         tea.setUid( "uid" );
 
@@ -237,7 +237,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void failWhenTeaOptionValueIsNotValid()
+    void failWhenTeaOptionValueIsNotValid()
     {
         tea.setUid( "uid" );
 
@@ -255,7 +255,7 @@ class TrackedEntityAttributeServiceTest
     }
 
     @Test
-    public void doNothingWhenTeaOptionValueIsNull()
+    void doNothingWhenTeaOptionValueIsNull()
     {
         tea.setUid( "uid" );
         assertNull( trackedEntityAttributeService.validateValueType( tea, "COE" ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationRuleTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationRuleTest.java
@@ -113,7 +113,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testWhenPasswordIsNullOrEmpty()
+    void testWhenPasswordIsNullOrEmpty()
     {
         CredentialsInfo credentialsInfoNoPassword = new CredentialsInfo( USERNAME, "", EMAIL, true );
 
@@ -126,7 +126,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testSpecialCharValidationRule()
+    void testSpecialCharValidationRule()
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( USERNAME, STRONG_PASSWORD, EMAIL, true );
 
@@ -140,7 +140,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testDigitValidationRule()
+    void testDigitValidationRule()
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( USERNAME, STRONG_PASSWORD, EMAIL, true );
 
@@ -154,7 +154,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testDictionaryValidationRule()
+    void testDictionaryValidationRule()
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( USERNAME, STRONG_PASSWORD, EMAIL, true );
 
@@ -168,7 +168,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testLengthValidationRule()
+    void testLengthValidationRule()
     {
         Mockito.when( systemSettingManager.getIntSetting( SettingKey.MIN_PASSWORD_LENGTH ) )
             .thenReturn( MIN_LENGTH );
@@ -188,7 +188,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testUpperCaseValidationRule()
+    void testUpperCaseValidationRule()
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( USERNAME, STRONG_PASSWORD, EMAIL, true );
 
@@ -202,7 +202,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testUserParameterValidationRule()
+    void testUserParameterValidationRule()
     {
         CredentialsInfo credentialsInfo = new CredentialsInfo( USERNAME, STRONG_PASSWORD, EMAIL, true );
 
@@ -216,7 +216,7 @@ class PasswordValidationRuleTest
     }
 
     @Test
-    public void testPasswordHistoryValidationRule()
+    void testPasswordHistoryValidationRule()
     {
         List<String> history = ListUtils.newList( STRONG_PASSWORD, STRONG_PASSWORD + "1", STRONG_PASSWORD + "2",
             STRONG_PASSWORD + "2", STRONG_PASSWORD + "4", STRONG_PASSWORD + "5", STRONG_PASSWORD + "6",

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationRuleTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/PasswordValidationRuleTest.java
@@ -52,7 +52,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-public class PasswordValidationRuleTest
+class PasswordValidationRuleTest
 {
     private static final int MIN_LENGTH = 8;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerCrudTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerCrudTest.java
@@ -81,7 +81,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class TrackerCrudTest
+class TrackerCrudTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerCrudTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerCrudTest.java
@@ -212,7 +212,7 @@ class TrackerCrudTest
     }
 
     @Test
-    public void shouldAddTrackedEntityWithCreateStrategy()
+    void shouldAddTrackedEntityWithCreateStrategy()
     {
         List<TrackedEntityInstance> trackedEntityInstanceList = Collections.singletonList( trackedEntityInstance );
 
@@ -229,7 +229,7 @@ class TrackerCrudTest
     }
 
     @Test
-    public void shouldUpdateTrackedEntityWithUpdateStrategy()
+    void shouldUpdateTrackedEntityWithUpdateStrategy()
     {
         List<TrackedEntityInstance> trackedEntityInstanceList = Collections.singletonList( trackedEntityInstance );
 
@@ -248,7 +248,7 @@ class TrackerCrudTest
     }
 
     @Test
-    public void shouldDeleteTrackedEntityWithDeleteStrategy()
+    void shouldDeleteTrackedEntityWithDeleteStrategy()
     {
         List<TrackedEntityInstance> trackedEntityInstanceList = Collections.singletonList( trackedEntityInstance );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -214,7 +214,7 @@ class DefaultCompleteDataSetRegistrationExchangeServiceTest
     }
 
     @Test
-    public void verifyUserHasNoWritePermissionOnCategoryOption()
+    void verifyUserHasNoWritePermissionOnCategoryOption()
     {
         OrganisationUnit organisationUnit = createOrganisationUnit( 'A' );
         DataSet dataSetA = createDataSet( 'A', new MonthlyPeriodType() );
@@ -301,7 +301,7 @@ class DefaultCompleteDataSetRegistrationExchangeServiceTest
     }
 
     @Test
-    public void testValidateAssertMissingDataSet()
+    void testValidateAssertMissingDataSet()
     {
         ExportParams params = new ExportParams()
             .setOrganisationUnits( Sets.newHashSet( new OrganisationUnit() ) )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeServiceTest.java
@@ -105,7 +105,7 @@ import com.google.common.collect.Sets;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultCompleteDataSetRegistrationExchangeServiceTest
+class DefaultCompleteDataSetRegistrationExchangeServiceTest
 {
     @Mock
     private CompleteDataSetRegistrationExchangeStore cdsrStore;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
@@ -56,7 +56,7 @@ import com.google.common.collect.ImmutableList;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class JdbcEventCommentStoreTest
+class JdbcEventCommentStoreTest
 {
 
     private JdbcEventCommentStore jdbcEventCommentStore;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventCommentStoreTest.java
@@ -72,7 +72,7 @@ class JdbcEventCommentStoreTest
     }
 
     @Test
-    public void verifyPSITableIsNotQueriedWhenNoComments()
+    void verifyPSITableIsNotQueriedWhenNoComments()
     {
         List<ProgramStageInstance> programStageInstanceList = getProgramStageList( false );
         jdbcEventCommentStore.saveAllComments( programStageInstanceList );
@@ -80,7 +80,7 @@ class JdbcEventCommentStoreTest
     }
 
     @Test
-    public void verifyPSITableIsNotQueriedWhenCommentsTextEmpty()
+    void verifyPSITableIsNotQueriedWhenCommentsTextEmpty()
     {
         List<ProgramStageInstance> programStageInstanceList = getProgramStageList( true, true );
         jdbcEventCommentStore.saveAllComments( programStageInstanceList );
@@ -88,7 +88,7 @@ class JdbcEventCommentStoreTest
     }
 
     @Test
-    public void verifyPSITableIsQueriedWhenComments()
+    void verifyPSITableIsQueriedWhenComments()
     {
         List<ProgramStageInstance> programStageInstanceList = getProgramStageList( true );
         jdbcEventCommentStore.saveAllComments( programStageInstanceList );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -101,7 +101,7 @@ class JdbcEventStoreTest
     }
 
     @Test
-    public void verifyEventDataValuesAreProcessedOnceForEachPSI()
+    void verifyEventDataValuesAreProcessedOnceForEachPSI()
     {
         mockRowSet();
         EventSearchParams eventSearchParams = new EventSearchParams();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -63,7 +63,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class JdbcEventStoreTest
+class JdbcEventStoreTest
 {
     private JdbcEventStore subject;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AbstractSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AbstractSupplierTest.java
@@ -50,7 +50,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public abstract class AbstractSupplierTest<T>
+abstract class AbstractSupplierTest<T>
 {
     @Mock
     protected NamedParameterJdbcTemplate jdbcTemplate;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
@@ -67,7 +67,7 @@ import org.springframework.jdbc.core.RowMapper;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class AttributeOptionComboLoaderTest
+class AttributeOptionComboLoaderTest
 {
     @Mock
     protected JdbcTemplate jdbcTemplate;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/AttributeOptionComboLoaderTest.java
@@ -84,7 +84,7 @@ class AttributeOptionComboLoaderTest
     }
 
     @Test
-    public void verifyGetDefaultCategoryOptionCombo()
+    void verifyGetDefaultCategoryOptionCombo()
     {
         when( jdbcTemplate.queryForObject( anyString(), any( RowMapper.class ) ) )
             .thenReturn( new CategoryOptionCombo() );
@@ -101,7 +101,7 @@ class AttributeOptionComboLoaderTest
     }
 
     @Test
-    public void verifyGetCategoryOption()
+    void verifyGetCategoryOption()
     {
         get( IdScheme.ID, "12345", "categoryoptioncomboid = 12345" );
         get( IdScheme.UID, "abcdef", "uid = 'abcdef'" );
@@ -110,7 +110,7 @@ class AttributeOptionComboLoaderTest
     }
 
     @Test
-    public void verifyGetAttributeOptionComboWithNullCategoryCombo()
+    void verifyGetAttributeOptionComboWithNullCategoryCombo()
     {
         assertThrows( IllegalQueryException.class,
             () -> subject.getAttributeOptionCombo( null, "", "", IdScheme.UID ),
@@ -118,7 +118,7 @@ class AttributeOptionComboLoaderTest
     }
 
     @Test
-    public void verifyGetAttributeOptionComboWithNonExistingCategoryOption()
+    void verifyGetAttributeOptionComboWithNonExistingCategoryOption()
     {
         CategoryCombo cc = new CategoryCombo();
 
@@ -128,7 +128,7 @@ class AttributeOptionComboLoaderTest
     }
 
     @Test
-    public void verifyGetAttributeOptionCombo()
+    void verifyGetAttributeOptionCombo()
     {
         // prepare data
         CategoryCombo cc = createCategoryCombo( 'B' );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramInstanceSupplierTest.java
@@ -77,7 +77,7 @@ class ProgramInstanceSupplierTest extends AbstractSupplierTest<ProgramInstance>
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
         throws SQLException
     {
         // mock resultset data

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplierTest.java
@@ -61,7 +61,7 @@ class ProgramOrgUnitSupplierTest extends AbstractSupplierTest<Long>
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
         throws SQLException
     {
         // Org Unit //

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramOrgUnitSupplierTest.java
@@ -49,7 +49,7 @@ import com.google.common.collect.ImmutableList;
 /**
  * @author Luciano Fiandesio
  */
-public class ProgramOrgUnitSupplierTest extends AbstractSupplierTest<Long>
+class ProgramOrgUnitSupplierTest extends AbstractSupplierTest<Long>
 {
 
     private ProgramOrgUnitSupplier subject;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramStageInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramStageInstanceSupplierTest.java
@@ -76,7 +76,7 @@ class ProgramStageInstanceSupplierTest extends AbstractSupplierTest<ProgramStage
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
         throws SQLException
     {
         // mock resultset data

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierTest.java
@@ -55,7 +55,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
-public class ProgramSupplierTest extends AbstractSupplierTest<Program>
+class ProgramSupplierTest extends AbstractSupplierTest<Program>
 {
 
     private ProgramSupplier subject;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/TrackedEntityInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/context/TrackedEntityInstanceSupplierTest.java
@@ -74,7 +74,7 @@ class TrackedEntityInstanceSupplierTest extends AbstractSupplierTest<TrackedEnti
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
         throws SQLException
     {
         // mock resultset data

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/ImportOptionsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/ImportOptionsPreProcessorTest.java
@@ -41,7 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class ImportOptionsPreProcessorTest
+class ImportOptionsPreProcessorTest
 {
 
     private ImportOptionsPreProcessor subject;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/ImportOptionsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/preprocess/ImportOptionsPreProcessorTest.java
@@ -53,7 +53,7 @@ class ImportOptionsPreProcessorTest
     }
 
     @Test
-    public void verifyExceptionIsThrownOnMissingImportOptions()
+    void verifyExceptionIsThrownOnMissingImportOptions()
     {
         WorkContext wc = WorkContext.builder().build();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/relationship/JacksonRelationshipServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/relationship/JacksonRelationshipServiceTest.java
@@ -70,7 +70,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class JacksonRelationshipServiceTest
+class JacksonRelationshipServiceTest
 {
     @Mock
     protected DbmsManager dbmsManager;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/relationship/JacksonRelationshipServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/relationship/JacksonRelationshipServiceTest.java
@@ -129,7 +129,7 @@ class JacksonRelationshipServiceTest
     }
 
     @Test
-    public void verifyRelationshipIsImportedIfDoesNotExist()
+    void verifyRelationshipIsImportedIfDoesNotExist()
     {
         when(
             relationshipService.getRelationshipByRelationship( any( org.hisp.dhis.relationship.Relationship.class ) ) )
@@ -142,7 +142,7 @@ class JacksonRelationshipServiceTest
     }
 
     @Test
-    public void verifyRelationshipIsNotImportedWhenDoesExist()
+    void verifyRelationshipIsNotImportedWhenDoesExist()
     {
         org.hisp.dhis.relationship.Relationship daoRelationship = new org.hisp.dhis.relationship.Relationship();
         daoRelationship.setUid( "12345" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
@@ -64,7 +64,7 @@ import org.mockito.stubbing.Answer;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultMetadataExportServiceTest
+class DefaultMetadataExportServiceTest
 {
     @Mock
     private SchemaService schemaService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
@@ -91,7 +91,7 @@ class DefaultMetadataExportServiceTest
     private DefaultMetadataExportService service;
 
     @Test
-    public void getMetadataWithDependenciesAsNodeSharing()
+    void getMetadataWithDependenciesAsNodeSharing()
     {
         Attribute attribute = new Attribute();
         SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata = new SetMap<>();
@@ -115,7 +115,7 @@ class DefaultMetadataExportServiceTest
     }
 
     @Test
-    public void getMetadataWithDependenciesAsNodeSkipSharing()
+    void getMetadataWithDependenciesAsNodeSkipSharing()
     {
         Attribute attribute = new Attribute();
         SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata = new SetMap<>();
@@ -140,7 +140,7 @@ class DefaultMetadataExportServiceTest
     }
 
     @Test
-    public void getParamsFromMapIncludedSecondary()
+    void getParamsFromMapIncludedSecondary()
     {
         Mockito.when( schemaService.getSchemaByPluralName( Mockito.eq( "jobConfigurations" ) ) )
             .thenReturn( new Schema( JobConfiguration.class, "jobConfiguration", "jobConfigurations" ) );
@@ -157,7 +157,7 @@ class DefaultMetadataExportServiceTest
     }
 
     @Test
-    public void getParamsFromMapNotIncludedSecondary()
+    void getParamsFromMapNotIncludedSecondary()
     {
         Mockito.when( schemaService.getSchemaByPluralName( Mockito.eq( "jobConfigurations" ) ) )
             .thenReturn( new Schema( JobConfiguration.class, "jobConfiguration", "jobConfigurations" ) );
@@ -174,7 +174,7 @@ class DefaultMetadataExportServiceTest
     }
 
     @Test
-    public void getParamsFromMapNoSecondary()
+    void getParamsFromMapNoSecondary()
     {
         Mockito.when( schemaService.getSchemaByPluralName( Mockito.eq( "options" ) ) )
             .thenReturn( new Schema( Option.class, "option", "options" ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContextTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContextTest.java
@@ -70,13 +70,13 @@ class MetadataRetryContextTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldGetRetryContextCorrectly()
+    void testShouldGetRetryContextCorrectly()
     {
         assertEquals( retryContext, metadataRetryContext.getRetryContext() );
     }
 
     @Test
-    public void testShouldSetRetryContextCorrectly()
+    void testShouldSetRetryContextCorrectly()
     {
         RetryContext newMock = mock( RetryContext.class );
 
@@ -86,7 +86,7 @@ class MetadataRetryContextTest extends DhisSpringTest
     }
 
     @Test
-    public void testIfVersionIsNull()
+    void testIfVersionIsNull()
     {
         metadataRetryContext.updateRetryContext( testKey, testMessage, null );
 
@@ -95,7 +95,7 @@ class MetadataRetryContextTest extends DhisSpringTest
     }
 
     @Test
-    public void testIfVersionIsNotNull()
+    void testIfVersionIsNotNull()
     {
         metadataRetryContext.updateRetryContext( testKey, testMessage, mockVersion );
 
@@ -104,7 +104,7 @@ class MetadataRetryContextTest extends DhisSpringTest
     }
 
     @Test
-    public void testIfSummaryIsNull()
+    void testIfSummaryIsNull()
     {
         MetadataSyncSummary metadataSyncSummary = mock( MetadataSyncSummary.class );
 
@@ -116,7 +116,7 @@ class MetadataRetryContextTest extends DhisSpringTest
     }
 
     @Test
-    public void testIfSummaryIsNotNull()
+    void testIfSummaryIsNotNull()
     {
         MetadataSyncSummary testSummary = new MetadataSyncSummary();
         ImportReport importReport = new ImportReport();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContextTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataRetryContextTest.java
@@ -49,8 +49,7 @@ import org.springframework.retry.RetryContext;
  * @author aamerm
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataRetryContextTest
-    extends DhisSpringTest
+class MetadataRetryContextTest extends DhisSpringTest
 {
     @Mock
     RetryContext retryContext;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -62,7 +62,7 @@ import org.springframework.retry.support.RetryTemplate;
  * @author aamerm
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataSyncJobParametersTest
+class MetadataSyncJobParametersTest
 {
     @Mock
     private SystemSettingManager systemSettingManager;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJobParametersTest.java
@@ -110,8 +110,8 @@ class MetadataSyncJobParametersTest
     // TODO: can we write more tests. This might cover a lot more tests.
     // TODO: don't test on how it happens. test for the result
     @Test
-    public void testShouldRunAllTasksInSequence()
-        throws Exception
+    void testShouldRunAllTasksInSequence()
+        throws DhisVersionMismatchException
     {
         when( metadataSyncService.doMetadataSync( any( MetadataSyncParams.class ) ) ).thenReturn( metadataSyncSummary );
         when( metadataSyncPreProcessor.handleCurrentMetadataVersion( metadataRetryContext ) )
@@ -135,7 +135,7 @@ class MetadataSyncJobParametersTest
     }
 
     @Test
-    public void testHandleMetadataSyncIsThrowingException()
+    void testHandleMetadataSyncIsThrowingException()
         throws DhisVersionMismatchException
     {
         when( metadataSyncService.doMetadataSync( any( MetadataSyncParams.class ) ) )
@@ -166,7 +166,7 @@ class MetadataSyncJobParametersTest
     }
 
     @Test
-    public void testShouldAbortIfDHISVersionMismatch()
+    void testShouldAbortIfDHISVersionMismatch()
         throws DhisVersionMismatchException
     {
         metadataVersions.add( metadataVersion );
@@ -196,8 +196,8 @@ class MetadataSyncJobParametersTest
     }
 
     @Test
-    public void testShouldAbortIfErrorInSyncSummary()
-        throws Exception
+    void testShouldAbortIfErrorInSyncSummary()
+        throws DhisVersionMismatchException
     {
         metadataVersions.add( metadataVersion );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHookTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class JobConfigurationObjectBundleHookTest
+class JobConfigurationObjectBundleHookTest
 {
     private static final String CRON_HOURLY = "0 0 * ? * *";
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHookTest.java
@@ -80,7 +80,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateInternalNonConfigurableChangeError()
+    void validateInternalNonConfigurableChangeError()
     {
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
             .thenReturn( analyticsTableJobConfig );
@@ -99,7 +99,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateInternalNonConfigurableChange()
+    void validateInternalNonConfigurableChange()
     {
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
             .thenReturn( analyticsTableJobConfig );
@@ -117,7 +117,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateInternalNonConfigurableShownValidationErrorNonE7010()
+    void validateInternalNonConfigurableShownValidationErrorNonE7010()
     {
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
             .thenReturn( analyticsTableJobConfig );
@@ -137,7 +137,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateInternalNonConfigurableShownValidationErrorE7010Configurable()
+    void validateInternalNonConfigurableShownValidationErrorE7010Configurable()
     {
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
             .thenReturn( analyticsTableJobConfig );
@@ -162,7 +162,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateInternalNonConfigurableShownValidationErrorE7010NoPrevious()
+    void validateInternalNonConfigurableShownValidationErrorE7010NoPrevious()
     {
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
             .thenReturn( null );
@@ -183,7 +183,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateInternalNonConfigurableIgnoredValidationErrorE7010()
+    void validateInternalNonConfigurableIgnoredValidationErrorE7010()
     {
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( "jsdhJSJHD" ) ) )
             .thenReturn( analyticsTableJobConfig );
@@ -202,7 +202,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateCronExpressionForCronTypeJobs()
+    void validateCronExpressionForCronTypeJobs()
     {
         String jobConfigUid = "jsdhJSJHD";
         Mockito.when( jobConfigurationService.getJobConfigurationByUid( Mockito.eq( jobConfigUid ) ) )
@@ -221,7 +221,7 @@ class JobConfigurationObjectBundleHookTest
     }
 
     @Test
-    public void validateDelayForFixedIntervalTypeJobs()
+    void validateDelayForFixedIntervalTypeJobs()
     {
         String jobConfigUid = "o8kG3Qk3nG3";
         JobConfiguration contAnalyticsTableJobConfig = new JobConfiguration();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -100,7 +100,7 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyNullObjectIsIgnored()
+    void verifyNullObjectIsIgnored()
     {
         subject.preCreate( null, null );
 
@@ -108,7 +108,7 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyMissingBundleIsIgnored()
+    void verifyMissingBundleIsIgnored()
     {
         subject.preCreate( programA, null );
 
@@ -116,7 +116,7 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyProgramInstanceIsSavedForEventProgram()
+    void verifyProgramInstanceIsSavedForEventProgram()
     {
         ArgumentCaptor<ProgramInstance> argument = ArgumentCaptor.forClass( ProgramInstance.class );
 
@@ -133,7 +133,7 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyProgramInstanceIsNotSavedForTrackerProgram()
+    void verifyProgramInstanceIsNotSavedForTrackerProgram()
     {
         ArgumentCaptor<ProgramInstance> argument = ArgumentCaptor.forClass( ProgramInstance.class );
 
@@ -144,13 +144,13 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyProgramValidates()
+    void verifyProgramValidates()
     {
         assertEquals( 0, subject.validate( programA, null ).size() );
     }
 
     @Test
-    public void verifyProgramFailsValidation()
+    void verifyProgramFailsValidation()
     {
         ProgramInstanceQueryParams programInstanceQueryParams = new ProgramInstanceQueryParams();
         programInstanceQueryParams.setProgram( programA );
@@ -167,7 +167,7 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyValidationIsSkippedWhenObjectIsTransient()
+    void verifyValidationIsSkippedWhenObjectIsTransient()
     {
         Program transientObj = createProgram( 'A' );
         subject.validate( transientObj, null );
@@ -176,7 +176,7 @@ class ProgramObjectBundleHookTest
     }
 
     @Test
-    public void verifyUpdateProgramStage()
+    void verifyUpdateProgramStage()
     {
         ProgramStage programStage = createProgramStage( 'A', 1 );
         programA.getProgramStages().add( programStage );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramObjectBundleHookTest.java
@@ -68,7 +68,7 @@ import com.google.common.collect.Lists;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class ProgramObjectBundleHookTest
+class ProgramObjectBundleHookTest
 {
     private ProgramObjectBundleHook subject;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -61,7 +61,7 @@ import com.google.common.collect.ImmutableList;
  * @author Luca Cambi
  */
 @ExtendWith( MockitoExtension.class )
-public class ProgramRuleVariableObjectBundleHookTest
+class ProgramRuleVariableObjectBundleHookTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleVariableObjectBundleHookTest.java
@@ -97,7 +97,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldFailInsertAlreadyExisting()
+    void shouldFailInsertAlreadyExisting()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE );
@@ -111,7 +111,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldNotFailUpdateExistingSameUid()
+    void shouldNotFailUpdateExistingSameUid()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
@@ -132,7 +132,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldNotFailUpdateExistingMoreThanOneSameUid()
+    void shouldNotFailUpdateExistingMoreThanOneSameUid()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
@@ -158,7 +158,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldFailUpdateExistingDifferentUid()
+    void shouldFailUpdateExistingDifferentUid()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
@@ -180,7 +180,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldFailValidationInvalidCountAndInvalidName()
+    void shouldFailValidationInvalidCountAndInvalidName()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE );
@@ -197,7 +197,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldFailValidationInvalidName()
+    void shouldFailValidationInvalidName()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( objectBundle.getImportMode() ).thenReturn( ImportStrategy.CREATE_AND_UPDATE );
@@ -226,7 +226,7 @@ class ProgramRuleVariableObjectBundleHookTest
     }
 
     @Test
-    public void shouldPassValidationWithValidName()
+    void shouldPassValidationWithValidName()
     {
         when( programRuleVariable.getProgram() ).thenReturn( program );
         when( programRuleVariable.getName() ).thenReturn( "WordAndWord" );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageObjectBundleHookTest.java
@@ -52,7 +52,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class ProgramStageObjectBundleHookTest
+class ProgramStageObjectBundleHookTest
 {
     private ProgramStageObjectBundleHook subject;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramStageObjectBundleHookTest.java
@@ -95,7 +95,7 @@ class ProgramStageObjectBundleHookTest
     }
 
     @Test
-    public void testValidateDataElementAcl()
+    void testValidateDataElementAcl()
     {
         ObjectBundleParams objectBundleParams = new ObjectBundleParams();
         objectBundleParams.setPreheatIdentifier( PreheatIdentifier.UID );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityTypeObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityTypeObjectBundleHookTest.java
@@ -79,7 +79,7 @@ class TrackedEntityTypeObjectBundleHookTest
     }
 
     @Test
-    public void shouldReportNoErrorTetHasNoTeas()
+    void shouldReportNoErrorTetHasNoTeas()
     {
 
         assertEquals( 0, trackedEntityTypeObjectBundleHook.validate( trackedEntityType, bundle ).size() );
@@ -87,7 +87,7 @@ class TrackedEntityTypeObjectBundleHookTest
     }
 
     @Test
-    public void shouldReportNoErrorTeaExists()
+    void shouldReportNoErrorTeaExists()
     {
 
         when( preheat.get( any(), any() ) ).thenReturn( new TrackedEntityAttribute() );
@@ -103,7 +103,7 @@ class TrackedEntityTypeObjectBundleHookTest
     }
 
     @Test
-    public void shouldReportErrorTeaNotExists()
+    void shouldReportErrorTeaNotExists()
     {
 
         trackedEntityAttribute = new TrackedEntityAttribute();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityTypeObjectBundleHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/TrackedEntityTypeObjectBundleHookTest.java
@@ -53,7 +53,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class TrackedEntityTypeObjectBundleHookTest
+class TrackedEntityTypeObjectBundleHookTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidatingEventCheckerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidatingEventCheckerTest.java
@@ -63,7 +63,7 @@ import com.google.common.collect.ImmutableMap;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class ValidatingEventCheckerTest
+class ValidatingEventCheckerTest
 {
     @Mock
     private SchemaValidator schemaValidator;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidatingEventCheckerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ValidatingEventCheckerTest.java
@@ -90,7 +90,7 @@ class ValidatingEventCheckerTest
     }
 
     @Test
-    public void verifyValidationFactoryProcessValidationCheck()
+    void verifyValidationFactoryProcessValidationCheck()
     {
         ObjectBundle bundle = createObjectBundle();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
@@ -90,8 +90,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenVersionNameNotPresentInParameters()
-        throws MetadataSyncServiceException
+    void testShouldThrowExceptionWhenVersionNameNotPresentInParameters()
     {
         assertThrows( MetadataSyncServiceException.class,
             () -> metadataSyncService.getParamsFromMap( parameters ),
@@ -99,8 +98,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParametersAreNull()
-        throws MetadataSyncServiceException
+    void testShouldThrowExceptionWhenParametersAreNull()
     {
         assertThrows( MetadataSyncServiceException.class,
             () -> metadataSyncService.getParamsFromMap( null ),
@@ -109,8 +107,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParametersHaveVersionNameAsNull()
-        throws MetadataSyncServiceException
+    void testShouldThrowExceptionWhenParametersHaveVersionNameAsNull()
     {
         parameters.put( "versionName", null );
 
@@ -119,8 +116,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParametersHaveVersionNameAssignedToEmptyList()
-        throws MetadataSyncServiceException
+    void testShouldThrowExceptionWhenParametersHaveVersionNameAssignedToEmptyList()
     {
         parameters.put( "versionName", new ArrayList<>() );
 
@@ -129,7 +125,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldReturnNullWhenVersionNameIsAssignedToListHavingNullEntry()
+    void testShouldReturnNullWhenVersionNameIsAssignedToListHavingNullEntry()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( null );
@@ -140,7 +136,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldReturnNullWhenVersionNameIsAssignedToListHavingEmptyString()
+    void testShouldReturnNullWhenVersionNameIsAssignedToListHavingEmptyString()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( "" );
@@ -151,7 +147,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldGetExceptionIfRemoteVersionIsNotAvailable()
+    void testShouldGetExceptionIfRemoteVersionIsNotAvailable()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( "testVersion" );
@@ -164,7 +160,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldGetMetadataVersionForGivenVersionName()
+    void testShouldGetMetadataVersionForGivenVersionName()
     {
         parameters.put( "versionName", new ArrayList<>() );
         parameters.get( "versionName" ).add( "testVersion" );
@@ -177,14 +173,14 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenSyncParamsIsNull()
+    void testShouldThrowExceptionWhenSyncParamsIsNull()
     {
         assertThrows( MetadataSyncServiceException.class, () -> metadataSyncService.doMetadataSync( null ),
             "MetadataSyncParams cant be null" );
     }
 
     @Test
-    public void testShouldThrowExceptionWhenVersionIsNulInSyncParams()
+    void testShouldThrowExceptionWhenVersionIsNulInSyncParams()
     {
         MetadataSyncParams syncParams = new MetadataSyncParams();
         syncParams.setVersion( null );
@@ -194,7 +190,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenSnapshotReturnsNullForGivenVersion()
+    void testShouldThrowExceptionWhenSnapshotReturnsNullForGivenVersion()
     {
 
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
@@ -209,7 +205,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenDHISVersionsMismatch()
+    void testShouldThrowExceptionWhenDHISVersionsMismatch()
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
@@ -227,7 +223,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldNotThrowExceptionWhenDHISVersionsMismatch()
+    void testShouldNotThrowExceptionWhenDHISVersionsMismatch()
         throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
@@ -245,7 +241,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenSnapshotNotPassingIntegrity()
+    void testShouldThrowExceptionWhenSnapshotNotPassingIntegrity()
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
         MetadataVersion metadataVersion = new MetadataVersion( "testVersion", VersionType.ATOMIC );
@@ -262,7 +258,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldStoreMetadataSnapshotInDataStoreAndImport()
+    void testShouldStoreMetadataSnapshotInDataStoreAndImport()
         throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
@@ -290,7 +286,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldNotStoreMetadataSnapshotInDataStoreWhenAlreadyExistsInLocalStore()
+    void testShouldNotStoreMetadataSnapshotInDataStoreWhenAlreadyExistsInLocalStore()
         throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = Mockito.mock( MetadataSyncParams.class );
@@ -319,7 +315,7 @@ class DefaultMetadataSyncServiceTest
     }
 
     @Test
-    public void testShouldVerifyImportParamsAtomicTypeForTheGivenBestEffortVersion()
+    void testShouldVerifyImportParamsAtomicTypeForTheGivenBestEffortVersion()
         throws DhisVersionMismatchException
     {
         MetadataSyncParams syncParams = new MetadataSyncParams();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/DefaultMetadataSyncServiceTest.java
@@ -61,7 +61,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author sultanm
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultMetadataSyncServiceTest
+class DefaultMetadataSyncServiceTest
 {
 
     private MetadataSyncService metadataSyncService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
@@ -54,7 +54,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author aamerm
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataSyncDelegateTest
+class MetadataSyncDelegateTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncDelegateTest.java
@@ -70,7 +70,7 @@ class MetadataSyncDelegateTest
     private RenderService renderService;
 
     @Test
-    public void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInLocal()
+    void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInLocal()
     {
         String versionSnapshot = "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         SystemInfo systemInfo = new SystemInfo();
@@ -80,7 +80,7 @@ class MetadataSyncDelegateTest
     }
 
     @Test
-    public void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInRemote()
+    void testShouldVerifyIfStopSyncReturnFalseIfNoSystemVersionInRemote()
     {
         String versionSnapshot = "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         SystemInfo systemInfo = new SystemInfo();
@@ -91,7 +91,7 @@ class MetadataSyncDelegateTest
     }
 
     @Test
-    public void testShouldVerifyIfStopSyncReturnTrueIfDHISVersionMismatch()
+    void testShouldVerifyIfStopSyncReturnTrueIfDHISVersionMismatch()
         throws IOException
     {
         String versionSnapshot = "{\"system:\": {\"date\":\"2016-06-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\","
@@ -112,7 +112,7 @@ class MetadataSyncDelegateTest
     }
 
     @Test
-    public void testShouldVerifyIfStopSyncReturnFalseIfDHISVersionSame()
+    void testShouldVerifyIfStopSyncReturnFalseIfDHISVersionSame()
         throws IOException
     {
         String versionSnapshot = "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
@@ -131,7 +131,7 @@ class MetadataSyncDelegateTest
     }
 
     @Test
-    public void testShouldVerifyIfStopSyncReturnFalseIfStopSyncIsNotSet()
+    void testShouldVerifyIfStopSyncReturnFalseIfStopSyncIsNotSet()
     {
         String versionSnapshot = "{\"system:\": {\"date\":\"2016-05-24T05:27:25.128+0000\", \"version\": \"2.26\"}, \"name\":\"testVersion\",\"created\":\"2016-05-26T11:43:59.787+0000\",\"type\":\"BEST_EFFORT\",\"id\":\"ktwh8PHNwtB\",\"hashCode\":\"12wa32d4f2et3tyt5yu6i\"}";
         SystemInfo systemInfo = new SystemInfo();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
@@ -93,7 +93,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenNoVersionSet()
+    void testShouldThrowExceptionWhenNoVersionSet()
     {
         syncParams.setImportParams( null );
         assertThrows( MetadataSyncServiceException.class,
@@ -102,7 +102,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenNoImportParams()
+    void testShouldThrowExceptionWhenNoImportParams()
     {
         syncParams.setVersion( metadataVersion );
         syncParams.setImportParams( null );
@@ -113,7 +113,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenImportServiceFails()
+    void testShouldThrowExceptionWhenImportServiceFails()
     {
         syncParams.setImportParams( new MetadataImportParams() );
         syncParams.setVersion( metadataVersion );
@@ -126,7 +126,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldImportMetadata()
+    void testShouldImportMetadata()
     {
         syncParams.setImportParams( new MetadataImportParams() );
         syncParams.setVersion( metadataVersion );
@@ -154,7 +154,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldImportMetadataWhenBestEffortWithWarnings()
+    void testShouldImportMetadataWhenBestEffortWithWarnings()
     {
         syncParams.setImportParams( new MetadataImportParams() );
         syncParams.setVersion( metadataVersion );
@@ -182,7 +182,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenClassListMapIsNull()
+    void testShouldThrowExceptionWhenClassListMapIsNull()
         throws IOException
     {
         syncParams.setImportParams( new MetadataImportParams() );
@@ -201,7 +201,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenParsingClassListMap()
+    void testShouldThrowExceptionWhenParsingClassListMap()
         throws IOException
     {
         syncParams.setImportParams( new MetadataImportParams() );
@@ -221,7 +221,7 @@ class MetadataSyncImportHandlerTest
     }
 
     @Test
-    public void testShouldReturnDefaultSummaryWhenImportStatusIsError()
+    void testShouldReturnDefaultSummaryWhenImportStatusIsError()
     {
         syncParams.setImportParams( new MetadataImportParams() );
         syncParams.setVersion( metadataVersion );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncImportHandlerTest.java
@@ -61,7 +61,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author anilkumk
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataSyncImportHandlerTest
+class MetadataSyncImportHandlerTest
 {
     @Mock
     MetadataImportService metadataImportService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessorTest.java
@@ -80,7 +80,7 @@ class MetadataSyncPostProcessorTest
     }
 
     @Test
-    public void testShouldSendSuccessEmailIfSyncSummaryIsOk()
+    void testShouldSendSuccessEmailIfSyncSummaryIsOk()
     {
         metadataSyncSummary.setImportReport( new ImportReport() );
         metadataSyncSummary.getImportReport().setStatus( Status.OK );
@@ -94,7 +94,7 @@ class MetadataSyncPostProcessorTest
     }
 
     @Test
-    public void testShouldSendSuccessEmailIfSyncSummaryIsWarning()
+    void testShouldSendSuccessEmailIfSyncSummaryIsWarning()
     {
         metadataSyncSummary.setImportReport( new ImportReport() );
         metadataSyncSummary.getImportReport().setStatus( Status.WARNING );
@@ -109,7 +109,7 @@ class MetadataSyncPostProcessorTest
     }
 
     @Test
-    public void testShouldSendSuccessEmailIfSyncSummaryIsError()
+    void testShouldSendSuccessEmailIfSyncSummaryIsError()
     {
         metadataSyncSummary.setImportReport( new ImportReport() );
         metadataSyncSummary.getImportReport().setStatus( Status.ERROR );
@@ -125,7 +125,7 @@ class MetadataSyncPostProcessorTest
     }
 
     @Test
-    public void testShouldSendEmailToAdminWithProperSubjectAndBody()
+    void testShouldSendEmailToAdminWithProperSubjectAndBody()
     {
         ImportReport importReport = mock( ImportReport.class );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSyncPostProcessorTest.java
@@ -52,7 +52,7 @@ import org.springframework.retry.RetryContext;
  * @author aamerm
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataSyncPostProcessorTest
+class MetadataSyncPostProcessorTest
 {
     @Mock
     private EmailService emailService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSystemSettingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSystemSettingServiceTest.java
@@ -61,7 +61,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldGetRemoteUserName()
+    void testShouldGetRemoteUserName()
     {
         String remoteInstanceUserName = metadataSystemSettingService.getRemoteInstanceUserName();
 
@@ -69,7 +69,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldGetRemotePassword()
+    void testShouldGetRemotePassword()
     {
         String remoteInstancePassword = metadataSystemSettingService.getRemoteInstancePassword();
 
@@ -77,7 +77,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldDownloadMetadataVersionForGivenVersionName()
+    void testShouldDownloadMetadataVersionForGivenVersionName()
     {
         String downloadVersionUrl = metadataSystemSettingService.getVersionDetailsUrl( "Version_Name" );
 
@@ -85,7 +85,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldDownloadMetadataVersionSnapshotForGivenVersionName()
+    void testShouldDownloadMetadataVersionSnapshotForGivenVersionName()
     {
         String downloadVersionUrl = metadataSystemSettingService.getDownloadVersionSnapshotURL( "Version_Name" );
 
@@ -93,7 +93,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldGetAllVersionsCreatedAfterTheGivenVersionName()
+    void testShouldGetAllVersionsCreatedAfterTheGivenVersionName()
     {
         String metadataDifferenceUrl = metadataSystemSettingService.getMetaDataDifferenceURL( "Version_Name" );
 
@@ -102,7 +102,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldGetEntireVersionHistoryWhenNoVersionNameIsGiven()
+    void testShouldGetEntireVersionHistoryWhenNoVersionNameIsGiven()
     {
         String versionHistoryUrl = metadataSystemSettingService.getEntireVersionHistory();
 
@@ -110,7 +110,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldGetStopMetadataSyncSettingValue()
+    void testShouldGetStopMetadataSyncSettingValue()
     {
         Boolean stopMetadataSync = metadataSystemSettingService.getStopMetadataSyncSetting();
 
@@ -118,7 +118,7 @@ class MetadataSystemSettingServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testShouldReturnFalseIfStopMetadataSyncSettingValueIsNull()
+    void testShouldReturnFalseIfStopMetadataSyncSettingValueIsNull()
     {
         systemSettingManager.saveSystemSetting( SettingKey.STOP_METADATA_SYNC, null );
         Boolean stopMetadataSync = metadataSystemSettingService.getStopMetadataSyncSetting();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSystemSettingServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/sync/MetadataSystemSettingServiceTest.java
@@ -43,8 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author anilkumk
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataSystemSettingServiceTest
-    extends DhisSpringTest
+class MetadataSystemSettingServiceTest extends DhisSpringTest
 {
     @Autowired
     SystemSettingManager systemSettingManager;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -57,8 +57,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author sultanm
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultMetadataVersionServiceTest
-    extends TransactionalIntegrationTest
+class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
 {
     @Autowired
     private MetadataVersionService versionService;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.List;
 
@@ -110,7 +109,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldAddVersions()
+    void testShouldAddVersions()
     {
         long idA = versionService.addVersion( versionA );
         long idB = versionService.addVersion( versionB );
@@ -123,7 +122,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldDeleteAVersion()
+    void testShouldDeleteAVersion()
     {
         long id = versionService.addVersion( versionA );
 
@@ -133,7 +132,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldGetVersionsBasedOnIdOrName()
+    void testShouldGetVersionsBasedOnIdOrName()
     {
         long idA = versionService.addVersion( versionA );
 
@@ -145,7 +144,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldReturnTheLatestVersion()
+    void testShouldReturnTheLatestVersion()
     {
         versionService.addVersion( versionA );
         sleepFor( 100 );
@@ -155,7 +154,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testGetInitialVersion()
+    void testGetInitialVersion()
     {
         versionService.addVersion( versionA );
         sleepFor( 100 );
@@ -165,7 +164,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldReturnVersionsBetweenGivenTimeStamps()
+    void testShouldReturnVersionsBetweenGivenTimeStamps()
     {
         List<MetadataVersion> versions = null;
         Date startDate = new Date();
@@ -189,7 +188,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldReturnAllVersionsInSystem()
+    void testShouldReturnAllVersionsInSystem()
     {
         assertEquals( 0, versionService.getAllVersions().size() );
         versionService.addVersion( versionA );
@@ -202,8 +201,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldSaveVersionAndSnapShot()
-        throws NoSuchAlgorithmException
+    void testShouldSaveVersionAndSnapShot()
     {
         versionService.addVersion( versionA );
         versionService.saveVersion( VersionType.ATOMIC );
@@ -240,7 +238,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldCreateASnapshotThatContainsOnlyDelta()
+    void testShouldCreateASnapshotThatContainsOnlyDelta()
     {
         versionService.addVersion( versionA );
         DataElement de1 = createDataElement( 'A' );
@@ -259,8 +257,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldGiveValidVersionDataIfExists()
-        throws Exception
+    void testShouldGiveValidVersionDataIfExists()
     {
         versionService.createMetadataVersionInDataStore( "myVersion", "myJson" );
 
@@ -268,14 +265,13 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldReturnNullWhenAVersionDoesNotExist()
-        throws Exception
+    void testShouldReturnNullWhenAVersionDoesNotExist()
     {
         assertEquals( null, versionService.getVersionData( "myNonExistingVersion" ) );
     }
 
     @Test
-    public void testShouldStoreSnapshotInMetadataStore()
+    void testShouldStoreSnapshotInMetadataStore()
     {
         versionService.createMetadataVersionInDataStore( "myVersion", "mySnapshot" );
 
@@ -285,21 +281,21 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
-    public void testShouldThrowMetadataVersionServiceExceptionWhenSnapshotIsEmpty()
+    void testShouldThrowMetadataVersionServiceExceptionWhenSnapshotIsEmpty()
     {
         assertThrows( MetadataVersionServiceException.class,
             () -> versionService.createMetadataVersionInDataStore( "myVersion", "" ) );
     }
 
     @Test
-    public void testShouldThrowMetadataVersionServiceExceptionWhenSnapshotIsNull()
+    void testShouldThrowMetadataVersionServiceExceptionWhenSnapshotIsNull()
     {
         assertThrows( MetadataVersionServiceException.class,
             () -> versionService.createMetadataVersionInDataStore( "myVersion", null ) );
     }
 
     @Test
-    public void shouldThrowAnExceptionWhenVersionAndItsShanpShotAreNull()
+    void shouldThrowAnExceptionWhenVersionAndItsShanpShotAreNull()
     {
         assertThrows( MetadataVersionServiceException.class,
             () -> versionService.isMetadataPassingIntegrity( null, null ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
@@ -68,7 +68,7 @@ import org.springframework.http.HttpStatus;
  * @author anilkumk
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataVersionDelegateTest
+class MetadataVersionDelegateTest
 {
     private MetadataVersionDelegate target;
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/MetadataVersionDelegateTest.java
@@ -116,7 +116,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenServerNotAvailable()
+    void testShouldThrowExceptionWhenServerNotAvailable()
     {
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( false, "test_message", null );
         when( synchronizationManager.isRemoteServerAvailable() ).thenReturn( availabilityStatus );
@@ -126,7 +126,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldGetRemoteVersionNullWhenDhisResponseReturnsNull()
+    void testShouldGetRemoteVersionNullWhenDhisResponseReturnsNull()
     {
 
         AvailabilityStatus availabilityStatus = new AvailabilityStatus( true, "test_message", null );
@@ -144,7 +144,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenHTTPRequestFails()
+    void testShouldThrowExceptionWhenHTTPRequestFails()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -165,8 +165,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldGetRemoteMetadataVersionWithStatusOk()
-        throws Exception
+    void testShouldGetRemoteMetadataVersionWithStatusOk()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -190,11 +189,14 @@ class MetadataVersionDelegateTest
             assertEquals( metadataVersion.getName(), remoteMetadataVersion.getName() );
             assertEquals( metadataVersion, remoteMetadataVersion );
         }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
     }
 
     @Test
-    public void testShouldGetMetaDataDifferenceWithStatusOk()
-        throws Exception
+    void testShouldGetMetaDataDifferenceWithStatusOk()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -233,11 +235,14 @@ class MetadataVersionDelegateTest
             assertEquals( metadataVersionList.get( 0 ).getName(), metaDataDifference.get( 0 ).getName() );
             assertEquals( metadataVersionList.get( 0 ).getHashCode(), metaDataDifference.get( 0 ).getHashCode() );
         }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
     }
 
     @Test
-    public void testShouldThrowExceptionWhenRenderServiceThrowsExceptionWhileGettingMetadataDifference()
-        throws Exception
+    void testShouldThrowExceptionWhenRenderServiceThrowsExceptionWhileGettingMetadataDifference()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -266,10 +271,14 @@ class MetadataVersionDelegateTest
             assertThrows( MetadataVersionServiceException.class, () -> target.getMetaDataDifference( metadataVersion ),
                 "Exception occurred while trying to do JSON conversion. Caused by: " );
         }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
     }
 
     @Test
-    public void testShouldReturnEmptyMetadataDifference()
+    void testShouldReturnEmptyMetadataDifference()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -300,7 +309,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithClientError()
+    void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithClientError()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -330,7 +339,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithServerError()
+    void testShouldThrowExceptionWhenGettingRemoteMetadataVersionWithServerError()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -361,8 +370,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldThrowExceptionWhenRenderServiceThrowsException()
-        throws Exception
+    void testShouldThrowExceptionWhenRenderServiceThrowsException()
     {
         when( metadataSystemSettingService.getRemoteInstanceUserName() ).thenReturn( username );
         when( metadataSystemSettingService.getRemoteInstancePassword() ).thenReturn( password );
@@ -382,10 +390,14 @@ class MetadataVersionDelegateTest
             assertThrows( MetadataVersionServiceException.class, () -> target.getRemoteMetadataVersion( "testVersion" ),
                 "Exception occurred while trying to do JSON conversion for metadata version" );
         }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
     }
 
     @Test
-    public void testShouldDownloadMetadataVersion()
+    void testShouldDownloadMetadataVersion()
     {
         when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) )
             .thenReturn( downloadUrl );
@@ -411,7 +423,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldReturnNullOnInValidDHISResponse()
+    void testShouldReturnNullOnInValidDHISResponse()
     {
         when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) )
             .thenReturn( downloadUrl );
@@ -434,7 +446,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldNotGetMetadataVersionIfRemoteServerIsUnavailable()
+    void testShouldNotGetMetadataVersionIfRemoteServerIsUnavailable()
     {
         when( metadataSystemSettingService.getDownloadVersionSnapshotURL( "testVersion" ) )
             .thenReturn( downloadUrl );
@@ -456,7 +468,7 @@ class MetadataVersionDelegateTest
     }
 
     @Test
-    public void testShouldAddNewMetadataVersion()
+    void testShouldAddNewMetadataVersion()
     {
         target.addNewMetadataVersion( metadataVersion );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -65,7 +65,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * Unit tests for {@link DefaultFieldFilterService}.
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultFieldFilterServiceTest
+class DefaultFieldFilterServiceTest
 {
     private FieldParser fieldParser = new DefaultFieldParser();
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -100,7 +100,7 @@ class DefaultFieldFilterServiceTest
     }
 
     @Test
-    public void toCollectionNodeSkipSharingNoFields()
+    void toCollectionNodeSkipSharingNoFields()
         throws Exception
     {
         final Attribute attribute = new Attribute();
@@ -134,7 +134,7 @@ class DefaultFieldFilterServiceTest
     }
 
     @Test
-    public void toCollectionNodeSkipSharingOwner()
+    void toCollectionNodeSkipSharingOwner()
         throws Exception
     {
         final Attribute attribute = new Attribute();

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -76,7 +76,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class DefaultFieldFilterServiceTest
+class DefaultFieldFilterServiceTest
 {
     @Mock
     private SessionFactory sessionFactory;

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterServiceTest.java
@@ -115,7 +115,7 @@ class DefaultFieldFilterServiceTest
     }
 
     @Test
-    public void baseIdentifiableIdOnly()
+    void baseIdentifiableIdOnly()
     {
         final OrganisationUnit ou1 = new OrganisationUnit();
         ou1.setUid( "abc1" );
@@ -165,7 +165,7 @@ class DefaultFieldFilterServiceTest
     }
 
     @Test
-    public void baseIdentifiableName()
+    void baseIdentifiableName()
     {
         final OrganisationUnit ou1 = new OrganisationUnit();
         ou1.setUid( "abc1" );
@@ -209,7 +209,7 @@ class DefaultFieldFilterServiceTest
     }
 
     @Test
-    public void defaultClass()
+    void defaultClass()
     {
         final CategoryOption co1 = new CategoryOption();
         co1.setUid( "abc1" );
@@ -266,7 +266,7 @@ class DefaultFieldFilterServiceTest
     }
 
     @Test
-    public void baseIdentifiable()
+    void baseIdentifiable()
     {
         final OrganisationUnit ou1 = new OrganisationUnit();
         ou1.setUid( "abc1" );

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/transformers/PluckNodeTransformerTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/transformers/PluckNodeTransformerTest.java
@@ -95,13 +95,13 @@ class PluckNodeTransformerTest
     }
 
     @Test
-    public void name()
+    void name()
     {
         Assertions.assertEquals( "pluck", transformer.name() );
     }
 
     @Test
-    public void withoutArg()
+    void withoutArg()
     {
         Node result = transformer.transform( collectionNode, null );
         Assertions.assertTrue( result instanceof CollectionNode );
@@ -121,7 +121,7 @@ class PluckNodeTransformerTest
     }
 
     @Test
-    public void withArg()
+    void withArg()
     {
         Node result = transformer.transform( collectionNode, Collections.singletonList( "name" ) );
         Assertions.assertTrue( result instanceof CollectionNode );

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/transformers/PluckNodeTransformerTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/transformers/PluckNodeTransformerTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class PluckNodeTransformerTest
+class PluckNodeTransformerTest
 {
     private final PluckNodeTransformer transformer = new PluckNodeTransformer();
 

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
@@ -75,7 +75,7 @@ import org.springframework.context.ApplicationEventPublisher;
  * Created by zubair@dhis2.org on 05.02.18.
  */
 @ExtendWith( MockitoExtension.class )
-public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
+class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 {
 
     private static final String NOTIFICATION_UID = "123abc";

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
@@ -123,19 +123,19 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void test_acceptBehaviorForActionAssign()
+    void test_acceptBehaviorForActionAssign()
     {
         assertFalse( implementer.accept( setMandatoryFieldFalse ) );
     }
 
     @Test
-    public void test_acceptBehaviorForActionSendMessage()
+    void test_acceptBehaviorForActionSendMessage()
     {
         assertTrue( implementer.accept( ruleActionSendMessage ) );
     }
 
     @Test
-    public void test_implementWithProgramInstanceWithTemplate()
+    void test_implementWithProgramInstanceWithTemplate()
     {
 
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
@@ -165,7 +165,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void test_implementWithProgramStageInstanceWithTemplate()
+    void test_implementWithProgramStageInstanceWithTemplate()
     {
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
 
@@ -195,7 +195,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void test_loggingServiceKey()
+    void test_loggingServiceKey()
     {
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
 
@@ -221,7 +221,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSendRepeatableFlag()
+    void testSendRepeatableFlag()
     {
         when( templateStore.getByUid( anyString() ) ).thenReturn( template );
 
@@ -249,7 +249,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void test_NothingHappensIfTemplateDoesNotExist()
+    void test_NothingHappensIfTemplateDoesNotExist()
     {
         // overriding stub to check null templates
         when( templateStore.getByUid( anyString() ) ).thenReturn( null );
@@ -261,7 +261,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void test_NothingHappensIfTemplateDoesNotExistForPSI()
+    void test_NothingHappensIfTemplateDoesNotExistForPSI()
     {
         when( templateStore.getByUid( anyString() ) ).thenReturn( null );
 
@@ -271,7 +271,7 @@ class NotificationRuleActionImplementerTest extends DhisConvenienceTest
     }
 
     @Test
-    public void test_NothingHappensIfActionIsNull()
+    void test_NothingHappensIfActionIsNull()
     {
         assertThrows( NullPointerException.class,
             () -> implementer.implement( null, programInstance ), "Rule Effect cannot be null" );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -151,7 +151,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWhenNoImplementableActionExist_programInstance()
+    void testWhenNoImplementableActionExist_programInstance()
     {
         setProgramRuleActionType_ShowError();
 
@@ -160,7 +160,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWithImplementableActionExist_programInstance()
+    void testWithImplementableActionExist_programInstance()
     {
         doAnswer( invocationOnMock -> {
             ruleEffects.add( (RuleEffect) invocationOnMock.getArguments()[0] );
@@ -200,7 +200,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWithImplementableActionExist_programStageInstance()
+    void testWithImplementableActionExist_programStageInstance()
     {
         doAnswer( invocationOnMock -> {
             ruleEffects.add( (RuleEffect) invocationOnMock.getArguments()[0] );
@@ -234,7 +234,7 @@ class ProgramRuleEngineServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testGetDescription()
+    void testGetDescription()
     {
         RuleValidationResult result = RuleValidationResult.builder().isValid( true ).build();
         when( programRuleService.getProgramRule( anyString() ) ).thenReturn( programRuleA );

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineServiceTest.java
@@ -82,7 +82,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class ProgramRuleEngineServiceTest extends DhisConvenienceTest
+class ProgramRuleEngineServiceTest extends DhisConvenienceTest
 {
 
     private static final String NOTIFICATION_UID = "abc123";

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -177,7 +177,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMappedProgramRules()
+    void testMappedProgramRules()
     {
         when( programRuleService.getAllProgramRule() ).thenReturn( programRules );
 
@@ -187,7 +187,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWhenProgramRuleConditionIsNull()
+    void testWhenProgramRuleConditionIsNull()
     {
         when( programRuleService.getAllProgramRule() ).thenReturn( programRules );
 
@@ -201,7 +201,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWhenProgramRuleActionIsNull()
+    void testWhenProgramRuleActionIsNull()
     {
         when( programRuleService.getAllProgramRule() ).thenReturn( programRules );
 
@@ -215,7 +215,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMappedRuleVariableValues()
+    void testMappedRuleVariableValues()
     {
         when( programRuleVariableService.getAllProgramRuleVariable() ).thenReturn( programRuleVariables );
         RuleVariableAttribute ruleVariableAttribute;
@@ -244,13 +244,13 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testExceptionWhenMandatoryFieldIsMissingInRuleEvent()
+    void testExceptionWhenMandatoryFieldIsMissingInRuleEvent()
     {
         assertThrows( IllegalStateException.class, () -> subject.toMappedRuleEvent( programStageInstanceC ) );
     }
 
     @Test
-    public void testExceptionIfDataElementIsNull()
+    void testExceptionIfDataElementIsNull()
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( null );
 
@@ -260,7 +260,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMappedRuleEvent()
+    void testMappedRuleEvent()
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
 
@@ -282,7 +282,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMappedRuleEventsWithFilter()
+    void testMappedRuleEventsWithFilter()
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
 
@@ -308,7 +308,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMappedRuleEvents()
+    void testMappedRuleEvents()
     {
         when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
 
@@ -319,7 +319,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testExceptionWhenMandatoryValueMissingMappedEnrollment()
+    void testExceptionWhenMandatoryValueMissingMappedEnrollment()
     {
         List<TrackedEntityAttributeValue> trackedEntityAttributeValues = Lists.newArrayList();
         assertThrows( IllegalStateException.class,
@@ -327,7 +327,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testMappedEnrollment()
+    void testMappedEnrollment()
     {
         RuleEnrollment ruleEnrollment = subject.toMappedRuleEnrollment( programInstance, Lists.newArrayList() );
 
@@ -338,7 +338,7 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testGetItemStore()
+    void testGetItemStore()
     {
         String env_variable = "Completed date";
         Constant constant = new Constant();

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -88,7 +88,7 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( org.mockito.junit.jupiter.MockitoExtension.class )
-public class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
+class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
 {
 
     private static final String SAMPLE_VALUE_A = "textValueA";

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/orgunitprofile/OrgUnitProfileServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/orgunitprofile/OrgUnitProfileServiceTest.java
@@ -110,7 +110,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testSave()
+    void testSave()
     {
         OrgUnitProfile orgUnitProfile = createOrgUnitProfile( Lists.newArrayList( "Attribute1", "Attribute2" ),
             Lists.newArrayList( "GroupSet1", "GroupSet2" ), Lists.newArrayList( "DataItem1", "DataItem2" ) );
@@ -126,7 +126,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testUpdateOrgUnitProfile()
+    void testUpdateOrgUnitProfile()
     {
         OrgUnitProfile orgUnitProfile = createOrgUnitProfile( Lists.newArrayList( "Attribute1", "Attribute2" ),
             Lists.newArrayList( "GroupSet1", "GroupSet2" ), Lists.newArrayList( "DataItem1", "DataItem2" ) );
@@ -147,7 +147,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetProfileDataWithoutOrgUnitProfile()
+    void testGetProfileDataWithoutOrgUnitProfile()
     {
         Attribute attribute = createAttribute( 'A' );
         attribute.setOrganisationUnitAttribute( true );
@@ -187,7 +187,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testGetProfileDataWithOrgUnitProfile()
+    void testGetProfileDataWithOrgUnitProfile()
     {
         Attribute attribute = createAttribute( 'A' );
         attribute.setOrganisationUnitAttribute( true );
@@ -231,7 +231,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidator()
+    void testValidator()
     {
         Attribute attribute = createAttribute( 'A' );
         attribute.setOrganisationUnitAttribute( true );
@@ -259,7 +259,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testValidateNonAggregateableDataElement()
+    void testValidateNonAggregateableDataElement()
     {
         DataElement deA = createDataElement( 'A' );
         deA.setValueType( ValueType.NUMBER );
@@ -279,7 +279,7 @@ class OrgUnitProfileServiceTest extends DhisSpringTest
     }
 
     @Test
-    public void testDeletionHandling()
+    void testDeletionHandling()
     {
         OrganisationUnitGroupSet groupSet = createOrganisationUnitGroupSet( 'A' );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/orgunitprofile/OrgUnitProfileServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/orgunitprofile/OrgUnitProfileServiceTest.java
@@ -70,7 +70,7 @@ import com.google.common.collect.Lists;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class OrgUnitProfileServiceTest extends DhisSpringTest
+class OrgUnitProfileServiceTest extends DhisSpringTest
 {
 
     @Autowired

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -333,8 +333,10 @@ class PredictionAnalyticsDataFetcherTest extends DhisConvenienceTest
     // Tests
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testGetAocData()
+    void testGetAocData()
     {
         for ( int i = 0; i < TEST_SIZE; i++ )
         {
@@ -378,7 +380,7 @@ class PredictionAnalyticsDataFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testGetNonAocData()
+    void testGetNonAocData()
     {
         when( analyticsService.getAggregatedDataValues( any( DataQueryParams.class ) ) )
             .thenAnswer( p -> getMockGrid( p ) );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -70,7 +70,7 @@ import com.google.common.collect.Lists;
  * @author Jim Grace
  */
 @ExtendWith( MockitoExtension.class )
-public class PredictionAnalyticsDataFetcherTest extends DhisConvenienceTest
+class PredictionAnalyticsDataFetcherTest extends DhisConvenienceTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
@@ -230,8 +230,10 @@ class PredictionDataValueFetcherTest extends DhisConvenienceTest
     // Tests
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testGetDataValues()
+    void testGetDataValues()
     {
         when( categoryService.getCategoryOptionCombo( cocA.getId() ) ).thenReturn( cocA );
         when( categoryService.getCategoryOptionCombo( cocB.getId() ) ).thenReturn( cocB );
@@ -257,7 +259,7 @@ class PredictionDataValueFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testOrgUnitsOutOfOrder()
+    void testOrgUnitsOutOfOrder()
     {
         when( dataValueService.getDeflatedDataValues( any( DataExportParams.class ) ) ).thenAnswer( p -> {
             BlockingQueue<DeflatedDataValue> blockingQueue = ((DataExportParams) p.getArgument( 0 )).getBlockingQueue();
@@ -272,7 +274,7 @@ class PredictionDataValueFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testNoDataValues()
+    void testNoDataValues()
     {
         when( dataValueService.getDeflatedDataValues( any( DataExportParams.class ) ) ).thenAnswer( p -> {
             BlockingQueue<DeflatedDataValue> blockingQueue = ((DataExportParams) p.getArgument( 0 )).getBlockingQueue();
@@ -290,7 +292,7 @@ class PredictionDataValueFetcherTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testProducerException()
+    void testProducerException()
     {
         when( dataValueService.getDeflatedDataValues( any() ) ).thenAnswer( p -> {
             throw new ArithmeticException();

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
@@ -80,7 +80,7 @@ import com.google.common.collect.Sets;
  * @author Jim Grace
  */
 @ExtendWith( MockitoExtension.class )
-public class PredictionDataValueFetcherTest extends DhisConvenienceTest
+class PredictionDataValueFetcherTest extends DhisConvenienceTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionWriterTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionWriterTest.java
@@ -63,7 +63,7 @@ import com.google.common.collect.Sets;
  * @author Jim Grace
  */
 @ExtendWith( MockitoExtension.class )
-public class PredictionWriterTest extends DhisConvenienceTest
+class PredictionWriterTest extends DhisConvenienceTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionWriterTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionWriterTest.java
@@ -176,8 +176,10 @@ class PredictionWriterTest extends DhisConvenienceTest
     // Tests
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+
     @Test
-    public void testWriteIntoExistingPeriod()
+    void testWriteIntoExistingPeriod()
     {
         writer.write( Lists.newArrayList( dataValueA ), NO_OLD_DATA );
 
@@ -187,7 +189,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWriteIntoNewPeriod()
+    void testWriteIntoNewPeriod()
     {
         writer.write( Lists.newArrayList( dataValueB ), NO_OLD_DATA );
 
@@ -197,7 +199,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWriteInsignificantZero()
+    void testWriteInsignificantZero()
     {
         writer.write( Lists.newArrayList( dataValueA0 ), NO_OLD_DATA );
 
@@ -208,7 +210,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWritePredictionUnchanged()
+    void testWritePredictionUnchanged()
     {
         writer.write( Lists.newArrayList( dataValueA ), Lists.newArrayList( dataValueA ) );
 
@@ -219,7 +221,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWriteInsignificantZeroWithOldPrediction()
+    void testWriteInsignificantZeroWithOldPrediction()
     {
         writer.write( Lists.newArrayList( dataValueA0 ), Lists.newArrayList( dataValueA ) );
 
@@ -229,7 +231,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWriteInsignificantZeroWithOldDeletedPrediction()
+    void testWriteInsignificantZeroWithOldDeletedPrediction()
     {
         writer.write( Lists.newArrayList( dataValueA0 ), Lists.newArrayList( dataValueADeleted ) );
 
@@ -240,7 +242,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWriteDeletingOldPrediction()
+    void testWriteDeletingOldPrediction()
     {
         writer.write( NO_PREDICTED_DATA, Lists.newArrayList( dataValueA ) );
 
@@ -250,7 +252,7 @@ class PredictionWriterTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testWriteNotDeletingOldDeletedPrediction()
+    void testWriteNotDeletingOldDeletedPrediction()
     {
         writer.write( NO_PREDICTED_DATA, Lists.newArrayList( dataValueADeleted ) );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/sharing/CascadeSharingTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/sharing/CascadeSharingTest.java
@@ -45,8 +45,7 @@ import org.hisp.dhis.user.sharing.Sharing;
 
 import com.google.common.collect.Lists;
 
-public abstract class CascadeSharingTest
-    extends DhisSpringTest
+abstract class CascadeSharingTest extends DhisSpringTest
 {
     protected DimensionalItemObject baseDimensionalItemObject( final String dimensionItem, DimensionItemType type )
     {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -74,7 +74,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class DataValidationTaskTest
+class DataValidationTaskTest
 {
     @Mock
     private ExpressionService expressionService;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -143,7 +143,7 @@ class DataValidationTaskTest
      * Verify that a single rule passes against a Data Element
      */
     @Test
-    public void verifySimpleValidation_oneRule_noErrors()
+    void verifySimpleValidation_oneRule_noErrors()
     {
         Expression leftExpression = createExpression2( 'A', "#{FUrCpcvMAmC.OrDRjJL9bTS}" );
         Expression rightExpression = createExpression2( 'B', "-10" );
@@ -192,7 +192,7 @@ class DataValidationTaskTest
     }
 
     @Test
-    public void verifyValidationSkippedOnNoData()
+    void verifyValidationSkippedOnNoData()
     {
         Expression leftExpression = createExpression2( 'A', "#{FUrCpcvMAmC.OrDRjJL9bTS}" );
         Expression rightExpression = createExpression2( 'B', "-10" );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/visualization/VisualizationGridServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/visualization/VisualizationGridServiceTest.java
@@ -59,7 +59,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class VisualizationGridServiceTest
+class VisualizationGridServiceTest
 {
     @Mock
     private VisualizationService visualizationService;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/visualization/VisualizationGridServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/visualization/VisualizationGridServiceTest.java
@@ -86,7 +86,7 @@ class VisualizationGridServiceTest
     }
 
     @Test
-    public void getVisualizationGridByUserWhenItHasOrganisationUnitLevels()
+    void getVisualizationGridByUserWhenItHasOrganisationUnitLevels()
     {
         // Given
         final String anyVisualizationUid = "adbet5RTs";
@@ -121,7 +121,7 @@ class VisualizationGridServiceTest
     }
 
     @Test
-    public void getVisualizationGridByUserWhenItHasItemOrganisationUnitGroups()
+    void getVisualizationGridByUserWhenItHasItemOrganisationUnitGroups()
     {
         // Given
         final String anyVisualizationUid = "adbet5RTs";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerImporterServiceTest.java
@@ -61,7 +61,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Zubair Asghar
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackerImporterServiceTest
+class TrackerImporterServiceTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerImporterServiceTest.java
@@ -116,7 +116,7 @@ class TrackerImporterServiceTest
     }
 
     @Test
-    public void testSkipSideEffect()
+    void testSkipSideEffect()
     {
         TrackerImportParams parameters = TrackerImportParams.builder()
             .events( params.getEvents() )
@@ -136,7 +136,7 @@ class TrackerImporterServiceTest
     }
 
     @Test
-    public void testWithSideEffects()
+    void testWithSideEffects()
     {
         doAnswer( invocationOnMock -> null ).when( trackerBundleService ).handleTrackerSideEffects( anyList() );
         when( trackerBundleService.create( any( TrackerImportParams.class ) ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerNotificationMessageManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerNotificationMessageManagerTest.java
@@ -61,7 +61,7 @@ import org.springframework.beans.factory.ObjectFactory;
  * @author Zubair Asghar
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackerNotificationMessageManagerTest
+class TrackerNotificationMessageManagerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerNotificationMessageManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerNotificationMessageManagerTest.java
@@ -95,7 +95,7 @@ class TrackerNotificationMessageManagerTest
     private ArgumentCaptor<Runnable> runnableCaptor;
 
     @Test
-    public void test_add_job()
+    void test_add_job()
     {
         doNothing().when( messageManager ).sendQueue( anyString(), any( TrackerSideEffectDataBundle.class ) );
 
@@ -110,7 +110,7 @@ class TrackerNotificationMessageManagerTest
     }
 
     @Test
-    public void test_message_consumer()
+    void test_message_consumer()
         throws JMSException,
         IOException
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerRuleEngineMessageManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerRuleEngineMessageManagerTest.java
@@ -96,7 +96,7 @@ class TrackerRuleEngineMessageManagerTest
     private ArgumentCaptor<Runnable> runnableArgumentCaptor;
 
     @Test
-    public void test_add_job()
+    void test_add_job()
     {
         doNothing().when( messageManager ).sendQueue( anyString(), any( TrackerSideEffectDataBundle.class ) );
 
@@ -112,7 +112,7 @@ class TrackerRuleEngineMessageManagerTest
     }
 
     @Test
-    public void test_message_consumer()
+    void test_message_consumer()
         throws JMSException,
         IOException
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerRuleEngineMessageManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/job/TrackerRuleEngineMessageManagerTest.java
@@ -62,7 +62,7 @@ import org.springframework.beans.factory.ObjectFactory;
  * @author Zubair Asghar
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackerRuleEngineMessageManagerTest
+class TrackerRuleEngineMessageManagerTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
@@ -96,7 +96,7 @@ class DefaultTrackerPreheatServiceTest
     }
 
     @Test
-    public void shouldGetFromContextAndAdd()
+    void shouldGetFromContextAndAdd()
     {
         when( applicationContext.getBean( bean.capture(), preheatSupplierClassCaptor.capture() ) )
             .thenReturn( classBasedSupplier );
@@ -111,7 +111,7 @@ class DefaultTrackerPreheatServiceTest
     }
 
     @Test
-    public void shouldDoNothingWhenSupplierBeanNotFound()
+    void shouldDoNothingWhenSupplierBeanNotFound()
     {
         when( applicationContext.getBean( bean.capture(), preheatSupplierClassCaptor.capture() ) )
             .thenThrow( new BeanCreationException( "e" ) );
@@ -124,7 +124,7 @@ class DefaultTrackerPreheatServiceTest
     }
 
     @Test
-    public void shouldDoNothingWhenAddException()
+    void shouldDoNothingWhenAddException()
     {
         when( applicationContext.getBean( bean.capture(), preheatSupplierClassCaptor.capture() ) )
             .thenReturn( classBasedSupplier );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatServiceTest.java
@@ -61,7 +61,7 @@ import com.google.common.collect.ImmutableList;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class DefaultTrackerPreheatServiceTest
+class DefaultTrackerPreheatServiceTest
 {
     @Mock
     private IdentifiableObjectManager manager;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplierTest.java
@@ -96,7 +96,7 @@ class ClassBasedSupplierTest
     }
 
     @Test
-    public void verifyGenericStrategy()
+    void verifyGenericStrategy()
     {
         when( strategiesMap.getOrDefault( anyString(), anyString() ) )
             .thenReturn( Constant.GENERIC_STRATEGY_BEAN );
@@ -109,7 +109,7 @@ class ClassBasedSupplierTest
     }
 
     @Test
-    public void verifyClassBasedSupplierStrategy()
+    void verifyClassBasedSupplierStrategy()
     {
         when( strategiesMap.getOrDefault( anyString(), anyString() ) )
             .thenReturn( "classbasedstrategy" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplierTest.java
@@ -56,7 +56,7 @@ import org.springframework.context.ApplicationContext;
  * @author Cambi Luca
  */
 @ExtendWith( MockitoExtension.class )
-public class ClassBasedSupplierTest
+class ClassBasedSupplierTest
 {
     private ClassBasedSupplier classBasedSupplier;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
@@ -122,7 +122,7 @@ class FileResourceSupplierTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
     {
         FileResource fileResource = createFileResource( 'A', "FileResource".getBytes() );
         fileResource.setUid( FILE_RESOURCE_UID );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
@@ -59,7 +59,7 @@ import com.google.common.collect.Sets;
  * @author Enrico Colasante
  */
 @ExtendWith( MockitoExtension.class )
-public class FileResourceSupplierTest extends DhisConvenienceTest
+class FileResourceSupplierTest extends DhisConvenienceTest
 {
 
     private static final String NUMERIC_DATA_ELEMENT_UID = "numericDataElement";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplierTest.java
@@ -56,7 +56,7 @@ import org.springframework.core.env.Environment;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class PeriodTypeSupplierTest
+class PeriodTypeSupplierTest
 {
 
     private PeriodTypeSupplier supplier;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplierTest.java
@@ -81,7 +81,7 @@ class PeriodTypeSupplierTest
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
     {
         final List<Period> periods = rnd.objects( Period.class, 20 ).collect( Collectors.toList() );
         when( periodStore.getAll() ).thenReturn( periods );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
@@ -61,7 +61,7 @@ import com.google.common.collect.Lists;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class ProgramInstanceSupplierTest extends DhisConvenienceTest
+class ProgramInstanceSupplierTest extends DhisConvenienceTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplierTest.java
@@ -105,7 +105,7 @@ class ProgramInstanceSupplierTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifySupplierWhenNoEventProgramArePresent()
+    void verifySupplierWhenNoEventProgramArePresent()
     {
         // given
         TrackerPreheat preheat = new TrackerPreheat();
@@ -126,7 +126,7 @@ class ProgramInstanceSupplierTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifySupplierWhenNoProgramsArePresent()
+    void verifySupplierWhenNoProgramsArePresent()
     {
         // given
         TrackerPreheat preheat = new TrackerPreheat();
@@ -146,7 +146,7 @@ class ProgramInstanceSupplierTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
     {
         // given
         TrackerPreheat preheat = new TrackerPreheat();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplierTest.java
@@ -57,7 +57,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class UserSupplierTest
+class UserSupplierTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplierTest.java
@@ -69,7 +69,7 @@ class UserSupplierTest
     private final BeanRandomizer rnd = BeanRandomizer.create( Event.class, "assignedUser" );
 
     @Test
-    public void verifySupplier()
+    void verifySupplier()
     {
         final List<Event> events = rnd.objects( Event.class, 5 ).collect( Collectors.toList() );
         events.forEach( e -> e.setAssignedUser( CodeGenerator.generateUid() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
@@ -97,7 +97,7 @@ class AbstractSchemaStrategyCachingTest
     }
 
     @Test
-    public void verifyFetchWildcardObjectsFromDbAndPutInCache()
+    void verifyFetchWildcardObjectsFromDbAndPutInCache()
     {
         // Given
         final Schema schema = new RelationshipTypeSchemaDescriptor().getSchema();
@@ -122,7 +122,7 @@ class AbstractSchemaStrategyCachingTest
     }
 
     @Test
-    public void verifyObjectInCacheIsReturned()
+    void verifyObjectInCacheIsReturned()
     {
         // Given
         final Schema schema = new ProgramSchemaDescriptor().getSchema();
@@ -144,7 +144,7 @@ class AbstractSchemaStrategyCachingTest
     }
 
     @Test
-    public void verifyObjectNotInCacheIsFetchedFromDbAndPutInCache()
+    void verifyObjectNotInCacheIsFetchedFromDbAndPutInCache()
     {
         // Given
         final Schema schema = new ProgramSchemaDescriptor().getSchema();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
@@ -71,7 +71,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class AbstractSchemaStrategyCachingTest
+class AbstractSchemaStrategyCachingTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategyTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategyTest.java
@@ -54,7 +54,7 @@ import com.google.common.collect.Lists;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackerEntityInstanceStrategyTest
+class TrackerEntityInstanceStrategyTest
 {
     @InjectMocks
     private TrackerEntityInstanceStrategy strategy;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategyTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategyTest.java
@@ -65,7 +65,7 @@ class TrackerEntityInstanceStrategyTest
     private final BeanRandomizer rnd = BeanRandomizer.create();
 
     @Test
-    public void verifyStrategyFiltersOutNonRootTei()
+    void verifyStrategyFiltersOutNonRootTei()
     {
         // Create preheat params
         final List<TrackedEntity> trackedEntities = rnd.objects( TrackedEntity.class, 2 )
@@ -93,7 +93,7 @@ class TrackerEntityInstanceStrategyTest
     }
 
     @Test
-    public void verifyStrategyIgnoresPersistedTei()
+    void verifyStrategyIgnoresPersistedTei()
     {
         // Create preheat params
         final List<TrackedEntity> trackedEntities = rnd.objects( TrackedEntity.class, 2 )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/AbstractImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/AbstractImportValidationTest.java
@@ -42,8 +42,7 @@ import org.springframework.core.io.ClassPathResource;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public abstract class AbstractImportValidationTest
-    extends TrackerTest
+public abstract class AbstractImportValidationTest extends TrackerTest
 {
     @Autowired
     protected TrackerBundleService trackerBundleService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -81,7 +81,7 @@ class DefaultTrackerValidationServiceTest
     }
 
     @Test
-    public void shouldNotValidateMissingUser()
+    void shouldNotValidateMissingUser()
     {
         when( bundle.getValidationMode() ).thenReturn( ValidationMode.SKIP );
         trackerValidationService.validate( bundle );
@@ -89,7 +89,7 @@ class DefaultTrackerValidationServiceTest
     }
 
     @Test
-    public void shouldNotValidateSuperUserSkip()
+    void shouldNotValidateSuperUserSkip()
     {
         when( bundle.getUser() ).thenReturn( user );
         when( user.isSuper() ).thenReturn( true );
@@ -101,7 +101,7 @@ class DefaultTrackerValidationServiceTest
     }
 
     @Test
-    public void shouldValidateSuperUserNoSkip()
+    void shouldValidateSuperUserNoSkip()
     {
         when( bundle.getUser() ).thenReturn( user );
         when( user.isSuper() ).thenReturn( true );
@@ -118,7 +118,7 @@ class DefaultTrackerValidationServiceTest
     }
 
     @Test
-    public void shouldValidateHookNoError()
+    void shouldValidateHookNoError()
     {
         when( bundle.getUser() ).thenReturn( user );
         when( user.isSuper() ).thenReturn( false );
@@ -138,7 +138,7 @@ class DefaultTrackerValidationServiceTest
     }
 
     @Test
-    public void shouldValidateHookWithErrors()
+    void shouldValidateHookWithErrors()
     {
         when( bundle.getUser() ).thenReturn( user );
         when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -55,7 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith( MockitoExtension.class )
-public class DefaultTrackerValidationServiceTest
+class DefaultTrackerValidationServiceTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedAttributeValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedAttributeValidationServiceTest.java
@@ -78,14 +78,14 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldThrowWhenTeaIsNull()
+    void shouldThrowWhenTeaIsNull()
     {
         assertThrows( IllegalArgumentException.class,
             () -> trackedEntityAttributeService.validateValueType( null, "" ) );
     }
 
     @Test
-    public void shouldThrowWhenNotAValidDate()
+    void shouldThrowWhenNotAValidDate()
     {
         tea.setValueType( ValueType.DATE );
         String teaValue = "Firstname";
@@ -94,14 +94,14 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldThrowWhenNullValue()
+    void shouldThrowWhenNullValue()
     {
         assertThrows( IllegalArgumentException.class,
             () -> trackedEntityAttributeService.validateValueType( tea, null ) );
     }
 
     @Test
-    public void shouldFailValueOverMaxLength()
+    void shouldFailValueOverMaxLength()
     {
         StringBuilder stringBuilder = new StringBuilder();
 
@@ -114,7 +114,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailValidationWhenTextValueAndDifferentValueType()
+    void shouldFailValidationWhenTextValueAndDifferentValueType()
     {
         tea.setValueType( ValueType.NUMBER );
         assertNotNull( trackedEntityAttributeService.validateValueType( tea, "value" ) );
@@ -124,7 +124,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailValidationWhenInvalidDate()
+    void shouldFailValidationWhenInvalidDate()
     {
         tea.setValueType( ValueType.DATE );
         assertThrows( IllegalFieldValueException.class,
@@ -132,7 +132,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailValidationWhenInvalidDateFormat()
+    void shouldFailValidationWhenInvalidDateFormat()
     {
         tea.setValueType( ValueType.DATE );
         assertNotNull( trackedEntityAttributeService.validateValueType( tea, "19700131" ) );
@@ -140,7 +140,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void successValidationWhenValidDate()
+    void successValidationWhenValidDate()
     {
         tea.setValueType( ValueType.DATE );
         assertNull( trackedEntityAttributeService.validateValueType( tea, "1970-01-01" ) );
@@ -148,7 +148,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void successWhenTextValueIsCorrect()
+    void successWhenTextValueIsCorrect()
     {
         tea.setValueType( ValueType.TEXT );
         assertNull( trackedEntityAttributeService.validateValueType( tea, "Firstname" ) );
@@ -164,7 +164,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailWhenUserCredentialNotFound()
+    void shouldFailWhenUserCredentialNotFound()
     {
         when( userService.getUserCredentialsByUsername( "user" ) ).thenReturn( null );
 
@@ -173,7 +173,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void successWhenUserCredentialExists()
+    void successWhenUserCredentialExists()
     {
         when( userService.getUserCredentialsByUsername( "user" ) ).thenReturn( new UserCredentials() );
 
@@ -182,14 +182,14 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailWhenInvalidDateTime()
+    void shouldFailWhenInvalidDateTime()
     {
         tea.setValueType( ValueType.DATETIME );
         assertNotNull( trackedEntityAttributeService.validateValueType( tea, "1970-01-01" ) );
     }
 
     @Test
-    public void successWhenValidDateTime()
+    void successWhenValidDateTime()
     {
         tea.setValueType( ValueType.DATETIME );
         assertNull( trackedEntityAttributeService.validateValueType( tea, "1970-01-01T00:00:00.000+02:00" ) );
@@ -197,7 +197,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailWhenImageValidationFail()
+    void shouldFailWhenImageValidationFail()
     {
         when( fileResourceService.getFileResource( "uid" ) ).thenReturn( null );
 
@@ -206,7 +206,7 @@ class TrackedAttributeValidationServiceTest
     }
 
     @Test
-    public void shouldFailWhenInvalidImageFormat()
+    void shouldFailWhenInvalidImageFormat()
     {
         when( fileResourceService.getFileResource( "uid" ) ).thenReturn( fileResource );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedAttributeValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedAttributeValidationServiceTest.java
@@ -48,7 +48,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class TrackedAttributeValidationServiceTest
+class TrackedAttributeValidationServiceTest
 {
 
     private TrackedAttributeValidationService trackedEntityAttributeService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -52,7 +52,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Enrico Colasante
  */
 @ExtendWith( MockitoExtension.class )
-public class AssignedUserValidationHookTest
+class AssignedUserValidationHookTest
 {
 
     private static final String USER_ID = "ABCDEF12345";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -86,7 +86,7 @@ class AssignedUserValidationHookTest
     }
 
     @Test
-    public void testAssignedUserIsValid()
+    void testAssignedUserIsValid()
     {
         // given
         Event event = new Event();
@@ -103,7 +103,7 @@ class AssignedUserValidationHookTest
     }
 
     @Test
-    public void testEventWithNotValidUserUid()
+    void testEventWithNotValidUserUid()
     {
         // given
         Event event = new Event();
@@ -121,7 +121,7 @@ class AssignedUserValidationHookTest
     }
 
     @Test
-    public void testEventWithUserNotPresentInPreheat()
+    void testEventWithUserNotPresentInPreheat()
     {
         // given
         Event event = new Event();
@@ -143,7 +143,7 @@ class AssignedUserValidationHookTest
     }
 
     @Test
-    public void testEventWithNotEnabledUserAssignment()
+    void testEventWithNotEnabledUserAssignment()
     {
         // given
         Event event = new Event();
@@ -166,7 +166,7 @@ class AssignedUserValidationHookTest
     }
 
     @Test
-    public void testEventWithNullEnabledUserAssignment()
+    void testEventWithNullEnabledUserAssignment()
     {
         // given
         Event event = new Event();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -66,7 +66,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentAttributeValidationHookTest
+class EnrollmentAttributeValidationHookTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -125,7 +125,7 @@ class EnrollmentAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValidationWhenValueIsNullAndAttributeIsMandatory()
+    void shouldFailValidationWhenValueIsNullAndAttributeIsMandatory()
     {
         // given 1 attribute has null value
         Attribute attribute = Attribute.builder().attribute( trackedAttribute ).valueType( ValueType.TEXT )
@@ -153,7 +153,7 @@ class EnrollmentAttributeValidationHookTest
     }
 
     @Test
-    public void shouldPassValidationWhenValueIsNullAndAttributeIsNotMandatory()
+    void shouldPassValidationWhenValueIsNullAndAttributeIsNotMandatory()
     {
         // given 1 attribute has null value
         Attribute attribute = Attribute.builder().attribute( trackedAttribute ).valueType( ValueType.TEXT )
@@ -180,7 +180,7 @@ class EnrollmentAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValidationWhenValueIsNullAndAttributeIsNotMandatoryAndAttributeNotExistsInTei()
+    void shouldFailValidationWhenValueIsNullAndAttributeIsNotMandatoryAndAttributeNotExistsInTei()
     {
         // given 1 attribute has null value and do not exists in Tei
         Attribute attribute = Attribute.builder().attribute( trackedAttribute ).valueType( ValueType.TEXT )
@@ -210,7 +210,7 @@ class EnrollmentAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValidationWhenAttributeIsNotPresentInDB()
+    void shouldFailValidationWhenAttributeIsNotPresentInDB()
     {
         Attribute attribute = Attribute.builder()
             .attribute( "invalidAttribute" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentDateValidationHookTest
+class EnrollmentDateValidationHookTest
 {
 
     private EnrollmentDateValidationHook hookToTest;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -72,7 +72,7 @@ class EnrollmentDateValidationHookTest
     }
 
     @Test
-    public void testMandatoryDatesMustBePresent()
+    void testMandatoryDatesMustBePresent()
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setProgram( CodeGenerator.generateUid() );
@@ -89,7 +89,7 @@ class EnrollmentDateValidationHookTest
     }
 
     @Test
-    public void testDatesMustNotBeInTheFuture()
+    void testDatesMustNotBeInTheFuture()
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setProgram( CodeGenerator.generateUid() );
@@ -110,7 +110,7 @@ class EnrollmentDateValidationHookTest
     }
 
     @Test
-    public void testDatesShouldBeAllowedOnSameDayIfFutureDatesAreNotAllowed()
+    void testDatesShouldBeAllowedOnSameDayIfFutureDatesAreNotAllowed()
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setProgram( CodeGenerator.generateUid() );
@@ -129,7 +129,7 @@ class EnrollmentDateValidationHookTest
     }
 
     @Test
-    public void testDatesCanBeInTheFuture()
+    void testDatesCanBeInTheFuture()
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setProgram( CodeGenerator.generateUid() );
@@ -151,7 +151,7 @@ class EnrollmentDateValidationHookTest
     }
 
     @Test
-    public void testFailOnMissingOccurredAtDate()
+    void testFailOnMissingOccurredAtDate()
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setProgram( CodeGenerator.generateUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -55,7 +55,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentGeoValidationHookTest
+class EnrollmentGeoValidationHookTest
 {
 
     private static final String PROGRAM = "Program";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -80,7 +80,7 @@ class EnrollmentGeoValidationHookTest
     }
 
     @Test
-    public void testGeometryIsValid()
+    void testGeometryIsValid()
     {
         // given
         Enrollment enrollment = new Enrollment();
@@ -97,7 +97,7 @@ class EnrollmentGeoValidationHookTest
     }
 
     @Test
-    public void testEnrollmentWithNoProgramThrowsAnError()
+    void testEnrollmentWithNoProgramThrowsAnError()
     {
         // given
         Enrollment enrollment = new Enrollment();
@@ -110,7 +110,7 @@ class EnrollmentGeoValidationHookTest
     }
 
     @Test
-    public void testProgramWithNullFeatureTypeFailsGeometryValidation()
+    void testProgramWithNullFeatureTypeFailsGeometryValidation()
     {
         // given
         Enrollment enrollment = new Enrollment();
@@ -131,7 +131,7 @@ class EnrollmentGeoValidationHookTest
     }
 
     @Test
-    public void testProgramWithFeatureTypeNoneFailsGeometryValidation()
+    void testProgramWithFeatureTypeNoneFailsGeometryValidation()
     {
         // given
         Enrollment enrollment = new Enrollment();
@@ -153,7 +153,7 @@ class EnrollmentGeoValidationHookTest
     }
 
     @Test
-    public void testProgramWithFeatureTypeDifferentFromGeometryFails()
+    void testProgramWithFeatureTypeDifferentFromGeometryFails()
     {
         // given
         Enrollment enrollment = new Enrollment();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -65,7 +65,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentInExistingValidationHookTest
+class EnrollmentInExistingValidationHookTest
 {
 
     private EnrollmentInExistingValidationHook hookToTest;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -119,7 +119,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldExitCancelledStatus()
+    void shouldExitCancelledStatus()
     {
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.CANCELLED );
         hookToTest.validateEnrollment( validationErrorReporter, enrollment );
@@ -128,7 +128,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldThrowProgramNotFound()
+    void shouldThrowProgramNotFound()
     {
         when( enrollment.getProgram() ).thenReturn( null );
         assertThrows( NullPointerException.class,
@@ -136,7 +136,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldExitProgramOnlyEnrollOnce()
+    void shouldExitProgramOnlyEnrollOnce()
     {
         Program program = new Program();
         program.setOnlyEnrollOnce( false );
@@ -149,7 +149,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldThrowTrackedEntityNotFound()
+    void shouldThrowTrackedEntityNotFound()
     {
         Program program = new Program();
         program.setOnlyEnrollOnce( true );
@@ -162,7 +162,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldPassValidation()
+    void shouldPassValidation()
     {
         Program program = new Program();
         program.setOnlyEnrollOnce( true );
@@ -175,7 +175,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldFailActiveEnrollmentAlreadyInPayload()
+    void shouldFailActiveEnrollmentAlreadyInPayload()
     {
         setEnrollmentInPayload( EnrollmentStatus.ACTIVE );
 
@@ -189,7 +189,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldFailNotActiveEnrollmentAlreadyInPayloadAndEnrollOnce()
+    void shouldFailNotActiveEnrollmentAlreadyInPayloadAndEnrollOnce()
     {
         Program program = new Program();
         program.setUid( programUid );
@@ -208,7 +208,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldPassNotActiveEnrollmentAlreadyInPayloadAndNotEnrollOnce()
+    void shouldPassNotActiveEnrollmentAlreadyInPayloadAndNotEnrollOnce()
     {
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
 
@@ -218,7 +218,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldFailActiveEnrollmentAlreadyInDb()
+    void shouldFailActiveEnrollmentAlreadyInDb()
     {
         setTeiInDb();
 
@@ -232,7 +232,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldFailNotActiveEnrollmentAlreadyInDbAndEnrollOnce()
+    void shouldFailNotActiveEnrollmentAlreadyInDbAndEnrollOnce()
     {
         Program program = new Program();
         program.setUid( programUid );
@@ -251,7 +251,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldPassNotActiveEnrollmentAlreadyInDbAndNotEnrollOnce()
+    void shouldPassNotActiveEnrollmentAlreadyInDbAndNotEnrollOnce()
     {
         setTeiInDb( ProgramStatus.COMPLETED );
 
@@ -261,7 +261,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldFailAnotherEnrollmentAndEnrollOnce()
+    void shouldFailAnotherEnrollmentAndEnrollOnce()
     {
         Program program = new Program();
         program.setUid( programUid );
@@ -282,7 +282,7 @@ class EnrollmentInExistingValidationHookTest
     }
 
     @Test
-    public void shouldPassWhenAnotherEnrollmentAndNotEnrollOnce()
+    void shouldPassWhenAnotherEnrollmentAndNotEnrollOnce()
     {
         Program program = new Program();
         program.setUid( programUid );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -62,7 +62,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EnrollmentNoteValidationHookTest
+class EnrollmentNoteValidationHookTest
 {
 
     // Class under test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -80,7 +80,7 @@ class EnrollmentNoteValidationHookTest
     }
 
     @Test
-    public void testNoteWithExistingUidWarnings()
+    void testNoteWithExistingUidWarnings()
     {
         // Given
         final Note note = rnd.nextObject( Note.class );
@@ -106,7 +106,7 @@ class EnrollmentNoteValidationHookTest
     }
 
     @Test
-    public void testNoteWithExistingUidAndNoTextIsIgnored()
+    void testNoteWithExistingUidAndNoTextIsIgnored()
     {
         // Given
         final Note note = rnd.nextObject( Note.class );
@@ -130,7 +130,7 @@ class EnrollmentNoteValidationHookTest
     }
 
     @Test
-    public void testNotesAreValidWhenUidDoesNotExist()
+    void testNotesAreValidWhenUidDoesNotExist()
     {
         // Given
         final List<Note> notes = rnd.objects( Note.class, 5 ).collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -158,7 +158,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDefaultCoc()
+    void testDefaultCoc()
     {
         // given
         program.setCategoryCombo( defaultCatCombo );
@@ -174,7 +174,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testDefaultCocWithNonDefaultCatCombo()
+    void testDefaultCocWithNonDefaultCatCombo()
     {
         // given
         program.setCategoryCombo( catCombo );
@@ -191,7 +191,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testNoCategoryOptionDates()
+    void testNoCategoryOptionDates()
     {
         // when
         when( validationContext.getCachedEventCategoryOptionCombo( any() ) )
@@ -204,7 +204,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testBetweenCategoryOptionDates()
+    void testBetweenCategoryOptionDates()
     {
         // given
         catOption.setStartDate( ONE_YEAR_BEFORE_EVENT );
@@ -221,7 +221,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testBeforeCategoryOptionStart()
+    void testBeforeCategoryOptionStart()
     {
         // given
         catOption.setStartDate( ONE_YEAR_AFTER_EVENT );
@@ -238,7 +238,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testAfterCategoryOptionEnd()
+    void testAfterCategoryOptionEnd()
     {
         // given
         catOption.setEndDate( ONE_YEAR_BEFORE_EVENT );
@@ -255,7 +255,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testBeforeOpenDaysAfterCoEndDate()
+    void testBeforeOpenDaysAfterCoEndDate()
     {
         // given
         catOption.setEndDate( ONE_YEAR_BEFORE_EVENT );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -68,7 +68,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventCategoryOptValidationHookTest extends DhisConvenienceTest
+class EventCategoryOptValidationHookTest extends DhisConvenienceTest
 {
 
     @Mock

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -116,7 +116,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void successValidationWhenDataElementIsValid()
+    void successValidationWhenDataElementIsValid()
     {
         // Given
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( getDataValue() ) );
@@ -130,7 +130,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void successValidationWhenCreatedAtIsNull()
+    void successValidationWhenCreatedAtIsNull()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -146,7 +146,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenUpdatedAtIsNull()
+    void failValidationWhenUpdatedAtIsNull()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -162,7 +162,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenDataElementIsInvalid()
+    void failValidationWhenDataElementIsInvalid()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -180,7 +180,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenMandatoryDataElementIsNotPresent()
+    void failValidationWhenMandatoryDataElementIsNotPresent()
     {
         // Given
 
@@ -213,7 +213,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failSuccessWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
+    void failSuccessWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
     {
         // Given
         ProgramStage programStage = new ProgramStage();
@@ -244,7 +244,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenDataElementIsNotPresentInProgramStage()
+    void failValidationWhenDataElementIsNotPresentInProgramStage()
     {
         // Given
         ProgramStage programStage = new ProgramStage();
@@ -279,7 +279,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenDataElementValueTypeIsNull()
+    void failValidationWhenDataElementValueTypeIsNull()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -301,7 +301,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenFileResourceIsNull()
+    void failValidationWhenFileResourceIsNull()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -325,7 +325,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void successValidationWhenFileResourceValueIsNullAndDataElementIsNotCompulsory()
+    void successValidationWhenFileResourceValueIsNullAndDataElementIsNotCompulsory()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -351,7 +351,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenFileResourceValueIsNullAndDataElementIsCompulsory()
+    void failValidationWhenFileResourceValueIsNullAndDataElementIsCompulsory()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -382,7 +382,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void validationWhenDataElementValueIsNullAndValidationStrategyOnUpdate()
+    void validationWhenDataElementValueIsNullAndValidationStrategyOnUpdate()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -424,7 +424,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void validationWhenDataElementValueIsNullAndValidationStrategyOnComplete()
+    void validationWhenDataElementValueIsNullAndValidationStrategyOnComplete()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -464,7 +464,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void validationWhenDataElementValueIsNullAndEventStatusSkippedOrScheduled()
+    void validationWhenDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -502,7 +502,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void successValidationWhenDataElementIsNullAndDataElementIsNotCompulsory()
+    void successValidationWhenDataElementIsNullAndDataElementIsNotCompulsory()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -532,7 +532,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenFileResourceIsAlreadyAssigned()
+    void failValidationWhenFileResourceIsAlreadyAssigned()
     {
         // Given
         DataValue validDataValue = getDataValue();
@@ -559,7 +559,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationWhenDataElementValueTypeIsInvalid()
+    void failValidationWhenDataElementValueTypeIsInvalid()
     {
         runAndAssertValidationForDataValue( ValueType.NUMBER, "not_a_number" );
         runAndAssertValidationForDataValue( ValueType.UNIT_INTERVAL, "3" );
@@ -578,7 +578,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void successValidationDataElementOptionValueIsValid()
+    void successValidationDataElementOptionValueIsValid()
     {
         DataValue validDataValue = getDataValue();
         validDataValue.setValue( "code" );
@@ -612,7 +612,7 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    public void failValidationDataElementOptionValueIsInValid()
+    void failValidationDataElementOptionValueIsInValid()
     {
         DataValue validDataValue = getDataValue();
         validDataValue.setDataElement( dataElementUid );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -71,7 +71,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventDataValuesValidationHookTest
+class EventDataValuesValidationHookTest
 {
 
     private EventDataValuesValidationHook hookToTest;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -67,7 +67,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventDateValidationHookTest extends DhisConvenienceTest
+class EventDateValidationHookTest extends DhisConvenienceTest
 {
 
     private static final String PROGRAM_WITH_REGISTRATION_ID = "ProgramWithRegistration";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -98,7 +98,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsValid()
+    void testEventIsValid()
     {
         // given
         Event event = new Event();
@@ -120,7 +120,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenOccurredDateIsNotPresentAndProgramIsWithoutRegistration()
+    void testEventIsNotValidWhenOccurredDateIsNotPresentAndProgramIsWithoutRegistration()
     {
         // given
         Event event = new Event();
@@ -138,7 +138,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsActive()
+    void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsActive()
     {
         // given
         Event event = new Event();
@@ -156,7 +156,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsCompleted()
+    void testEventIsNotValidWhenOccurredDateIsNotPresentAndEventIsCompleted()
     {
         // given
         Event event = new Event();
@@ -174,7 +174,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenScheduledDateIsNotPresentAndEventIsSchedule()
+    void testEventIsNotValidWhenScheduledDateIsNotPresentAndEventIsSchedule()
     {
         // given
         Event event = new Event();
@@ -193,7 +193,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenCompletedAtIsNotPresentAndEventIsCompleted()
+    void testEventIsNotValidWhenCompletedAtIsNotPresentAndEventIsCompleted()
     {
         // given
         Event event = new Event();
@@ -212,7 +212,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenCompletedAtIsTooSoonAndEventIsCompleted()
+    void testEventIsNotValidWhenCompletedAtIsTooSoonAndEventIsCompleted()
     {
         // given
         Event event = new Event();
@@ -232,7 +232,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenOccurredAtAndScheduledAtAreNotPresent()
+    void testEventIsNotValidWhenOccurredAtAndScheduledAtAreNotPresent()
     {
         // given
         Event event = new Event();
@@ -252,7 +252,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testEventIsNotValidWhenDateBelongsToExpiredPeriod()
+    void testEventIsNotValidWhenDateBelongsToExpiredPeriod()
     {
         // given
         Event event = new Event();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -80,7 +80,7 @@ class EventGeoValidationHookTest
     }
 
     @Test
-    public void testGeometryIsValid()
+    void testGeometryIsValid()
     {
         // given
         Event event = new Event();
@@ -97,7 +97,7 @@ class EventGeoValidationHookTest
     }
 
     @Test
-    public void testEventWithNoProgramStageThrowsAnError()
+    void testEventWithNoProgramStageThrowsAnError()
     {
         // given
         Event event = new Event();
@@ -111,7 +111,7 @@ class EventGeoValidationHookTest
     }
 
     @Test
-    public void testProgramStageWithNullFeatureTypeFailsGeometryValidation()
+    void testProgramStageWithNullFeatureTypeFailsGeometryValidation()
     {
         // given
         Event event = new Event();
@@ -131,7 +131,7 @@ class EventGeoValidationHookTest
     }
 
     @Test
-    public void testProgramStageWithFeatureTypeNoneFailsGeometryValidation()
+    void testProgramStageWithFeatureTypeNoneFailsGeometryValidation()
     {
         // given
         Event event = new Event();
@@ -153,7 +153,7 @@ class EventGeoValidationHookTest
     }
 
     @Test
-    public void testProgramStageWithFeatureTypeDifferentFromGeometryFails()
+    void testProgramStageWithFeatureTypeDifferentFromGeometryFails()
     {
         // given
         Event event = new Event();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -55,7 +55,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventGeoValidationHookTest
+class EventGeoValidationHookTest
 {
 
     private static final String PROGRAM_STAGE = "ProgramStage";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -62,7 +62,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventNoteValidationHookTest
+class EventNoteValidationHookTest
 {
 
     // Class under test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -80,7 +80,7 @@ class EventNoteValidationHookTest
     }
 
     @Test
-    public void testNoteWithExistingUidWarnings()
+    void testNoteWithExistingUidWarnings()
     {
         // Given
         final Note note = rnd.nextObject( Note.class );
@@ -106,7 +106,7 @@ class EventNoteValidationHookTest
     }
 
     @Test
-    public void testNoteWithExistingUidAndNoTextIsIgnored()
+    void testNoteWithExistingUidAndNoTextIsIgnored()
     {
         // Given
         final Note note = rnd.nextObject( Note.class );
@@ -130,7 +130,7 @@ class EventNoteValidationHookTest
     }
 
     @Test
-    public void testNotesAreValidWhenUidDoesNotExist()
+    void testNotesAreValidWhenUidDoesNotExist()
     {
         // Given
         final List<Note> notes = rnd.objects( Note.class, 5 ).collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -217,7 +217,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEnrollment()
+    void verifyValidationSuccessForEnrollment()
     {
         setupEnrollments();
         Enrollment enrollment = Enrollment.builder()
@@ -235,7 +235,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEnrollmentIsNotARegistration()
+    void verifyValidationFailsWhenEnrollmentIsNotARegistration()
     {
         setupEnrollments();
         Enrollment enrollment = Enrollment.builder()
@@ -254,7 +254,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEnrollmentAndProgramOrganisationUnitDontMatch()
+    void verifyValidationFailsWhenEnrollmentAndProgramOrganisationUnitDontMatch()
     {
         setupEnrollments();
         Enrollment enrollment = Enrollment.builder()
@@ -273,7 +273,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEnrollmentAndProgramTeiTypeDontMatch()
+    void verifyValidationFailsWhenEnrollmentAndProgramTeiTypeDontMatch()
     {
         setupEnrollments();
         Enrollment enrollment = Enrollment.builder()
@@ -292,7 +292,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEnrollmentAndProgramTeiTypeDontMatchAndTEIIsInPayload()
+    void verifyValidationFailsWhenEnrollmentAndProgramTeiTypeDontMatchAndTEIIsInPayload()
     {
         setupEnrollments();
         Enrollment enrollment = Enrollment.builder()
@@ -320,7 +320,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEvent()
+    void verifyValidationSuccessForEvent()
     {
         setupForEvents();
         Event event = Event.builder()
@@ -339,7 +339,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEventAndProgramStageProgramDontMatch()
+    void verifyValidationFailsWhenEventAndProgramStageProgramDontMatch()
     {
         setupForEvents();
         Event event = Event.builder()
@@ -360,7 +360,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenProgramIsRegistrationAndEnrollmentIsMissing()
+    void verifyValidationFailsWhenProgramIsRegistrationAndEnrollmentIsMissing()
     {
         setupForEvents();
         Event event = Event.builder()
@@ -381,7 +381,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEventAndEnrollmentProgramDontMatch()
+    void verifyValidationFailsWhenEventAndEnrollmentProgramDontMatch()
     {
         setupForEvents();
         Event event = Event.builder()
@@ -403,7 +403,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenEventAndProgramOrganisationUnitDontMatch()
+    void verifyValidationFailsWhenEventAndProgramOrganisationUnitDontMatch()
     {
         setupForEvents();
         Event event = Event.builder()
@@ -425,7 +425,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsWhenLinkedTrackedEntityIsNotFound()
+    void verifyValidationFailsWhenLinkedTrackedEntityIsNotFound()
     {
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
 
@@ -457,7 +457,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessWhenLinkedTrackedEntityIsFound()
+    void verifyValidationSuccessWhenLinkedTrackedEntityIsFound()
     {
 
         TrackedEntityInstance validTrackedEntity = new TrackedEntityInstance();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -83,7 +83,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
+class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 {
 
     private static final String PROGRAM_WITHOUT_REGISTRATION_ID = "PROGRAM_WITHOUT_REGISTRATION_ID";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -121,7 +121,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationSuccessWhenIsCreateAndTeiIsNotPresent()
+    void verifyTrackedEntityValidationSuccessWhenIsCreateAndTeiIsNotPresent()
     {
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder()
@@ -139,7 +139,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationSuccessWhenTeiIsNotPresent()
+    void verifyTrackedEntityValidationSuccessWhenTeiIsNotPresent()
     {
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder()
@@ -155,7 +155,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationSuccessWhenIsUpdate()
+    void verifyTrackedEntityValidationSuccessWhenIsUpdate()
     {
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder()
@@ -171,7 +171,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsWhenIsSoftDeleted()
+    void verifyTrackedEntityValidationFailsWhenIsSoftDeleted()
     {
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder()
@@ -188,7 +188,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsWhenIsCreateAndTEIIsAlreadyPresent()
+    void verifyTrackedEntityValidationFailsWhenIsCreateAndTEIIsAlreadyPresent()
     {
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder()
@@ -207,7 +207,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsWhenIsUpdateAndTEIIsNotPresent()
+    void verifyTrackedEntityValidationFailsWhenIsUpdateAndTEIIsNotPresent()
     {
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder()
@@ -226,7 +226,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccessWhenIsCreateAndEnrollmentIsNotPresent()
+    void verifyEnrollmentValidationSuccessWhenIsCreateAndEnrollmentIsNotPresent()
     {
         // given
         Enrollment enrollment = Enrollment.builder()
@@ -244,7 +244,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccessWhenEnrollmentIsNotPresent()
+    void verifyEnrollmentValidationSuccessWhenEnrollmentIsNotPresent()
     {
         // given
         Enrollment enrollment = Enrollment.builder()
@@ -260,7 +260,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccessWhenIsUpdate()
+    void verifyEnrollmentValidationSuccessWhenIsUpdate()
     {
         // given
         Enrollment enrollment = Enrollment.builder()
@@ -276,7 +276,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenIsSoftDeleted()
+    void verifyEnrollmentValidationFailsWhenIsSoftDeleted()
     {
         // given
         Enrollment enrollment = Enrollment.builder()
@@ -293,7 +293,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenIsCreateAndEnrollmentIsAlreadyPresent()
+    void verifyEnrollmentValidationFailsWhenIsCreateAndEnrollmentIsAlreadyPresent()
     {
         // given
         Enrollment enrollment = Enrollment.builder()
@@ -312,7 +312,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenIsUpdateAndEnrollmentIsNotPresent()
+    void verifyEnrollmentValidationFailsWhenIsUpdateAndEnrollmentIsNotPresent()
     {
         // given
         Enrollment enrollment = Enrollment.builder()
@@ -331,7 +331,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationSuccessWhenIsCreateAndEventIsNotPresent()
+    void verifyEventValidationSuccessWhenIsCreateAndEventIsNotPresent()
     {
         // given
         Event event = Event.builder()
@@ -349,7 +349,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationSuccessWhenEventIsNotPresent()
+    void verifyEventValidationSuccessWhenEventIsNotPresent()
     {
         // given
         Event event = Event.builder()
@@ -365,7 +365,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationSuccessWhenIsUpdate()
+    void verifyEventValidationSuccessWhenIsUpdate()
     {
         // given
         Event event = Event.builder()
@@ -381,7 +381,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenIsSoftDeleted()
+    void verifyEventValidationFailsWhenIsSoftDeleted()
     {
         // given
         Event event = Event.builder()
@@ -398,7 +398,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenIsCreateAndEventIsAlreadyPresent()
+    void verifyEventValidationFailsWhenIsCreateAndEventIsAlreadyPresent()
     {
         // given
         Event event = Event.builder()
@@ -417,7 +417,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenIsUpdateAndEventIsNotPresent()
+    void verifyEventValidationFailsWhenIsUpdateAndEventIsNotPresent()
     {
         // given
         Event event = Event.builder()
@@ -436,7 +436,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationSuccessWhenIsCreate()
+    void verifyRelationshipValidationSuccessWhenIsCreate()
     {
         // given
         Relationship rel = Relationship.builder()
@@ -453,7 +453,7 @@ class PreCheckExistenceValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationFailsWhenUpdate()
+    void verifyRelationshipValidationFailsWhenUpdate()
     {
         // given
         Relationship rel = getPayloadRelationship();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -69,7 +69,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class PreCheckExistenceValidationHookTest
+class PreCheckExistenceValidationHookTest
 {
 
     private PreCheckExistenceValidationHook validationHook;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -62,7 +62,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class PreCheckMandatoryFieldsValidationHookTest
+class PreCheckMandatoryFieldsValidationHookTest
 {
 
     private PreCheckMandatoryFieldsValidationHook validationHook;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -88,7 +88,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationSuccess()
+    void verifyTrackedEntityValidationSuccess()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntityType( CodeGenerator.generateUid() )
@@ -102,7 +102,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsOnMissingOrgUnit()
+    void verifyTrackedEntityValidationFailsOnMissingOrgUnit()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntityType( CodeGenerator.generateUid() )
@@ -116,7 +116,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsOnMissingTrackedEntityType()
+    void verifyTrackedEntityValidationFailsOnMissingTrackedEntityType()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntityType( null )
@@ -130,7 +130,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccess()
+    void verifyEnrollmentValidationSuccess()
     {
         Enrollment enrollment = Enrollment.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -145,7 +145,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsOnMissingTrackedEntity()
+    void verifyEnrollmentValidationFailsOnMissingTrackedEntity()
     {
         Enrollment enrollment = Enrollment.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -160,7 +160,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsOnMissingProgram()
+    void verifyEnrollmentValidationFailsOnMissingProgram()
     {
         Enrollment enrollment = Enrollment.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -175,7 +175,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsOnMissingOrgUnit()
+    void verifyEnrollmentValidationFailsOnMissingOrgUnit()
     {
         Enrollment enrollment = Enrollment.builder()
             .orgUnit( null )
@@ -190,7 +190,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationSuccess()
+    void verifyEventValidationSuccess()
     {
         Event event = Event.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -205,7 +205,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsOnMissingProgram()
+    void verifyEventValidationFailsOnMissingProgram()
     {
         Event event = Event.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -220,7 +220,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsOnMissingProgramStageReferenceToProgram()
+    void verifyEventValidationFailsOnMissingProgramStageReferenceToProgram()
     {
         Event event = Event.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -239,7 +239,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsOnMissingProgramStage()
+    void verifyEventValidationFailsOnMissingProgramStage()
     {
         Event event = Event.builder()
             .orgUnit( CodeGenerator.generateUid() )
@@ -254,7 +254,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsOnMissingOrgUnit()
+    void verifyEventValidationFailsOnMissingOrgUnit()
     {
         Event event = Event.builder()
             .orgUnit( null )
@@ -269,7 +269,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationSuccess()
+    void verifyRelationshipValidationSuccess()
     {
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
@@ -289,7 +289,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationFailsOnMissingFrom()
+    void verifyRelationshipValidationFailsOnMissingFrom()
     {
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
@@ -306,7 +306,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationFailsOnMissingTo()
+    void verifyRelationshipValidationFailsOnMissingTo()
     {
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
@@ -323,7 +323,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationFailsOnMissingRelationshipType()
+    void verifyRelationshipValidationFailsOnMissingRelationshipType()
     {
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -69,7 +69,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Enrico Colasante
  */
 @ExtendWith( MockitoExtension.class )
-public class PreCheckMetaValidationHookTest
+class PreCheckMetaValidationHookTest
 {
 
     private static final String ORG_UNIT_UID = "OrgUnitUid";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -100,7 +100,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationSuccess()
+    void verifyTrackedEntityValidationSuccess()
     {
         // given
         TrackedEntity tei = validTei();
@@ -118,7 +118,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsWhenOrgUnitIsNotPresentInDb()
+    void verifyTrackedEntityValidationFailsWhenOrgUnitIsNotPresentInDb()
     {
         // given
         TrackedEntity tei = validTei();
@@ -136,7 +136,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsWhenTrackedEntityTypeIsNotPresentInDb()
+    void verifyTrackedEntityValidationFailsWhenTrackedEntityTypeIsNotPresentInDb()
     {
         // given
         TrackedEntity tei = validTei();
@@ -154,7 +154,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccess()
+    void verifyEnrollmentValidationSuccess()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -173,7 +173,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccessWhenTeiIsInPayload()
+    void verifyEnrollmentValidationSuccessWhenTeiIsInPayload()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -193,7 +193,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenOrgUnitIsNotPresentInDb()
+    void verifyEnrollmentValidationFailsWhenOrgUnitIsNotPresentInDb()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -212,7 +212,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenTrackedEntityIsNotPresentInDbOrPayload()
+    void verifyEnrollmentValidationFailsWhenTrackedEntityIsNotPresentInDbOrPayload()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -231,7 +231,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenProgramIsNotPresentInDb()
+    void verifyEnrollmentValidationFailsWhenProgramIsNotPresentInDb()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -250,7 +250,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationSuccess()
+    void verifyEventValidationSuccess()
     {
         // given
         Event event = validEvent();
@@ -269,7 +269,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenProgramIsNotPresentInDb()
+    void verifyEventValidationFailsWhenProgramIsNotPresentInDb()
     {
         // given
         Event event = validEvent();
@@ -288,7 +288,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenProgramStageIsNotPresentInDb()
+    void verifyEventValidationFailsWhenProgramStageIsNotPresentInDb()
     {
         // given
         Event event = validEvent();
@@ -307,7 +307,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenOrgUnitIsNotPresentInDb()
+    void verifyEventValidationFailsWhenOrgUnitIsNotPresentInDb()
     {
         // given
         Event event = validEvent();
@@ -326,7 +326,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationSuccess()
+    void verifyRelationshipValidationSuccess()
     {
         // given
         Relationship relationship = validRelationship();
@@ -343,7 +343,7 @@ class PreCheckMetaValidationHookTest
     }
 
     @Test
-    public void verifyRelationshipValidationFailsWhenRelationshipTypeIsNotPresentInDb()
+    void verifyRelationshipValidationFailsWhenRelationshipTypeIsNotPresentInDb()
     {
         // given
         Relationship relationship = validRelationship();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -77,7 +77,7 @@ import com.google.common.collect.Sets;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
+class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 {
 
     private static final String ORG_UNIT_ID = "ORG_UNIT_ID";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -143,7 +143,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForTrackedEntity()
+    void verifyValidationSuccessForTrackedEntity()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( CodeGenerator.generateUid() )
@@ -162,7 +162,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForTrackedEntityWithNoProgramInstancesUsingDeleteStrategy()
+    void verifyValidationSuccessForTrackedEntityWithNoProgramInstancesUsingDeleteStrategy()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -182,7 +182,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyCaptureScopeIsCheckedForTrackedEntityCreation()
+    void verifyCaptureScopeIsCheckedForTrackedEntityCreation()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -203,7 +203,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifySearchScopeIsCheckedForTrackedEntityUpdation()
+    void verifySearchScopeIsCheckedForTrackedEntityUpdation()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -225,7 +225,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifySearchScopeIsCheckedForTrackedEntityDeletion()
+    void verifySearchScopeIsCheckedForTrackedEntityDeletion()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -247,7 +247,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForTrackedEntityWithDeletedProgramInstancesUsingDeleteStrategy()
+    void verifyValidationSuccessForTrackedEntityWithDeletedProgramInstancesUsingDeleteStrategy()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -267,7 +267,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForTrackedEntityUsingDeleteStrategyAndUserWithCascadeAuthority()
+    void verifyValidationSuccessForTrackedEntityUsingDeleteStrategyAndUserWithCascadeAuthority()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -288,7 +288,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsForTrackedEntityUsingDeleteStrategyAndUserWithoutCascadeAuthority()
+    void verifyValidationFailsForTrackedEntityUsingDeleteStrategyAndUserWithoutCascadeAuthority()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -309,7 +309,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEnrollment()
+    void verifyValidationSuccessForEnrollment()
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -331,7 +331,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyCaptureScopeIsCheckedForEnrollmentCreation()
+    void verifyCaptureScopeIsCheckedForEnrollmentCreation()
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -354,7 +354,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyCaptureScopeIsCheckedForEnrollmentDeletion()
+    void verifyCaptureScopeIsCheckedForEnrollmentDeletion()
     {
         String enrollmentUid = CodeGenerator.generateUid();
         Enrollment enrollment = Enrollment.builder()
@@ -379,7 +379,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyCaptureScopeIsCheckedForEnrollmentProgramWithoutRegistration()
+    void verifyCaptureScopeIsCheckedForEnrollmentProgramWithoutRegistration()
     {
         program.setProgramType( ProgramType.WITHOUT_REGISTRATION );
 
@@ -406,7 +406,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEnrollmentWithoutEventsUsingDeleteStrategy()
+    void verifyValidationSuccessForEnrollmentWithoutEventsUsingDeleteStrategy()
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -429,7 +429,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEnrollmentUsingDeleteStrategyAndUserWithCascadeAuthority()
+    void verifyValidationSuccessForEnrollmentUsingDeleteStrategyAndUserWithCascadeAuthority()
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -453,7 +453,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsForEnrollmentUsingDeleteStrategyAndUserWithoutCascadeAuthority()
+    void verifyValidationFailsForEnrollmentUsingDeleteStrategyAndUserWithoutCascadeAuthority()
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -477,7 +477,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEventUsingDeleteStrategy()
+    void verifyValidationSuccessForEventUsingDeleteStrategy()
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -502,7 +502,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForNonTrackerEventUsingCreateStrategy()
+    void verifyValidationSuccessForNonTrackerEventUsingCreateStrategy()
     {
         program.setProgramType( ProgramType.WITHOUT_REGISTRATION );
         Event event = Event.builder()
@@ -526,7 +526,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForTrackerEventCreation()
+    void verifyValidationSuccessForTrackerEventCreation()
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -552,7 +552,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForTrackerEventUpdation()
+    void verifyValidationSuccessForTrackerEventUpdation()
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -576,7 +576,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEventUsingUpdateStrategy()
+    void verifyValidationSuccessForEventUsingUpdateStrategy()
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -601,7 +601,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationSuccessForEventUsingUpdateStrategyAndUserWithAuthority()
+    void verifyValidationSuccessForEventUsingUpdateStrategyAndUserWithAuthority()
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
@@ -627,7 +627,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void verifyValidationFailsForEventUsingUpdateStrategyAndUserWithoutAuthority()
+    void verifyValidationFailsForEventUsingUpdateStrategyAndUserWithoutAuthority()
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -105,7 +105,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationSuccess()
+    void verifyTrackedEntityValidationSuccess()
     {
         // given
         TrackedEntity trackedEntity = validTei();
@@ -119,7 +119,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyTrackedEntityValidationFailsWhenUpdateTrackedEntityType()
+    void verifyTrackedEntityValidationFailsWhenUpdateTrackedEntityType()
     {
         // given
         TrackedEntity trackedEntity = validTei();
@@ -135,7 +135,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationSuccess()
+    void verifyEnrollmentValidationSuccess()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -149,7 +149,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenUpdateProgram()
+    void verifyEnrollmentValidationFailsWhenUpdateProgram()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -166,7 +166,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEnrollmentValidationFailsWhenUpdateTrackedEntity()
+    void verifyEnrollmentValidationFailsWhenUpdateTrackedEntity()
     {
         // given
         Enrollment enrollment = validEnrollment();
@@ -183,7 +183,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationSuccess()
+    void verifyEventValidationSuccess()
     {
         // given
         Event event = validEvent();
@@ -197,7 +197,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenUpdateProgramStage()
+    void verifyEventValidationFailsWhenUpdateProgramStage()
     {
         // given
         Event event = validEvent();
@@ -214,7 +214,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     }
 
     @Test
-    public void verifyEventValidationFailsWhenUpdateEnrollment()
+    void verifyEventValidationFailsWhenUpdateEnrollment()
     {
         // given
         Event event = validEvent();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -64,7 +64,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class PreCheckUpdatableFieldsValidationHookTest
+class PreCheckUpdatableFieldsValidationHookTest
 {
 
     private final static String TRACKED_ENTITY_TYPE_ID = "TrackedEntityTypeId";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -101,7 +101,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnInvalidRelationshipType()
+    void verifyValidationFailsOnInvalidRelationshipType()
     {
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
@@ -122,7 +122,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnFromWithMultipleDataset()
+    void verifyValidationFailsOnFromWithMultipleDataset()
     {
         String relationshipUid = "nBx6auGDUHG";
         Relationship relationship = Relationship.builder()
@@ -156,7 +156,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnFromWithNoDataset()
+    void verifyValidationFailsOnFromWithNoDataset()
     {
         String relationshipUid = "nBx6auGDUHG";
         Relationship relationship = Relationship.builder()
@@ -188,7 +188,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnToWithMultipleDataset()
+    void verifyValidationFailsOnToWithMultipleDataset()
     {
         String relationshipUid = "nBx6auGDUHG";
         Relationship relationship = Relationship.builder()
@@ -222,7 +222,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnInvalidToConstraint()
+    void verifyValidationFailsOnInvalidToConstraint()
     {
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
 
@@ -250,7 +250,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnInvalidToConstraintOfTypeProgramStage()
+    void verifyValidationFailsOnInvalidToConstraintOfTypeProgramStage()
     {
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, PROGRAM_STAGE_INSTANCE );
 
@@ -278,7 +278,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnInvalidFromConstraint()
+    void verifyValidationFailsOnInvalidFromConstraint()
     {
         RelationshipType relType = createRelTypeConstraint( PROGRAM_INSTANCE, TRACKED_ENTITY_INSTANCE );
 
@@ -306,7 +306,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnInvalidToTrackedEntityType()
+    void verifyValidationFailsOnInvalidToTrackedEntityType()
     {
         RelationshipType relType = createRelTypeConstraint( PROGRAM_INSTANCE, TRACKED_ENTITY_INSTANCE );
         String trackedEntityUid = CodeGenerator.generateUid();
@@ -349,7 +349,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsOnInvalidFromTrackedEntityType()
+    void verifyValidationFailsOnInvalidFromTrackedEntityType()
     {
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, PROGRAM_INSTANCE );
         String trackedEntityUid = CodeGenerator.generateUid();
@@ -393,7 +393,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationFailsWhenParentObjectFailed()
+    void verifyValidationFailsWhenParentObjectFailed()
     {
         reporter = new ValidationErrorReporter( ctx );
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
@@ -435,7 +435,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyValidationSuccessWhenSomeObjectsFailButNoParentObject()
+    void verifyValidationSuccessWhenSomeObjectsFailButNoParentObject()
     {
         reporter = new ValidationErrorReporter( ctx );
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
@@ -471,7 +471,7 @@ class RelationshipsValidationHookTest
     }
 
     @Test
-    public void verifyFailAuto()
+    void verifyFailAuto()
     {
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
         String uid = CodeGenerator.generateUid();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -73,7 +73,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class RelationshipsValidationHookTest
+class RelationshipsValidationHookTest
 {
 
     private RelationshipsValidationHook validationHook;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -109,7 +109,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testSingleEventIsPassingValidation()
+    void testSingleEventIsPassingValidation()
     {
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ) );
         bundle.setEvents( events );
@@ -121,7 +121,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testOneEventInNotRepeatableProgramStageAndOneAlreadyOnDBAreNotPassingValidation()
+    void testOneEventInNotRepeatableProgramStageAndOneAlreadyOnDBAreNotPassingValidation()
     {
         // given
         Event event = notRepeatableEvent( "A" );
@@ -146,7 +146,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTwoEventInNotRepeatableProgramStageAreNotPassingValidation()
+    void testTwoEventInNotRepeatableProgramStageAreNotPassingValidation()
     {
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ), notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
@@ -166,7 +166,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTwoEventInRepeatableProgramStageArePassingValidation()
+    void testTwoEventInRepeatableProgramStageArePassingValidation()
     {
         List<Event> events = Lists.newArrayList( repeatableEvent( "A" ), repeatableEvent( "B" ) );
         bundle.setEvents( events );
@@ -178,7 +178,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTwoEventsInNotRepeatableProgramStageWhenOneIsInvalidArePassingValidation()
+    void testTwoEventsInNotRepeatableProgramStageWhenOneIsInvalidArePassingValidation()
     {
         Event invalidEvent = notRepeatableEvent( "A" );
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
@@ -192,7 +192,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTwoEventsInNotRepeatableProgramStageButInDifferentEnrollmentsArePassingValidation()
+    void testTwoEventsInNotRepeatableProgramStageButInDifferentEnrollmentsArePassingValidation()
     {
         Event eventEnrollmentA = notRepeatableEvent( "A" );
         Event eventEnrollmentB = notRepeatableEvent( "B" );
@@ -207,7 +207,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
-    public void testTwoProgramEventsInSameProgramStageArePassingValidation()
+    void testTwoProgramEventsInSameProgramStageArePassingValidation()
     {
         Event eventProgramA = programEvent( "A" );
         Event eventProgramB = programEvent( "B" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -65,7 +65,7 @@ import com.google.common.collect.Lists;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class RepeatedEventsValidationHookTest extends DhisConvenienceTest
+class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 {
 
     private final static String NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION = "NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -66,7 +66,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class TrackedEntityAttributeValidationHookTest
+class TrackedEntityAttributeValidationHookTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -90,7 +90,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldPassValidation()
+    void shouldPassValidation()
     {
         TrackedEntityAttribute trackedEntityAttribute = new TrackedEntityAttribute();
         trackedEntityAttribute.setUid( "uid" );
@@ -114,7 +114,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValidationMandatoryFields()
+    void shouldFailValidationMandatoryFields()
     {
         String tet = "tet";
 
@@ -153,7 +153,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValidationMissingTea()
+    void shouldFailValidationMissingTea()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .attributes( Arrays.asList( Attribute.builder().attribute( "aaaaa" ).build(),
@@ -174,7 +174,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailMissingAttributeValue()
+    void shouldFailMissingAttributeValue()
     {
         String tea = "tea";
         String tet = "tet";
@@ -208,7 +208,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValueTooLong()
+    void shouldFailValueTooLong()
     {
         ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
 
@@ -231,7 +231,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailDataValueIsValid()
+    void shouldFailDataValueIsValid()
     {
         ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
 
@@ -247,7 +247,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailEncryptionStatus()
+    void shouldFailEncryptionStatus()
     {
         when( trackedEntityAttribute.isConfidentialBool() ).thenReturn( true );
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.AGE );
@@ -270,7 +270,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailOptionSetNotValid()
+    void shouldFailOptionSetNotValid()
     {
         TrackedEntityAttribute trackedEntityAttribute = getTrackedEntityAttributeWithOptionSet();
 
@@ -294,7 +294,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldPassValidationValueInOptionSet()
+    void shouldPassValidationValueInOptionSet()
     {
         TrackedEntityAttribute trackedEntityAttribute = getTrackedEntityAttributeWithOptionSet();
 
@@ -316,7 +316,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldPassValidationWhenValueIsNullAndAttributeIsNotMandatory()
+    void shouldPassValidationWhenValueIsNullAndAttributeIsNotMandatory()
     {
         TrackedEntityTypeAttribute trackedEntityTypeAttribute = new TrackedEntityTypeAttribute();
 
@@ -347,7 +347,7 @@ class TrackedEntityAttributeValidationHookTest
     }
 
     @Test
-    public void shouldFailValidationWhenValueIsNullAndAttributeIsMandatory()
+    void shouldFailValidationWhenValueIsNullAndAttributeIsMandatory()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .attributes(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackerValidationHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackerValidationHookServiceTest.java
@@ -47,7 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith( MockitoExtension.class )
-public class TrackerValidationHookServiceTest
+class TrackerValidationHookServiceTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackerValidationHookServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackerValidationHookServiceTest.java
@@ -54,7 +54,7 @@ class TrackerValidationHookServiceTest
     private TrackerValidationHookService trackerValidationHookService;
 
     @Test
-    public void shouldSortList()
+    void shouldSortList()
     {
         ReflectionTestUtils.setField( trackerValidationHookService, "validationOrder",
             Arrays.asList( PreCheckUidValidationHook.class, EnrollmentAttributeValidationHook.class,
@@ -85,7 +85,7 @@ class TrackerValidationHookServiceTest
     }
 
     @Test
-    public void shouldFilterRuleEngineValidationHooks()
+    void shouldFilterRuleEngineValidationHooks()
     {
         ReflectionTestUtils.setField( trackerValidationHookService, "ruleEngineValidationHooks",
             Arrays.asList( EnrollmentRuleValidationHook.class, EventRuleValidationHook.class ) );

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceValidationTest.java
@@ -97,7 +97,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testSuccessfulValidation()
+    void testSuccessfulValidation()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withDataElements( Lists.newArrayList( deA, deB, deC ) )
@@ -109,7 +109,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testErrorValidation()
+    void testErrorValidation()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withDataElements( Lists.newArrayList( deA, deB, deC ) )
@@ -121,7 +121,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testErrorNoDataElements()
+    void testErrorNoDataElements()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withStartEndDate( getDate( 2020, 1, 1 ), getDate( 2020, 7, 1 ) )
@@ -132,7 +132,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testErrorStartAfterEndDates()
+    void testErrorStartAfterEndDates()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withDataElements( Lists.newArrayList( deA, deB, deC ) )
@@ -144,7 +144,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testErrorNegativeThreshold()
+    void testErrorNegativeThreshold()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withDataElements( Lists.newArrayList( deA, deB, deC ) )
@@ -157,7 +157,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testErrorNegativeMaxResults()
+    void testErrorNegativeMaxResults()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withDataElements( Lists.newArrayList( deA, deB, deC ) )
@@ -170,7 +170,7 @@ class OutlierDetectionServiceValidationTest
     }
 
     @Test
-    public void testErrorDataStartDateAfterDataEndDate()
+    void testErrorDataStartDateAfterDataEndDate()
     {
         OutlierDetectionRequest request = new OutlierDetectionRequest.Builder()
             .withDataElements( Lists.newArrayList( deA, deB, deC ) )

--- a/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/test/java/org/hisp/dhis/outlierdetection/service/OutlierDetectionServiceValidationTest.java
@@ -55,7 +55,7 @@ import com.google.common.collect.Lists;
  * @author Lars Helge Overland
  */
 @ExtendWith( MockitoExtension.class )
-public class OutlierDetectionServiceValidationTest
+class OutlierDetectionServiceValidationTest
 {
 
     @Mock

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/AuditManagerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/AuditManagerTest.java
@@ -46,7 +46,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class AuditManagerTest
+class AuditManagerTest
 {
     private AuditManager auditManager;
 

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/AuditManagerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/AuditManagerTest.java
@@ -74,7 +74,7 @@ class AuditManagerTest
     }
 
     @Test
-    public void testCollectAuditAttributes()
+    void testCollectAuditAttributes()
     {
         DataElement dataElement = new DataElement();
         dataElement.setUid( "DataElementUID" );

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
@@ -75,7 +75,7 @@ class AuditMatrixConfigurerTest
     }
 
     @Test
-    public void verifyConfigurationForMatrixIsIngested()
+    void verifyConfigurationForMatrixIsIngested()
     {
         when( config.getProperty( ConfigurationKey.AUDIT_METADATA_MATRIX ) ).thenReturn( "READ;" );
         when( config.getProperty( ConfigurationKey.AUDIT_TRACKER_MATRIX ) ).thenReturn( "CREATE;READ;UPDATE;DELETE" );
@@ -97,7 +97,7 @@ class AuditMatrixConfigurerTest
     }
 
     @Test
-    public void allDisabled()
+    void allDisabled()
     {
         when( config.getProperty( ConfigurationKey.AUDIT_METADATA_MATRIX ) ).thenReturn( "DISABLED" );
         when( config.getProperty( ConfigurationKey.AUDIT_TRACKER_MATRIX ) ).thenReturn( "DISABLED" );
@@ -111,7 +111,7 @@ class AuditMatrixConfigurerTest
     }
 
     @Test
-    public void verifyInvalidConfigurationIsIgnored()
+    void verifyInvalidConfigurationIsIgnored()
     {
         when( config.getProperty( ConfigurationKey.AUDIT_METADATA_MATRIX ) ).thenReturn( "READX;UPDATE" );
 
@@ -121,7 +121,7 @@ class AuditMatrixConfigurerTest
     }
 
     @Test
-    public void verifyDefaultAuditingConfiguration()
+    void verifyDefaultAuditingConfiguration()
     {
         matrix = this.subject.configure();
         assertMatrixDisabled( METADATA, READ );

--- a/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/test/java/org/hisp/dhis/artemis/audit/configuration/AuditMatrixConfigurerTest.java
@@ -59,7 +59,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class AuditMatrixConfigurerTest
+class AuditMatrixConfigurerTest
 {
     @Mock
     private DhisConfigurationProvider config;

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
@@ -51,7 +51,7 @@ import org.springframework.mock.env.MockEnvironment;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class HibernateDatabaseInfoProviderTest
+class HibernateDatabaseInfoProviderTest
 {
 
     @Mock

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
@@ -74,9 +74,9 @@ class HibernateDatabaseInfoProviderTest
         provider = new HibernateDatabaseInfoProvider( config, jdbcTemplate, environment );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void init()
+    @Test
+    void init()
         throws SQLException
     {
         Mockito.when( jdbcTemplate.queryForObject( Mockito.eq( "select 'checking db connection';" ),

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationLoggerUtilTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationLoggerUtilTest.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
  * @author Luca Cambi <luca@dhis2.org>
  */
 @ExtendWith( MockitoExtension.class )
-public class NotificationLoggerUtilTest
+class NotificationLoggerUtilTest
 {
 
     @Mock

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationLoggerUtilTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationLoggerUtilTest.java
@@ -49,7 +49,7 @@ class NotificationLoggerUtilTest
     private static String logMessage = "logMessage";
 
     @Test
-    public void shouldLogDebugLevel()
+    void shouldLogDebugLevel()
     {
 
         NotificationLoggerUtil.log( logger, NotificationLevel.DEBUG, logMessage );
@@ -61,7 +61,7 @@ class NotificationLoggerUtilTest
     }
 
     @Test
-    public void shouldLogInfoLevel()
+    void shouldLogInfoLevel()
     {
 
         NotificationLoggerUtil.log( logger, NotificationLevel.INFO, logMessage );
@@ -73,7 +73,7 @@ class NotificationLoggerUtilTest
     }
 
     @Test
-    public void shouldLogWarnLevel()
+    void shouldLogWarnLevel()
     {
 
         NotificationLoggerUtil.log( logger, NotificationLevel.WARN, logMessage );
@@ -85,7 +85,7 @@ class NotificationLoggerUtilTest
     }
 
     @Test
-    public void shouldLogErrorLevel()
+    void shouldLogErrorLevel()
     {
 
         NotificationLoggerUtil.log( logger, NotificationLevel.ERROR, logMessage );

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/MathUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/MathUtilsTest.java
@@ -281,7 +281,7 @@ class MathUtilsTest
     }
 
     @Test
-    public void testGetRounded()
+    void testGetRounded()
     {
         assertEquals( 10, MathUtils.getRounded( 10.00 ), DELTA );
         assertEquals( 10, MathUtils.getRounded( 10 ), DELTA );
@@ -293,7 +293,7 @@ class MathUtilsTest
     }
 
     @Test
-    public void testRoundToSignificantDigits()
+    void testRoundToSignificantDigits()
     {
         assertEquals( 0.1, MathUtils.roundToSignificantDigits( .1357, 1 ), DELTA );
         assertEquals( 0.14, MathUtils.roundToSignificantDigits( .1357, 2 ), DELTA );
@@ -317,7 +317,7 @@ class MathUtilsTest
     }
 
     @Test
-    public void testRoundFraction()
+    void testRoundFraction()
     {
         assertEquals( 1.0, MathUtils.roundFraction( 1.357, 1 ), DELTA );
         assertEquals( 1.4, MathUtils.roundFraction( 1.357, 2 ), DELTA );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
@@ -72,7 +72,7 @@ class RequestIdentifierFilterTest
     }
 
     @Test
-    public void testIsDisabled()
+    void testIsDisabled()
         throws ServletException,
         IOException
     {
@@ -83,7 +83,7 @@ class RequestIdentifierFilterTest
     }
 
     @Test
-    public void testIsEnabled()
+    void testIsEnabled()
         throws ServletException,
         IOException
     {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/servlet/filter/RequestIdentifierFilterTest.java
@@ -57,7 +57,7 @@ import org.slf4j.MDC;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class RequestIdentifierFilterTest
+class RequestIdentifierFilterTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
@@ -35,7 +35,7 @@ import org.hisp.dhis.webapi.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.http.HttpStatus;
 
-public abstract class AbstractDataValueControllerTest extends DhisControllerConvenienceTest
+abstract class AbstractDataValueControllerTest extends DhisControllerConvenienceTest
 {
 
     protected String dataElementId;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -56,7 +56,7 @@ import com.google.common.net.HttpHeaders;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class DashboardControllerTest
+class DashboardControllerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -78,14 +78,14 @@ class DashboardControllerTest
     private DashboardController controller;
 
     @Test
-    public void getWithDependencies()
+    void getWithDependencies()
         throws Exception
     {
         getWithDependencies( false );
     }
 
     @Test
-    public void getWithDependenciesAsDownload()
+    void getWithDependenciesAsDownload()
         throws Exception
     {
         getWithDependencies( true );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerMockTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerMockTest.java
@@ -55,7 +55,7 @@ import com.google.common.net.HttpHeaders;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class DataSetControllerMockTest
+class DataSetControllerMockTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerMockTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerMockTest.java
@@ -74,16 +74,17 @@ class DataSetControllerMockTest
     private DataSetController controller;
 
     @Test
-    public void getWithDependencies()
+    void getWithDependencies()
         throws Exception
     {
         getWithDependencies( false );
     }
 
     @Test
-    public void getWithDependenciesAsDownload()
+    void getWithDependenciesAsDownload()
         throws Exception
     {
+
         getWithDependencies( true );
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
@@ -62,7 +62,7 @@ class FileResourceControllerMockTest
     private FileResourceUtils fileResourceUtils;
 
     @Test
-    public void testGetOrgUnitImage()
+    void testGetOrgUnitImage()
         throws WebMessageException,
         IOException
     {
@@ -80,7 +80,7 @@ class FileResourceControllerMockTest
     }
 
     @Test
-    public void testGetDataValue()
+    void testGetDataValue()
     {
         controller = new FileResourceController( fileResourceService, fileResourceUtils );
         FileResource fileResource = new FileResource();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerMockTest.java
@@ -47,7 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 @ExtendWith( MockitoExtension.class )
-public class FileResourceControllerMockTest
+class FileResourceControllerMockTest
 {
 
     private FileResourceController controller;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
@@ -55,7 +55,7 @@ import com.google.common.net.HttpHeaders;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class CategoryComboControllerTest
+class CategoryComboControllerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
@@ -74,14 +74,14 @@ class CategoryComboControllerTest
     private CategoryComboController controller;
 
     @Test
-    public void getWithDependencies()
+    void getWithDependencies()
         throws Exception
     {
         getWithDependencies( false );
     }
 
     @Test
-    public void getWithDependenciesAsDownload()
+    void getWithDependenciesAsDownload()
         throws Exception
     {
         getWithDependencies( true );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramControllerTest.java
@@ -81,7 +81,7 @@ class ProgramControllerTest
     }
 
     @Test
-    public void getWithDependenciesAsDownload()
+    void getWithDependenciesAsDownload()
         throws Exception
     {
         getWithDependencies( true );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/ProgramControllerTest.java
@@ -55,7 +55,7 @@ import com.google.common.net.HttpHeaders;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class ProgramControllerTest
+class ProgramControllerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerTest.java
@@ -65,14 +65,14 @@ class MetadataExportControllerTest
     private MetadataImportExportController controller;
 
     @Test
-    public void withoutDownload()
+    void withoutDownload()
     {
         ResponseEntity<RootNode> responseEntity = controller.getMetadata( false, null, false );
         Assertions.assertNull( responseEntity.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );
     }
 
     @Test
-    public void withDownload()
+    void withDownload()
     {
         ResponseEntity<RootNode> responseEntity = controller.getMetadata( false, null, true );
         Assertions.assertNotNull( responseEntity.getHeaders().get( HttpHeaders.CONTENT_DISPOSITION ) );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerTest.java
@@ -47,7 +47,7 @@ import org.springframework.http.ResponseEntity;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataExportControllerTest
+class MetadataExportControllerTest
 {
     @Mock
     private MetadataExportService metadataExportService;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtilsTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtilsTest.java
@@ -53,7 +53,7 @@ import com.google.common.net.HttpHeaders;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class MetadataExportControllerUtilsTest
+class MetadataExportControllerUtilsTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtilsTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/metadata/MetadataExportControllerUtilsTest.java
@@ -63,7 +63,7 @@ class MetadataExportControllerUtilsTest
     private MetadataExportService exportService;
 
     @Test
-    public void getWithDependencies()
+    void getWithDependencies()
     {
         final Map<String, List<String>> parameterValuesMap = new HashMap<>();
         final MetadataExportParams exportParams = new MetadataExportParams();
@@ -85,7 +85,7 @@ class MetadataExportControllerUtilsTest
     }
 
     @Test
-    public void getWithDependenciesAsDownload()
+    void getWithDependenciesAsDownload()
     {
         final Map<String, List<String>> parameterValuesMap = new HashMap<>();
         final MetadataExportParams exportParams = new MetadataExportParams();
@@ -108,7 +108,7 @@ class MetadataExportControllerUtilsTest
     }
 
     @Test
-    public void createResponseEntity()
+    void createResponseEntity()
     {
         final RootNode rootNode = new RootNode( "test" );
         final ResponseEntity<RootNode> responseEntity = MetadataExportControllerUtils.createResponseEntity( rootNode,
@@ -119,7 +119,7 @@ class MetadataExportControllerUtilsTest
     }
 
     @Test
-    public void createResponseEntityAsDownload()
+    void createResponseEntityAsDownload()
     {
         final RootNode rootNode = new RootNode( "test" );
         final ResponseEntity<RootNode> responseEntity = MetadataExportControllerUtils.createResponseEntity( rootNode,

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverterTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverterTest.java
@@ -85,50 +85,50 @@ class AbstractRootNodeMessageConverterTest
     }
 
     @Test
-    public void isAttachmentNull()
+    void isAttachmentNull()
     {
         Assertions.assertFalse( converter.isAttachment( null ) );
     }
 
     @Test
-    public void isAttachmentInline()
+    void isAttachmentInline()
     {
         Assertions.assertFalse( converter.isAttachment( "inline; filename=test.txt" ) );
     }
 
     @Test
-    public void isAttachment()
+    void isAttachment()
     {
         Assertions.assertTrue( converter.isAttachment( "attachment; filename=test.txt" ) );
     }
 
     @Test
-    public void getExtensibleAttachmentFilenameNull()
+    void getExtensibleAttachmentFilenameNull()
     {
         Assertions.assertNull( converter.getExtensibleAttachmentFilename( null ) );
     }
 
     @Test
-    public void getExtensibleAttachmentFilenameInline()
+    void getExtensibleAttachmentFilenameInline()
     {
         Assertions.assertNull( converter.getExtensibleAttachmentFilename( "inline; filename=metadata" ) );
     }
 
     @Test
-    public void getExtensibleAttachmentFilename()
+    void getExtensibleAttachmentFilename()
     {
         Assertions.assertEquals( "metadata",
             converter.getExtensibleAttachmentFilename( "attachment; filename=metadata" ) );
     }
 
     @Test
-    public void getExtensibleAttachmentFilenameOther()
+    void getExtensibleAttachmentFilenameOther()
     {
         Assertions.assertNull( converter.getExtensibleAttachmentFilename( "attachment; filename=other" ) );
     }
 
     @Test
-    public void writeInternalWithoutAttachmentUncompressed()
+    void writeInternalWithoutAttachmentUncompressed()
         throws IOException
     {
         Mockito.doAnswer( invocation -> {
@@ -143,7 +143,7 @@ class AbstractRootNodeMessageConverterTest
     }
 
     @Test
-    public void writeInternalWithAttachmentUncompressed()
+    void writeInternalWithAttachmentUncompressed()
         throws IOException
     {
         Mockito.doAnswer( invocation -> {
@@ -162,7 +162,7 @@ class AbstractRootNodeMessageConverterTest
     }
 
     @Test
-    public void writeInternalWithAttachmentGzip()
+    void writeInternalWithAttachmentGzip()
         throws IOException
     {
         Mockito.doAnswer( invocation -> {
@@ -182,7 +182,7 @@ class AbstractRootNodeMessageConverterTest
     }
 
     @Test
-    public void writeInternalWithoutAttachmentGzip()
+    void writeInternalWithoutAttachmentGzip()
         throws IOException
     {
         Mockito.doAnswer( invocation -> {
@@ -201,7 +201,7 @@ class AbstractRootNodeMessageConverterTest
     }
 
     @Test
-    public void writeInternalWithoutAttachmentZip()
+    void writeInternalWithoutAttachmentZip()
         throws IOException
     {
         Mockito.doAnswer( invocation -> {
@@ -221,7 +221,7 @@ class AbstractRootNodeMessageConverterTest
     }
 
     @Test
-    public void writeInternalWithAttachmentZip()
+    void writeInternalWithAttachmentZip()
         throws IOException
     {
         Mockito.doAnswer( invocation -> {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverterTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/mvc/messageconverter/AbstractRootNodeMessageConverterTest.java
@@ -58,7 +58,7 @@ import com.google.common.net.HttpHeaders;
  * @author Volker Schmidt <volker@dhis2.org>
  */
 @ExtendWith( MockitoExtension.class )
-public class AbstractRootNodeMessageConverterTest
+class AbstractRootNodeMessageConverterTest
 {
     @Mock
     private NodeService nodeService;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -78,7 +78,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class AnalyticsControllerTest
+class AnalyticsControllerTest
 {
 
     private final static String ENDPOINT = "/analytics";

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -121,7 +121,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyJsonRequest()
+    void verifyJsonRequest()
         throws Exception
     {
         // Then
@@ -134,7 +134,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyXmlRequest()
+    void verifyXmlRequest()
         throws Exception
     {
         // Then
@@ -150,7 +150,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyHtmlRequest()
+    void verifyHtmlRequest()
         throws Exception
     {
         // Then
@@ -166,7 +166,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyHtmlCssRequest()
+    void verifyHtmlCssRequest()
         throws Exception
     {
         // Then
@@ -182,7 +182,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyCsvRequest()
+    void verifyCsvRequest()
         throws Exception
     {
         // Then
@@ -199,7 +199,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyXlsRequest()
+    void verifyXlsRequest()
         throws Exception
     {
         // Then
@@ -222,7 +222,7 @@ class AnalyticsControllerTest
     }
 
     @Test
-    public void verifyJrxmlRequest()
+    void verifyJrxmlRequest()
         throws Exception
     {
         when( analyticsService.getAggregatedDataValues( Mockito.any( DataQueryParams.class ) ) )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -84,7 +84,7 @@ class DashboardControllerTest
     }
 
     @Test
-    public void verifyEndpointWithNoArgs()
+    void verifyEndpointWithNoArgs()
         throws Exception
     {
         mockMvc.perform( get( ENDPOINT ) ).andExpect( status().isOk() );
@@ -93,7 +93,7 @@ class DashboardControllerTest
     }
 
     @Test
-    public void verifyEndpointWithMaxArg()
+    void verifyEndpointWithMaxArg()
         throws Exception
     {
         mockMvc.perform( get( ENDPOINT ).param( "max", "VISUALIZATION" ) ).andExpect( status().isOk() );
@@ -102,7 +102,7 @@ class DashboardControllerTest
     }
 
     @Test
-    public void verifyEndpointWithAllArg()
+    void verifyEndpointWithAllArg()
         throws Exception
     {
         mockMvc.perform(
@@ -116,7 +116,7 @@ class DashboardControllerTest
     }
 
     @Test
-    public void verifyEndpointWithSearchQueryWithNoArgs()
+    void verifyEndpointWithSearchQueryWithNoArgs()
         throws Exception
     {
         mockMvc.perform( get( ENDPOINT + "/alfa" ) ).andExpect( status().isOk() );
@@ -125,7 +125,7 @@ class DashboardControllerTest
     }
 
     @Test
-    public void verifyEndpointWithSearchQueryWithMaxArg()
+    void verifyEndpointWithSearchQueryWithMaxArg()
         throws Exception
     {
         mockMvc.perform(
@@ -137,7 +137,7 @@ class DashboardControllerTest
     }
 
     @Test
-    public void verifyEndpointWithSearchQueryWithAllArg()
+    void verifyEndpointWithSearchQueryWithAllArg()
         throws Exception
     {
         mockMvc.perform(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -52,7 +52,7 @@ import com.google.common.collect.Sets;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class DashboardControllerTest
+class DashboardControllerTest
 {
 
     private MockMvc mockMvc;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -72,7 +72,7 @@ class SharingControllerTest
     private SharingController sharingController;
 
     @Test
-    public void notSystemDefaultMetadataNoAccess()
+    void notSystemDefaultMetadataNoAccess()
     {
         final OrganisationUnit organisationUnit = new OrganisationUnit();
 
@@ -84,7 +84,7 @@ class SharingControllerTest
     }
 
     @Test
-    public void systemDefaultMetadataNoAccess()
+    void systemDefaultMetadataNoAccess()
     {
         final Category category = new Category();
         category.setName( Category.DEFAULT_NAME + "x" );
@@ -97,7 +97,7 @@ class SharingControllerTest
     }
 
     @Test
-    public void systemDefaultMetadata()
+    void systemDefaultMetadata()
         throws Exception
     {
         final Category category = new Category();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SharingControllerTest.java
@@ -54,7 +54,7 @@ import org.springframework.security.access.AccessDeniedException;
  * @author Volker Schmidt
  */
 @ExtendWith( MockitoExtension.class )
-public class SharingControllerTest
+class SharingControllerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -98,7 +98,7 @@ import com.jayway.jsonpath.JsonPath;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class DataElementOperandControllerTest
+class DataElementOperandControllerTest
 {
 
     private MockMvc mockMvc;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataelement/DataElementOperandControllerTest.java
@@ -165,7 +165,7 @@ class DataElementOperandControllerTest
     }
 
     @Test
-    public void verifyPaginationGetFirstPage()
+    void verifyPaginationGetFirstPage()
         throws Exception
     {
         int pageSize = 15;
@@ -219,7 +219,7 @@ class DataElementOperandControllerTest
     }
 
     @Test
-    public void verifyPaginationGetThirdPage()
+    void verifyPaginationGetThirdPage()
         throws Exception
     {
         int pageSize = 25;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryControllerTest.java
@@ -97,7 +97,7 @@ class DataItemQueryControllerTest
     }
 
     @Test
-    public void testGetWithSuccess()
+    void testGetWithSuccess()
     {
         // Given
         final Map<String, String> anyUrlParameters = new HashMap<>();
@@ -125,7 +125,7 @@ class DataItemQueryControllerTest
     }
 
     @Test
-    public void testGetWhenItemsAreNotFound()
+    void testGetWhenItemsAreNotFound()
     {
         // Given
         final Map<String, String> anyUrlParameters = new HashMap<>();
@@ -152,7 +152,7 @@ class DataItemQueryControllerTest
     }
 
     @Test
-    public void testGetWhenAclIsInvalid()
+    void testGetWhenAclIsInvalid()
     {
         // Given
         final Map<String, String> anyUrlParameters = new HashMap<>();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemQueryControllerTest.java
@@ -72,7 +72,7 @@ import org.springframework.http.ResponseEntity;
  * @author maikel arabori
  */
 @ExtendWith( MockitoExtension.class )
-public class DataItemQueryControllerTest
+class DataItemQueryControllerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
@@ -92,7 +92,7 @@ class DataItemServiceFacadeTest
     }
 
     @Test
-    public void testRetrieveDataItemEntities()
+    void testRetrieveDataItemEntities()
     {
         // Given
         final Class<? extends BaseIdentifiableObject> targetEntity = Indicator.class;
@@ -119,7 +119,7 @@ class DataItemServiceFacadeTest
     }
 
     @Test
-    public void testRetrieveDataItemEntitiesWhenTargetEntitiesIsEmpty()
+    void testRetrieveDataItemEntitiesWhenTargetEntitiesIsEmpty()
     {
         // Given
         final Set<Class<? extends BaseIdentifiableObject>> anyTargetEntities = emptySet();
@@ -137,7 +137,7 @@ class DataItemServiceFacadeTest
     }
 
     @Test
-    public void testExtractTargetEntitiesUsingEqualsFilter()
+    void testExtractTargetEntitiesUsingEqualsFilter()
     {
         // Given
         final Set<Class<? extends BaseIdentifiableObject>> expectedTargetEntities = new HashSet<>(
@@ -153,7 +153,7 @@ class DataItemServiceFacadeTest
     }
 
     @Test
-    public void testExtractTargetEntitiesUsingInFilter()
+    void testExtractTargetEntitiesUsingInFilter()
     {
         // Given
         final Set<Class<? extends BaseIdentifiableObject>> expectedTargetEntities = new HashSet<>(
@@ -169,7 +169,7 @@ class DataItemServiceFacadeTest
     }
 
     @Test
-    public void testExtractTargetEntitiesWhenThereIsNoExplicitTargetSet()
+    void testExtractTargetEntitiesWhenThereIsNoExplicitTargetSet()
     {
         // Given
         final Set<String> noTargetEntitiesFilters = emptySet();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/DataItemServiceFacadeTest.java
@@ -74,7 +74,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
  * @author maikel arabori
  */
 @ExtendWith( MockitoExtension.class )
-public class DataItemServiceFacadeTest
+class DataItemServiceFacadeTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
@@ -80,7 +80,7 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
  * @author maikel arabori
  */
 @ExtendWith( MockitoExtension.class )
-public class ResponseHandlerTest
+class ResponseHandlerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
@@ -105,7 +105,7 @@ class ResponseHandlerTest
     }
 
     @Test
-    public void testAddResultsToNodeWithSuccess()
+    void testAddResultsToNodeWithSuccess()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
@@ -127,7 +127,7 @@ class ResponseHandlerTest
     }
 
     @Test
-    public void testAddPaginationToNodeWithSuccess()
+    void testAddPaginationToNodeWithSuccess()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
@@ -150,7 +150,7 @@ class ResponseHandlerTest
     }
 
     @Test
-    public void testAddPaginationToNodeWhenPagingIsFalse()
+    void testAddPaginationToNodeWhenPagingIsFalse()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
@@ -171,7 +171,7 @@ class ResponseHandlerTest
     }
 
     @Test
-    public void testAddPaginationToNodeWhenTargetEntitiesIsEmpty()
+    void testAddPaginationToNodeWhenTargetEntitiesIsEmpty()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
@@ -64,7 +64,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class DataValidatorTest
+class DataValidatorTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
@@ -162,7 +162,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testValidateAttributeOptionComboWithValidData()
+    void testValidateAttributeOptionComboWithValidData()
     {
         // Initially
         dataValidator.validateAttributeOptionCombo( optionComboA, periodJan, dataSetA, dataElementA );
@@ -201,7 +201,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testGetMissingDataElement()
+    void testGetMissingDataElement()
     {
         final String uid = CodeGenerator.generateUid();
 
@@ -214,7 +214,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testInvalidPeriod()
+    void testInvalidPeriod()
     {
         IllegalQueryException ex = assertThrows( IllegalQueryException.class,
             () -> dataValidator.getAndValidatePeriod( "502" ) );
@@ -223,7 +223,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testGetMissingOrgUnit()
+    void testGetMissingOrgUnit()
     {
         final String uid = CodeGenerator.generateUid();
 
@@ -236,7 +236,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testValidateAttributeOptionComboWithEarlyData()
+    void testValidateAttributeOptionComboWithEarlyData()
     {
         // Given
         categoryOptionA.setStartDate( feb15 );
@@ -248,7 +248,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testValidateAttributeOptionComboWithLateData()
+    void testValidateAttributeOptionComboWithLateData()
     {
         // Given
         categoryOptionA.setEndDate( jan15 );
@@ -260,7 +260,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void testValidateAttributeOptionComboWithLateAdjustedData()
+    void testValidateAttributeOptionComboWithLateAdjustedData()
     {
         // Given
         categoryOptionA.setEndDate( jan15 );
@@ -273,7 +273,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void validateBooleanDataValueWhenValuesAreAcceptableTrue()
+    void validateBooleanDataValueWhenValuesAreAcceptableTrue()
     {
         // Given
         final DataElement aBooleanTypeDataElement = new DataElement();
@@ -303,7 +303,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void validateBooleanDataValueWhenValuesAreAcceptableFalse()
+    void validateBooleanDataValueWhenValuesAreAcceptableFalse()
     {
         // Given
         final DataElement aBooleanTypeDataElement = new DataElement();
@@ -333,7 +333,7 @@ class DataValidatorTest
     }
 
     @Test
-    public void validateBooleanDataValueWhenValueIsNotValid()
+    void validateBooleanDataValueWhenValueIsNotValid()
     {
         // Given
         String anInvalidBooleanValue = "InvalidValue";

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dimension/DimensionItemPageHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dimension/DimensionItemPageHandlerTest.java
@@ -75,7 +75,7 @@ class DimensionItemPageHandlerTest
     }
 
     @Test
-    public void testAddPaginationToNodeWithSuccess()
+    void testAddPaginationToNodeWithSuccess()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
@@ -96,7 +96,7 @@ class DimensionItemPageHandlerTest
     }
 
     @Test
-    public void testAddPaginationToNodeWhenPagingIsFalse()
+    void testAddPaginationToNodeWhenPagingIsFalse()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
@@ -116,7 +116,7 @@ class DimensionItemPageHandlerTest
     }
 
     @Test
-    public void testAddPaginationToNodeWhenNoPagingIsSet()
+    void testAddPaginationToNodeWhenNoPagingIsSet()
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dimension/DimensionItemPageHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dimension/DimensionItemPageHandlerTest.java
@@ -60,7 +60,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author maikel arabori
  */
 @ExtendWith( MockitoExtension.class )
-public class DimensionItemPageHandlerTest
+class DimensionItemPageHandlerTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToParamsMapperTest.java
@@ -127,7 +127,7 @@ class EventRequestToParamsMapperTest
     }
 
     @Test
-    public void testEventRequestToSearchParamsMapperSuccess()
+    void testEventRequestToSearchParamsMapperSuccess()
     {
 
         EventSearchParams eventSearchParams = requestToSearchParamsMapper.map( "programuid",

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToParamsMapperTest.java
@@ -69,7 +69,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class EventRequestToParamsMapperTest
+class EventRequestToParamsMapperTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -55,7 +55,7 @@ import org.springframework.web.util.NestedServletException;
  * @author Enrico Colasante
  */
 @ExtendWith( MockitoExtension.class )
-public class RelationshipControllerTest
+class RelationshipControllerTest
 {
     private MockMvc mockMvc;
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/RelationshipControllerTest.java
@@ -99,19 +99,19 @@ class RelationshipControllerTest
     }
 
     @Test
-    public void verifyEndpointWithNoArgs()
+    void verifyEndpointWithNoArgs()
     {
         assertThrows( NestedServletException.class, () -> mockMvc.perform( get( ENDPOINT ) ) );
     }
 
     @Test
-    public void verifyEndpointWithNotFoundTei()
+    void verifyEndpointWithNotFoundTei()
     {
         assertThrows( NestedServletException.class, () -> mockMvc.perform( get( ENDPOINT ).param( "tei", TEI_ID ) ) );
     }
 
     @Test
-    public void verifyEndpointWithTei()
+    void verifyEndpointWithTei()
         throws Exception
     {
         when( trackedEntityInstanceService.getTrackedEntityInstance( TEI_ID ) ).thenReturn( tei );
@@ -122,14 +122,14 @@ class RelationshipControllerTest
     }
 
     @Test
-    public void verifyEndpointWithNotFoundEvent()
+    void verifyEndpointWithNotFoundEvent()
     {
         assertThrows( NestedServletException.class,
             () -> mockMvc.perform( get( ENDPOINT ).param( "event", EVENT_ID ) ) );
     }
 
     @Test
-    public void verifyEndpointWithEvent()
+    void verifyEndpointWithEvent()
         throws Exception
     {
         when( programStageInstanceService.getProgramStageInstance( EVENT_ID ) ).thenReturn( event );
@@ -140,14 +140,14 @@ class RelationshipControllerTest
     }
 
     @Test
-    public void verifyEndpointWithNotFoundEnrollment()
+    void verifyEndpointWithNotFoundEnrollment()
     {
         assertThrows( NestedServletException.class, () -> mockMvc
             .perform( get( ENDPOINT ).param( "enrollment", ENROLLMENT_ID ) ) );
     }
 
     @Test
-    public void verifyEndpointWithEnrollment()
+    void verifyEndpointWithEnrollment()
         throws Exception
     {
         when( programInstanceService.getProgramInstance( ENROLLMENT_ID ) ).thenReturn( enrollment );
@@ -158,13 +158,13 @@ class RelationshipControllerTest
     }
 
     @Test
-    public void testGetRelationshipNotPresent()
+    void testGetRelationshipNotPresent()
     {
         assertThrows( NestedServletException.class, () -> mockMvc.perform( get( ENDPOINT + "/" + REL_ID ) ) );
     }
 
     @Test
-    public void testGetRelationship()
+    void testGetRelationship()
         throws Exception
     {
         when( relationshipService.getRelationshipByUid( REL_ID ) ).thenReturn( relationship );
@@ -172,7 +172,7 @@ class RelationshipControllerTest
     }
 
     @Test
-    public void testDeleteRelationship()
+    void testDeleteRelationship()
         throws Exception
     {
         when( relationshipService.getRelationshipByUid( REL_ID ) ).thenReturn( relationship );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceControllerTest.java
@@ -61,7 +61,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  * @author Luca Cambi <luca@dhis2.org>
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackedEntityInstanceControllerTest
+class TrackedEntityInstanceControllerTest
 {
 
     private MockMvc mockMvc;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceControllerTest.java
@@ -108,7 +108,7 @@ class TrackedEntityInstanceControllerTest
     }
 
     @Test
-    public void shouldCallSyncStrategy()
+    void shouldCallSyncStrategy()
         throws Exception
     {
 
@@ -126,7 +126,7 @@ class TrackedEntityInstanceControllerTest
     }
 
     @Test
-    public void shouldCallAsyncStrategy()
+    void shouldCallAsyncStrategy()
         throws Exception
     {
         mockMvc.perform( post( ENDPOINT )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureControllerTest.java
@@ -92,7 +92,7 @@ class GeoFeatureControllerTest
     }
 
     @Test
-    public void verifyGeoFeaturesReturnsOuData()
+    void verifyGeoFeaturesReturnsOuData()
         throws Exception
     {
         OrganisationUnit ouA = createOrgUnitWithCoordinates();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureControllerTest.java
@@ -60,7 +60,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  * @author Luciano Fiandesio
  */
 @ExtendWith( MockitoExtension.class )
-public class GeoFeatureControllerTest
+class GeoFeatureControllerTest
 {
     private MockMvc mockMvc;
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -80,7 +80,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackerImportControllerTest
+class TrackerImportControllerTest
 {
 
     private final static String ENDPOINT = "/" + TrackerControllerSupport.RESOURCE_PATH;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -116,7 +116,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifyAsync()
+    void verifyAsync()
         throws Exception
     {
 
@@ -131,7 +131,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifyAsyncForCsv()
+    void verifyAsyncForCsv()
         throws Exception
     {
 
@@ -148,7 +148,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifySyncResponseShouldBeOkWhenImportReportStatusIsOk()
+    void verifySyncResponseShouldBeOkWhenImportReportStatusIsOk()
         throws Exception
     {
         // When
@@ -187,7 +187,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifySyncResponseForCsvShouldBeOkWhenImportReportStatusIsOk()
+    void verifySyncResponseForCsvShouldBeOkWhenImportReportStatusIsOk()
         throws Exception
     {
         // When
@@ -226,7 +226,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifySyncResponseShouldBeConflictWhenImportReportStatusIsError()
+    void verifySyncResponseShouldBeConflictWhenImportReportStatusIsError()
         throws Exception
     {
         String errorMessage = "errorMessage";
@@ -261,7 +261,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifySyncResponseForCsvShouldBeConflictWhenImportReportStatusIsError()
+    void verifySyncResponseForCsvShouldBeConflictWhenImportReportStatusIsError()
         throws Exception
     {
         String errorMessage = "errorMessage";
@@ -296,7 +296,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifyShouldFindJob()
+    void verifyShouldFindJob()
         throws Exception
     {
         String uid = CodeGenerator.generateUid();
@@ -323,7 +323,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifyShouldFindJobReport()
+    void verifyShouldFindJobReport()
         throws Exception
     {
         String uid = CodeGenerator.generateUid();
@@ -370,7 +370,7 @@ class TrackerImportControllerTest
     }
 
     @Test
-    public void verifyShouldThrowWhenJobReportNotFound()
+    void verifyShouldThrowWhenJobReportNotFound()
         throws Exception
     {
         String uid = CodeGenerator.generateUid();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
@@ -81,7 +81,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class UserControllerTest
+class UserControllerTest
 {
     @Mock
     private UserService userService;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/user/UserControllerTest.java
@@ -130,9 +130,9 @@ class UserControllerTest
         parsedUser.setGroups( new HashSet<>( Arrays.asList( userGroup1, userGroup2 ) ) );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void updateUserGroups()
+    @Test
+    void updateUserGroups()
     {
         when( userService.getUser( "def2" ) ).thenReturn( user );
 
@@ -148,7 +148,7 @@ class UserControllerTest
     }
 
     @Test
-    public void updateUserGroupsNotOk()
+    void updateUserGroupsNotOk()
     {
         if ( isInStatusUpdatedOK( createReportWith( Status.ERROR, Stats::incUpdated ) ) )
         {
@@ -161,7 +161,7 @@ class UserControllerTest
     }
 
     @Test
-    public void updateUserGroupsNotUpdated()
+    void updateUserGroupsNotUpdated()
     {
         if ( isInStatusUpdatedOK( createReportWith( Status.OK, Stats::incCreated ) ) )
         {
@@ -173,9 +173,9 @@ class UserControllerTest
         verifyNoInteractions( userGroupService );
     }
 
-    @Test
     @SuppressWarnings( "unchecked" )
-    public void updateUserGroupsSameUser()
+    @Test
+    void updateUserGroupsSameUser()
     {
         currentUser.setId( 1001 );
         currentUser.setUid( "def2" );
@@ -228,7 +228,7 @@ class UserControllerTest
     }
 
     @Test
-    public void expireUserInTheFutureDoesNotExpireSession()
+    void expireUserInTheFutureDoesNotExpireSession()
         throws Exception
     {
         setUpUserExpireScenarios();
@@ -241,7 +241,7 @@ class UserControllerTest
     }
 
     @Test
-    public void expireUserNowDoesExpireSession()
+    void expireUserNowDoesExpireSession()
         throws Exception
     {
         setUpUserExpireScenarios();
@@ -255,7 +255,7 @@ class UserControllerTest
     }
 
     @Test
-    public void unexpireUserDoesUpdateUserCredentials()
+    void unexpireUserDoesUpdateUserCredentials()
         throws Exception
     {
         setUpUserExpireScenarios();
@@ -266,7 +266,7 @@ class UserControllerTest
     }
 
     @Test
-    public void updateUserExpireRequiresUserCredentialBasedAuthority()
+    void updateUserExpireRequiresUserCredentialBasedAuthority()
     {
         setUpUserExpireScenarios();
         // executing user has no authorities
@@ -282,7 +282,7 @@ class UserControllerTest
     }
 
     @Test
-    public void updateUserExpireRequiresGroupBasedAuthority()
+    void updateUserExpireRequiresGroupBasedAuthority()
     {
         setUpUserExpireScenarios();
         when( userService.canAddOrUpdateUser( any(), any() ) ).thenReturn( false );
@@ -295,7 +295,7 @@ class UserControllerTest
     }
 
     @Test
-    public void updateUserExpireRequiresShareBasedAuthority()
+    void updateUserExpireRequiresShareBasedAuthority()
     {
         setUpUserExpireScenarios();
         when( aclService.canUpdate( currentUser, user ) ).thenReturn( false );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/DefaultLinkServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/DefaultLinkServiceTest.java
@@ -55,7 +55,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class DefaultLinkServiceTest
+class DefaultLinkServiceTest
 {
     @Mock
     private SchemaService schemaService;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/DefaultLinkServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/DefaultLinkServiceTest.java
@@ -69,7 +69,7 @@ class DefaultLinkServiceTest
     private MockHttpServletRequest request = new MockHttpServletRequest();
 
     @Test
-    public void noLinks()
+    void noLinks()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -88,7 +88,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void nextLinkDefaultParameters()
+    void nextLinkDefaultParameters()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -116,7 +116,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void nextLinkParameters()
+    void nextLinkParameters()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -148,7 +148,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void prevLinkDefaultParameters()
+    void prevLinkDefaultParameters()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -176,7 +176,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void nextLink()
+    void nextLink()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -204,7 +204,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void nextLinkWithDotsInPath()
+    void nextLinkWithDotsInPath()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -232,7 +232,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void prevLinkParameters()
+    void prevLinkParameters()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {
@@ -263,7 +263,7 @@ class DefaultLinkServiceTest
     }
 
     @Test
-    public void prevLinkParametersPage1()
+    void prevLinkParametersPage1()
     {
         Mockito.when( schemaService.getDynamicSchema( Mockito.eq( OrganisationUnit.class ) ) )
             .thenAnswer( invocation -> {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/WebCacheTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/WebCacheTest.java
@@ -64,7 +64,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.CacheControl;
 
 @ExtendWith( MockitoExtension.class )
-public class WebCacheTest
+class WebCacheTest
 {
 
     @Mock

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/WebCacheTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/WebCacheTest.java
@@ -82,7 +82,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsNoCache()
+    void testGetCacheControlForWhenCacheStrategyIsNoCache()
     {
         // Given
         final CacheControl expectedCacheControl = noCache();
@@ -95,7 +95,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsRespectSystemSetting()
+    void testGetCacheControlForWhenCacheStrategyIsRespectSystemSetting()
     {
         // Given
         final CacheStrategy strategy = CACHE_5_MINUTES;
@@ -111,7 +111,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetAnalyticsCacheControlForWhenTimeToLiveIsZero()
+    void testGetAnalyticsCacheControlForWhenTimeToLiveIsZero()
     {
         // Given
         final long zeroTimeToLive = 0;
@@ -127,7 +127,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetAnalyticsCacheControlForWhenTimeToLiveIsNegative()
+    void testGetAnalyticsCacheControlForWhenTimeToLiveIsNegative()
     {
         // Given
         final long zeroTimeToLive = -1;
@@ -143,7 +143,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetAnalyticsCacheControlForWhenTimeToLiveIsPositive()
+    void testGetAnalyticsCacheControlForWhenTimeToLiveIsPositive()
     {
         // Given
         final long positiveTimeToLive = 60;
@@ -159,7 +159,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsRespectSystemSettingNotUsedInObjectBasis()
+    void testGetCacheControlForWhenCacheStrategyIsRespectSystemSettingNotUsedInObjectBasis()
     {
         // Given
         givenCacheStartegy( RESPECT_SYSTEM_SETTING );
@@ -169,7 +169,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache1Minute()
+    void testGetCacheControlForWhenCacheStrategyIsCache1Minute()
     {
         // Given
         final CacheStrategy strategy = CACHE_1_MINUTE;
@@ -184,7 +184,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache5Minutes()
+    void testGetCacheControlForWhenCacheStrategyIsCache5Minutes()
     {
         // Given
         final CacheStrategy strategy = CACHE_5_MINUTES;
@@ -199,7 +199,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache10Minutes()
+    void testGetCacheControlForWhenCacheStrategyIsCache10Minutes()
     {
         // Given
         final CacheStrategy strategy = CACHE_10_MINUTES;
@@ -214,7 +214,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache15Minutes()
+    void testGetCacheControlForWhenCacheStrategyIsCache15Minutes()
     {
         // Given
         final CacheStrategy strategy = CACHE_15_MINUTES;
@@ -229,7 +229,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache30Minutes()
+    void testGetCacheControlForWhenCacheStrategyIsCache30Minutes()
     {
         // Given
         final CacheStrategy strategy = CACHE_30_MINUTES;
@@ -244,7 +244,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache1Hour()
+    void testGetCacheControlForWhenCacheStrategyIsCache1Hour()
     {
         // Given
         final CacheStrategy strategy = CACHE_1_HOUR;
@@ -259,7 +259,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testGetCacheControlForWhenCacheStrategyIsCache2Weeks()
+    void testGetCacheControlForWhenCacheStrategyIsCache2Weeks()
     {
         // Given
         final CacheStrategy strategy = CACHE_TWO_WEEKS;
@@ -274,7 +274,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testSetCacheabilityWhenCacheabilityIsSetToPublic()
+    void testSetCacheabilityWhenCacheabilityIsSetToPublic()
     {
         // Given
         givenCacheability( PUBLIC );
@@ -286,7 +286,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testSetCacheabilityWhenCacheabilityIsSetToPrivate()
+    void testSetCacheabilityWhenCacheabilityIsSetToPrivate()
     {
         // Given
         givenCacheability( PRIVATE );
@@ -298,7 +298,7 @@ class WebCacheTest
     }
 
     @Test
-    public void testSetCacheabilityWhenCacheabilityIsSetToNull()
+    void testSetCacheabilityWhenCacheabilityIsSetToNull()
     {
         // Given
         givenCacheability( null );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerImplTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerImplTest.java
@@ -65,7 +65,7 @@ import org.springframework.http.MediaType;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-public class TrackedEntityInstanceStrategyHandlerImplTest
+class TrackedEntityInstanceStrategyHandlerImplTest
 {
     @InjectMocks
     private TrackedEntityInstanceAsyncStrategyImpl trackedEntityInstanceAsyncStrategy;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerImplTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerImplTest.java
@@ -103,7 +103,7 @@ class TrackedEntityInstanceStrategyHandlerImplTest
     }
 
     @Test
-    public void shouldCallSyncTrackedEntityJsonSyncStrategy()
+    void shouldCallSyncTrackedEntityJsonSyncStrategy()
         throws IOException,
         BadRequestException
     {
@@ -123,9 +123,9 @@ class TrackedEntityInstanceStrategyHandlerImplTest
     }
 
     @Test
-    public void shouldCallSyncTrackedEntityXmlSyncStrategy()
-        throws IOException,
-        BadRequestException
+    void shouldCallSyncTrackedEntityXmlSyncStrategy()
+        throws BadRequestException,
+        IOException
     {
         when( trackedEntityInstanceService.getTrackedEntityInstancesXml( any() ) )
             .thenReturn( trackedEntityInstanceList );
@@ -143,9 +143,9 @@ class TrackedEntityInstanceStrategyHandlerImplTest
     }
 
     @Test
-    public void shouldCallAsyncTrackedEntityJsonAsyncStrategy()
-        throws IOException,
-        BadRequestException
+    void shouldCallAsyncTrackedEntityJsonAsyncStrategy()
+        throws BadRequestException,
+        IOException
     {
         when( trackedEntityInstanceService.getTrackedEntityInstancesJson( any() ) )
             .thenReturn( trackedEntityInstanceList );
@@ -162,7 +162,7 @@ class TrackedEntityInstanceStrategyHandlerImplTest
     }
 
     @Test
-    public void shouldCallAsyncTrackedEntityXmlAsyncStrategy()
+    void shouldCallAsyncTrackedEntityXmlAsyncStrategy()
         throws IOException,
         BadRequestException
     {
@@ -181,7 +181,7 @@ class TrackedEntityInstanceStrategyHandlerImplTest
     }
 
     @Test
-    public void shouldThrowMediaTypeNotAllowed()
+    void shouldThrowMediaTypeNotAllowed()
         throws IOException
     {
         when( trackedEntityInstanceService.getTrackedEntityInstancesJson( any() ) )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerTest.java
@@ -68,9 +68,9 @@ class TrackedEntityInstanceStrategyHandlerTest
     private ImportOptions importOptions;
 
     @Test
-    public void shouldCallSyncTrackedEntitySyncStrategy()
-        throws IOException,
-        BadRequestException
+    void shouldCallSyncTrackedEntitySyncStrategy()
+        throws BadRequestException,
+        IOException
     {
         when( importOptions.isAsync() ).thenReturn( false );
 
@@ -84,9 +84,9 @@ class TrackedEntityInstanceStrategyHandlerTest
     }
 
     @Test
-    public void shouldCallAsyncTrackedEntitySyncStrategy()
-        throws IOException,
-        BadRequestException
+    void shouldCallAsyncTrackedEntitySyncStrategy()
+        throws BadRequestException,
+        IOException
     {
         when( importOptions.isAsync() ).thenReturn( true );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/old/tracker/imports/TrackedEntityInstanceStrategyHandlerTest.java
@@ -52,7 +52,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author Luca Cambi <luca@dhis2.org>
  */
 @ExtendWith( MockitoExtension.class )
-public class TrackedEntityInstanceStrategyHandlerTest
+class TrackedEntityInstanceStrategyHandlerTest
 {
 
     @InjectMocks

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerImplTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerImplTest.java
@@ -67,7 +67,7 @@ class TrackerImportStrategyHandlerImplTest
     MessageManager messageManager;
 
     @Test
-    public void shouldCreateReportAsyncFalse()
+    void shouldCreateReportAsyncFalse()
     {
         TrackerImportReportRequest trackerImportReportRequest = TrackerImportReportRequest
             .builder()
@@ -88,7 +88,7 @@ class TrackerImportStrategyHandlerImplTest
     }
 
     @Test
-    public void shouldSendMessageToQueueAsync()
+    void shouldSendMessageToQueueAsync()
     {
         ArgumentCaptor<String> queueNameCaptor = ArgumentCaptor.forClass( String.class );
         ArgumentCaptor<TrackerMessage> trackerMessageCaptor = ArgumentCaptor.forClass( TrackerMessage.class );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerImplTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerImplTest.java
@@ -52,7 +52,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class TrackerImportStrategyHandlerImplTest
+class TrackerImportStrategyHandlerImplTest
 {
     @InjectMocks
     TrackerImportAsyncStrategyImpl importAsyncStrategy;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerTest.java
@@ -59,7 +59,7 @@ class TrackerImportStrategyHandlerTest
     ContextService contextService;
 
     @Test
-    public void shouldImportAsync()
+    void shouldImportAsync()
     {
         TrackerImportReportRequest trackerImportReportRequest = TrackerImportReportRequest
             .builder()
@@ -77,7 +77,7 @@ class TrackerImportStrategyHandlerTest
     }
 
     @Test
-    public void shouldNotImportAsync()
+    void shouldNotImportAsync()
     {
         TrackerImportReportRequest trackerImportReportRequest = TrackerImportReportRequest
             .builder()

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/strategy/tracker/imports/TrackerImportStrategyHandlerTest.java
@@ -44,7 +44,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith( MockitoExtension.class )
-public class TrackerImportStrategyHandlerTest
+class TrackerImportStrategyHandlerTest
 {
     @InjectMocks
     TrackerImportStrategyImpl importStrategy;


### PR DESCRIPTION
Reduce visibility of test classes/methods #9496 JUnit 5 does not require them to be public anymore so they show up as linting errors in Sonarqube

Fixes linting errors introduced in the migration https://github.com/dhis2/dhis2-core/pull/9467

See clean linting result https://github.com/dhis2/dhis2-core/pull/9496#issuecomment-996509859 😄 