### PR TITLE
fix: coGroup: too many option combos DHIS2-12278

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionComboStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionComboStore.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.dataelement.DataElement;
 
 /**
  * @author Lars Helge Overland
@@ -46,14 +47,16 @@ public interface CategoryOptionComboStore
 
     /**
      * Fetch all {@link CategoryOptionCombo} from a given
-     * {@link CategoryOptionGroup} uid.
+     * {@link CategoryOptionGroup} uid, that are also contained in the
+     * {@link CategoryCombo} of the {@link DataElement}.
      *
      * A {@link CategoryOptionGroup} is a collection of {@link CategoryOption}.
      * Therefore, this method finds all {@link CategoryOptionCombo} for all the
      * members of the given {@link CategoryOptionGroup}
      *
      * @param groupId a {@link CategoryOptionGroup} uid
+     * @param dataElementId a {@link DataElement} uid
      * @return a List of {@link CategoryOptionCombo} or empty List
      */
-    List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupId );
+    List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupId, String dataElementId );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolver.java
@@ -84,16 +84,17 @@ public class CategoryOptionGroupResolver implements ExpressionResolver
                     .replace( CATEGORY_OPTION_GROUP_PREFIX, EMPTY_STRING )
                     .split( LOGICAL_AND ) ).collect( Collectors.toList() );
 
-                expression = getExpression( expression, id, cogUidList );
+                expression = getExpression( expression, id, cogUidList, id.getId0() );
             }
         }
 
         return expression;
     }
 
-    private String getExpression( String expression, DimensionalItemId id, List<String> cogUidList )
+    private String getExpression( String expression, DimensionalItemId id, List<String> cogUidList,
+        String dataElementId )
     {
-        List<String> cocUidIntersection = getCategoryOptionCombosIntersection( cogUidList );
+        List<String> cocUidIntersection = getCategoryOptionCombosIntersection( cogUidList, dataElementId );
 
         if ( cocUidIntersection == null || cocUidIntersection.isEmpty() )
         {
@@ -111,7 +112,7 @@ public class CategoryOptionGroupResolver implements ExpressionResolver
         return expression;
     }
 
-    private List<String> getCategoryOptionCombosIntersection( List<String> cogUidList )
+    private List<String> getCategoryOptionCombosIntersection( List<String> cogUidList, String dataElementId )
     {
         List<String> cocUidIntersection = null;
 
@@ -120,7 +121,8 @@ public class CategoryOptionGroupResolver implements ExpressionResolver
             CategoryOptionGroup cog = categoryOptionGroupStore
                 .getByUid( cogUid );
 
-            List<String> cocUids = categoryOptionComboStore.getCategoryOptionCombosByGroupUid( cog.getUid() )
+            List<String> cocUids = categoryOptionComboStore
+                .getCategoryOptionCombosByGroupUid( cog.getUid(), dataElementId )
                 .stream()
                 .map( BaseIdentifiableObject::getUid )
                 .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupTaglessResolver.java
@@ -62,9 +62,10 @@ public class CategoryOptionGroupTaglessResolver
 
     private final CategoryOptionComboStore categoryOptionComboStore;
 
-    private Set<String> resolveCoCFromCog( String categoryOptionGroupUid )
+    private Set<String> resolveCoCFromCog( String categoryOptionGroupUid, String dataElementUid )
     {
-        return categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroupUid ).stream()
+        return categoryOptionComboStore.getCategoryOptionCombosByGroupUid( categoryOptionGroupUid, dataElementUid )
+            .stream()
             .map( BaseIdentifiableObject::getUid ).collect( Collectors.toSet() );
     }
 
@@ -140,7 +141,7 @@ public class CategoryOptionGroupTaglessResolver
         Optional<String> cogUid = getCategoryOptionGroupUid( uid );
         if ( cogUid.isPresent() )
         {
-            Set<String> cocs = resolveCoCFromCog( cogUid.get() );
+            Set<String> cocs = resolveCoCFromCog( cogUid.get(), dataElementUid );
             resolvedExpression = Arrays.asList( resolve( cocs, dataElementUid, uid2 ).split( "\\+" ) );
         }
         return resolvedExpression;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
@@ -47,9 +47,9 @@ public class ExpressionResolvers implements ExpressionResolverCollection
 
     public ExpressionResolvers(
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupTaglessResolver" ) ExpressionResolver cogTaglessExpressionResolver,
-        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupResolver" ) ExpressionResolver cogExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionResolver" ) ExpressionResolver coExpressionResolver,
-        @Qualifier( "org.hisp.dhis.analytics.resolver.DataElementGroupResolver" ) ExpressionResolver degExpressionResolver )
+        @Qualifier( "org.hisp.dhis.analytics.resolver.DataElementGroupResolver" ) ExpressionResolver degExpressionResolver,
+        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupResolver" ) ExpressionResolver cogExpressionResolver )
     {
         checkNotNull( cogTaglessExpressionResolver );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/resolver/ExpressionResolvers.java
@@ -46,28 +46,28 @@ public class ExpressionResolvers implements ExpressionResolverCollection
     private final List<ExpressionResolver> expressionResolvers;
 
     public ExpressionResolvers(
-        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupTaglessResolver" ) ExpressionResolver cogTaglessExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionResolver" ) ExpressionResolver coExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.DataElementGroupResolver" ) ExpressionResolver degExpressionResolver,
+        @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupTaglessResolver" ) ExpressionResolver cogTaglessExpressionResolver,
         @Qualifier( "org.hisp.dhis.analytics.resolver.CategoryOptionGroupResolver" ) ExpressionResolver cogExpressionResolver )
     {
-        checkNotNull( cogTaglessExpressionResolver );
-
-        checkNotNull( cogExpressionResolver );
-
         checkNotNull( coExpressionResolver );
 
         checkNotNull( degExpressionResolver );
 
+        checkNotNull( cogTaglessExpressionResolver );
+
+        checkNotNull( cogExpressionResolver );
+
         expressionResolvers = new ArrayList<>();
-
-        expressionResolvers.add( cogTaglessExpressionResolver );
-
-        expressionResolvers.add( cogExpressionResolver );
 
         expressionResolvers.add( coExpressionResolver );
 
         expressionResolvers.add( degExpressionResolver );
+
+        expressionResolvers.add( cogTaglessExpressionResolver );
+
+        expressionResolvers.add( cogExpressionResolver );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/resolver/CategoryOptionGroupResolverTest.java
@@ -121,7 +121,8 @@ class CategoryOptionGroupResolverTest
 
         cocList.add( coc3 );
 
-        when( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( anyString() ) ).thenReturn( cocList );
+        when( categoryOptionComboStore.getCategoryOptionCombosByGroupUid( anyString(), anyString() ) )
+            .thenReturn( cocList );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/hibernate/HibernateCategoryOptionComboStore.java
@@ -30,12 +30,6 @@ package org.hisp.dhis.category.hibernate;
 import java.util.List;
 import java.util.Set;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Join;
-import javax.persistence.criteria.JoinType;
-import javax.persistence.criteria.Root;
-
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -115,15 +109,20 @@ public class HibernateCategoryOptionComboStore
     }
 
     @Override
