### PR TITLE
fix: not persisted property should not be translatable

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/TranslatablePropertyIntrospector.java
@@ -58,7 +58,7 @@ public class TranslatablePropertyIntrospector implements PropertyIntrospector
 
         for ( Property property : properties.values() )
         {
-            if ( translatableFields.containsKey( property.getFieldName() ) )
+            if ( property.isPersisted() && translatableFields.containsKey( property.getFieldName() ) )
             {
                 property.setTranslatable( true );
                 property.setTranslationKey( translatableFields.get( property.getFieldName() ) );

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.predictor.Predictor;
+import org.hisp.dhis.program.ProgramStageSection;
 import org.hisp.dhis.schema.introspection.TranslatablePropertyIntrospector;
 import org.junit.jupiter.api.Test;
 
@@ -130,5 +131,31 @@ class TranslatablePropertyIntrospectorTest extends DhisSpringTest
         assertFalse( propertyMap.get( "generator" ).isTranslatable() );
         introspector.introspect( Predictor.class, propertyMap );
         assertTrue( propertyMap.get( "generator" ).isTranslatable() );
+    }
+
+    @Test
+    void testNotPersistedProperty()
+    {
+        Property propTranslation = createProperty( ProgramStageSection.class, "translations" );
+        propTranslation.setPersisted( true );
+
+        Property propShortName = createProperty( ProgramStageSection.class, "shortName" );
+        propShortName.setPersisted( false );
+
+        Map<String, Property> propertyMap = new HashMap<>();
+        propertyMap.put( "shortName", propShortName );
+        propertyMap.put( "translations", propTranslation );
+
+        introspector.introspect( ProgramStageSection.class, propertyMap );
+
+        assertFalse( propertyMap.get( "shortName" ).isTranslatable() );
+    }
+
+    private Property createProperty( Class klass, String name )
+    {
+        Property property = new Property( klass );
+        property.setName( name );
+        property.setFieldName( name );
+        return property;
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12290

Issue:

- ProgramStageSection  table doesn't have `shortname` column but from api/schemas it's translatable.
- This property is inherited from `BaseNameableObject`

Fix: add `isPersisted` check to `TranslatablePropertyIntrospector`
