### PR TITLE
fix: periodOffset only in indicators DHIS2-12258

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -62,6 +62,7 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ORGUNIT_ANC
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ORGUNIT_GROUP;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.OUG_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PERCENTILE_CONT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PERIOD_OFFSET;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.R_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV_POP;
@@ -119,6 +120,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.parser.expression.ExpressionItemMethod;
+import org.hisp.dhis.parser.expression.function.PeriodOffset;
 import org.hisp.dhis.parser.expression.function.VectorAvg;
 import org.hisp.dhis.parser.expression.function.VectorCount;
 import org.hisp.dhis.parser.expression.function.VectorMax;
@@ -210,6 +212,7 @@ public class DefaultExpressionService
         .<Integer, ExpressionItem> builder()
         .putAll( BASE_EXPRESSION_ITEMS )
         .put( N_BRACE, new DimItemIndicator() )
+        .put( PERIOD_OFFSET, new PeriodOffset() )
         .build();
 
     private static final ImmutableMap<ParseType, ImmutableMap<Integer, ExpressionItem>> PARSE_TYPE_EXPRESSION_ITEMS = ImmutableMap

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -50,6 +50,11 @@ public class ParserUtils
 {
     public final static double DOUBLE_VALUE_IF_NULL = 0.0;
 
+    /**
+     * These are common expression items that are used in ALL types of DHIS2
+     * expressions. Items that are only used in some types of expressions are
+     * defined elsewhere.
+     */
     public final static ImmutableMap<Integer, ExpressionItem> COMMON_EXPRESSION_ITEMS = ImmutableMap
         .<Integer, ExpressionItem> builder()
 
@@ -88,7 +93,6 @@ public class ParserUtils
         .put( LEAST, new FunctionLeast() )
         .put( LOG, new FunctionLog() )
         .put( LOG10, new FunctionLog10() )
-        .put( PERIOD_OFFSET, new PeriodOffset() )
 
         // Data items
 


### PR DESCRIPTION
See [DHIS2-12258](https://jira.dhis2.org/browse/DHIS2-12258). The `.periodOffset()` expression function should be valid only in indicator expressions.

I also added a comment in `ParserUtils` to document `COMMON_EXPRESSION_ITEMS`, so hopefully this will reduce the chance of this type of error in the future.