### PR TITLE
feat: Gist API CSV output for object and property collections

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -144,6 +144,10 @@ final class GistLogic
         {
             return Transform.SIZE;
         }
+        if ( target == Transform.NONE && property.isCollection() )
+        {
+            return Transform.SIZE;
+        }
         return target == Transform.AUTO ? Transform.NONE : target;
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistCsvControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistCsvControllerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.WebClient.Accept;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+/**
+ * Tests the CSV output features of the Gist API.
+ *
+ * @author Jan Bernitt
+ */
+class GistCsvControllerTest extends AbstractGistControllerTest
+{
+    private static final MediaType TEXT_CSV = new MediaType( "text", "csv" );
+
+    @Test
+    void testList()
+    {
+        assertUserCsv( GET( "/users/gist?fields=id,code,education,twitter,employer", Accept( TEXT_CSV ) ) );
+    }
+
+    @Test
+    void testObject()
+    {
+        assertUserCsv( GET( "/users/" + getSuperuserUid() + "/gist?fields=id,code,education,twitter,employer",
+            Accept( TEXT_CSV ) ) );
+    }
+
+    @Test
+    void testPropertyList()
+    {
+        String id = GET( "/userGroups/gist?fields=id&headless=true" ).content().getString( 0 ).string();
+        assertUserCsv(
+            GET( "/userGroups/" + id + "/users/gist?fields=id,code,education,twitter,employer", Accept( TEXT_CSV ) ) );
+    }
+
+    private void assertUserCsv( HttpResponse response )
+    {
+        assertLinesMatch( List.of( "id,code,education,twitter,employer", getSuperuserUid() + ",admin,.*" ),
+            List.of( response.content( TEXT_CSV ).split( "\n" ) ) );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -31,7 +31,9 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.webapi.json.JsonArray;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -31,9 +31,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.webapi.json.JsonArray;
@@ -66,6 +64,15 @@ class GistFieldsControllerTest extends AbstractGistControllerTest
         assertEquals( singletonList( "groupX" ),
             GET( "/users/{uid}/userGroups/gist?fields=name&headless=true", getSuperuserUid() ).content()
                 .stringValues() );
+    }
+
+    @Test
+    void testField_Collection_DefaultIsSize()
+    {
+        JsonArray matches = GET( "/userGroups/gist?fields=name,users&headless=true" ).content();
+        assertEquals( 1, matches.size() );
+        assertEquals( 1, matches.getObject( 0 ).getNumber( "users" ).intValue() );
+        assertTrue( matches.getObject( 0 ).getObject( "apiEndpoints" ).getString( "users" ).exists() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -40,11 +40,7 @@ import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.common.NamedParams;
-import org.hisp.dhis.common.PrimaryKeyObject;
-import org.hisp.dhis.common.UserContext;
+import org.hisp.dhis.common.*;
 import org.hisp.dhis.gist.GistAutoType;
 import org.hisp.dhis.gist.GistQuery;
 import org.hisp.dhis.gist.GistQuery.Comparison;
@@ -104,6 +100,15 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
             .withFilter( new Filter( "id", Comparison.EQ, uid ) ) );
     }
 
+    @GetMapping( value = "/{uid}/gist", produces = "text/csv" )
+    public void getObjectGistAsCsv( @PathVariable( "uid" ) String uid,
+        HttpServletRequest request, HttpServletResponse response )
+        throws IOException
+    {
+        gistToCsvResponse( response, createGistQuery( request, getEntityClass(), GistAutoType.L )
+            .withFilter( new Filter( "id", Comparison.EQ, uid ) ) );
+    }
+
     @GetMapping( value = "/gist", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody ResponseEntity<JsonNode> getObjectListGist(
         HttpServletRequest request, HttpServletResponse response )
@@ -113,7 +118,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
     }
 
     @GetMapping( value = "/gist", produces = "text/csv" )
-    public @ResponseBody void getObjectListGistAsCsv( HttpServletRequest request, HttpServletResponse response )
+    public void getObjectListGistAsCsv( HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
         gistToCsvResponse( response, createGistQuery( request, getEntityClass(), GistAutoType.S ) );
@@ -127,7 +132,6 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
         throws Exception
     {
         Property objProperty = getSchema().getProperty( property );
-
         if ( objProperty == null )
         {
             throw new BadRequestException( "No such property: " + property );
@@ -140,16 +144,35 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
                 .withField( property ) );
         }
 
-        @SuppressWarnings( "unchecked" )
-        GistQuery query = createGistQuery( request, (Class<IdentifiableObject>) objProperty.getItemKlass(),
-            GistAutoType.M )
-                .withOwner( Owner.builder()
-                    .id( uid )
-                    .type( getEntityClass() )
-                    .collectionProperty( property ).build() );
-
-        return gistToJsonArrayResponse( request, query,
+        return gistToJsonArrayResponse( request, createPropertyQuery( uid, property, request, objProperty ),
             schemaService.getDynamicSchema( objProperty.getItemKlass() ) );
+    }
+
+    @GetMapping( value = "/{uid}/{property}/gist", produces = "text/csv" )
+    public void getObjectPropertyGistAsCsv(
+        @PathVariable( "uid" ) String uid,
+        @PathVariable( "property" ) String property,
+        HttpServletRequest request, HttpServletResponse response )
+        throws Exception
+    {
+        Property objProperty = getSchema().getProperty( property );
+        if ( objProperty == null )
+        {
+            throw new BadRequestException( "No such property: " + property );
+        }
+        gistToCsvResponse( response, createPropertyQuery( uid, property, request, objProperty ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private GistQuery createPropertyQuery( @PathVariable( "uid" ) String uid,
+        @PathVariable( "property" ) String property, HttpServletRequest request, Property objProperty )
+    {
+        return createGistQuery( request, (Class<IdentifiableObject>) objProperty.getItemKlass(), GistAutoType.M )
+            .withOwner( Owner.builder()
+                .id( uid )
+                .type( getEntityClass() )
+                .collectionProperty( property )
+                .build() );
     }
 
     private static GistQuery createGistQuery( HttpServletRequest request,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -40,7 +40,11 @@ import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.NamedParams;
+import org.hisp.dhis.common.PrimaryKeyObject;
+import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.gist.GistAutoType;
 import org.hisp.dhis.gist.GistQuery;
 import org.hisp.dhis.gist.GistQuery.Comparison;


### PR DESCRIPTION
Recently noticed while testing that I originally only added CSV responses for Gist API for the main list, not the object and collection property listing. This PR adds CSV for these too and covers CSV with tests.

This PR also does a small correction for the default transformation used on collection properties that could be `NONE` instead of `SIZE` which basically excluded the collection from being included.