### PR TITLE
chore: assert on error/warning codes, type, uid in tracker error reports TECH-880

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import lombok.Data;
 
@@ -141,6 +142,16 @@ public class ValidationErrorReporter
     public boolean hasErrors()
     {
         return !this.reportList.isEmpty();
+    }
+
+    public boolean hasErrorReport( Predicate<TrackerErrorReport> test )
+    {
+        return reportList.stream().anyMatch( test );
+    }
+
+    public boolean hasWarningReport( Predicate<TrackerWarningReport> test )
+    {
+        return warningsReportList.stream().anyMatch( test );
     }
 
     public boolean hasWarnings()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.report;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.junit.jupiter.api.Test;
+
+class ValidationErrorReporterTest
+{
+
+    @Test
+    void hasErrorReportFound()
+    {
+
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerErrorReport error = TrackerErrorReport.builder()
+            .errorCode( TrackerErrorCode.E1000 )
+            .trackerType( TrackerType.EVENT )
+            .build( bundle );
+        reporter.getReportList().add( error );
+
+        assertTrue( reporter.hasErrorReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
+    }
+
+    @Test
+    void hasErrorReportNotFoundIfEmpty()
+    {
+
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+
+        assertFalse( reporter.hasErrorReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
+    }
+
+    @Test
+    void hasErrorReportNotFound()
+    {
+
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerErrorReport error = TrackerErrorReport.builder()
+            .errorCode( TrackerErrorCode.E1000 )
+            .trackerType( TrackerType.EVENT )
+            .build( bundle );
+        reporter.getReportList().add( error );
+
+        assertFalse( reporter.hasErrorReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
+    }
+
+    @Test
+    void hasWarningReportFound()
+    {
+
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerWarningReport warning = TrackerWarningReport.builder()
+            .warningCode( TrackerErrorCode.E1000 )
+            .trackerType( TrackerType.EVENT )
+            .build( bundle );
+        reporter.getWarningsReportList().add( warning );
+
+        assertTrue( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
+    }
+
+    @Test
+    void hasWarningReportNotFoundIfEmpty()
+    {
+
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+
+        assertFalse( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
+    }
+
+    @Test
+    void hasWarningReportNotFound()
+    {
+
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerWarningReport warning = TrackerWarningReport.builder()
+            .warningCode( TrackerErrorCode.E1000 )
+            .trackerType( TrackerType.EVENT )
+            .build( bundle );
+        reporter.getWarningsReportList().add( warning );
+
+        assertFalse( reporter.hasWarningReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
@@ -54,15 +54,6 @@ class ValidationErrorReporterTest
     }
 
     @Test
-    void hasErrorReportNotFoundIfEmpty()
-    {
-
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
-
-        assertFalse( reporter.hasErrorReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
-    }
-
-    @Test
     void hasErrorReportNotFound()
     {
 
@@ -90,15 +81,6 @@ class ValidationErrorReporterTest
         reporter.getWarningsReportList().add( warning );
 
         assertTrue( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
-    }
-
-    @Test
-    void hasWarningReportNotFoundIfEmpty()
-    {
-
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
-
-        assertFalse( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationOrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationOrderTest.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class DefaultTrackerValidationServiceOrderTest extends DhisSpringTest
+class TrackerValidationOrderTest extends DhisSpringTest
 {
     @Autowired
     TrackerValidationService trackerValidationService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import lombok.Builder;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.TrackerValidationReport;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.hooks.AbstractTrackerDtoValidationHook;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+class TrackerValidationServiceReportTest
+{
+
+    @Builder
+    private static class ValidationHook extends AbstractTrackerDtoValidationHook
+    {
+        boolean removeOnError;
+
+        private BiConsumer<ValidationErrorReporter, Event> validateEvent;
+
+        private BiConsumer<ValidationErrorReporter, Enrollment> validateEnrollment;
+
+        @Override
+        public void validateEvent( ValidationErrorReporter reporter, Event event )
+        {
+            if ( this.validateEvent != null )
+            {
+                this.validateEvent.accept( reporter, event );
+            }
+        }
+
+        @Override
+        public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+        {
+            if ( this.validateEnrollment != null )
+            {
+                this.validateEnrollment.accept( reporter, enrollment );
+            }
+        }
+
+        @Override
+        public boolean removeOnError()
+        {
+            return this.removeOnError;
+        }
+    }
+
+    @Test
+    void reportAndRemoveInvalidFromBundleWithRemoveOnErrorHook()
+    {
+
+        // Test shows
+        // 1. all ValidationErrorReports created by the individual hooks
+        // are merged across hooks and DTOs and returned as one report from the
+        // TrackerValidationService
+        // 2. the TrackerBundle is mutated to only contain valid DTOs after
+        // validation
+        // Currently the bundle is mutated by
+        // 1. AbstractTrackerDtoValidationHook removes invalid DTOs if the hook
+        // has removeOnError == true
+        // 2. DefaultTrackerValidationService removes invalid DTOs if the hook
+        // has removeOnError == false
+
+        // Note: the current AbstractTrackerDtoValidationHook relies on the
+        // bundle "DTO" lists to be mutable
+        // it uses iterator.remove() in validateTrackerDtos()
+        // which is why we cannot use List.of(), Arrays.asList()
+        Event validEvent = event();
+        Event invalidEvent = event();
+        List<Event> events = new ArrayList<>();
+        events.add( invalidEvent );
+        events.add( validEvent );
+
+        Enrollment validEnrollment = enrollment();
+        Enrollment invalidEnrollment = enrollment();
+        List<Enrollment> enrollments = new ArrayList<>();
+        enrollments.add( validEnrollment );
+        enrollments.add( invalidEnrollment );
+
+        TrackerBundle bundle = TrackerBundle.builder()
+                .validationMode( ValidationMode.FULL )
+                .skipRuleEngine( true )
+                .events( events )
+                .enrollments( enrollments )
+                .build();
+
+        ValidationHook removeOnError = ValidationHook.builder()
+                .removeOnError( true )
+                .validateEvent( ( reporter, event ) -> {
+                    if ( invalidEvent.equals( event ) )
+                    {
+                        reporter.addError(
+                                TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                                        .trackerType( TrackerType.EVENT )
+                                        .uid( event.getUid() ) );
+                    }
+                } )
+                .build();
+        ValidationHook doNotRemoveOnError = ValidationHook.builder()
+                .removeOnError( false )
+                .validateEnrollment( ( reporter, enrollment ) -> {
+                    if ( invalidEnrollment.equals( enrollment ) )
+                    {
+                        reporter.addError(
+                                TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
+                                        .trackerType( TrackerType.ENROLLMENT )
+                                        .uid( enrollment.getUid() ) );
+                    }
+                } )
+                .build();
+        TrackerValidationService validationService = new DefaultTrackerValidationService(
+                List.of( removeOnError, doNotRemoveOnError ),
+                Collections.emptyList() );
+
+        TrackerValidationReport report = validationService.validate( bundle );
+
+        assertTrue( report.hasErrors() );
+        assertEquals( 2, report.getErrorReports().size() );
+        assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
+                && TrackerType.EVENT == err.getTrackerType()
+                && invalidEvent.getUid().equals( err.getUid() ) ) );
+        assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1069 == err.getErrorCode()
+                && TrackerType.ENROLLMENT == err.getTrackerType()
+                && invalidEnrollment.getUid().equals( err.getUid() ) ) );
+
+        assertFalse( bundle.getEvents().contains( invalidEvent ) );
+        assertFalse( bundle.getEnrollments().contains( invalidEnrollment ) );
+        assertTrue( bundle.getEvents().contains( validEvent ) );
+        assertTrue( bundle.getEnrollments().contains( validEnrollment ) );
+    }
+
+    @NotNull
+    private Enrollment enrollment()
+    {
+        Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
+        return enrollment;
+    }
+
+    @NotNull
+    private Event event()
+    {
+        Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
+        return event;
+    }
+
+    @Test
+    void failFastDoesNotCallHooksAfterFailure()
+    {
+
+        Event validEvent = event();
+        Event invalidEvent = event();
+        List<Event> events = new ArrayList<>();
+        events.add( invalidEvent );
+        events.add( validEvent );
+
+        TrackerBundle bundle = TrackerBundle.builder()
+                .validationMode( ValidationMode.FAIL_FAST )
+                .skipRuleEngine( true )
+                .events( events )
+                .build();
+
+        ValidationHook hook1 = ValidationHook.builder()
+                .removeOnError( true )
+                .validateEvent( ( reporter, event ) -> {
+                    if ( invalidEvent.equals( event ) )
+                    {
+                        reporter.addError(
+                                TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                                        .trackerType( TrackerType.EVENT )
+                                        .uid( event.getUid() ) );
+                    }
+                } ).build();
+        TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
+        TrackerValidationService validationService = new DefaultTrackerValidationService( List.of( hook1 ),
+                Collections.emptyList() );
+
+        TrackerValidationReport report = validationService.validate( bundle );
+
+        assertTrue( report.hasErrors() );
+        assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
+                && TrackerType.EVENT == err.getTrackerType()
+                && invalidEvent.getUid().equals( err.getUid() ) ) );
+
+        // TODO(TECH-880): Is this intentional? When in FAIL_FAST mode,
+        // reporter.addError() throws a FailFastException
+        // which makes sure we exit early and do not call any more hooks. It
+        // also leads to no call to reporter.merge()
+        // which is what adds DTOs into the invalidDTO list.
+        assertTrue( bundle.getEvents().contains( invalidEvent ) );
+        assertTrue( bundle.getEvents().contains( validEvent ) );
+
+        verifyNoInteractions( hook2 );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
@@ -124,50 +124,50 @@ class TrackerValidationServiceReportTest
         enrollments.add( invalidEnrollment );
 
         TrackerBundle bundle = TrackerBundle.builder()
-                .validationMode( ValidationMode.FULL )
-                .skipRuleEngine( true )
-                .events( events )
-                .enrollments( enrollments )
-                .build();
+            .validationMode( ValidationMode.FULL )
+            .skipRuleEngine( true )
+            .events( events )
+            .enrollments( enrollments )
+            .build();
 
         ValidationHook removeOnError = ValidationHook.builder()
-                .removeOnError( true )
-                .validateEvent( ( reporter, event ) -> {
-                    if ( invalidEvent.equals( event ) )
-                    {
-                        reporter.addError(
-                                TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
-                                        .trackerType( TrackerType.EVENT )
-                                        .uid( event.getUid() ) );
-                    }
-                } )
-                .build();
+            .removeOnError( true )
+            .validateEvent( ( reporter, event ) -> {
+                if ( invalidEvent.equals( event ) )
+                {
+                    reporter.addError(
+                        TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                            .trackerType( TrackerType.EVENT )
+                            .uid( event.getUid() ) );
+                }
+            } )
+            .build();
         ValidationHook doNotRemoveOnError = ValidationHook.builder()
-                .removeOnError( false )
-                .validateEnrollment( ( reporter, enrollment ) -> {
-                    if ( invalidEnrollment.equals( enrollment ) )
-                    {
-                        reporter.addError(
-                                TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
-                                        .trackerType( TrackerType.ENROLLMENT )
-                                        .uid( enrollment.getUid() ) );
-                    }
-                } )
-                .build();
+            .removeOnError( false )
+            .validateEnrollment( ( reporter, enrollment ) -> {
+                if ( invalidEnrollment.equals( enrollment ) )
+                {
+                    reporter.addError(
+                        TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
+                            .trackerType( TrackerType.ENROLLMENT )
+                            .uid( enrollment.getUid() ) );
+                }
+            } )
+            .build();
         TrackerValidationService validationService = new DefaultTrackerValidationService(
-                List.of( removeOnError, doNotRemoveOnError ),
-                Collections.emptyList() );
+            List.of( removeOnError, doNotRemoveOnError ),
+            Collections.emptyList() );
 
         TrackerValidationReport report = validationService.validate( bundle );
 
         assertTrue( report.hasErrors() );
         assertEquals( 2, report.getErrorReports().size() );
         assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
-                && TrackerType.EVENT == err.getTrackerType()
-                && invalidEvent.getUid().equals( err.getUid() ) ) );
+            && TrackerType.EVENT == err.getTrackerType()
+            && invalidEvent.getUid().equals( err.getUid() ) ) );
         assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1069 == err.getErrorCode()
-                && TrackerType.ENROLLMENT == err.getTrackerType()
-                && invalidEnrollment.getUid().equals( err.getUid() ) ) );
+            && TrackerType.ENROLLMENT == err.getTrackerType()
+            && invalidEnrollment.getUid().equals( err.getUid() ) ) );
 
         assertFalse( bundle.getEvents().contains( invalidEvent ) );
         assertFalse( bundle.getEnrollments().contains( invalidEnrollment ) );
