### PR TITLE
fix: Remove duplicated FK [TECH-905]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_22__Remove_mistake_of_duplicated_FK_in_visualization_organisationunits.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_22__Remove_mistake_of_duplicated_FK_in_visualization_organisationunits.sql
@@ -1,0 +1,5 @@
+-- This script relates to the issue https://jira.dhis2.org/browse/TECH-795
+-- Removes a duplicated FK/constraint that was added by mistake, in visualization_organisationunits.
+
+alter table if exists visualization_organisationunits
+    drop constraint if exists fkvisualization_organisationunits_organisationunitid;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_22__Remove_mistake_of_duplicated_FK_in_visualization_organisationunits.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_22__Remove_mistake_of_duplicated_FK_in_visualization_organisationunits.sql
@@ -1,4 +1,4 @@
--- This script relates to the issue https://jira.dhis2.org/browse/TECH-795
+-- This script relates to the issue https://jira.dhis2.org/browse/TECH-905
 -- Removes a duplicated FK/constraint that was added by mistake, in visualization_organisationunits.
 
 alter table if exists visualization_organisationunits


### PR DESCRIPTION
Duplicated FK `fkvisualization_organisationunits_organisationunitid` that can be removed.

The correct one is already in place and is named: `fk_visualization_organisationunits_organisationunitid`