### PR TITLE
build: Add javadoc generation stage to canary pipeline [DEVOPS-114] [2.37]

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -58,6 +58,32 @@ pipeline {
                 sh './copy-war-s3.sh canary ${GIT_BRANCH}'
             }
         }
+
+        stage ('Generate Javadocs') {
+            steps {
+                echo 'Generating Javadocs ...'
+                script {
+                    withMaven(options: [artifactsPublisher(disabled: true)]) {
+                        sh 'mvn --batch-mode --no-transfer-progress clean install javadoc:aggregate -DskipTests=true -Dmaven.test.skip=true -f dhis-2/pom.xml'
+                    }
+                }
+            }
+
+            post {
+                success {
+                    javadoc javadocDir: 'dhis-2/target/site/apidocs', keepAll: false
+                }
+            }
+        }
+
+        stage ('Sync Javadocs') {
+            steps {
+                echo 'Syncing Javadocs ...'
+                sh 'curl "https://raw.githubusercontent.com/dhis2/dhis2-server-setup/master/ci/scripts/sync-javadocs-s3.sh" -O'
+                sh 'chmod +x sync-javadocs-s3.sh'
+                sh './sync-javadocs-s3.sh ${GIT_BRANCH}'
+            }
+        }
     }
 
     post {


### PR DESCRIPTION
Related to https://github.com/dhis2/dhis2-core/pull/9536

The changes from the `master` won't be backported 1 to 1 to the supported 2.37, 2.36 and 2.35 branches.
No need for delomboking and extra changes outside of the Jenkins pipeline script here, as `JDK11` is currently only required on the `master` branch (future 2.38 version).