@@ -202,32 +202,32 @@ class TrackerValidationServiceReportTest
         events.add( validEvent );
 
         TrackerBundle bundle = TrackerBundle.builder()
-                .validationMode( ValidationMode.FAIL_FAST )
-                .skipRuleEngine( true )
-                .events( events )
-                .build();
+            .validationMode( ValidationMode.FAIL_FAST )
+            .skipRuleEngine( true )
+            .events( events )
+            .build();
 
         ValidationHook hook1 = ValidationHook.builder()
-                .removeOnError( true )
-                .validateEvent( ( reporter, event ) -> {
-                    if ( invalidEvent.equals( event ) )
-                    {
-                        reporter.addError(
-                                TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
-                                        .trackerType( TrackerType.EVENT )
-                                        .uid( event.getUid() ) );
-                    }
-                } ).build();
+            .removeOnError( true )
+            .validateEvent( ( reporter, event ) -> {
+                if ( invalidEvent.equals( event ) )
+                {
+                    reporter.addError(
+                        TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                            .trackerType( TrackerType.EVENT )
+                            .uid( event.getUid() ) );
+                }
+            } ).build();
         TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
         TrackerValidationService validationService = new DefaultTrackerValidationService( List.of( hook1 ),
-                Collections.emptyList() );
+            Collections.emptyList() );
 
         TrackerValidationReport report = validationService.validate( bundle );
 
         assertTrue( report.hasErrors() );
         assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
-                && TrackerType.EVENT == err.getTrackerType()
-                && invalidEvent.getUid().equals( err.getUid() ) ) );
+            && TrackerType.EVENT == err.getTrackerType()
+            && invalidEvent.getUid().equals( err.getUid() ) ) );
 
         // TODO(TECH-880): Is this intentional? When in FAIL_FAST mode,
         // reporter.addError() throws a FailFastException

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertValidationErrorReporter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation.hooks;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+
+public class AssertValidationErrorReporter
+{
+
+    public static void hasTrackerError( ValidationErrorReporter reporter, TrackerErrorCode code, TrackerType type,
+        String uid )
+    {
+        assertTrue( reporter.hasErrors(), "error not found since reporter has no errors" );
+        assertTrue( reporter.hasErrorReport( err -> code == err.getErrorCode() &&
+            type == err.getTrackerType() &&
+            uid.equals( err.getUid() ) ),
+            String.format( "error with code %s, type %s, uid %s not found in reporter with %d error(s)", code, type,
+                uid, reporter.getReportList().size() ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -27,18 +27,20 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1118;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.TrackerIdentifier;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
@@ -107,6 +109,7 @@ class AssignedUserValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( "not_valid_uid" );
         event.setProgramStage( PROGRAM_STAGE );
 
@@ -117,7 +120,9 @@ class AssignedUserValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1118 ) );
+        assertEquals( E1118, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
     }
 
     @Test
@@ -125,6 +130,7 @@ class AssignedUserValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
@@ -139,7 +145,9 @@ class AssignedUserValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1118 ) );
+        assertEquals( E1118, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
     }
 
     @Test
@@ -147,6 +155,7 @@ class AssignedUserValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
@@ -162,7 +171,9 @@ class AssignedUserValidationHookTest
         // then
         assertFalse( reporter.hasErrors() );
         assertTrue( reporter.hasWarnings() );
-        assertThat( reporter.getWarningsReportList().get( 0 ).getWarningCode(), is( TrackerErrorCode.E1120 ) );
+        assertEquals( E1120, reporter.getWarningsReportList().get( 0 ).getWarningCode() );
+        assertEquals( TrackerType.EVENT, reporter.getWarningsReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getWarningsReportList().get( 0 ).getUid() );
     }
 
     @Test
@@ -185,6 +196,8 @@ class AssignedUserValidationHookTest
         // then
         assertFalse( reporter.hasErrors() );
         assertTrue( reporter.hasWarnings() );
-        assertThat( reporter.getWarningsReportList().get( 0 ).getWarningCode(), is( TrackerErrorCode.E1120 ) );
+        assertEquals( E1120, reporter.getWarningsReportList().get( 0 ).getWarningCode() );
+        assertEquals( TrackerType.EVENT, reporter.getWarningsReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getWarningsReportList().get( 0 ).getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1118;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -120,9 +119,9 @@ class AssignedUserValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1118, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1118.equals( err.getErrorCode() ) &&
+            TrackerType.EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -145,9 +144,9 @@ class AssignedUserValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1118, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1118.equals( err.getErrorCode() ) &&
+            TrackerType.EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -171,9 +170,9 @@ class AssignedUserValidationHookTest
         // then
         assertFalse( reporter.hasErrors() );
         assertTrue( reporter.hasWarnings() );
-        assertEquals( E1120, reporter.getWarningsReportList().get( 0 ).getWarningCode() );
-        assertEquals( TrackerType.EVENT, reporter.getWarningsReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getWarningsReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasWarningReport( r -> E1120.equals( r.getWarningCode() ) &&
+            TrackerType.EVENT.equals( r.getTrackerType() ) &&
+            event.getUid().equals( r.getUid() ) ) );
     }
 
     @Test
