### PR TITLE
fix: Run a group's predictors in order [DHIS2-12091] (#9525)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/PredictorGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/predictor/PredictorGroup.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.predictor;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -92,6 +95,15 @@ public class PredictorGroup
         }
 
         members.clear();
+    }
+
+    public List<Predictor> getSortedMembers()
+    {
+        List<Predictor> predictors = new ArrayList<>( members );
+
+        predictors.sort( Comparator.comparing( BaseIdentifiableObject::getName ) );
+
+        return predictors;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -239,7 +239,7 @@ public class DefaultPredictionService
 
                 for ( PredictorGroup predictorGroup : predictorGroupList )
                 {
-                    predictorList.addAll( predictorGroup.getMembers() );
+                    predictorList.addAll( predictorGroup.getSortedMembers() );
                 }
             }
         }


### PR DESCRIPTION
(cherry picked from commit 31b080a939378ed9c2013abba9b349d463302344)