### PR TITLE
docs: fix comment about invalidating shared cache

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
@@ -136,8 +136,7 @@ public interface Cache<V>
     void invalidate( String key );
 
     /**
-     * Discards all entries in this cache instance. If a shared cache is used,
-     * this method does not clear anything.
+     * Discards all entries in this cache instance.
      */
     void invalidateAll();
 


### PR DESCRIPTION
A comment in `Cache.invalidateAll` from 4 years ago said that "If a shared cache is used, this method does not clear anything." However two years ago in [TECH-248](https://jira.dhis2.org/browse/TECH-248) `RedisCache.invalidateAll` was implemented, so this comment was overcome by events.