@@ -181,6 +180,7 @@ class AssignedUserValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
@@ -196,8 +196,8 @@ class AssignedUserValidationHookTest
         // then
         assertFalse( reporter.hasErrors() );
         assertTrue( reporter.hasWarnings() );
-        assertEquals( E1120, reporter.getWarningsReportList().get( 0 ).getWarningCode() );
-        assertEquals( TrackerType.EVENT, reporter.getWarningsReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getWarningsReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasWarningReport( r -> E1120.equals( r.getWarningCode() ) &&
+            TrackerType.EVENT.equals( r.getTrackerType() ) &&
+            event.getUid().equals( r.getUid() ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1118;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -118,10 +119,7 @@ class AssignedUserValidationHookTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1118.equals( err.getErrorCode() ) &&
-            TrackerType.EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1118, TrackerType.EVENT, event.getUid() );
     }
 
     @Test
@@ -143,10 +141,7 @@ class AssignedUserValidationHookTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1118.equals( err.getErrorCode() ) &&
-            TrackerType.EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1118, TrackerType.EVENT, event.getUid() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -147,12 +147,12 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext, enrollment );
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertThat( validationErrorReporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertTrue(
-            validationErrorReporter.hasErrorReport( err -> TrackerErrorCode.E1076.equals( err.getErrorCode() ) &&
+            reporter.hasErrorReport( err -> TrackerErrorCode.E1076.equals( err.getErrorCode() ) &&
                 TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
                 enrollment.getUid().equals( err.getUid() ) ) );
     }
@@ -178,10 +178,10 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext, enrollment );
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertThat( validationErrorReporter.getReportList(), hasSize( 0 ) );
+        assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
 
     @Test
