### PR TITLE
test: blacklists eventCharts endpoint

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportBasedOnSchemasTest.java
@@ -105,6 +105,7 @@ public class MetadataImportBasedOnSchemasTest
             "users",
             "organisationUnitLevels",
             "programRuleActions",
+            "eventCharts",
             "programStages" ); // blacklisted because contains
                                     // conditionally required properties, which
                                     // are not marked as required


### PR DESCRIPTION
eventCharts schema returns `PIVOT_TABLE` and `LINE_LIST` as values of `type` enum, but this endpoint doesn't support them anymore, so sometimes that test fails. Removing the test to limit flakiness.  