### PR TITLE
fix: store last analytics table runtime as formatted duration [DHIS2-12259]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -137,7 +137,7 @@ public class DefaultAnalyticsTableGenerator
             systemSettingManager.saveSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE,
                 params.getStartTime() );
             systemSettingManager.saveSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_RUNTIME,
-                clock.getTime() );
+                clock.time() );
         }
     }
 


### PR DESCRIPTION
### Summary
During the refactoring the setting the stores the last successful analytics table generation runtime accidentally got stored from `getTime()` (which returns a `long`) instead of `time()` (which returns a formatted `String`).

### Manual Testing
* open scheduler app
* create a new job to generate analytics tables
* run the new job manually and wait for the job to finish, you can check `/api/scheduling/running/` and `/api/scheduling/completed/` to see when it is done
* open _About DHIS2_ info (click on your user menu)
* check the time is no longer presented in milliseconds but a formatted time period

Note that the job needs to run once in order to see the corrected formatting as the old value from last run which is stored was produced with the code that was not yet corrected.