@@ -204,16 +204,16 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext, enrollment );
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertThat( validationErrorReporter.getReportList(), hasSize( 2 ) );
+        assertThat( reporter.getReportList(), hasSize( 2 ) );
         assertTrue(
-            validationErrorReporter.hasErrorReport( err -> TrackerErrorCode.E1076.equals( err.getErrorCode() ) &&
+            reporter.hasErrorReport( err -> TrackerErrorCode.E1076.equals( err.getErrorCode() ) &&
                 TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
                 enrollment.getUid().equals( err.getUid() ) ) );
         assertTrue(
-            validationErrorReporter.hasErrorReport( err -> TrackerErrorCode.E1018.equals( err.getErrorCode() ) &&
+            reporter.hasErrorReport( err -> TrackerErrorCode.E1018.equals( err.getErrorCode() ) &&
                 TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
                 enrollment.getUid().equals( err.getUid() ) ) );
     }
@@ -227,21 +227,21 @@ class EnrollmentAttributeValidationHookTest
             .value( "value" )
             .build();
 
-        when( program.getProgramAttributes() ).thenReturn( Arrays.asList() );
+        when( program.getProgramAttributes() ).thenReturn( Collections.emptyList() );
 
-        when( enrollment.getAttributes() ).thenReturn( Arrays.asList( attribute ) );
+        when( enrollment.getAttributes() ).thenReturn( Collections.singletonList( attribute ) );
         when( trackedEntityInstance.getTrackedEntityAttributeValues() )
             .thenReturn( new HashSet<>( Collections
                 .singletonList( new TrackedEntityAttributeValue( trackedEntityAttribute, trackedEntityInstance ) ) ) );
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext, enrollment );
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertThat( validationErrorReporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertTrue(
-            validationErrorReporter.hasErrorReport( err -> TrackerErrorCode.E1006.equals( err.getErrorCode() ) &&
+            reporter.hasErrorReport( err -> TrackerErrorCode.E1006.equals( err.getErrorCode() ) &&
                 TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
                 enrollment.getUid().equals( err.getUid() ) ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -151,10 +151,7 @@ class EnrollmentAttributeValidationHookTest
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertTrue(
-            reporter.hasErrorReport( err -> TrackerErrorCode.E1076.equals( err.getErrorCode() ) &&
-                TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-                enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -208,14 +205,8 @@ class EnrollmentAttributeValidationHookTest
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 2 ) );
-        assertTrue(
-            reporter.hasErrorReport( err -> TrackerErrorCode.E1076.equals( err.getErrorCode() ) &&
-                TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-                enrollment.getUid().equals( err.getUid() ) ) );
-        assertTrue(
-            reporter.hasErrorReport( err -> TrackerErrorCode.E1018.equals( err.getErrorCode() ) &&
-                TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-                enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
+        hasTrackerError( reporter, TrackerErrorCode.E1018, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -240,9 +231,9 @@ class EnrollmentAttributeValidationHookTest
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertTrue(
-            reporter.hasErrorReport( err -> TrackerErrorCode.E1006.equals( err.getErrorCode() ) &&
-                TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-                enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter,
+            TrackerErrorCode.E1006,
+            TrackerType.ENROLLMENT,
+            enrollment.getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -32,8 +32,8 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1020;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1021;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1023;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1025;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
@@ -87,10 +87,7 @@ class EnrollmentDateValidationHookTest
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1025.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1025, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -110,13 +107,8 @@ class EnrollmentDateValidationHookTest
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1020.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
-        assertTrue( reporter.hasErrorReport( err -> E1021.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1020, ENROLLMENT, enrollment.getUid() );
+        hasTrackerError( reporter, E1021, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -177,10 +169,7 @@ class EnrollmentDateValidationHookTest
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1023.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1023, ENROLLMENT, enrollment.getUid() );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -27,8 +27,11 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1020;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1021;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1023;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1025;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -40,7 +43,6 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +77,7 @@ class EnrollmentDateValidationHookTest
     void testMandatoryDatesMustBePresent()
     {
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( CodeGenerator.generateUid() );
         enrollment.setOccurredAt( Instant.now() );
 
@@ -85,13 +88,16 @@ class EnrollmentDateValidationHookTest
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1025 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1025.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
     void testDatesMustNotBeInTheFuture()
     {
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( CodeGenerator.generateUid() );
         final Instant dateInTheFuture = Instant.now().plus( Duration.ofDays( 2 ) );
 
@@ -105,8 +111,12 @@ class EnrollmentDateValidationHookTest
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1020 ) );
-        assertThat( reporter.getReportList().get( 1 ).getErrorCode(), is( TrackerErrorCode.E1021 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1020.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
+        assertTrue( reporter.hasErrorReport( err -> E1021.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -132,9 +142,9 @@ class EnrollmentDateValidationHookTest
     void testDatesCanBeInTheFuture()
     {
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( CodeGenerator.generateUid() );
         final Instant dateInTheFuture = Instant.now().plus( Duration.ofDays( 2 ) );
-
         enrollment.setOccurredAt( dateInTheFuture );
         enrollment.setEnrolledAt( dateInTheFuture );
 
@@ -154,6 +164,7 @@ class EnrollmentDateValidationHookTest
     void testFailOnMissingOccurredAtDate()
     {
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( CodeGenerator.generateUid() );
 
         enrollment.setEnrolledAt( Instant.now() );
@@ -167,7 +178,9 @@ class EnrollmentDateValidationHookTest
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1023 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1023.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -114,6 +115,7 @@ class EnrollmentGeoValidationHookTest
     {
         // given
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
@@ -137,6 +139,7 @@ class EnrollmentGeoValidationHookTest
     {
         // given
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
@@ -161,6 +164,7 @@ class EnrollmentGeoValidationHookTest
     {
         // given
         Enrollment enrollment = new Enrollment();
+        enrollment.setEnrollment( CodeGenerator.generateUid() );
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -30,9 +30,9 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1012;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1074;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.CodeGenerator;
@@ -128,10 +128,7 @@ class EnrollmentGeoValidationHookTest
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1074.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1074, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -153,10 +150,7 @@ class EnrollmentGeoValidationHookTest
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1012, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -178,9 +172,6 @@ class EnrollmentGeoValidationHookTest
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1012, ENROLLMENT, enrollment.getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1012;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1074;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,7 +39,6 @@ import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -127,7 +127,9 @@ class EnrollmentGeoValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1074 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1074.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -149,7 +151,9 @@ class EnrollmentGeoValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1012 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -171,6 +175,8 @@ class EnrollmentGeoValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1012 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -85,7 +85,7 @@ class EnrollmentInExistingValidationHookTest
     @Mock
     private TrackedEntityInstance trackedEntityInstance;
 
-    private ValidationErrorReporter validationErrorReporter;
+    private ValidationErrorReporter reporter;
 
     private static final String programUid = "program";
 
@@ -115,14 +115,14 @@ class EnrollmentInExistingValidationHookTest
         program.setUid( programUid );
 
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
-        validationErrorReporter = new ValidationErrorReporter( validationContext );
+        reporter = new ValidationErrorReporter( validationContext );
     }
 
     @Test
     void shouldExitCancelledStatus()
     {
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.CANCELLED );
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
         verify( validationContext, times( 0 ) ).getProgram( programUid );
     }
@@ -132,7 +132,7 @@ class EnrollmentInExistingValidationHookTest
     {
         when( enrollment.getProgram() ).thenReturn( null );
         assertThrows( NullPointerException.class,
-            () -> hookToTest.validateEnrollment( validationErrorReporter, enrollment ) );
+            () -> hookToTest.validateEnrollment( reporter, enrollment ) );
     }
 
     @Test
@@ -143,7 +143,7 @@ class EnrollmentInExistingValidationHookTest
 
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.COMPLETED );
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
         verify( validationContext.getBundle(), times( 0 ) ).getPreheat();
     }
@@ -158,7 +158,7 @@ class EnrollmentInExistingValidationHookTest
 
         when( enrollment.getTrackedEntity() ).thenReturn( null );
         assertThrows( NullPointerException.class,
-            () -> hookToTest.validateEnrollment( validationErrorReporter, enrollment ) );
+            () -> hookToTest.validateEnrollment( reporter, enrollment ) );
     }
 
     @Test
@@ -169,9 +169,9 @@ class EnrollmentInExistingValidationHookTest
 
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertFalse( validationErrorReporter.hasErrors() );
+        assertFalse( reporter.hasErrors() );
     }
 
     @Test
@@ -179,12 +179,12 @@ class EnrollmentInExistingValidationHookTest
     {
         setEnrollmentInPayload( EnrollmentStatus.ACTIVE );
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( validationErrorReporter.getReportList(),
+        assertThat( reporter.getReportList(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
     }
 
@@ -198,12 +198,12 @@ class EnrollmentInExistingValidationHookTest
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( validationErrorReporter.getReportList(),
+        assertThat( reporter.getReportList(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
     }
 
@@ -212,9 +212,9 @@ class EnrollmentInExistingValidationHookTest
     {
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertFalse( validationErrorReporter.hasErrors() );
+        assertFalse( reporter.hasErrors() );
     }
 
     @Test
@@ -222,12 +222,12 @@ class EnrollmentInExistingValidationHookTest
     {
         setTeiInDb();
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( validationErrorReporter.getReportList(),
+        assertThat( reporter.getReportList(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
     }
 
@@ -241,12 +241,12 @@ class EnrollmentInExistingValidationHookTest
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
         setTeiInDb( ProgramStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( validationErrorReporter.getReportList(),
+        assertThat( reporter.getReportList(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
     }
 
@@ -255,9 +255,9 @@ class EnrollmentInExistingValidationHookTest
     {
         setTeiInDb( ProgramStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertFalse( validationErrorReporter.hasErrors() );
+        assertFalse( reporter.hasErrors() );
     }
 
     @Test
@@ -271,12 +271,12 @@ class EnrollmentInExistingValidationHookTest
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
         setTeiInDb();
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( validationErrorReporter.getReportList(),
+        assertThat( reporter.getReportList(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
 
     }
@@ -292,9 +292,9 @@ class EnrollmentInExistingValidationHookTest
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
         setTeiInDb();
 
-        hookToTest.validateEnrollment( validationErrorReporter, enrollment );
+        hookToTest.validateEnrollment( reporter, enrollment );
 
-        assertFalse( validationErrorReporter.hasErrors() );
+        assertFalse( reporter.hasErrors() );
 
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1015;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1016;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -40,7 +41,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
@@ -183,9 +183,7 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertTrue( reporter.hasErrorReport( err -> E1015.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1015, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -203,9 +201,7 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertTrue( reporter.hasErrorReport( err -> E1016.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1016, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -228,9 +224,7 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertTrue( reporter.hasErrorReport( err -> E1015.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1015, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -247,9 +241,7 @@ class EnrollmentInExistingValidationHookTest
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
-        assertTrue( reporter.hasErrorReport( err -> E1016.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1016, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -277,11 +269,7 @@ class EnrollmentInExistingValidationHookTest
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
-
-        assertTrue( reporter.hasErrorReport( err -> E1016.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
-
+        hasTrackerError( reporter, E1016, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -308,7 +296,7 @@ class EnrollmentInExistingValidationHookTest
 
     private void setTeiInDb( ProgramStatus programStatus )
     {
-        when( preheat.getTrackedEntityToProgramInstanceMap() ).thenReturn( new HashMap<String, List<ProgramInstance>>()
+        when( preheat.getTrackedEntityToProgramInstanceMap() ).thenReturn( new HashMap<>()
         {
             {
                 ProgramInstance programInstance = new ProgramInstance();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1015;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1016;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,7 +51,6 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -104,6 +102,7 @@ class EnrollmentInExistingValidationHookTest
         when( enrollment.getTrackedEntity() ).thenReturn( trackedEntity );
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.ACTIVE );
         when( enrollment.getEnrollment() ).thenReturn( enrollmentUid );
+        when( enrollment.getUid() ).thenReturn( enrollmentUid );
 
         when( validationContext.getTrackedEntityInstance( trackedEntity ) ).thenReturn( trackedEntityInstance );
         when( trackedEntityInstance.getUid() ).thenReturn( trackedEntity );
@@ -115,7 +114,7 @@ class EnrollmentInExistingValidationHookTest
         program.setUid( programUid );
 
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
-        reporter = new ValidationErrorReporter( validationContext );
+        reporter = new ValidationErrorReporter( validationContext, enrollment );
     }
 
     @Test
@@ -184,8 +183,9 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( reporter.getReportList(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
+        assertTrue( reporter.hasErrorReport( err -> E1015.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -203,8 +203,9 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( reporter.getReportList(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
+        assertTrue( reporter.hasErrorReport( err -> E1016.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -227,8 +228,9 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( reporter.getReportList(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
+        assertTrue( reporter.hasErrorReport( err -> E1015.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -245,9 +247,9 @@ class EnrollmentInExistingValidationHookTest
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
-
-        assertThat( reporter.getReportList(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
+        assertTrue( reporter.hasErrorReport( err -> E1016.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -276,8 +278,9 @@ class EnrollmentInExistingValidationHookTest
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
 
-        assertThat( reporter.getReportList(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1016 ) ) ) );
+        assertTrue( reporter.hasErrorReport( err -> E1016.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
 
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -29,7 +29,8 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1119;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -47,7 +48,6 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,7 +101,9 @@ class EnrollmentNoteValidationHookTest
 
         // Then
         assertTrue( reporter.hasWarnings() );
-        assertThat( reporter.getWarningsReportList().get( 0 ).getWarningCode(), is( TrackerErrorCode.E1119 ) );
+        assertTrue( reporter.hasWarningReport( warn -> E1119.equals( warn.getWarningCode() ) &&
+            ENROLLMENT.equals( warn.getTrackerType() ) &&
+            enrollment.getUid().equals( warn.getUid() ) ) );
         assertThat( enrollment.getNotes(), hasSize( 0 ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -34,8 +34,8 @@ import static org.hisp.dhis.tracker.ValidationMode.FULL;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1055;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1056;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1057;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -189,10 +189,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         hook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1055.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1055, EVENT, event.getUid() );
     }
 
     @Test
@@ -238,10 +235,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         hook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1056.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1056, EVENT, event.getUid() );
     }
 
     @Test
@@ -257,10 +251,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         hook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1057.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1057, EVENT, event.getUid() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -27,11 +27,13 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 import static org.hisp.dhis.category.CategoryOption.DEFAULT_NAME;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.ValidationMode.FULL;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1055;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1056;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1057;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,13 +47,13 @@ import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.mock.MockI18nFormat;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
@@ -136,6 +138,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( catCombo );
 
         event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( program.getUid() );
         event.setOccurredAt( EVENT_INSTANT );
 
@@ -187,7 +190,9 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1055 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1055.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -234,7 +239,9 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1056 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1056.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -251,7 +258,9 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1057 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1057.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -34,8 +34,8 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1043;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1046;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1047;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1050;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -138,11 +138,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1031.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
-
+        hasTrackerError( reporter, E1031, EVENT, event.getUid() );
     }
 
     @Test
@@ -160,10 +156,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1031.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1031, EVENT, event.getUid() );
     }
 
     @Test
@@ -181,10 +174,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1031.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1031, EVENT, event.getUid() );
     }
 
     @Test
@@ -203,10 +193,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1050.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1050, EVENT, event.getUid() );
     }
 
     @Test
@@ -225,10 +212,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1042.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1042, EVENT, event.getUid() );
     }
 
     @Test
@@ -248,10 +232,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1043.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1043, EVENT, event.getUid() );
     }
 
     @Test
@@ -271,10 +252,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1046.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1046, EVENT, event.getUid() );
     }
 
     @Test
@@ -293,10 +271,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1047.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1047, EVENT, event.getUid() );
     }
 
     private Program getProgramWithRegistration()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -27,8 +27,13 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1031;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1042;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1043;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1046;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1047;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1050;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -39,6 +44,7 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.program.Program;
@@ -46,7 +52,6 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
@@ -124,6 +129,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITHOUT_REGISTRATION_ID );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
@@ -133,7 +139,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1031 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1031.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
 
     }
 
@@ -142,6 +150,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setStatus( EventStatus.ACTIVE );
 
@@ -152,7 +161,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1031 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1031.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -160,6 +171,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setStatus( EventStatus.COMPLETED );
 
@@ -170,7 +182,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1031 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1031.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -178,6 +192,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( Instant.now() );
         event.setStatus( EventStatus.SCHEDULE );
@@ -189,7 +204,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1050 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1050.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -197,6 +214,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( now() );
         event.setStatus( EventStatus.COMPLETED );
@@ -208,7 +226,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1042 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1042.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -216,6 +236,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( now() );
         event.setCompletedAt( sevenDaysAgo() );
@@ -228,7 +249,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1043 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1043.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -236,6 +259,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( null );
         event.setScheduledAt( null );
@@ -248,7 +272,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1046 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1046.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -256,6 +282,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setOccurredAt( sevenDaysAgo() );
         event.setStatus( EventStatus.ACTIVE );
@@ -267,7 +294,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1047 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1047.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     private Program getProgramWithRegistration()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -27,18 +27,21 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.organisationunit.FeatureType.MULTI_POLYGON;
+import static org.hisp.dhis.organisationunit.FeatureType.NONE;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1012;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1074;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,6 +118,7 @@ class EventGeoValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
@@ -127,7 +131,9 @@ class EventGeoValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1074 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1074.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -135,6 +141,7 @@ class EventGeoValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
@@ -142,14 +149,16 @@ class EventGeoValidationHookTest
 
         // when
         ProgramStage programStage = new ProgramStage();
-        programStage.setFeatureType( FeatureType.NONE );
+        programStage.setFeatureType( NONE );
         when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
 
         this.hookToTest.validateEvent( reporter, event );
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1012 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -157,6 +166,7 @@ class EventGeoValidationHookTest
     {
         // given
         Event event = new Event();
+        event.setEvent( CodeGenerator.generateUid() );
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
@@ -164,13 +174,15 @@ class EventGeoValidationHookTest
 
         // when
         ProgramStage programStage = new ProgramStage();
-        programStage.setFeatureType( FeatureType.MULTI_POLYGON );
+        programStage.setFeatureType( MULTI_POLYGON );
         when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
 
         this.hookToTest.validateEvent( reporter, event );
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1012 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -32,9 +32,9 @@ import static org.hisp.dhis.organisationunit.FeatureType.NONE;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1012;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1074;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.CodeGenerator;
@@ -130,10 +130,7 @@ class EventGeoValidationHookTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1074.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1074, EVENT, event.getUid() );
     }
 
     @Test
@@ -155,10 +152,7 @@ class EventGeoValidationHookTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1012, EVENT, event.getUid() );
     }
 
     @Test
@@ -180,9 +174,6 @@ class EventGeoValidationHookTest
         this.hookToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1012.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1012, EVENT, event.getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -42,6 +41,7 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
@@ -101,7 +101,9 @@ class EventNoteValidationHookTest
 
         // Then
         assertTrue( reporter.hasWarnings() );
-        assertThat( reporter.getWarningsReportList().get( 0 ).getWarningCode(), is( TrackerErrorCode.E1119 ) );
+        assertTrue( reporter.hasWarningReport( r -> TrackerErrorCode.E1119.equals( r.getWarningCode() ) &&
+            TrackerType.EVENT.equals( r.getTrackerType() ) &&
+            event.getUid().equals( r.getUid() ) ) );
         assertThat( event.getNotes(), hasSize( 0 ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -30,6 +30,9 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1002;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1030;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1032;
@@ -184,7 +187,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1114 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1114.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -203,7 +208,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1002 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1002.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -222,7 +229,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1063 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1063.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -289,7 +298,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1113 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1113.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -308,7 +319,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1080 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1080.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -327,7 +340,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1081 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1081.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -394,7 +409,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1082 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1082.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -413,7 +430,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1030 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1030.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -432,7 +451,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1032 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1032.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
@@ -52,6 +51,7 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -485,7 +485,9 @@ class PreCheckExistenceValidationHookTest
 
         // then
         assertFalse( reporter.hasErrors() );
-        assertThat( reporter.getWarningsReportList().get( 0 ).getWarningCode(), is( E4015 ) );
+        assertTrue( reporter.hasWarningReport( r -> E4015.equals( r.getWarningCode() ) &&
+            TrackerType.RELATIONSHIP.equals( r.getTrackerType() ) &&
+            rel.getUid().equals( r.getUid() ) ) );
     }
 
     private TrackedEntityInstance getSoftDeletedTei()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -42,6 +42,7 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1082;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1113;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1114;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4015;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -186,10 +187,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1114.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1114, TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -207,10 +205,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1002.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1002, TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -228,10 +223,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1063.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1063, TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -297,10 +289,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1113.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1113, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -318,10 +307,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1080.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1080, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -339,10 +325,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1081.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1081, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -408,10 +391,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1082.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1082, EVENT, event.getUid() );
     }
 
     @Test
@@ -429,10 +409,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1030.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1030, EVENT, event.getUid() );
     }
 
     @Test
@@ -450,10 +427,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1032.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1032, EVENT, event.getUid() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1008;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -251,9 +252,7 @@ class PreCheckMandatoryFieldsValidationHookTest
 
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertTrue( reporter.hasErrorReport( err -> E1008.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1008, EVENT, event.getUid() );
     }
 
     @Test
@@ -387,9 +386,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertTrue( reporter.hasErrorReport( err -> errorCode.equals( err.getErrorCode() ) &&
-            type.equals( err.getTrackerType() ) &&
-            uid.equals( err.getUid() ) ) );
+        hasTrackerError( reporter, errorCode, type, uid );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Missing required " + entity + " property: `" + property + "`." ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -30,6 +30,11 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1008;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -38,6 +43,7 @@ import static org.mockito.Mockito.when;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -91,6 +97,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     void verifyTrackedEntityValidationSuccess()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( CodeGenerator.generateUid() )
             .trackedEntityType( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .build();
@@ -105,6 +112,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     void verifyTrackedEntityValidationFailsOnMissingOrgUnit()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( CodeGenerator.generateUid() )
             .trackedEntityType( CodeGenerator.generateUid() )
             .orgUnit( null )
             .build();
@@ -112,13 +120,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
-        assertMissingPropertyForTrackedEntity( reporter, "orgUnit" );
+        assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "orgUnit" );
     }
 
     @Test
     void verifyTrackedEntityValidationFailsOnMissingTrackedEntityType()
     {
         TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( CodeGenerator.generateUid() )
             .trackedEntityType( null )
             .orgUnit( CodeGenerator.generateUid() )
             .build();
@@ -126,13 +135,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
-        assertMissingPropertyForTrackedEntity( reporter, "trackedEntityType" );
+        assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "trackedEntityType" );
     }
 
     @Test
     void verifyEnrollmentValidationSuccess()
     {
         Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .program( CodeGenerator.generateUid() )
             .trackedEntity( CodeGenerator.generateUid() )
@@ -148,6 +158,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     void verifyEnrollmentValidationFailsOnMissingTrackedEntity()
     {
         Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .program( CodeGenerator.generateUid() )
             .trackedEntity( null )
@@ -156,13 +167,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
         validationHook.validateEnrollment( reporter, enrollment );
 
-        assertMissingPropertyForEnrollment( reporter, "trackedEntity" );
+        assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "trackedEntity" );
     }
 
     @Test
     void verifyEnrollmentValidationFailsOnMissingProgram()
     {
         Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .program( null )
             .trackedEntity( CodeGenerator.generateUid() )
@@ -171,13 +183,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
         validationHook.validateEnrollment( reporter, enrollment );
 
-        assertMissingPropertyForEnrollment( reporter, "program" );
+        assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "program" );
     }
 
     @Test
     void verifyEnrollmentValidationFailsOnMissingOrgUnit()
     {
         Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
             .orgUnit( null )
             .program( CodeGenerator.generateUid() )
             .trackedEntity( CodeGenerator.generateUid() )
@@ -186,13 +199,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
         validationHook.validateEnrollment( reporter, enrollment );
 
-        assertMissingPropertyForEnrollment( reporter, "orgUnit" );
+        assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "orgUnit" );
     }
 
     @Test
     void verifyEventValidationSuccess()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .programStage( CodeGenerator.generateUid() )
             .program( CodeGenerator.generateUid() )
@@ -208,6 +222,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     void verifyEventValidationFailsOnMissingProgram()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .programStage( CodeGenerator.generateUid() )
             .program( null )
@@ -216,13 +231,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
         validationHook.validateEvent( reporter, event );
 
-        assertMissingPropertyForEvent( reporter, "program" );
+        assertMissingPropertyForEvent( reporter, event.getUid(), "program" );
     }
 
     @Test
     void verifyEventValidationFailsOnMissingProgramStageReferenceToProgram()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .programStage( CodeGenerator.generateUid() )
             .build();
@@ -235,13 +251,16 @@ class PreCheckMandatoryFieldsValidationHookTest
 
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1008 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1008.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
     void verifyEventValidationFailsOnMissingProgramStage()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
             .programStage( null )
             .program( CodeGenerator.generateUid() )
@@ -250,13 +269,14 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
         validationHook.validateEvent( reporter, event );
 
-        assertMissingPropertyForEvent( reporter, "programStage" );
+        assertMissingPropertyForEvent( reporter, event.getUid(), "programStage" );
     }
 
     @Test
     void verifyEventValidationFailsOnMissingOrgUnit()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .orgUnit( null )
             .programStage( CodeGenerator.generateUid() )
             .program( CodeGenerator.generateUid() )
@@ -265,7 +285,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
         validationHook.validateEvent( reporter, event );
 
-        assertMissingPropertyForEvent( reporter, "orgUnit" );
+        assertMissingPropertyForEvent( reporter, event.getUid(), "orgUnit" );
     }
 
     @Test
@@ -302,7 +322,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertMissingPropertyForRelationship( reporter, "from" );
+        assertMissingPropertyForRelationship( reporter, relationship.getUid(), "from" );
     }
 
     @Test
@@ -319,7 +339,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertMissingPropertyForRelationship( reporter, "to" );
+        assertMissingPropertyForRelationship( reporter, relationship.getUid(), "to" );
     }
 
     @Test
@@ -338,35 +358,38 @@ class PreCheckMandatoryFieldsValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertMissingPropertyForRelationship( reporter, "relationshipType" );
+        assertMissingPropertyForRelationship( reporter, relationship.getUid(), "relationshipType" );
     }
 
-    private void assertMissingPropertyForTrackedEntity( ValidationErrorReporter reporter, String property )
+    private void assertMissingPropertyForTrackedEntity( ValidationErrorReporter reporter, String uid, String property )
     {
-        assertMissingProperty( reporter, "tracked entity", property, TrackerErrorCode.E1121 );
+        assertMissingProperty( reporter, TRACKED_ENTITY, "tracked entity", uid, property, TrackerErrorCode.E1121 );
     }
 
-    private void assertMissingPropertyForEnrollment( ValidationErrorReporter reporter, String property )
+    private void assertMissingPropertyForEnrollment( ValidationErrorReporter reporter, String uid, String property )
     {
-        assertMissingProperty( reporter, "enrollment", property, TrackerErrorCode.E1122 );
+        assertMissingProperty( reporter, ENROLLMENT, "enrollment", uid, property, TrackerErrorCode.E1122 );
     }
 
-    private void assertMissingPropertyForEvent( ValidationErrorReporter reporter, String property )
+    private void assertMissingPropertyForEvent( ValidationErrorReporter reporter, String uid, String property )
     {
-        assertMissingProperty( reporter, "event", property, TrackerErrorCode.E1123 );
+        assertMissingProperty( reporter, EVENT, "event", uid, property, TrackerErrorCode.E1123 );
     }
 
-    private void assertMissingPropertyForRelationship( ValidationErrorReporter reporter, String property )
+    private void assertMissingPropertyForRelationship( ValidationErrorReporter reporter, String uid, String property )
     {
-        assertMissingProperty( reporter, "relationship", property, TrackerErrorCode.E1124 );
+        assertMissingProperty( reporter, RELATIONSHIP, "relationship", uid, property, TrackerErrorCode.E1124 );
     }
 
-    private void assertMissingProperty( ValidationErrorReporter reporter, String entity, String property,
+    private void assertMissingProperty( ValidationErrorReporter reporter, TrackerType type, String entity, String uid,
+        String property,
         TrackerErrorCode errorCode )
     {
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( errorCode ) );
+        assertTrue( reporter.hasErrorReport( err -> errorCode.equals( err.getErrorCode() ) &&
+            type.equals( err.getTrackerType() ) &&
+            uid.equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Missing required " + entity + " property: `" + property + "`." ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -27,8 +27,10 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1005;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1010;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1011;
@@ -132,7 +134,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1049 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1049.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            tei.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -150,7 +154,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1005 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1005.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            tei.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -208,7 +214,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1070 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1070.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -227,7 +235,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1068 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1068.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -246,7 +256,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1069 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1069.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -284,7 +296,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1010 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1010.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -303,7 +317,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1013 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1013.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -322,7 +338,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1011 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1011.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -355,7 +373,9 @@ class PreCheckMetaValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E4006 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4006.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
     }
 
     private TrackedEntity validTei()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -40,8 +40,8 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1068;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1069;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1070;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4006;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -133,10 +133,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateTrackedEntity( reporter, tei );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1049.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            tei.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1049, TRACKED_ENTITY, tei.getUid() );
     }
 
     @Test
@@ -153,10 +150,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateTrackedEntity( reporter, tei );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1005.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            tei.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1005, TRACKED_ENTITY, tei.getUid() );
     }
 
     @Test
@@ -213,10 +207,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1070.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1070, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -234,10 +225,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1068.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1068, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -255,10 +243,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1069.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1069, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -295,10 +280,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1010.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1010, EVENT, event.getUid() );
     }
 
     @Test
@@ -316,10 +298,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1013.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1013, EVENT, event.getUid() );
     }
 
     @Test
@@ -337,10 +316,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1011.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1011, EVENT, event.getUid() );
     }
 
     @Test
@@ -372,10 +348,7 @@ class PreCheckMetaValidationHookTest
         validatorToTest.validateRelationship( reporter, relationship );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4006.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4006, RELATIONSHIP, relationship.getUid() );
     }
 
     private TrackedEntity validTei()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -27,11 +27,15 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1000;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1001;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1003;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1083;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1091;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1100;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1103;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1104;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -54,6 +58,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -319,7 +324,85 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1100 ) );
+        assertEquals( E1100, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
+    void verifyValidationFailsForTrackedEntityWithUserNotInOrgUnitCaptureScopeHierarchy()
+    {
+        TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( TEI_ID )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntityType( TEI_TYPE_ID )
+            .build();
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
+            .thenReturn( false );
+        when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+
+        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+
+        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
+    void verifyValidationFailsForTrackedEntityUpdateWithUserNotInOrgUnitSearchHierarchy()
+    {
+        TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( TEI_ID )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntityType( TEI_TYPE_ID )
+            .build();
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
+            .thenReturn( false );
+        when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+
+        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1003, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
+    void verifyValidationFailsForTrackedEntityAndUserWithoutWriteAccess()
+    {
+        TrackedEntity trackedEntity = TrackedEntity.builder()
+            .trackedEntity( CodeGenerator.generateUid() )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntityType( TEI_TYPE_ID )
+            .build();
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
+            .thenReturn( true );
+        when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( false );
+        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+
+        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1001, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
     }
 
     @Test
@@ -463,6 +546,33 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
+    void verifyValidationFailsForEnrollmentWithoutEventsUsingDeleteStrategyAndUserNotInOrgUnitHierarchy()
+    {
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntity( TEI_ID )
+            .program( PROGRAM_ID )
+            .build();
+        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
+        when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( false );
+        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
+            .thenReturn( false );
+        when( aclService.canDataWrite( user, program ) ).thenReturn( true );
+        when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, enrollment );
+
+        validatorToTest.validateEnrollment( reporter, enrollment );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
     void verifyValidationFailsForEnrollmentUsingDeleteStrategyAndUserWithoutCascadeAuthority()
     {
         Enrollment enrollment = Enrollment.builder()
@@ -484,7 +594,63 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1103 ) );
+        assertEquals( E1103, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
+    void verifyValidationFailsForEnrollmentDeletionAndUserWithoutProgramWriteAccess()
+    {
+        String enrollmentUid = CodeGenerator.generateUid();
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( enrollmentUid )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntity( TEI_ID )
+            .program( PROGRAM_ID )
+            .build();
+        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
+        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( aclService.canDataWrite( user, program ) ).thenReturn( false );
+        when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
+        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
+            .thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, enrollment );
+
+        validatorToTest.validateEnrollment( reporter, enrollment );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1091, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
+    void verifyValidationFailsForEnrollmentDeletionAndUserWithoutTrackedEntityTypeReadAccess()
+    {
+        String enrollmentUid = CodeGenerator.generateUid();
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( enrollmentUid )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntity( TEI_ID )
+            .program( PROGRAM_ID )
+            .build();
+        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
+        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( aclService.canDataWrite( user, program ) ).thenReturn( true );
+        when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( false );
+        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
+            .thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, enrollment );
+
+        validatorToTest.validateEnrollment( reporter, enrollment );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1104, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
     }
 
     @Test
@@ -663,6 +829,65 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
+    void verifyValidationFailsForTrackerEventCreationAndUserNotInOrgUnitCaptureScope()
+    {
+        Event event = Event.builder()
+            .enrollment( CodeGenerator.generateUid() )
+            .orgUnit( ORG_UNIT_ID )
+            .programStage( PS_ID )
+            .program( PROGRAM_ID )
+            .build();
+        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
+        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
+        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
+            .thenReturn( false );
+        when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
+        when( aclService.canDataRead( user, program ) ).thenReturn( true );
+        when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, event );
+
+        validatorToTest.validateEvent( reporter, event );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
+    void verifyValidationFailsForEventCreationThatIsCreatableInSearchScopeAndUserNotInOrgUnitSearchHierarchy()
+    {
+        Event event = Event.builder()
+            .enrollment( CodeGenerator.generateUid() )
+            .orgUnit( ORG_UNIT_ID )
+            .programStage( PS_ID )
+            .program( PROGRAM_ID )
+            .status( EventStatus.SCHEDULE )
+            .build();
+        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
+        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
+        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
+            .thenReturn( false );
+        when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
+        when( aclService.canDataRead( user, program ) ).thenReturn( true );
+        when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx, event );
+
+        validatorToTest.validateEvent( reporter, event );
+
+        assertTrue( reporter.hasErrors() );
+        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+    }
+
+    @Test
     void verifyValidationFailsForEventUsingUpdateStrategyAndUserWithoutAuthority()
     {
         String enrollmentUid = CodeGenerator.generateUid();
@@ -690,7 +915,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEvent( reporter, event );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1083 ) );
+        assertEquals( E1083, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
+        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
     }
 
     private TrackedEntityInstance getTEIWithNoProgramInstances()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1091;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1100;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1103;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1104;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -324,9 +323,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1100, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1100.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -351,9 +350,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -376,9 +375,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1003, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1003.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -400,9 +399,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1001, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.TRACKED_ENTITY, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( trackedEntity.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1001.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -567,9 +566,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
+            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -594,9 +593,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1103, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1103.equals( err.getErrorCode() ) &&
+            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -621,9 +620,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1091, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1091.equals( err.getErrorCode() ) &&
+            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -648,9 +647,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1104, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.ENROLLMENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( enrollment.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1104.equals( err.getErrorCode() ) &&
+            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -832,6 +831,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     void verifyValidationFailsForTrackerEventCreationAndUserNotInOrgUnitCaptureScope()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .enrollment( CodeGenerator.generateUid() )
             .orgUnit( ORG_UNIT_ID )
             .programStage( PS_ID )
@@ -852,15 +852,16 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEvent( reporter, event );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
+            TrackerType.EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
     void verifyValidationFailsForEventCreationThatIsCreatableInSearchScopeAndUserNotInOrgUnitSearchHierarchy()
     {
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .enrollment( CodeGenerator.generateUid() )
             .orgUnit( ORG_UNIT_ID )
             .programStage( PS_ID )
@@ -882,9 +883,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEvent( reporter, event );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1000, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
+            TrackerType.EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -892,6 +893,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         String enrollmentUid = CodeGenerator.generateUid();
         Event event = Event.builder()
+            .event( CodeGenerator.generateUid() )
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
             .programStage( PS_ID )
@@ -915,9 +917,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEvent( reporter, event );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( E1083, reporter.getReportList().get( 0 ).getErrorCode() );
-        assertEquals( TrackerType.EVENT, reporter.getReportList().get( 0 ).getTrackerType() );
-        assertEquals( event.getUid(), reporter.getReportList().get( 0 ).getUid() );
+        assertTrue( reporter.hasErrorReport( err -> E1083.equals( err.getErrorCode() ) &&
+            TrackerType.EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     private TrackedEntityInstance getTEIWithNoProgramInstances()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -35,8 +35,8 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1091;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1100;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1103;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1104;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import org.apache.commons.lang3.StringUtils;
@@ -322,10 +322,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1100.equals( err.getErrorCode() ) &&
-            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1100, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -349,10 +346,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
-            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1000, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -374,10 +368,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1003.equals( err.getErrorCode() ) &&
-            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1003, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -398,10 +389,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1001.equals( err.getErrorCode() ) &&
-            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1001, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -565,10 +553,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
-            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1000, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -592,10 +577,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1103.equals( err.getErrorCode() ) &&
-            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1103, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -619,10 +601,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1091.equals( err.getErrorCode() ) &&
-            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1091, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -646,10 +625,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1104.equals( err.getErrorCode() ) &&
-            TrackerType.ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1104, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -851,10 +827,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEvent( reporter, event );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
-            TrackerType.EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1000, TrackerType.EVENT, event.getUid() );
     }
 
     @Test
@@ -882,10 +855,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEvent( reporter, event );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1000.equals( err.getErrorCode() ) &&
-            TrackerType.EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1000, TrackerType.EVENT, event.getUid() );
     }
 
     @Test
@@ -916,10 +886,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validateEvent( reporter, event );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1083.equals( err.getErrorCode() ) &&
-            TrackerType.EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1083, TrackerType.EVENT, event.getUid() );
     }
 
     private TrackedEntityInstance getTEIWithNoProgramInstances()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -32,8 +32,8 @@ import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
 import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1048;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -89,10 +89,7 @@ class PreCheckUidValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1048, TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -116,10 +113,7 @@ class PreCheckUidValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
         validationHook.validateEnrollment( reporter, enrollment );
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -132,10 +126,7 @@ class PreCheckUidValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
         validationHook.validateEnrollment( reporter, enrollment );
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
     }
 
     @Test
@@ -158,10 +149,7 @@ class PreCheckUidValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
         validationHook.validateEvent( reporter, event );
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1048, EVENT, event.getUid() );
     }
 
     @Test
@@ -173,10 +161,7 @@ class PreCheckUidValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
         validationHook.validateEvent( reporter, event );
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1048, EVENT, event.getUid() );
     }
 
     @Test
@@ -198,9 +183,6 @@ class PreCheckUidValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1048, RELATIONSHIP, relationship.getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -27,8 +27,10 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1048;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,7 +90,9 @@ class PreCheckUidValidationHookTest
         validationHook.validateTrackedEntity( reporter, trackedEntity );
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -113,7 +117,9 @@ class PreCheckUidValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -127,7 +133,9 @@ class PreCheckUidValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -151,7 +159,9 @@ class PreCheckUidValidationHookTest
         validationHook.validateEvent( reporter, event );
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -164,7 +174,9 @@ class PreCheckUidValidationHookTest
         validationHook.validateEvent( reporter, event );
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -187,6 +199,8 @@ class PreCheckUidValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1048 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1048.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -29,7 +29,9 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1126;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1127;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1128;
@@ -131,7 +133,9 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1126 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1126.equals( err.getErrorCode() ) &&
+            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            trackedEntity.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -161,7 +165,9 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1127 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1127.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "program" ) );
     }
 
