### PR TITLE
feat: provide data integrity summary check for programmatic checks [DHIS2-12214]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -503,7 +503,7 @@ public class DefaultDataIntegrityService
             .section( "Legacy" )
             .description( name.replace( '_', ' ' ) )
             .runDetailsCheck( c -> new DataIntegrityDetails( c, check.get() ) )
-            .runSummaryCheck( c -> null ) // not supported
+            .runSummaryCheck( c -> new DataIntegritySummary( c, check.get().size(), null ) )
             .build() );
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
@@ -61,13 +60,13 @@ class DataIntegritySummaryControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void testLegacyChecksOnly()
+    void testLegacyChecksHaveSummary()
     {
         for ( DataIntegrityCheckType type : DataIntegrityCheckType.values() )
         {
             JsonObject content = GET( "/dataIntegrity/summary?checks={name}", type.getName() ).content();
             JsonDataIntegritySummary summary = content.get( type.getName(), JsonDataIntegritySummary.class );
-            assertFalse( summary.exists() );
+            assertTrue( summary.exists() );
         }
     }
 


### PR DESCRIPTION
When I did the original PR #9364 I thought that we don't have a dedicated summary for the existing checks so we don't support it but that is not going to work well with the way the frontend app will use this. It is easy enough to just derive the summary from the details as all it does is state the count of the issues found in details. So this PR is just connecting the bits to make that happen.