### PR TITLE
fix: data value import no hard coded response mime type [DHIS2-12262]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -213,7 +213,7 @@ public class DataValueSetController
     // Post
     // -------------------------------------------------------------------------
 
-    @PostMapping( consumes = APPLICATION_XML_VALUE, produces = CONTENT_TYPE_XML )
+    @PostMapping( consumes = APPLICATION_XML_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postDxf2DataValueSet( ImportOptions importOptions, HttpServletRequest request )
@@ -229,7 +229,7 @@ public class DataValueSetController
         return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
-    @PostMapping( consumes = CONTENT_TYPE_XML_ADX, produces = CONTENT_TYPE_XML )
+    @PostMapping( consumes = CONTENT_TYPE_XML_ADX )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postAdxDataValueSet( ImportOptions importOptions, HttpServletRequest request )
@@ -246,7 +246,7 @@ public class DataValueSetController
         return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
-    @PostMapping( consumes = APPLICATION_JSON_VALUE, produces = CONTENT_TYPE_JSON )
+    @PostMapping( consumes = APPLICATION_JSON_VALUE )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postJsonDataValueSet( ImportOptions importOptions, HttpServletRequest request )
@@ -262,7 +262,7 @@ public class DataValueSetController
         return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
-    @PostMapping( consumes = "application/csv", produces = CONTENT_TYPE_JSON )
+    @PostMapping( consumes = "application/csv" )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postCsvDataValueSet( ImportOptions importOptions, HttpServletRequest request )
@@ -278,7 +278,7 @@ public class DataValueSetController
         return importSummary( summary ).withPlainResponseBefore( V38 );
     }
 
-    @PostMapping( consumes = CONTENT_TYPE_PDF, produces = CONTENT_TYPE_JSON )
+    @PostMapping( consumes = CONTENT_TYPE_PDF )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_DATAVALUE_ADD')" )
     @ResponseBody
     public WebMessage postPdfDataValueSet( ImportOptions importOptions, HttpServletRequest request )


### PR DESCRIPTION
### Summary
Limiting the response mime type is unnecessary and causes issues in the app that always wants JSON back. So we just loosen the mapping so the client can ask for any of the supported types using any of the supported ways to negotiate the response format.

### Manual Testing
* open Import/Export app
* run data value import using XML, JSON and CSV files in dry run
* check the app shows the "Job started" info followed by a result a bit later for any of the inputs

Tip: If you don't have proper input files use the data value export with uncompressed to create some.