### PR TITLE
fix: ProgramSection is not shown in Translations App

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSectionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSectionServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.program;
+
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserService;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author viet@dhis2.org
+ */
+public class ProgramSectionServiceTest
+    extends DhisSpringTest
+{
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    @Autowired
+    private UserService _userService;
+
+    @Autowired
+    private AclService aclService;
+
+    @Autowired
+    private CategoryService _categoryService;
+
+    @Override
+    public void setUpTest()
+    {
+        userService = _userService;
+        categoryService = _categoryService;
+    }
+
+    @Test
+    public void testUpdateWithAuthority()
+    {
+        Program program = createProgram( 'A' );
+        manager.save( program );
+
+        ProgramSection programSection = createProgramSection( 'A', program );
+
+        manager.save( programSection );
+
+        User userA = createUser( "A", "F_PROGRAM_PUBLIC_ADD" );
+        Assert.assertTrue( aclService.canUpdate( userA, programSection ) );
+
+        User userB = createUser( "B" );
+        Assert.assertFalse( aclService.canUpdate( userB, programSection ) );
+    }
+
+    @Test
+    public void testSaveWithoutAuthority()
+    {
+        Program program = createProgram( 'A' );
+        manager.save( program );
+
+        createUserAndInjectSecurityContext( false );
+        ProgramSection programSection = createProgramSection( 'A', program );
+        manager.save( programSection );
+
+        Assert.assertNotNull( manager.get( ProgramSection.class, programSection.getId() ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramSectionSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramSectionSchemaDescriptor.java
@@ -30,6 +30,10 @@ package org.hisp.dhis.schema.descriptors;
 import org.hisp.dhis.program.ProgramSection;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaDescriptor;
+import org.hisp.dhis.security.Authority;
+import org.hisp.dhis.security.AuthorityType;
+
+import com.google.common.collect.Lists;
 
 /**
  * @author Henning Håkonsen
@@ -49,6 +53,8 @@ public class ProgramSectionSchemaDescriptor
         Schema schema = new Schema( ProgramSection.class, SINGULAR, PLURAL );
         schema.setRelativeApiEndpoint( API_ENDPOINT );
         schema.setOrder( 1550 );
+
+        schema.add( new Authority( AuthorityType.CREATE_PUBLIC, Lists.newArrayList( "F_PROGRAM_PUBLIC_ADD" ) ) );
 
         return schema;
     }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -127,6 +127,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramSection;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
@@ -2614,6 +2615,16 @@ public abstract class DhisConvenienceTest
         userService.addUser( user );
         userService.addUserCredentials( credentials );
         return user;
+    }
+
+    protected final ProgramSection createProgramSection( char uniqueCharacter, Program program )
+    {
+        ProgramSection programSection = new ProgramSection();
+        programSection.setProgram( program );
+        programSection.setSortOrder( 0 );
+        programSection.setName( "ProgramSection" + uniqueCharacter );
+        programSection.setAutoFields();
+        return programSection;
     }
 
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ProgramSectionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ProgramSectionControllerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramSection;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author viet@dhis2.org
+ */
+public class ProgramSectionControllerTest
+    extends DhisControllerConvenienceTest
+{
+    @Autowired
+    private ObjectMapper jsonMapper;
+
+    @Test
+    public void testCreateWithProgramSection()
+        throws JsonProcessingException
+    {
+        switchToNewUser( "test", "F_PROGRAM_PUBLIC_ADD" );
+        Program program = createProgram( 'A' );
+
+        ProgramSection programSection = createProgramSection( 'A', program );
+
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programs", jsonMapper.writeValueAsString( program ) ) );
+
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programSections", jsonMapper.writeValueAsString( programSection ) ) );
+    }
+
+    @Test
+    public void testWithoutAuthority()
+        throws JsonProcessingException
+    {
+        Program program = createProgram( 'A' );
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programs", jsonMapper.writeValueAsString( program ) ) );
+        ProgramSection programSection = createProgramSection( 'A', program );
+
+        switchToNewUser( "test" );
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programSections", jsonMapper.writeValueAsString( programSection ) ) );
+    }
+
+    @Test
+    public void testDeleteProgramSectionNoAuthority()
+        throws JsonProcessingException
+    {
+        Program program = createProgram( 'A' );
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programs", jsonMapper.writeValueAsString( program ) ) );
+        ProgramSection programSection = createProgramSection( 'A', program );
+        String programSectionId = programSection.getUid();
+
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programSections", jsonMapper.writeValueAsString( programSection ) ) );
+
+        switchToNewUser( "test" );
+        assertStatus( HttpStatus.FORBIDDEN,
+            DELETE( "/programSections/" + programSectionId ) );
+    }
+
+    @Test
+    public void testDeleteProgramSection()
+        throws JsonProcessingException
+    {
+        switchToNewUser( "test", "F_PROGRAM_PUBLIC_ADD", "F_PROGRAM_DELETE" );
+        Program program = createProgram( 'A' );
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programs", jsonMapper.writeValueAsString( program ) ) );
+        ProgramSection programSection = createProgramSection( 'A', program );
+        String programSectionId = programSection.getUid();
+
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programSections", jsonMapper.writeValueAsString( programSection ) ) );
+
+        assertStatus( HttpStatus.OK,
+            DELETE( "/programSections/" + programSectionId ) );
+
+    }
+}


### PR DESCRIPTION
Issue:
- Translations App requires an object to have authority in order to be listed.
- ProgramSection doesn't have any authority defined in `ProgramSectionSchemaDescriptor`

Fix:
- Copy `F_PROGRAM_PUBLIC_ADD` from `ProgramSchemaDescriptor` to `ProgramSectionSchemaDescriptor`
- After this change, all user still can create `ProgramSection` as before. 

Test:
- Added unit test and controller test