### PR TITLE
refactor: fix ParserUtils coding conventions

### DIFF
--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -27,14 +27,64 @@
  */
 package org.hisp.dhis.parser.expression;
 
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AMPERSAND_2;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AND;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.C_BRACE;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.DIV;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.EQ;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.EXCLAMATION_POINT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.FIRST_NON_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.GEQ;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.GREATEST;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.GT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IF;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IS_NOT_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IS_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.LEAST;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.LEQ;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.LOG;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.LOG10;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.LT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MINUS;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MOD;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MUL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NE;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NOT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.OR;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PAREN;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PLUS;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.POWER;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.VERTICAL_BAR_2;
 
 import java.util.List;
 
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.dataitem.ItemConstant;
-import org.hisp.dhis.parser.expression.function.*;
-import org.hisp.dhis.parser.expression.operator.*;
+import org.hisp.dhis.parser.expression.function.FunctionFirstNonNull;
+import org.hisp.dhis.parser.expression.function.FunctionGreatest;
+import org.hisp.dhis.parser.expression.function.FunctionIf;
+import org.hisp.dhis.parser.expression.function.FunctionIsNotNull;
+import org.hisp.dhis.parser.expression.function.FunctionIsNull;
+import org.hisp.dhis.parser.expression.function.FunctionLeast;
+import org.hisp.dhis.parser.expression.function.FunctionLog;
+import org.hisp.dhis.parser.expression.function.FunctionLog10;
+import org.hisp.dhis.parser.expression.operator.OperatorCompareEqual;
+import org.hisp.dhis.parser.expression.operator.OperatorCompareGreaterThan;
+import org.hisp.dhis.parser.expression.operator.OperatorCompareGreaterThanOrEqual;
+import org.hisp.dhis.parser.expression.operator.OperatorCompareLessThan;
+import org.hisp.dhis.parser.expression.operator.OperatorCompareLessThanOrEqual;
+import org.hisp.dhis.parser.expression.operator.OperatorCompareNotEqual;
+import org.hisp.dhis.parser.expression.operator.OperatorGroupingParentheses;
+import org.hisp.dhis.parser.expression.operator.OperatorLogicalAnd;
+import org.hisp.dhis.parser.expression.operator.OperatorLogicalNot;
+import org.hisp.dhis.parser.expression.operator.OperatorLogicalOr;
+import org.hisp.dhis.parser.expression.operator.OperatorMathDivide;
+import org.hisp.dhis.parser.expression.operator.OperatorMathMinus;
+import org.hisp.dhis.parser.expression.operator.OperatorMathModulus;
+import org.hisp.dhis.parser.expression.operator.OperatorMathMultiply;
+import org.hisp.dhis.parser.expression.operator.OperatorMathPlus;
+import org.hisp.dhis.parser.expression.operator.OperatorMathPower;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 
@@ -48,14 +98,18 @@ import com.google.common.collect.ImmutableMap;
  */
 public class ParserUtils
 {
-    public final static double DOUBLE_VALUE_IF_NULL = 0.0;
+    private ParserUtils()
+    {
+    }
+
+    public static final double DOUBLE_VALUE_IF_NULL = 0.0;
 
     /**
      * These are common expression items that are used in ALL types of DHIS2
      * expressions. Items that are only used in some types of expressions are
      * defined elsewhere.
      */
-    public final static ImmutableMap<Integer, ExpressionItem> COMMON_EXPRESSION_ITEMS = ImmutableMap
+    public static final ImmutableMap<Integer, ExpressionItem> COMMON_EXPRESSION_ITEMS = ImmutableMap
         .<Integer, ExpressionItem> builder()
 
         // Non-comparison operators
@@ -100,23 +154,23 @@ public class ParserUtils
 
         .build();
 
-    public final static ExpressionItemMethod ITEM_GET_DESCRIPTIONS = ExpressionItem::getDescription;
+    public static final ExpressionItemMethod ITEM_GET_DESCRIPTIONS = ExpressionItem::getDescription;
 
-    public final static ExpressionItemMethod ITEM_GET_IDS = ExpressionItem::getItemId;
+    public static final ExpressionItemMethod ITEM_GET_IDS = ExpressionItem::getItemId;
 
-    public final static ExpressionItemMethod ITEM_GET_ORG_UNIT_GROUPS = ExpressionItem::getOrgUnitGroup;
+    public static final ExpressionItemMethod ITEM_GET_ORG_UNIT_GROUPS = ExpressionItem::getOrgUnitGroup;
 
-    public final static ExpressionItemMethod ITEM_EVALUATE = ExpressionItem::evaluate;
+    public static final ExpressionItemMethod ITEM_EVALUATE = ExpressionItem::evaluate;
 
-    public final static ExpressionItemMethod ITEM_GET_SQL = ExpressionItem::getSql;
+    public static final ExpressionItemMethod ITEM_GET_SQL = ExpressionItem::getSql;
 
-    public final static ExpressionItemMethod ITEM_REGENERATE = ExpressionItem::regenerate;
+    public static final ExpressionItemMethod ITEM_REGENERATE = ExpressionItem::regenerate;
 
     /**
      * Used for syntax checking when we don't have a list of actual periods for
      * collecting samples.
      */
-    public final static List<Period> DEFAULT_SAMPLE_PERIODS = ImmutableList.of(
+    public static final List<Period> DEFAULT_SAMPLE_PERIODS = ImmutableList.of(
         PeriodType.getPeriodFromIsoString( "20010101" ) );
 
     /**


### PR DESCRIPTION
- Expand wildcard imports
- Define a private class constructor to hide the public constructor
- change `final static` to `static final`