### PR TITLE
chore(deps): remove unused formatter

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -218,7 +218,6 @@
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
-        <maven-java-formatter-plugin.version>0.4</maven-java-formatter-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
@@ -615,25 +614,6 @@
                             </goals>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>com.googlecode.maven-java-formatter-plugin</groupId>
-                    <artifactId>maven-java-formatter-plugin</artifactId>
-                    <version>${maven-java-formatter-plugin.version}</version>
-                    <configuration>
-                        <configFile>${rootDir}DHISFormatter.xml</configFile>
-                        <lineEnding>LF</lineEnding>
-                    </configuration>
-                    <!-- Uncomment the following to add autoformatting when building -->
-                    <!--
-                    <executions>
-                      <execution>
-                        <goals>
-                          <goal>format</goal>
-                        </goals>
-                      </execution>
-                    </executions>
-                    -->
                 </plugin>
                 <plugin>
                     <groupId>org.owasp</groupId>


### PR DESCRIPTION
we use speedy-spotless-maven-plugin so we can remove this one