### PR TITLE
fix: OutputIdScheme rule for events [DHIS2-11181]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -51,7 +51,16 @@ import org.hisp.dhis.analytics.QueryKey;
 import org.hisp.dhis.analytics.QueryParamsBuilder;
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.analytics.TimeField;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.BaseDimensionalObject;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.DisplayProperty;
+import org.hisp.dhis.common.FallbackCoordinateFieldType;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
@@ -168,12 +177,6 @@ public class EventQueryParams
      * tracked entity instance.
      */
     private EventOutputType outputType;
-
-    /**
-     * Indicates the event output type which can be by event, enrollment type or
-     * tracked entity instance.
-     */
-    private IdScheme outputIdScheme;
 
     /**
      * Indicates the event status.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -603,10 +603,10 @@ public class DefaultEventAnalyticsService
      * data property indicated in the query. This happens only when a custom ID
      * Schema is set.
      *
-     * @param params the {@link DataQueryParams}.
+     * @param params the {@link EventQueryParams}.
      * @param grid the grid.
      */
-    private void maybeApplyIdScheme( DataQueryParams params, Grid grid )
+    private void maybeApplyIdScheme( EventQueryParams params, Grid grid )
     {
         if ( !params.isSkipMeta() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -589,6 +589,8 @@ public class DefaultEventAnalyticsService
             }
         }
 
+        maybeApplyIdScheme( params, grid );
+
         // ---------------------------------------------------------------------
         // Meta-data
         // ---------------------------------------------------------------------


### PR DESCRIPTION
This fixes a small bug introduced recently. Basically, the declaration `private IdScheme outputIdScheme` was "shadowing" the same declaration in the superclass.
So, when we invoked methods in the superclass that needed the `outputIdScheme`, it would be null depending on the situation.
_In addition I also added a missing call into a specific analytics events request._

One tiny refactoring was also included: changed the parameter `DataQueryParams` to `EventQueryParams` just to keep it aligned with the other methods in the respective class. This does not affect this fix.