-    public List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupUid )
+    public List<CategoryOptionCombo> getCategoryOptionCombosByGroupUid( String groupUid, String dataElementUid )
     {
-        CriteriaBuilder builder = getCriteriaBuilder();
-        CriteriaQuery<CategoryOptionCombo> query = builder.createQuery( CategoryOptionCombo.class );
-        Root<CategoryOptionCombo> root = query.from( CategoryOptionCombo.class );
-        Join<Object, Object> joinCatOption = root.join( "categoryOptions", JoinType.INNER );
-        Join<Object, Object> joinCatOptionGroup = joinCatOption.join( "groups", JoinType.INNER );
-        query.where( builder.equal( joinCatOptionGroup.get( "uid" ), groupUid ) );
-        return getSession().createQuery( query ).list();
+        final String hql = "select coc from DataElement de "
+            + "join de.categoryCombo cc "
+            + "join cc.optionCombos coc "
+            + "join coc.categoryOptions co "
+            + "join co.groups cog "
+            + "where cog.uid = :groupUid "
+            + "and de.uid = :dataElementUid";
+
+        return getQuery( hql )
+            .setParameter( "groupUid", groupUid )
+            .setParameter( "dataElementUid", dataElementUid )
+            .list();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/category/CategoryOptionComboStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/category/CategoryOptionComboStoreTest.java
@@ -37,6 +37,8 @@ import java.util.Set;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -56,6 +58,9 @@ class CategoryOptionComboStoreTest extends DhisSpringTest
 
     @Autowired
     private CategoryOptionGroupStore categoryOptionGroupStore;
+
+    @Autowired
+    private DataElementService dataElementService;
 
     private Category categoryA;
 
@@ -78,6 +83,8 @@ class CategoryOptionComboStoreTest extends DhisSpringTest
     private CategoryOptionCombo categoryOptionComboB;
 
     private CategoryOptionCombo categoryOptionComboC;
+
+    private DataElement dataElementA;
 
     // -------------------------------------------------------------------------
     // Fixture
@@ -111,6 +118,9 @@ class CategoryOptionComboStoreTest extends DhisSpringTest
         categoryComboB.addCategory( categoryA );
         categoryService.addCategoryCombo( categoryComboA );
         categoryService.addCategoryCombo( categoryComboB );
+        dataElementA = createDataElement( 'A' );
+        dataElementA.setCategoryCombo( categoryComboA );
+        dataElementService.addDataElement( dataElementA );
     }
 
     // -------------------------------------------------------------------------
@@ -262,10 +272,10 @@ class CategoryOptionComboStoreTest extends DhisSpringTest
         CategoryOptionGroup catOptionGroup = createCategoryOptionGroup( 'A' );
         catOptionGroup.addCategoryOption( categoryOptionA );
         catOptionGroup.addCategoryOption( categoryOptionB );
-        categoryOptionGroupStore.save( catOptionGroup );
+        categoryService.saveCategoryOptionGroup( catOptionGroup );
         List<CategoryOptionCombo> result = categoryOptionComboStore
-            .getCategoryOptionCombosByGroupUid( catOptionGroup.getUid() );
+            .getCategoryOptionCombosByGroupUid( catOptionGroup.getUid(), dataElementA.getUid() );
         assertNotNull( result );
-        assertEquals( 6, result.size() );
+        assertEquals( categoryComboA.getOptionCombos(), Sets.newHashSet( result ) );
     }
 }


### PR DESCRIPTION
See [DHIS2-12278](https://jira.dhis2.org/browse/DHIS2-12278). Too many category option combos are returned for a data element because the choices are not restricted to the data element's category combination. The fix is to add the data element's category combination to the query, further restricting the category option combos returned.

I changed the order in which the `ExpressionResolvers` are executed, so that the data elements are resolved before the category option groups. (We had it the other way around for parsing performance, but this needed to change in order to generate the correct category option combinations.)

Also I rewrote the query using HQL instead of the JPA Criteria API. (I found this easier to read. Others might as well.)