### PR TITLE
chore(deps): remove unused istack-commons-runtime

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/pom.xml
@@ -128,11 +128,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.sun.istack</groupId>
-      <artifactId>istack-commons-runtime</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -172,7 +172,6 @@
         <validation-api.version>2.0.1.Final</validation-api.version>
         <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
         <jep.version>2.4.2</jep.version>
-        <istack-commons-runtime.version>3.0.8</istack-commons-runtime.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -2308,26 +2307,6 @@
                 <groupId>io.micrometer</groupId>
                 <artifactId>micrometer-registry-prometheus</artifactId>
                 <version>${micrometer-registry-prometheus.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.sun.istack</groupId>
-                <artifactId>istack-commons-runtime</artifactId>
-                <version>${istack-commons-runtime.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15on</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bctsp-jdk15on</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcmail-jdk15on</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I would vote for removing the dependency (merging this PR) in favor of  updating it https://github.com/dhis2/dhis2-core/pull/9557