### PR TITLE
fix:  DHIS2 Can’t finish the analytic in version 2.37.1 [2.38-DHIS2-TECH899]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -507,7 +507,7 @@ public class JdbcAnalyticsTableManager
 
         sql.deleteCharAt( sql.length() - ",".length() );
 
-        sql.append( " where level > " + aggregationLevel );
+        sql.append( " where oulevel > " + aggregationLevel );
         sql.append( " and dx in (" + getQuotedCommaDelimitedString( dataElements ) + ")" );
 
         log.debug( "Aggregation level SQL: " + sql );


### PR DESCRIPTION
We changed in the past the analytics  table structure and renamed level to oulevel for some reason. But there is still sql query with "where level" left, written in 2016. The problem is visible only if you have some data in dataelementaggregationslevel table => only when data element aggregation levels are present. 