@@ -178,7 +184,9 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1127 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1127.equals( err.getErrorCode() ) &&
+            ENROLLMENT.equals( err.getTrackerType() ) &&
+            enrollment.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "trackedEntity" ) );
     }
 
@@ -209,7 +217,9 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1128 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1128.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "programStage" ) );
     }
 
@@ -226,7 +236,9 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( E1128 ) );
+        assertTrue( reporter.hasErrorReport( err -> E1128.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "enrollment" ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -35,8 +35,8 @@ import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1126;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1127;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1128;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -132,10 +132,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1126.equals( err.getErrorCode() ) &&
-            TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            trackedEntity.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1126, TRACKED_ENTITY, trackedEntity.getUid() );
     }
 
     @Test
@@ -164,10 +161,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1127.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1127, ENROLLMENT, enrollment.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "program" ) );
     }
 
@@ -183,10 +177,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1127.equals( err.getErrorCode() ) &&
-            ENROLLMENT.equals( err.getTrackerType() ) &&
-            enrollment.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1127, ENROLLMENT, enrollment.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "trackedEntity" ) );
     }
 
@@ -216,10 +207,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         validationHook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1128.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1128, EVENT, event.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "programStage" ) );
     }
 
@@ -235,10 +223,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         validationHook.validateEvent( reporter, event );
 
         // then
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E1128.equals( err.getErrorCode() ) &&
-            EVENT.equals( err.getTrackerType() ) &&
-            event.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E1128, EVENT, event.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "enrollment" ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -42,6 +42,7 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4010;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4013;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4014;
 import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
