### PR TITLE
feat: Isolated 'legacy' report/chart from event visualization [TECH-867]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventchart/EventChart.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventchart/EventChart.java
@@ -412,4 +412,16 @@ public class EventChart
     {
         this.value = value;
     }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isLegacy()
+    {
+        return legacy;
+    }
+
+    public void setLegacy( final boolean legacy )
+    {
+        this.legacy = legacy;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventreport/EventReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventreport/EventReport.java
@@ -588,4 +588,16 @@ public class EventReport
     {
         this.type = type;
     }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isLegacy()
+    {
+        return legacy;
+    }
+
+    public void setLegacy( final boolean legacy )
+    {
+        this.legacy = legacy;
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
@@ -298,7 +298,7 @@
         <property name="hideEmptyRows" access="field"/>
         <property name="showHierarchy" access="field"/>
         <property name="showDimensionLabels" access="field"/>
-        <property name="legacy" access="field"/>
         <property name="topLimit" access="field"/>
+        <property name="legacy"/>
     </class>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
@@ -291,7 +291,7 @@
         <property name="showData" access="field"/>
         <property name="percentStackedValues" access="field"/>
         <property name="cumulativeValues" access="field"/>
-        <property name="legacy" access="field"/>
+        <property name="legacy"/>
         <property name="type" length="40" not-null="true">
             <type name="org.hibernate.type.EnumType">
                 <param name="enumClass">org.hisp.dhis.eventvisualization.EventVisualizationType</param>

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/EventChartControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/EventChartControllerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.springframework.http.HttpStatus.CREATED;
+
+import java.util.Map;
+
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonNode;
+import org.hisp.dhis.webapi.json.JsonResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Controller tests for
+ * {@link org.hisp.dhis.webapi.controller.event.EventChartController}.
+ *
+ * @author maikel arabori
+ */
+class EventChartControllerTest extends DhisControllerConvenienceTest
+{
+
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    private Program mockProgram;
+
+    @BeforeEach
+    public void beforeEach()
+    {
+        mockProgram = createProgram( 'A' );
+        manager.save( mockProgram );
+    }
+
+    @Test
+    void testThatGetEventVisualizationsContainsLegacyEventCharts()
+    {
+        // Given
+        final String body = "{'name': 'Name Test', 'type':'GAUGE', 'program':{'id':'" + mockProgram.getUid()
+            + "'}}";
+
+        // When
+        final String uid = assertStatus( CREATED, POST( "/eventCharts/", body ) );
+
+        // Then
+        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
+        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+
+        assertThat( nodeMap.get( "name" ).toString(), containsString( "Name Test" ) );
+        assertThat( nodeMap.get( "type" ).toString(), containsString( "GAUGE" ) );
+    }
+
+    @Test
+    void testThatGetEventChartsDoesNotContainNewEventVisualizations()
+    {
+        // Given
+        final String body = "{'name': 'Name Test', 'type':'GAUGE', 'program':{'id':'" + mockProgram.getUid()
+            + "'}}";
+
+        // When
+        final String uid = assertStatus( CREATED, POST( "/eventVisualizations/", body ) );
+
+        // Then
+        final JsonResponse response = GET( "/eventCharts/" + uid ).content();
+        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+
+        assertThat( nodeMap.values(), is( empty() ) );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/EventReportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/EventReportControllerTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.springframework.http.HttpStatus.CREATED;
+
+import java.util.Map;
+
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonNode;
+import org.hisp.dhis.webapi.json.JsonResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Controller tests for
+ * {@link org.hisp.dhis.webapi.controller.event.EventReportController}.
+ *
+ * @author maikel arabori
+ */
+class EventReportControllerTest extends DhisControllerConvenienceTest
+{
+
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    private Program mockProgram;
+
+    @BeforeEach
+    public void beforeEach()
+    {
+        mockProgram = createProgram( 'A' );
+        manager.save( mockProgram );
+    }
+
+    @Test
+    void testThatGetEventVisualizationsContainsLegacyEventReports()
+    {
+        // Given
+        final String body = "{'name': 'Name Test', 'type':'LINE_LIST', 'program':{'id':'" + mockProgram.getUid()
+            + "'}}";
+
+        // When
+        final String uid = assertStatus( CREATED, POST( "/eventReports/", body ) );
+
+        // Then
+        final JsonResponse response = GET( "/eventVisualizations/" + uid ).content();
+        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+
+        assertThat( nodeMap.get( "name" ).toString(), containsString( "Name Test" ) );
+        assertThat( nodeMap.get( "type" ).toString(), containsString( "LINE_LIST" ) );
+    }
+
+    @Test
+    void testThatGetEventReportsDoesNotContainNewEventVisualizations()
+    {
+        // Given
+        final String body = "{'name': 'Name Test', 'type':'LINE_LIST', 'program':{'id':'" + mockProgram.getUid()
+            + "'}}";
+
+        // When
+        final String uid = assertStatus( CREATED, POST( "/eventVisualizations/", body ) );
+
+        // Then
+        final JsonResponse response = GET( "/eventReports/" + uid ).content();
+        final Map<String, JsonNode> nodeMap = (Map<String, JsonNode>) response.node().value();
+
+        assertThat( nodeMap.values(), is( empty() ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -49,8 +49,6 @@ import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.eventchart.EventChart;
-import org.hisp.dhis.eventreport.EventReport;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.fieldfilter.FieldFilterParams;
 import org.hisp.dhis.fieldfilter.FieldFilterService;
@@ -156,6 +154,15 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
     {
     }
 
+    /**
+     * Allows to append new filters to the incoming ones. Recommended only on
+     * very specific cases where forcing a new filter, programmatically, make
+     * sense.
+     */
+    protected void forceFiltering( final List<String> filters )
+    {
+    }
+
     // --------------------------------------------------------------------------
     // GET Full
     // --------------------------------------------------------------------------
@@ -169,7 +176,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
         List<Order> orders = orderParams.getOrders( getSchema() );
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-        forceFilterForEventChartOrReport( filters );
+        forceFiltering( filters );
 
         if ( fields.isEmpty() )
         {
@@ -251,6 +258,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
 
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
         List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
+        forceFiltering( filters );
 
         if ( fields.isEmpty() )
         {
@@ -589,26 +597,5 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
         }
 
         return InclusionStrategy.Include.NON_NULL;
-    }
-
-    /**
-     * @deprecated This is a temporary workaround to keep EventChart and
-     *             EventReport backward compatible with the new
-     *             EventVisualization entity.
-     *
-     * @param filters
-     */
-    @Deprecated
-    private void forceFilterForEventChartOrReport( final List<String> filters )
-    {
-        if ( getEntityClass().isAssignableFrom( EventChart.class ) )
-        {
-            filters.add( "type:!eq:PIVOT_TABLE" );
-            filters.add( "type:!eq:LINE_LIST" );
-        }
-        else if ( getEntityClass().isAssignableFrom( EventReport.class ) )
-        {
-            filters.add( "type:in:[PIVOT_TABLE,LINE_LIST]" );
-        }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.eventvisualization.EventVisualizationType.PIVOT_TABL
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -169,6 +170,21 @@ public class EventChartController
     // --------------------------------------------------------------------------
     // Hooks
     // --------------------------------------------------------------------------
+
+    /**
+     * @deprecated This is a temporary workaround to keep EventChart backward
+     *             compatible with the new EventVisualization entity.
+     *
+     * @param filters
+     */
+    @Deprecated
+    @Override
+    protected void forceFiltering( final List<String> filters )
+    {
+        filters.add( "type:!eq:PIVOT_TABLE" );
+        filters.add( "type:!eq:LINE_LIST" );
+        filters.add( "legacy:eq:true" );
+    }
 
     @Override
     protected void postProcessResponseEntity( EventChart eventChart, WebOptions options,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventChartController.java
@@ -173,7 +173,9 @@ public class EventChartController
 
     /**
      * @deprecated This is a temporary workaround to keep EventChart backward
-     *             compatible with the new EventVisualization entity.
+     *             compatible with the new EventVisualization entity. Only
+     *             legacy and chart related types can be returned by this
+     *             endpoint.
      *
      * @param filters
      */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.eventvisualization.EventVisualizationType.LINE_LIST;
 import static org.hisp.dhis.eventvisualization.EventVisualizationType.PIVOT_TABLE;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -106,6 +107,20 @@ public class EventReportController
     // --------------------------------------------------------------------------
     // Hooks
     // --------------------------------------------------------------------------
+
+    /**
+     * @deprecated This is a temporary workaround to keep EventReport backward
+     *             compatible with the new EventVisualization entity.
+     *
+     * @param filters
+     */
+    @Deprecated
+    @Override
+    protected void forceFiltering( final List<String> filters )
+    {
+        filters.add( "type:in:[PIVOT_TABLE,LINE_LIST]" );
+        filters.add( "legacy:eq:true" );
+    }
 
     @Override
     protected void postProcessResponseEntity( EventReport report, WebOptions options, Map<String, String> parameters )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventReportController.java
@@ -110,7 +110,9 @@ public class EventReportController
 
     /**
      * @deprecated This is a temporary workaround to keep EventReport backward
-     *             compatible with the new EventVisualization entity.
+     *             compatible with the new EventVisualization entity. Only
+     *             legacy and report related types can be returned by this
+     *             endpoint.
      *
      * @param filters
      */


### PR DESCRIPTION
This PR aims to filter out items created through the new endpoint `/eventVisualizations`.
Basically, items created by `/eventVisualizations` should not be readable by the legacy endpoints `/eventReports` and `/eventCharts`.
This is done because the new EventVisualization entity contains small differences that will break the existing apps Event Reports and Event Visualization.
