### PR TITLE
fix: (2.37) slow import and high memory allocation in NTI  (#9049)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationService.java
@@ -29,6 +29,9 @@ package org.hisp.dhis.program.notification;
 
 import java.util.Date;
 
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStageInstance;
+
 /**
  * @author Halvdan Hoem Grelland
  */
@@ -78,6 +81,8 @@ public interface ProgramNotificationService
      */
     void sendProgramRuleTriggeredNotifications( long pnt, long programInstance );
 
+    void sendProgramRuleTriggeredNotifications( long pnt, ProgramInstance programInstance );
+
     /**
      * Send completion notifications for the ProgramStageInstance triggered by
      * ProgramRule evaluation. {@link ProgramNotificationTemplate templates},
@@ -87,6 +92,8 @@ public interface ProgramNotificationService
      * @param programStageInstance the ProgramStageInstance id.
      */
     void sendProgramRuleTriggeredEventNotifications( long pnt, long programStageInstance );
+
+    void sendProgramRuleTriggeredEventNotifications( long pnt, ProgramStageInstance programStageInstance );
 
     /**
      * Send completion notifications for the ProgramInstance. If the Program is

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/RuleActionImplementer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/programrule/engine/RuleActionImplementer.java
@@ -43,10 +43,6 @@ public interface RuleActionImplementer
 {
     boolean accept( RuleAction ruleAction );
 
-    void implement( RuleEffect ruleEffect, ProgramInstance programInstance );
-
-    void implement( RuleEffect ruleEffect, ProgramStageInstance programStageInstance );
-
     /**
      * This method is directly called by SideEffectHandlerService to implement
      * actions
@@ -54,7 +50,7 @@ public interface RuleActionImplementer
      * @param ruleEffect received tracker importer
      * @param programInstance enrollment to implement the action against
      */
-    void implementEnrollmentAction( RuleEffect ruleEffect, String programInstance );
+    void implement( RuleEffect ruleEffect, ProgramInstance programInstance );
 
     /**
      * This method is directly called by SideEffectHandlerService to implement
@@ -63,5 +59,5 @@ public interface RuleActionImplementer
      * @param ruleEffect received tracker importer
      * @param programStageInstance event to implement the action against
      */
-    void implementEventAction( RuleEffect ruleEffect, String programStageInstance );
+    void implement( RuleEffect ruleEffect, ProgramStageInstance programStageInstance );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -288,10 +288,28 @@ public class DefaultProgramNotificationService
 
     @Override
     @Transactional
+    public void sendProgramRuleTriggeredNotifications( long pnt, ProgramInstance programInstance )
+    {
+        MessageBatch messageBatch = createProgramInstanceMessageBatch( notificationTemplateService.get( pnt ),
+            Collections.singletonList( programInstance ) );
+        sendAll( messageBatch );
+    }
+
+    @Override
+    @Transactional
     public void sendProgramRuleTriggeredEventNotifications( long pnt, long programStageInstance )
     {
         MessageBatch messageBatch = createProgramStageInstanceMessageBatch( notificationTemplateService.get( pnt ),
             Collections.singletonList( programStageInstanceStore.get( programStageInstance ) ) );
+        sendAll( messageBatch );
+    }
+
+    @Override
+    @Transactional
+    public void sendProgramRuleTriggeredEventNotifications( long pnt, ProgramStageInstance programStageInstance )
+    {
+        MessageBatch messageBatch = createProgramStageInstanceMessageBatch( notificationTemplateService.get( pnt ),
+            Collections.singletonList( programStageInstance ) );
         sendAll( messageBatch );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramRuleEnrollmentEvent.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramRuleEnrollmentEvent.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program.notification.event;
 
+import org.hisp.dhis.program.ProgramInstance;
 import org.springframework.context.ApplicationEvent;
 
 /**
@@ -36,9 +37,9 @@ public class ProgramRuleEnrollmentEvent extends ApplicationEvent
 {
     private long template;
 
-    private long programInstance;
+    private ProgramInstance programInstance;
 
-    public ProgramRuleEnrollmentEvent( Object source, long template, long programInstance )
+    public ProgramRuleEnrollmentEvent( Object source, long template, ProgramInstance programInstance )
     {
         super( source );
         this.template = template;
@@ -50,7 +51,7 @@ public class ProgramRuleEnrollmentEvent extends ApplicationEvent
         return template;
     }
 
-    public long getProgramInstance()
+    public ProgramInstance getProgramInstance()
     {
         return programInstance;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramRuleStageEvent.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/event/ProgramRuleStageEvent.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program.notification.event;
 
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.springframework.context.ApplicationEvent;
 
 /**
@@ -36,9 +37,9 @@ public class ProgramRuleStageEvent extends ApplicationEvent
 {
     private long template;
 
-    private long programStageInstance;
+    private ProgramStageInstance programStageInstance;
 
-    public ProgramRuleStageEvent( Object source, long template, long programStageInstance )
+    public ProgramRuleStageEvent( Object source, long template, ProgramStageInstance programStageInstance )
     {
         super( source );
         this.template = template;
@@ -50,7 +51,7 @@ public class ProgramRuleStageEvent extends ApplicationEvent
         return template;
     }
 
-    public long getProgramStageInstance()
+    public ProgramStageInstance getProgramStageInstance()
     {
         return programStageInstance;
     }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionAssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionAssignValueImplementer.java
@@ -98,18 +98,6 @@ public class RuleActionAssignValueImplementer implements RuleActionImplementer
         assignValue( ruleEffect, programInstance );
     }
 
-    @Override
-    public void implementEnrollmentAction( RuleEffect ruleEffect, String programInstance )
-    {
-        implement( ruleEffect, programInstanceService.getProgramInstance( programInstance ) );
-    }
-
-    @Override
-    public void implementEventAction( RuleEffect ruleEffect, String programStageInstance )
-    {
-        implement( ruleEffect, programStageInstanceService.getProgramStageInstance( programStageInstance ) );
-    }
-
     private void assignValue( RuleEffect ruleEffect, ProgramInstance programInstance )
     {
         if ( programInstance == null )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionScheduleMessageImplementer.java
@@ -186,20 +186,6 @@ public class RuleActionScheduleMessageImplementer extends NotificationRuleAction
 
     }
 
-    @Override
-    @Transactional
-    public void implementEnrollmentAction( RuleEffect ruleEffect, String programInstance )
-    {
-        implement( ruleEffect, programInstanceService.getProgramInstance( programInstance ) );
-    }
-
-    @Override
-    @Transactional
-    public void implementEventAction( RuleEffect ruleEffect, String programStageInstance )
-    {
-        implement( ruleEffect, programStageInstanceService.getProgramStageInstance( programStageInstance ) );
-    }
-
     // -------------------------------------------------------------------------
     // Supportive Methods
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/RuleActionSendMessageImplementer.java
@@ -98,7 +98,7 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
 
         String key = generateKey( template, programInstance );
 
-        publisher.publishEvent( new ProgramRuleEnrollmentEvent( this, template.getId(), programInstance.getId() ) );
+        publisher.publishEvent( new ProgramRuleEnrollmentEvent( this, template.getId(), programInstance ) );
 
         if ( result.getLogEntry() != null )
         {
@@ -137,7 +137,7 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
 
         String key = generateKey( template, pi );
 
-        publisher.publishEvent( new ProgramRuleStageEvent( this, template.getId(), programStageInstance.getId() ) );
+        publisher.publishEvent( new ProgramRuleStageEvent( this, template.getId(), programStageInstance ) );
 
         if ( result.getLogEntry() != null )
         {
@@ -151,18 +151,6 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
         notificationLoggingService.save( entry );
     }
 
-    @Override
-    public void implementEnrollmentAction( RuleEffect ruleEffect, String programInstance )
-    {
-        implement( ruleEffect, programInstanceService.getProgramInstance( programInstance ) );
-    }
-
-    @Override
-    public void implementEventAction( RuleEffect ruleEffect, String programStageInstance )
-    {
-        implement( ruleEffect, programStageInstanceService.getProgramStageInstance( programStageInstance ) );
-    }
-
     private void handleSingleEvent( RuleEffect ruleEffect, ProgramStageInstance programStageInstance )
     {
         ProgramNotificationTemplate template = getNotificationTemplate( ruleEffect.ruleAction() );
@@ -172,6 +160,6 @@ public class RuleActionSendMessageImplementer extends NotificationRuleActionImpl
             return;
         }
 
-        publisher.publishEvent( new ProgramRuleStageEvent( this, template.getId(), programStageInstance.getId() ) );
+        publisher.publishEvent( new ProgramRuleStageEvent( this, template.getId(), programStageInstance ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/NotificationRuleActionImplementerTest.java
@@ -163,7 +163,7 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
         verify( publisher ).publishEvent( argumentEventCaptor.capture() );
         assertEquals( eventType, argumentEventCaptor.getValue() );
-        assertEquals( programInstance.getId(), ((ProgramRuleEnrollmentEvent) eventType).getProgramInstance() );
+        assertEquals( programInstance.getId(), ((ProgramRuleEnrollmentEvent) eventType).getProgramInstance().getId() );
     }
 
     @Test
@@ -192,7 +192,8 @@ public class NotificationRuleActionImplementerTest extends DhisConvenienceTest
 
         verify( publisher ).publishEvent( argumentEventCaptor.capture() );
         assertEquals( eventType, argumentEventCaptor.getValue() );
-        assertEquals( programStageInstance.getId(), ((ProgramRuleStageEvent) eventType).getProgramStageInstance() );
+        assertEquals( programStageInstance.getId(),
+            ((ProgramRuleStageEvent) eventType).getProgramStageInstance().getId() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
@@ -135,6 +135,8 @@ public class EnrollmentPersister extends AbstractTrackerPersister<Enrollment, Pr
             .object( programInstance.getUid() )
             .importStrategy( bundle.getImportStrategy() )
             .accessedBy( bundle.getUsername() )
+            .programInstance( programInstance )
+            .program( programInstance.getProgram() )
             .build();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
@@ -125,6 +125,8 @@ public class EventPersister extends AbstractTrackerPersister<Event, ProgramStage
             .object( programStageInstance.getUid() )
             .importStrategy( bundle.getImportStrategy() )
             .accessedBy( bundle.getUsername() )
+            .programStageInstance( programStageInstance )
+            .program( programStageInstance.getProgramStage().getProgram() )
             .build();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/job/TrackerSideEffectDataBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/job/TrackerSideEffectDataBundle.java
@@ -37,6 +37,9 @@ import lombok.Data;
 import org.hisp.dhis.artemis.Message;
 import org.hisp.dhis.artemis.MessageType;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.sideeffect.TrackerRuleEngineSideEffect;
@@ -66,6 +69,15 @@ public class TrackerSideEffectDataBundle implements Message
 
     @JsonProperty
     private JobConfiguration jobConfiguration;
+
+    @JsonProperty
+    private Program program;
+
+    @JsonProperty
+    private ProgramInstance programInstance;
+
+    @JsonProperty
+    private ProgramStageInstance programStageInstance;
 
     @JsonProperty
     @Builder.Default


### PR DESCRIPTION
This is a backport PR for [DHIS2-11979].
Main objective was to reduce database queries for fetching programstageinstance and programinstance when they are needed in rule-engine execution. Now TrackerSideEffectDataBundle contains all the information needed and there is no need to make database queries in order to run rules and also to execute rule effects.