+import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -124,10 +125,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4009.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4009, RELATIONSHIP, relationship.getUid() );
     }
 
     @Test
@@ -190,10 +188,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4013.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4013, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
             "Relationship Type `from` constraint is missing trackedEntity." ) );
     }
@@ -226,10 +221,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4001.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4001, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
             "Relationship Item `to` for Relationship `nBx6auGDUHG` is invalid: an Item can link only one Tracker entity." ) );
     }
@@ -256,10 +248,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4010.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a trackedEntity but a enrollment was found." ) );
     }
@@ -286,10 +275,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4010.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a event but a enrollment was found." ) );
     }
@@ -316,10 +302,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4010.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a enrollment but a event was found." ) );
     }
@@ -360,10 +343,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4014.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a Tracked Entity having type `"
                 + constraintTrackedEntityType.getUid() + "` but `" + teiTrackedEntityType.getUid() + "` was found." ) );
@@ -405,10 +385,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4014.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a Tracked Entity having type `"
                 + constraintTrackedEntityType.getUid() + "` but `" + trackedEntity.getTrackedEntityType()
@@ -515,10 +492,7 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( ctx, relationship );
         validationHook.validateRelationship( reporter, relationship );
 
-        assertTrue( reporter.hasErrors() );
-        assertTrue( reporter.hasErrorReport( err -> E4000.equals( err.getErrorCode() ) &&
-            RELATIONSHIP.equals( err.getTrackerType() ) &&
-            relationship.getUid().equals( err.getUid() ) ) );
+        hasTrackerError( reporter, E4000, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship: `" + relationship.getRelationship() + "` cannot link to itself" ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -34,6 +34,13 @@ import static org.hamcrest.Matchers.not;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_STAGE_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.TRACKED_ENTITY_INSTANCE;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4000;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4001;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4009;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4010;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4013;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4014;
 import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -118,7 +125,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4009 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4009.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -182,7 +191,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4013 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4013.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
             "Relationship Type `from` constraint is missing trackedEntity." ) );
     }
@@ -216,7 +227,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4001 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4001.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
             "Relationship Item `to` for Relationship `nBx6auGDUHG` is invalid: an Item can link only one Tracker entity." ) );
     }
@@ -244,7 +257,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4010 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4010.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a trackedEntity but a enrollment was found." ) );
     }
@@ -272,7 +287,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4010 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4010.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a event but a enrollment was found." ) );
     }
@@ -300,7 +317,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4010 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4010.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a enrollment but a event was found." ) );
     }
@@ -342,7 +361,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4014 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4014.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a Tracked Entity having type `"
                 + constraintTrackedEntityType.getUid() + "` but `" + teiTrackedEntityType.getUid() + "` was found." ) );
@@ -385,7 +406,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4014 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4014.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a Tracked Entity having type `"
                 + constraintTrackedEntityType.getUid() + "` but `" + trackedEntity.getTrackedEntityType()
@@ -493,7 +516,9 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4000 ) );
+        assertTrue( reporter.hasErrorReport( err -> E4000.equals( err.getErrorCode() ) &&
+            RELATIONSHIP.equals( err.getTrackerType() ) &&
+            relationship.getUid().equals( err.getUid() ) ) );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Relationship: `" + relationship.getRelationship() + "` cannot link to itself" ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1039;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -43,7 +45,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -139,7 +140,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         // then
         assertEquals( 1, errorReporter.getReportList().size() );
-        assertThat( errorReporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1039 ) );
+        assertTrue( errorReporter.hasErrorReport( err -> E1039.equals( err.getErrorCode() ) &&
+            EVENT.equals( err.getTrackerType() ) &&
+            event.getUid().equals( err.getUid() ) ) );
         assertThat( errorReporter.getReportList().get( 0 ).getErrorMessage(),
             is( "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
                 "`, is not repeatable and an event already exists." ) );
@@ -156,10 +159,14 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         assertEquals( 2, errorReporter.getReportList().size() );
         assertThat( errorReporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1039 ) );
+        assertThat( errorReporter.getReportList().get( 0 ).getTrackerType(), is( EVENT ) );
+        assertThat( errorReporter.getReportList().get( 0 ).getUid(), is( events.get( 0 ).getUid() ) );
         assertThat( errorReporter.getReportList().get( 0 ).getErrorMessage(),
             is( "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
                 "`, is not repeatable and an event already exists." ) );
         assertThat( errorReporter.getReportList().get( 1 ).getErrorCode(), is( TrackerErrorCode.E1039 ) );
+        assertThat( errorReporter.getReportList().get( 1 ).getTrackerType(), is( EVENT ) );
+        assertThat( errorReporter.getReportList().get( 1 ).getUid(), is( events.get( 1 ).getUid() ) );
         assertThat( errorReporter.getReportList().get( 1 ).getErrorMessage(),
             is( "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
                 "`, is not repeatable and an event already exists." ) );
@@ -182,7 +189,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     {
         Event invalidEvent = notRepeatableEvent( "A" );
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
-        ctx.getRootReporter().getInvalidDTOs().put( TrackerType.EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
+        ctx.getRootReporter().getInvalidDTOs().put( EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -105,12 +105,12 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( "trackedEntityType" )
             .build();
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertFalse( validationErrorReporter.hasErrors() );
-        assertEquals( 0, validationErrorReporter.getReportList().size() );
+        assertFalse( reporter.hasErrors() );
+        assertEquals( 0, reporter.getReportList().size() );
     }
 
     @Test
@@ -142,13 +142,13 @@ class TrackedEntityAttributeValidationHookTest
 
         when( validationContext.getTrackedEntityAttribute( anyString() ) ).thenReturn( contextAttribute );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( 1, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1090 ).count() );
     }
 
@@ -163,13 +163,13 @@ class TrackedEntityAttributeValidationHookTest
 
         when( validationContext.getTrackedEntityType( anyString() ) ).thenReturn( new TrackedEntityType() );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 2, validationErrorReporter.getReportList().size() );
-        assertEquals( 2, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 2, reporter.getReportList().size() );
+        assertEquals( 2, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1006 ).count() );
     }
 
@@ -197,20 +197,20 @@ class TrackedEntityAttributeValidationHookTest
         when( validationContext.getTrackedEntityType( tet ) ).thenReturn( trackedEntityType );
         when( validationContext.getTrackedEntityAttribute( tea ) ).thenReturn( trackedEntityAttribute );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( 1, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1076 ).count() );
     }
 
     @Test
     void shouldFailValueTooLong()
     {
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.TEXT );
 
@@ -221,28 +221,28 @@ class TrackedEntityAttributeValidationHookTest
             sbString.append( "a" );
         }
 
-        trackedEntityAttributeValidationHook.validateAttributeValue( validationErrorReporter,
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter,
             trackedEntityAttribute, sbString.toString() );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( 1, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1077 ).count() );
     }
 
     @Test
     void shouldFailDataValueIsValid()
     {
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.NUMBER );
 
-        trackedEntityAttributeValidationHook.validateAttributeValue( validationErrorReporter,
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter,
             trackedEntityAttribute, "value" );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( 1, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1085 ).count() );
     }
 
@@ -259,13 +259,13 @@ class TrackedEntityAttributeValidationHookTest
 
         when( validationContext.getTrackedEntityAttribute( anyString() ) ).thenReturn( trackedEntityAttribute );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateAttributeValue( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter,
             trackedEntityAttribute, "value" );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( 1, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1112 ).count() );
     }
 
@@ -283,13 +283,13 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( "trackedEntityType" )
             .build();
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( 1, validationErrorReporter.getReportList().stream()
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getReportList().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1125 ).count() );
     }
 
@@ -307,12 +307,12 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( "trackedEntityType" )
             .build();
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertFalse( validationErrorReporter.hasErrors() );
-        assertEquals( 0, validationErrorReporter.getReportList().size() );
+        assertFalse( reporter.hasErrors() );
+        assertEquals( 0, reporter.getReportList().size() );
     }
 
     @Test
@@ -338,12 +338,12 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( "trackedEntityType" )
             .build();
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertFalse( validationErrorReporter.hasErrors() );
-        assertEquals( 0, validationErrorReporter.getReportList().size() );
+        assertFalse( reporter.hasErrors() );
+        assertEquals( 0, reporter.getReportList().size() );
     }
 
     @Test
@@ -371,13 +371,13 @@ class TrackedEntityAttributeValidationHookTest
 
         when( validationContext.getTrackedEntityType( anyString() ) ).thenReturn( trackedEntityType );
 
-        ValidationErrorReporter validationErrorReporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( validationErrorReporter,
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
             trackedEntity );
 
-        assertTrue( validationErrorReporter.hasErrors() );
-        assertEquals( 1, validationErrorReporter.getReportList().size() );
-        assertEquals( TrackerErrorCode.E1076, validationErrorReporter.getReportList().get( 0 ).getErrorCode() );
+        assertTrue( reporter.hasErrors() );
+        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
     }
 
     private TrackedEntityAttribute getTrackedEntityAttributeWithOptionSet()


### PR DESCRIPTION
To accomplish envisioned refactoring https://github.com/dhis2/dhis2-core/pull/9523 (removing ValidationErrorReporter and its error report merge logic) I need to make sure that we also test on error/warning codes, type, uid in tracker error reports.

Took the idea from ErrorReportContainer to add a helper in ValidationErrorReporter to ease asserting that
a particular error is present. This gives us the flexibility to assert on one or many fields. anyMatch also
keeps the test flexible in case more errors are in the error list.

The hasErrorReport/WarningReport code can be moved to TrackerValidationReport once ValidationErrorReporter is removed.

Except for ValidationErrorReporter only tests were changed and added!
