### PR TITLE
chore: hollow out TrackerImportValidationContext TECH-880

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -219,6 +219,11 @@ public class TrackerBundle
             .collect( Collectors.toMap( RuleEffects::getTrackerObjectUid, RuleEffects::getRuleEffects ) );
     }
 
+    public TrackerImportStrategy getStrategy( TrackerDto dto )
+    {
+        return this.getResolvedStrategyMap().get( dto.getTrackerType() ).get( dto.getUid() );
+    }
+
     public TrackerImportStrategy setStrategy( TrackerDto dto, TrackerImportStrategy strategy )
     {
         return this.getResolvedStrategyMap().get( dto.getTrackerType() ).put( dto.getUid(), strategy );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
@@ -70,12 +70,6 @@ public class TrackerValidationReport
         addPerfReports( validationReport.getPerformanceReport() );
     }
 
-    public void add( ValidationErrorReporter validationReporter )
-    {
-        add( validationReporter.getReportList() );
-        addWarnings( validationReporter.getWarningsReportList() );
-    }
-
     public void add( List<TrackerErrorReport> errorReports )
     {
         for ( TrackerErrorReport errorReport : errorReports )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -159,6 +159,17 @@ public class ValidationErrorReporter
         return !this.warningsReportList.isEmpty();
     }
 
+    public void addError( TrackerErrorReport error )
+    {
+
+        getReportList().add( error );
+
+        if ( isFailFast() )
+        {
+            throw new ValidationFailFastException( getReportList() );
+        }
+    }
+
     public void addError( TrackerErrorReport.TrackerErrorReportBuilder builder )
     {
         builder.trackerType( this.dtoType );
@@ -174,6 +185,11 @@ public class ValidationErrorReporter
         {
             throw new ValidationFailFastException( getReportList() );
         }
+    }
+
+    public void addWarning( TrackerWarningReport warning )
+    {
+        getWarningsReportList().add( warning );
     }
 
     public void addWarning( TrackerWarningReport.TrackerWarningReportBuilder builder )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -37,18 +37,13 @@ import lombok.Data;
 
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
-import org.hisp.dhis.tracker.domain.*;
-import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.tracker.validation.ValidationFailFastException;
 
 /**
  * A class that collects {@link TrackerErrorReport} during the validation
  * process.
- *
- * Each {@link TrackerErrorReport} collection is connected to a specific Tracker
- * entity (Tracked Entity, Enrollment, etc.) via the "mainUid" attribute
- *
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -64,16 +59,6 @@ public class ValidationErrorReporter
     private final boolean isFailFast;
 
     private final TrackerImportValidationContext validationContext;
-
-    /*
-     * The Tracker object uid to which this reporter is associated.
-     */
-    private String mainId;
-
-    /*
-     * The type of object associated to this report
-     */
-    private TrackerType dtoType;
 
     /*
      * A map that keep tracks of all the invalid Tracker objects encountered
@@ -104,41 +89,6 @@ public class ValidationErrorReporter
         this.invalidDTOs = new HashMap<>();
     }
 
-    public ValidationErrorReporter( TrackerImportValidationContext context, TrackerDto dto, TrackerType trackerType )
-    {
-        this( context );
-        this.dtoType = trackerType;
-        this.mainId = dto.getUid();
-    }
-
-    public ValidationErrorReporter( TrackerImportValidationContext context, TrackedEntity trackedEntity )
-    {
-        this( context );
-        this.dtoType = TrackerType.TRACKED_ENTITY;
-        this.mainId = trackedEntity.getTrackedEntity();
-    }
-
-    public ValidationErrorReporter( TrackerImportValidationContext context, Enrollment enrollment )
-    {
-        this( context );
-        this.dtoType = TrackerType.ENROLLMENT;
-        this.mainId = enrollment.getEnrollment();
-    }
-
-    public ValidationErrorReporter( TrackerImportValidationContext context, Event event )
-    {
-        this( context );
-        this.dtoType = TrackerType.EVENT;
-        this.mainId = event.getEvent();
-    }
-
-    public ValidationErrorReporter( TrackerImportValidationContext context, Relationship relationship )
-    {
-        this( context );
-        this.dtoType = TrackerType.RELATIONSHIP;
-        this.mainId = relationship.getRelationship();
-    }
-
     public boolean hasErrors()
     {
         return !this.reportList.isEmpty();
@@ -161,25 +111,8 @@ public class ValidationErrorReporter
 
     public void addError( TrackerErrorReport error )
     {
-
         getReportList().add( error );
-
-        if ( isFailFast() )
-        {
-            throw new ValidationFailFastException( getReportList() );
-        }
-    }
-
-    public void addError( TrackerErrorReport.TrackerErrorReportBuilder builder )
-    {
-        builder.trackerType( this.dtoType );
-
-        if ( this.mainId != null )
-        {
-            builder.uid( this.mainId );
-        }
-
-        getReportList().add( builder.build( this.validationContext.getBundle() ) );
+        this.invalidDTOs.computeIfAbsent( error.getTrackerType(), k -> new ArrayList<>() ).add( error.getUid() );
 
         if ( isFailFast() )
         {
@@ -190,29 +123,6 @@ public class ValidationErrorReporter
     public void addWarning( TrackerWarningReport warning )
     {
         getWarningsReportList().add( warning );
-    }
-
-    public void addWarning( TrackerWarningReport.TrackerWarningReportBuilder builder )
-    {
-        builder.trackerType( this.dtoType );
-
-        if ( this.mainId != null )
-        {
-            builder.uid( this.mainId );
-        }
-        getWarningsReportList().add( builder.build( this.validationContext.getBundle() ) );
-    }
-
-    public void merge( ValidationErrorReporter reporter )
-    {
-        // add the root invalid object to the map, if invalid
-        if ( reporter.getReportList().size() > 0 )
-        {
-            this.invalidDTOs.computeIfAbsent( reporter.dtoType, k -> new ArrayList<>() ).add( reporter.mainId );
-
-            this.reportList.addAll( reporter.getReportList() );
-        }
-        this.warningsReportList.addAll( reporter.getWarningsReportList() );
     }
 
     /**
@@ -227,10 +137,5 @@ public class ValidationErrorReporter
     public boolean isInvalid( TrackerDto dto )
     {
         return this.isInvalid( dto.getTrackerType(), dto.getUid() );
-    }
-
-    public TrackerPreheat getPreheat()
-    {
-        return this.getValidationContext().getBundle().getPreheat();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -87,7 +87,10 @@ public class DefaultTrackerValidationService
         // Note that the bundle gets cloned internally, so the original bundle
         // is always available
         TrackerImportValidationContext context = new TrackerImportValidationContext( bundle );
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
+        // TODO(TECH-880) remove reliance on context from reporter, then context
+        // altogether.
+        // the bundle is probably enough
+        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
 
         try
         {
@@ -104,8 +107,12 @@ public class DefaultTrackerValidationService
         }
         catch ( ValidationFailFastException e )
         {
-            validationReport.add( e.getErrors() );
+            // exit early when in FAIL_FAST validation mode
         }
+        // TODO(TECH-880) can be removed once the ValidationErrorReporter is
+        // removed and we only work with TrackerValidationReport
+        validationReport.add( reporter.getReportList() );
+        validationReport.addWarnings( reporter.getWarningsReportList() );
 
         removeInvalidObjects( bundle, reporter );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -87,6 +87,7 @@ public class DefaultTrackerValidationService
         // Note that the bundle gets cloned internally, so the original bundle
         // is always available
         TrackerImportValidationContext context = new TrackerImportValidationContext( bundle );
+        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
 
         try
         {
@@ -94,7 +95,7 @@ public class DefaultTrackerValidationService
             {
                 Timer hookTimer = Timer.startTimer();
 
-                validationReport.add( hook.validate( context ) );
+                hook.validate( reporter, context );
 
                 validationReport.add( TrackerValidationHookTimerReport.builder()
                     .name( hook.getClass().getName() )
@@ -106,7 +107,7 @@ public class DefaultTrackerValidationService
             validationReport.add( e.getErrors() );
         }
 
-        removeInvalidObjects( bundle, context.getRootReporter() );
+        removeInvalidObjects( bundle, reporter );
 
         return validationReport;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
@@ -54,9 +54,9 @@ import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerIdentifierParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.*;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.ReferenceTrackerEntity;
-import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 
 import com.google.common.base.Preconditions;
 
@@ -73,16 +73,10 @@ public class TrackerImportValidationContext
 
     private TrackerBundle bundle;
 
-    /**
-     * Holds the accumulated errors generated during the validation process
-     */
-    private ValidationErrorReporter rootReporter;
-
     public TrackerImportValidationContext( TrackerBundle bundle )
     {
         // Create a copy of the bundle
         this.bundle = bundle;
-        this.rootReporter = ValidationErrorReporter.emptyReporter();
     }
 
     public TrackerImportStrategy getStrategy( TrackerDto dto )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
@@ -51,7 +51,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.TrackerIdentifierParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -224,11 +223,6 @@ public class TrackerImportValidationContext
     public Optional<ReferenceTrackerEntity> getReference( String uid )
     {
         return bundle.getPreheat().getReference( uid );
-    }
-
-    public TrackerIdentifierParams getIdentifiers()
-    {
-        return bundle.getPreheat().getIdentifiers();
     }
 
     public Map<String, List<String>> getProgramWithOrgUnitsMap()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerImportValidationContext.java
@@ -28,38 +28,17 @@
 package org.hisp.dhis.tracker.validation;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import lombok.Data;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
-import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackerDto;
-import org.hisp.dhis.tracker.preheat.ReferenceTrackerEntity;
 
 import com.google.common.base.Preconditions;
 
-// TODO is this class really needed? what is the purpose of this class and why aren't the two caches moved to preheat?
+// TODO(TECH-880) can this remaining cache be moved to the preheat?
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
@@ -68,19 +47,12 @@ public class TrackerImportValidationContext
 {
     private Map<String, CategoryOptionCombo> eventCocCacheMap = new HashMap<>();
 
-    private Map<String, String> cachedEventAOCProgramCC = new HashMap<>();
-
     private TrackerBundle bundle;
 
     public TrackerImportValidationContext( TrackerBundle bundle )
     {
         // Create a copy of the bundle
         this.bundle = bundle;
-    }
-
-    public TrackerImportStrategy getStrategy( TrackerDto dto )
-    {
-        return bundle.getResolvedStrategyMap().get( dto.getTrackerType() ).get( dto.getUid() );
     }
 
     public void cacheEventCategoryOptionCombo( String key, CategoryOptionCombo categoryOptionCombo )
@@ -101,132 +73,4 @@ public class TrackerImportValidationContext
         return eventCocCacheMap.get( key );
     }
 
-    public void putCachedEventAOCProgramCC( String cacheKey, String value )
-    {
-        cachedEventAOCProgramCC.put( cacheKey, value );
-    }
-
-    public Optional<String> getCachedEventAOCProgramCC( String cacheKey )
-    {
-        String cached = cachedEventAOCProgramCC.get( cacheKey );
-        if ( cached == null )
-        {
-            return Optional.empty();
-        }
-        return Optional.of( cached );
-    }
-
-    public OrganisationUnit getOrganisationUnit( String id )
-    {
-        return bundle.getPreheat().get( OrganisationUnit.class, id );
-    }
-
-    public TrackedEntityInstance getTrackedEntityInstance( String id )
-    {
-        return bundle.getPreheat().getTrackedEntity( bundle.getIdentifier(), id );
-    }
-
-    public TrackedEntityAttribute getTrackedEntityAttribute( String id )
-    {
-        return bundle.getPreheat().get( TrackedEntityAttribute.class, id );
-    }
-
-    public DataElement getDataElement( String id )
-    {
-        return bundle.getPreheat().get( DataElement.class, id );
-    }
-
-    public TrackedEntityType getTrackedEntityType( String id )
-    {
-        return bundle.getPreheat().get( TrackedEntityType.class, id );
-    }
-
-    public RelationshipType getRelationShipType( String id )
-    {
-        return bundle.getPreheat().get( RelationshipType.class, id );
-    }
-
-    public Program getProgram( String id )
-    {
-        return bundle.getPreheat().get( Program.class, id );
-    }
-
-    public ProgramInstance getProgramInstance( String id )
-    {
-        return bundle.getPreheat().getEnrollment( bundle.getIdentifier(), id );
-    }
-
-    public OrganisationUnit getOwnerOrganisationUnit( String teiUid, String programUid )
-    {
-        Map<String, TrackedEntityProgramOwnerOrgUnit> programOwner = bundle.getPreheat().getProgramOwner()
-            .get( teiUid );
-        if ( programOwner == null || programOwner.get( programUid ) == null )
-        {
-            return null;
-        }
-        else
-        {
-            return programOwner.get( programUid ).getOrganisationUnit();
-        }
-    }
-
-    public boolean programInstanceHasEvents( String programInstanceUid )
-    {
-        return bundle.getPreheat().getProgramInstanceWithOneOrMoreNonDeletedEvent().contains( programInstanceUid );
-    }
-
-    public boolean programStageHasEvents( String programStageUid, String enrollmentUid )
-    {
-        return bundle.getPreheat().getProgramStageWithEvents().contains( Pair.of( programStageUid, enrollmentUid ) );
-    }
-
-    public Optional<TrackedEntityComment> getNote( String uid )
-    {
-        return bundle.getPreheat().getNote( uid );
-    }
-
-    public ProgramStage getProgramStage( String id )
-    {
-        return bundle.getPreheat().get( ProgramStage.class, id );
-    }
-
-    public ProgramStageInstance getProgramStageInstance( String event )
-    {
-        return bundle.getPreheat().getEvent( bundle.getIdentifier(), event );
-    }
-
-    public org.hisp.dhis.relationship.Relationship getRelationship( Relationship relationship )
-    {
-        return bundle.getPreheat().getRelationship( bundle.getIdentifier(), relationship );
-    }
-
-    public CategoryOptionCombo getCategoryOptionCombo( String id )
-    {
-        return bundle.getPreheat().get( CategoryOptionCombo.class, id );
-    }
-
-    public CategoryOption getCategoryOption( String id )
-    {
-        return bundle.getPreheat().get( CategoryOption.class, id );
-    }
-
-    public boolean usernameExists( String username )
-    {
-        return bundle.getPreheat().getUsers().containsKey( username );
-    }
-
-    public FileResource getFileResource( String id )
-    {
-        return bundle.getPreheat().get( FileResource.class, id );
-    }
-
-    public Optional<ReferenceTrackerEntity> getReference( String uid )
-    {
-        return bundle.getPreheat().getReference( uid );
-    }
-
-    public Map<String, List<String>> getProgramWithOrgUnitsMap()
-    {
-        return bundle.getPreheat().getProgramWithOrgUnitsMap();
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/TrackerValidationHook.java
@@ -34,5 +34,5 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
  */
 public interface TrackerValidationHook
 {
-    ValidationErrorReporter validate( TrackerImportValidationContext bundle );
+    void validate( ValidationErrorReporter report, TrackerImportValidationContext bundle );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
@@ -164,7 +164,8 @@ public abstract class AbstractTrackerDtoValidationHook
         while ( iter.hasNext() )
         {
             TrackerDto dto = iter.next();
-            if ( needsToRun( context.getStrategy( dto ) ) )
+            if ( needsToRun(
+                context.getBundle().getStrategy( dto ) ) )
             {
                 validationMap.get( dto.getTrackerType() ).accept( reporter, dto );
                 if ( removeOnError() && didNotPassValidation( reporter, dto.getUid() ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
@@ -123,12 +123,12 @@ public abstract class AbstractTrackerDtoValidationHook
     }
 
     protected <T extends ValueTypedDimensionalItemObject> void validateOptionSet( ValidationErrorReporter reporter,
-        TrackerType type, String uid,
+        TrackerDto dto,
         T optionalObject, String value )
     {
         Optional.ofNullable( optionalObject.getOptionSet() )
             .ifPresent( optionSet -> addErrorIf( () -> optionSet.getOptions().stream().filter( Objects::nonNull )
-                .noneMatch( o -> o.getCode().equalsIgnoreCase( value ) ), reporter, type, uid, E1125, value,
+                .noneMatch( o -> o.getCode().equalsIgnoreCase( value ) ), reporter, dto, E1125, value,
                 optionalObject.getUid(), optionalObject.getClass().getSimpleName(),
                 optionalObject.getOptionSet().getOptions().stream().filter( Objects::nonNull ).map( Option::getCode )
                     .collect( Collectors.joining( "," ) ) ) );
@@ -175,47 +175,46 @@ public abstract class AbstractTrackerDtoValidationHook
         }
     }
 
-    protected void addError( ValidationErrorReporter report, TrackerType type, String uid, TrackerErrorCode code,
+    protected void addError( ValidationErrorReporter report, TrackerDto dto, TrackerErrorCode code,
         Object... args )
     {
         TrackerErrorReport error = TrackerErrorReport.builder()
-            .uid( uid )
-            .trackerType( type )
+            .uid( dto.getUid() )
+            .trackerType( dto.getTrackerType() )
             .errorCode( code )
             .addArgs( args )
             .build( report.getValidationContext().getBundle() );
         report.addError( error );
     }
 
-    protected void addWarning( ValidationErrorReporter report, TrackerType type, String uid, TrackerErrorCode code,
+    protected void addWarning( ValidationErrorReporter report, TrackerDto dto, TrackerErrorCode code,
         Object... args )
     {
         TrackerWarningReport warn = TrackerWarningReport.builder()
-            .uid( uid )
-            .trackerType( type )
+            .uid( dto.getUid() )
+            .trackerType( dto.getTrackerType() )
             .warningCode( code )
             .addArgs( args )
             .build( report.getValidationContext().getBundle() );
         report.addWarning( warn );
     }
 
-    protected void addErrorIf( Supplier<Boolean> expression, ValidationErrorReporter report, TrackerType type,
-        String uid, TrackerErrorCode code,
-        Object... args )
+    protected void addErrorIf( Supplier<Boolean> expression, ValidationErrorReporter report, TrackerDto dto,
+        TrackerErrorCode code, Object... args )
     {
         if ( expression.get() )
         {
-            addError( report, type, uid, code, args );
+            addError( report, dto, code, args );
         }
     }
 
-    protected void addErrorIfNull( Object object, ValidationErrorReporter report, TrackerType type, String uid,
+    protected void addErrorIfNull( Object object, ValidationErrorReporter report, TrackerDto dto,
         TrackerErrorCode code,
         Object... args )
     {
         if ( object == null )
         {
-            addError( report, type, uid, code, args );
+            addError( report, dto, code, args );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -33,8 +33,13 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
 import java.util.Optional;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.TrackerWarningReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
 
@@ -49,11 +54,27 @@ public class AssignedUserValidationHook
         {
             if ( isNotValidAssignedUserUid( event ) || assignedUserNotPresentInPreheat( reporter, event ) )
             {
-                addError( reporter, E1118, event.getAssignedUser() );
+                TrackerImportValidationContext context = reporter.getValidationContext();
+                TrackerBundle bundle = context.getBundle();
+                TrackerErrorReport error = TrackerErrorReport.builder()
+                    .uid( event.getUid() )
+                    .trackerType( TrackerType.EVENT )
+                    .errorCode( E1118 )
+                    .addArg( event.getAssignedUser() )
+                    .build( bundle );
+                reporter.addError( error );
             }
             if ( isNotEnabledUserAssignment( reporter, event ) )
             {
-                addWarning( reporter, E1120, event.getProgramStage() );
+                TrackerImportValidationContext context = reporter.getValidationContext();
+                TrackerBundle bundle = context.getBundle();
+                TrackerWarningReport warning = TrackerWarningReport.builder()
+                    .uid( event.getUid() )
+                    .trackerType( TrackerType.EVENT )
+                    .warningCode( E1120 )
+                    .addArg( event.getProgramStage() )
+                    .build( bundle );
+                reporter.addWarning( warning );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -33,13 +33,8 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
 import java.util.Optional;
 
 import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
-import org.hisp.dhis.tracker.report.TrackerWarningReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
-import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
 
@@ -54,27 +49,11 @@ public class AssignedUserValidationHook
         {
             if ( isNotValidAssignedUserUid( event ) || assignedUserNotPresentInPreheat( reporter, event ) )
             {
-                TrackerImportValidationContext context = reporter.getValidationContext();
-                TrackerBundle bundle = context.getBundle();
-                TrackerErrorReport error = TrackerErrorReport.builder()
-                    .uid( event.getUid() )
-                    .trackerType( TrackerType.EVENT )
-                    .errorCode( E1118 )
-                    .addArg( event.getAssignedUser() )
-                    .build( bundle );
-                reporter.addError( error );
+                addError( reporter, event, E1118, event.getAssignedUser() );
             }
             if ( isNotEnabledUserAssignment( reporter, event ) )
             {
-                TrackerImportValidationContext context = reporter.getValidationContext();
-                TrackerBundle bundle = context.getBundle();
-                TrackerWarningReport warning = TrackerWarningReport.builder()
-                    .uid( event.getUid() )
-                    .trackerType( TrackerType.EVENT )
-                    .warningCode( E1120 )
-                    .addArg( event.getProgramStage() )
-                    .build( bundle );
-                reporter.addWarning( warning );
+                addWarning( reporter, event, E1120, event.getProgramStage() );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
 import java.util.Optional;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.user.User;
@@ -60,7 +61,8 @@ public class AssignedUserValidationHook
 
     private Boolean isNotEnabledUserAssignment( ValidationErrorReporter reporter, Event event )
     {
-        Boolean userAssignmentEnabled = reporter.getValidationContext().getProgramStage( event.getProgramStage() )
+        Boolean userAssignmentEnabled = reporter.getValidationContext().getBundle().getPreheat()
+            .<ProgramStage> get( ProgramStage.class, event.getProgramStage() )
             .isEnableUserAssignment();
 
         return !Optional.ofNullable( userAssignmentEnabled )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
 import static com.google.api.client.util.Preconditions.checkNotNull;
-import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ATTRIBUTE_CANT_BE_NULL;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_CANT_BE_NULL;
 
@@ -39,9 +38,12 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
@@ -52,14 +54,17 @@ import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValida
 public abstract class AttributeValidationHook extends AbstractTrackerDtoValidationHook
 {
 
+    private final TrackerType trackerType;
+
     private final TrackedAttributeValidationService teAttrService;
 
-    protected AttributeValidationHook( TrackedAttributeValidationService teAttrService )
+    protected AttributeValidationHook( TrackerType trackerType, TrackedAttributeValidationService teAttrService )
     {
+        this.trackerType = trackerType;
         this.teAttrService = teAttrService;
     }
 
-    protected void validateAttrValueType( ValidationErrorReporter errorReporter, Attribute attr,
+    protected void validateAttrValueType( ValidationErrorReporter errorReporter, String uid, Attribute attr,
         TrackedEntityAttribute teAttr )
     {
         checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
@@ -100,13 +105,20 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
 
         if ( error != null )
         {
-            errorReporter.addError( newReport( TrackerErrorCode.E1007 )
+            TrackerBundle bundle = context.getBundle();
+            TrackerErrorReport err = TrackerErrorReport.builder()
+                .uid( uid )
+                .trackerType( this.trackerType )
+                .errorCode( TrackerErrorCode.E1007 )
                 .addArg( valueType.toString() )
-                .addArg( error ) );
+                .addArg( error )
+                .build( bundle );
+            errorReporter.addError( err );
         }
     }
 
     protected void validateAttributeUniqueness( ValidationErrorReporter errorReporter,
+        String uid,
         String value,
         TrackedEntityAttribute trackedEntityAttribute,
         TrackedEntityInstance trackedEntityInstance,
@@ -137,9 +149,15 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
                 && hasTheSameValue
                 && isNotSameTei )
             {
-                errorReporter.addError( newReport( TrackerErrorCode.E1064 )
+                TrackerBundle bundle = errorReporter.getValidationContext().getBundle();
+                TrackerErrorReport err = TrackerErrorReport.builder()
+                    .uid( uid )
+                    .trackerType( this.trackerType )
+                    .errorCode( TrackerErrorCode.E1064 )
                     .addArg( value )
-                    .addArg( trackedEntityAttribute.getUid() ) );
+                    .addArg( trackedEntityAttribute.getUid() )
+                    .build( bundle );
+                errorReporter.addError( err );
                 return;
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -38,9 +38,9 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
@@ -54,17 +54,14 @@ import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValida
 public abstract class AttributeValidationHook extends AbstractTrackerDtoValidationHook
 {
 
-    private final TrackerType trackerType;
-
     private final TrackedAttributeValidationService teAttrService;
 
-    protected AttributeValidationHook( TrackerType trackerType, TrackedAttributeValidationService teAttrService )
+    protected AttributeValidationHook( TrackedAttributeValidationService teAttrService )
     {
-        this.trackerType = trackerType;
         this.teAttrService = teAttrService;
     }
 
-    protected void validateAttrValueType( ValidationErrorReporter errorReporter, String uid, Attribute attr,
+    protected void validateAttrValueType( ValidationErrorReporter errorReporter, TrackerDto dto, Attribute attr,
         TrackedEntityAttribute teAttr )
     {
         checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
@@ -107,8 +104,8 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
         {
             TrackerBundle bundle = context.getBundle();
             TrackerErrorReport err = TrackerErrorReport.builder()
-                .uid( uid )
-                .trackerType( this.trackerType )
+                .uid( dto.getUid() )
+                .trackerType( dto.getTrackerType() )
                 .errorCode( TrackerErrorCode.E1007 )
                 .addArg( valueType.toString() )
                 .addArg( error )
@@ -118,7 +115,7 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
     }
 
     protected void validateAttributeUniqueness( ValidationErrorReporter errorReporter,
-        String uid,
+        TrackerDto dto,
         String value,
         TrackedEntityAttribute trackedEntityAttribute,
         TrackedEntityInstance trackedEntityInstance,
@@ -151,8 +148,8 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
             {
                 TrackerBundle bundle = errorReporter.getValidationContext().getBundle();
                 TrackerErrorReport err = TrackerErrorReport.builder()
-                    .uid( uid )
-                    .trackerType( this.trackerType )
+                    .uid( dto.getUid() )
+                    .trackerType( dto.getTrackerType() )
                     .errorCode( TrackerErrorCode.E1064 )
                     .addArg( value )
                     .addArg( trackedEntityAttribute.getUid() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -75,13 +75,14 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
 
         if ( valueType.equals( ValueType.ORGANISATION_UNIT ) )
         {
-            error = context.getOrganisationUnit( attr.getValue() ) == null
-                ? " Value " + attr.getValue() + " is not a valid org unit value"
-                : null;
+            error = context.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class,
+                attr.getValue() ) == null
+                    ? " Value " + attr.getValue() + " is not a valid org unit value"
+                    : null;
         }
         else if ( valueType.equals( ValueType.USERNAME ) )
         {
-            error = context.usernameExists( attr.getValue() ) ? null
+            error = context.getBundle().getPreheat().getUsers().containsKey( attr.getValue() ) ? null
                 : " Value " + attr.getValue() + " is not a valid username value";
         }
         else

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -91,7 +91,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
         for ( Attribute attribute : enrollment.getAttributes() )
         {
-            validateRequiredProperties( reporter, attribute, program );
+            validateRequiredProperties( reporter, enrollment, attribute, program );
 
             TrackedEntityAttribute teAttribute = context.getTrackedEntityAttribute( attribute.getAttribute() );
 
@@ -101,7 +101,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
                 attributeValueMap.put( attribute.getAttribute(), attribute.getValue() );
 
                 validateAttrValueType( reporter, enrollment.getUid(), attribute, teAttribute );
-                validateOptionSet( reporter, teAttribute, attribute.getValue() );
+                validateOptionSet( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), teAttribute,
+                    attribute.getValue() );
 
                 validateAttributeUniqueness( reporter,
                     enrollment.getUid(),
@@ -115,9 +116,11 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         validateMandatoryAttributes( reporter, program, attributeValueMap, enrollment );
     }
 
-    protected void validateRequiredProperties( ValidationErrorReporter reporter, Attribute attribute, Program program )
+    protected void validateRequiredProperties( ValidationErrorReporter reporter, Enrollment enrollment,
+        Attribute attribute, Program program )
     {
-        addErrorIfNull( attribute.getAttribute(), reporter, E1075, attribute );
+        addErrorIfNull( attribute.getAttribute(), reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1075,
+            attribute );
 
         Optional<ProgramTrackedEntityAttribute> optionalTrackedAttr = program.getProgramAttributes().stream()
             .filter( pa -> pa.getAttribute().getUid().equals( attribute.getAttribute() ) && pa.isMandatory() )
@@ -125,7 +128,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
         if ( optionalTrackedAttr.isPresent() )
         {
-            addErrorIfNull( attribute.getValue(), reporter, E1076, TrackedEntityAttribute.class.getSimpleName(),
+            addErrorIfNull( attribute.getValue(), reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1076,
+                TrackedEntityAttribute.class.getSimpleName(),
                 attribute.getAttribute() );
         }
 
@@ -134,7 +138,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             TrackedEntityAttribute teAttribute = reporter.getValidationContext()
                 .getTrackedEntityAttribute( attribute.getAttribute() );
 
-            addErrorIfNull( teAttribute, reporter, E1006, attribute.getAttribute() );
+            addErrorIfNull( teAttribute, reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1006,
+                attribute.getAttribute() );
         }
     }
 
@@ -168,14 +173,16 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             .filter( Map.Entry::getValue ) // <--- filter on mandatory flag
             .map( Map.Entry::getKey )
             .forEach( mandatoryProgramAttributeUid -> addErrorIf(
-                () -> !mergedAttributes.contains( mandatoryProgramAttributeUid ), reporter, E1018,
+                () -> !mergedAttributes.contains( mandatoryProgramAttributeUid ), reporter, TrackerType.ENROLLMENT,
+                enrollment.getUid(), E1018,
                 mandatoryProgramAttributeUid, program.getUid(), enrollment.getEnrollment() ) );
 
         // enrollment must not contain any attribute which is not defined in
         // program
         enrollmentNonEmptyAttributeUids
             .forEach(
-                ( attrUid, attrVal ) -> addErrorIf( () -> !programAttributesMap.containsKey( attrUid ), reporter, E1019,
+                ( attrUid, attrVal ) -> addErrorIf( () -> !programAttributesMap.containsKey( attrUid ), reporter,
+                    TrackerType.ENROLLMENT, enrollment.getUid(), E1019,
                     attrUid + "=" + attrVal ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -28,7 +28,11 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
 import static com.google.api.client.util.Preconditions.checkNotNull;
-import static org.hisp.dhis.tracker.report.TrackerErrorCode.*;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1006;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1018;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1019;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1075;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1076;
 
 import java.util.Collections;
 import java.util.Map;
@@ -44,6 +48,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -66,7 +71,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
     public EnrollmentAttributeValidationHook( TrackedAttributeValidationService teAttrService )
     {
-        super( teAttrService );
+        super( TrackerType.ENROLLMENT, teAttrService );
     }
 
     @Override
@@ -95,10 +100,11 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
                 attributeValueMap.put( attribute.getAttribute(), attribute.getValue() );
 
-                validateAttrValueType( reporter, attribute, teAttribute );
+                validateAttrValueType( reporter, enrollment.getUid(), attribute, teAttribute );
                 validateOptionSet( reporter, teAttribute, attribute.getValue() );
 
                 validateAttributeUniqueness( reporter,
+                    enrollment.getUid(),
                     attribute.getValue(),
                     teAttribute,
                     tei,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -78,13 +78,14 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        Program program = context.getProgram( enrollment.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, enrollment.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 
-        TrackedEntityInstance tei = context.getTrackedEntityInstance( enrollment.getTrackedEntity() );
+        TrackedEntityInstance tei = context.getBundle().getPreheat()
+            .getTrackedEntity( context.getBundle().getIdentifier(), enrollment.getTrackedEntity() );
 
-        OrganisationUnit orgUnit = context
-            .getOrganisationUnit( getOrgUnitUidFromTei( context, enrollment.getTrackedEntity() ) );
+        OrganisationUnit orgUnit = context.getBundle().getPreheat().get( OrganisationUnit.class,
+            getOrgUnitUidFromTei( context, enrollment.getTrackedEntity() ) );
 
         Map<String, String> attributeValueMap = Maps.newHashMap();
 
@@ -92,7 +93,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         {
             validateRequiredProperties( reporter, enrollment, attribute, program );
 
-            TrackedEntityAttribute teAttribute = context.getTrackedEntityAttribute( attribute.getAttribute() );
+            TrackedEntityAttribute teAttribute = context.getBundle().getPreheat().get( TrackedEntityAttribute.class,
+                attribute.getAttribute() );
 
             if ( attribute.getAttribute() != null && attribute.getValue() != null && teAttribute != null )
             {
@@ -133,8 +135,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
         if ( attribute.getAttribute() != null )
         {
-            TrackedEntityAttribute teAttribute = reporter.getValidationContext()
-                .getTrackedEntityAttribute( attribute.getAttribute() );
+            TrackedEntityAttribute teAttribute = reporter.getValidationContext().getBundle().getPreheat()
+                .get( TrackedEntityAttribute.class, attribute.getAttribute() );
 
             addErrorIfNull( teAttribute, reporter, enrollment, E1006, attribute.getAttribute() );
         }
@@ -201,7 +203,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
     private String getOrgUnitUidFromTei( TrackerImportValidationContext context, String teiUid )
     {
 
-        final Optional<ReferenceTrackerEntity> reference = context.getReference( teiUid );
+        final Optional<ReferenceTrackerEntity> reference = context.getBundle().getPreheat().getReference( teiUid );
         if ( reference.isPresent() )
         {
             final Optional<TrackedEntity> tei = context.getBundle()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TrackerIdScheme;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -71,7 +70,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
     public EnrollmentAttributeValidationHook( TrackedAttributeValidationService teAttrService )
     {
-        super( TrackerType.ENROLLMENT, teAttrService );
+        super( teAttrService );
     }
 
     @Override
@@ -100,12 +99,12 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
                 attributeValueMap.put( attribute.getAttribute(), attribute.getValue() );
 
-                validateAttrValueType( reporter, enrollment.getUid(), attribute, teAttribute );
+                validateAttrValueType( reporter, enrollment, attribute, teAttribute );
                 validateOptionSet( reporter, enrollment, teAttribute,
                     attribute.getValue() );
 
                 validateAttributeUniqueness( reporter,
-                    enrollment.getUid(),
+                    enrollment,
                     attribute.getValue(),
                     teAttribute,
                     tei,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -101,7 +101,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
                 attributeValueMap.put( attribute.getAttribute(), attribute.getValue() );
 
                 validateAttrValueType( reporter, enrollment.getUid(), attribute, teAttribute );
-                validateOptionSet( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), teAttribute,
+                validateOptionSet( reporter, enrollment, teAttribute,
                     attribute.getValue() );
 
                 validateAttributeUniqueness( reporter,
@@ -119,8 +119,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
     protected void validateRequiredProperties( ValidationErrorReporter reporter, Enrollment enrollment,
         Attribute attribute, Program program )
     {
-        addErrorIfNull( attribute.getAttribute(), reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1075,
-            attribute );
+        addErrorIfNull( attribute.getAttribute(), reporter, enrollment, E1075, attribute );
 
         Optional<ProgramTrackedEntityAttribute> optionalTrackedAttr = program.getProgramAttributes().stream()
             .filter( pa -> pa.getAttribute().getUid().equals( attribute.getAttribute() ) && pa.isMandatory() )
@@ -128,7 +127,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 
         if ( optionalTrackedAttr.isPresent() )
         {
-            addErrorIfNull( attribute.getValue(), reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1076,
+            addErrorIfNull( attribute.getValue(), reporter, enrollment, E1076,
                 TrackedEntityAttribute.class.getSimpleName(),
                 attribute.getAttribute() );
         }
@@ -138,8 +137,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             TrackedEntityAttribute teAttribute = reporter.getValidationContext()
                 .getTrackedEntityAttribute( attribute.getAttribute() );
 
-            addErrorIfNull( teAttribute, reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1006,
-                attribute.getAttribute() );
+            addErrorIfNull( teAttribute, reporter, enrollment, E1006, attribute.getAttribute() );
         }
     }
 
@@ -173,8 +171,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             .filter( Map.Entry::getValue ) // <--- filter on mandatory flag
             .map( Map.Entry::getKey )
             .forEach( mandatoryProgramAttributeUid -> addErrorIf(
-                () -> !mergedAttributes.contains( mandatoryProgramAttributeUid ), reporter, TrackerType.ENROLLMENT,
-                enrollment.getUid(), E1018,
+                () -> !mergedAttributes.contains( mandatoryProgramAttributeUid ), reporter,
+                enrollment, E1018,
                 mandatoryProgramAttributeUid, program.getUid(), enrollment.getEnrollment() ) );
 
         // enrollment must not contain any attribute which is not defined in
@@ -182,7 +180,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         enrollmentNonEmptyAttributeUids
             .forEach(
                 ( attrUid, attrVal ) -> addErrorIf( () -> !programAttributesMap.containsKey( attrUid ), reporter,
-                    TrackerType.ENROLLMENT, enrollment.getUid(), E1019,
+                    enrollment, E1019,
                     attrUid + "=" + attrVal ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.util.Objects;
 
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -66,7 +67,7 @@ public class EnrollmentDateValidationHook
         if ( Boolean.TRUE.equals( program.getDisplayIncidentDate() ) &&
             Objects.isNull( enrollment.getOccurredAt() ) )
         {
-            addError( reporter, E1023, enrollment.getOccurredAt() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1023, enrollment.getOccurredAt() );
         }
     }
 
@@ -76,7 +77,7 @@ public class EnrollmentDateValidationHook
 
         if ( Objects.isNull( enrollment.getEnrolledAt() ) )
         {
-            addError( reporter, E1025, enrollment.getEnrolledAt() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1025, enrollment.getEnrolledAt() );
         }
     }
 
@@ -91,14 +92,14 @@ public class EnrollmentDateValidationHook
             && Boolean.FALSE.equals( program.getSelectEnrollmentDatesInFuture() )
             && enrollment.getEnrolledAt().atOffset( ZoneOffset.UTC ).toLocalDate().isAfter( now ) )
         {
-            addError( reporter, E1020, enrollment.getEnrolledAt() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1020, enrollment.getEnrolledAt() );
         }
 
         if ( Objects.nonNull( enrollment.getOccurredAt() )
             && Boolean.FALSE.equals( program.getSelectIncidentDatesInFuture() )
             && enrollment.getOccurredAt().atOffset( ZoneOffset.UTC ).toLocalDate().isAfter( now ) )
         {
-            addError( reporter, E1021, enrollment.getOccurredAt() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1021, enrollment.getOccurredAt() );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
@@ -40,7 +40,6 @@ import java.time.ZoneOffset;
 import java.util.Objects;
 
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -67,7 +66,7 @@ public class EnrollmentDateValidationHook
         if ( Boolean.TRUE.equals( program.getDisplayIncidentDate() ) &&
             Objects.isNull( enrollment.getOccurredAt() ) )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1023, enrollment.getOccurredAt() );
+            addError( reporter, enrollment, E1023, enrollment.getOccurredAt() );
         }
     }
 
@@ -77,7 +76,7 @@ public class EnrollmentDateValidationHook
 
         if ( Objects.isNull( enrollment.getEnrolledAt() ) )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1025, enrollment.getEnrolledAt() );
+            addError( reporter, enrollment, E1025, enrollment.getEnrolledAt() );
         }
     }
 
@@ -92,14 +91,14 @@ public class EnrollmentDateValidationHook
             && Boolean.FALSE.equals( program.getSelectEnrollmentDatesInFuture() )
             && enrollment.getEnrolledAt().atOffset( ZoneOffset.UTC ).toLocalDate().isAfter( now ) )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1020, enrollment.getEnrolledAt() );
+            addError( reporter, enrollment, E1020, enrollment.getEnrolledAt() );
         }
 
         if ( Objects.nonNull( enrollment.getOccurredAt() )
             && Boolean.FALSE.equals( program.getSelectIncidentDatesInFuture() )
             && enrollment.getOccurredAt().atOffset( ZoneOffset.UTC ).toLocalDate().isAfter( now ) )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1021, enrollment.getOccurredAt() );
+            addError( reporter, enrollment, E1021, enrollment.getOccurredAt() );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
@@ -59,7 +59,7 @@ public class EnrollmentDateValidationHook
 
         validateMandatoryDates( reporter, enrollment );
 
-        Program program = context.getProgram( enrollment.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, enrollment.getProgram() );
 
         validateEnrollmentDatesNotInFuture( reporter, program, enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.api.client.util.Preconditions.checkNotNull;
 
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -53,7 +54,7 @@ public class EnrollmentGeoValidationHook
 
         if ( enrollment.getGeometry() != null )
         {
-            ValidationUtils.validateGeometry( reporter,
+            ValidationUtils.validateGeometry( reporter, TrackerType.ENROLLMENT, enrollment.getUid(),
                 enrollment.getGeometry(),
                 program.getFeatureType() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
@@ -47,7 +47,7 @@ public class EnrollmentGeoValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        Program program = context.getProgram( enrollment.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, enrollment.getProgram() );
 
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.api.client.util.Preconditions.checkNotNull;
 
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -54,7 +53,7 @@ public class EnrollmentGeoValidationHook
 
         if ( enrollment.getGeometry() != null )
         {
-            ValidationUtils.validateGeometry( reporter, TrackerType.ENROLLMENT, enrollment.getUid(),
+            ValidationUtils.validateGeometry( reporter, enrollment,
                 enrollment.getGeometry(),
                 program.getFeatureType() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 
 import org.hisp.dhis.program.*;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -118,13 +119,13 @@ public class EnrollmentInExistingValidationHook
 
             if ( !activeOnly.isEmpty() )
             {
-                addError( reporter, E1015, tei, program );
+                addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1015, tei, program );
             }
         }
 
         if ( Boolean.TRUE.equals( program.getOnlyEnrollOnce() ) && !mergedEnrollments.isEmpty() )
         {
-            addError( reporter, E1016, tei, program );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1016, tei, program );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -63,7 +63,7 @@ public class EnrollmentInExistingValidationHook
 
         TrackerImportValidationContext validationContext = reporter.getValidationContext();
 
-        Program program = validationContext.getProgram( enrollment.getProgram() );
+        Program program = validationContext.getBundle().getPreheat().get( Program.class, enrollment.getProgram() );
 
         checkNotNull( program, PROGRAM_CANT_BE_NULL );
 
@@ -139,9 +139,11 @@ public class EnrollmentInExistingValidationHook
 
     private TrackedEntityInstance getTrackedEntityInstance( ValidationErrorReporter reporter, String uid )
     {
-        TrackedEntityInstance tei = reporter.getValidationContext().getTrackedEntityInstance( uid );
+        TrackerImportValidationContext trackerImportValidationContext = reporter.getValidationContext();
+        TrackedEntityInstance tei = trackerImportValidationContext.getBundle().getPreheat()
+            .getTrackedEntity( trackerImportValidationContext.getBundle().getIdentifier(), uid );
 
-        if ( tei == null && reporter.getValidationContext().getReference( uid ).isPresent() )
+        if ( tei == null && reporter.getValidationContext().getBundle().getPreheat().getReference( uid ).isPresent() )
         {
             tei = new TrackedEntityInstance();
             tei.setUid( uid );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -38,7 +38,6 @@ import java.util.stream.Stream;
 
 import org.hisp.dhis.program.*;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -119,13 +118,13 @@ public class EnrollmentInExistingValidationHook
 
             if ( !activeOnly.isEmpty() )
             {
-                addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1015, tei, program );
+                addError( reporter, enrollment, E1015, tei, program );
             }
         }
 
         if ( Boolean.TRUE.equals( program.getOnlyEnrollOnce() ) && !mergedEnrollments.isEmpty() )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1016, tei, program );
+            addError( reporter, enrollment, E1016, tei, program );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -40,6 +41,7 @@ public class EnrollmentNoteValidationHook extends AbstractTrackerDtoValidationHo
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        enrollment.setNotes( ValidationUtils.validateNotes( reporter, enrollment.getNotes() ) );
+        enrollment.setNotes( ValidationUtils.validateNotes( reporter, TrackerType.ENROLLMENT, enrollment.getUid(),
+            enrollment.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -41,7 +40,7 @@ public class EnrollmentNoteValidationHook extends AbstractTrackerDtoValidationHo
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        enrollment.setNotes( ValidationUtils.validateNotes( reporter, TrackerType.ENROLLMENT, enrollment.getUid(),
+        enrollment.setNotes( ValidationUtils.validateNotes( reporter, enrollment,
             enrollment.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
@@ -68,6 +69,6 @@ public class EnrollmentRuleValidationHook
                 .getOrDefault( enrollment.getEnrollment(), Lists.newArrayList() ).stream() )
             .collect( Collectors.toList() );
 
-        addIssuesToReporter( reporter, programRuleIssues );
+        addIssuesToReporter( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), programRuleIssues );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
@@ -69,6 +68,6 @@ public class EnrollmentRuleValidationHook
                 .getOrDefault( enrollment.getEnrollment(), Lists.newArrayList() ).stream() )
             .collect( Collectors.toList() );
 
-        addIssuesToReporter( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), programRuleIssues );
+        addIssuesToReporter( reporter, enrollment, programRuleIssues );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.api.client.util.Preconditions.checkNotNull;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1056;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1057;
-import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
 
 import java.time.Instant;
 import java.util.Date;
@@ -43,6 +42,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -86,7 +86,7 @@ public class EventCategoryOptValidationHook
             && program.getCategoryCombo() != null
             && !program.getCategoryCombo().isDefault() )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1055 ) );
+            addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1055 );
             return;
         }
 
@@ -108,13 +108,13 @@ public class EventCategoryOptValidationHook
         {
             if ( option.getStartDate() != null && eventDate.compareTo( option.getStartDate() ) < 0 )
             {
-                addError( reporter, E1056, i18nFormat.formatDate( eventDate ),
+                addError( reporter, TrackerType.EVENT, event.getUid(), E1056, i18nFormat.formatDate( eventDate ),
                     i18nFormat.formatDate( option.getStartDate() ), option.getName() );
             }
 
             if ( option.getEndDate() != null && eventDate.compareTo( option.getAdjustedEndDate( program ) ) > 0 )
             {
-                addError( reporter, E1057, i18nFormat.formatDate( eventDate ),
+                addError( reporter, TrackerType.EVENT, event.getUid(), E1057, i18nFormat.formatDate( eventDate ),
                     i18nFormat.formatDate( option.getAdjustedEndDate( program ) ), option.getName(),
                     program.getName() );
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -86,7 +85,7 @@ public class EventCategoryOptValidationHook
             && program.getCategoryCombo() != null
             && !program.getCategoryCombo().isDefault() )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1055 );
+            addError( reporter, event, TrackerErrorCode.E1055 );
             return;
         }
 
@@ -108,13 +107,13 @@ public class EventCategoryOptValidationHook
         {
             if ( option.getStartDate() != null && eventDate.compareTo( option.getStartDate() ) < 0 )
             {
-                addError( reporter, TrackerType.EVENT, event.getUid(), E1056, i18nFormat.formatDate( eventDate ),
+                addError( reporter, event, E1056, i18nFormat.formatDate( eventDate ),
                     i18nFormat.formatDate( option.getStartDate() ), option.getName() );
             }
 
             if ( option.getEndDate() != null && eventDate.compareTo( option.getAdjustedEndDate( program ) ) > 0 )
             {
-                addError( reporter, TrackerType.EVENT, event.getUid(), E1057, i18nFormat.formatDate( eventDate ),
+                addError( reporter, event, E1057, i18nFormat.formatDate( eventDate ),
                     i18nFormat.formatDate( option.getAdjustedEndDate( program ) ), option.getName(),
                     program.getName() );
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -70,7 +70,7 @@ public class EventCategoryOptValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        Program program = context.getProgram( event.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, event.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
         checkNotNull( context.getBundle().getUser(), TrackerImporterAssertErrors.USER_CANT_BE_NULL );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -65,7 +65,7 @@ public class EventDataValuesValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = context.getBundle().getPreheat().get( ProgramStage.class, event.getProgramStage() );
 
         checkNotNull( programStage, TrackerImporterAssertErrors.PROGRAM_STAGE_CANT_BE_NULL );
 
@@ -73,7 +73,8 @@ public class EventDataValuesValidationHook
         {
             // event dates (createdAt, updatedAt) are ignored and set by the
             // system
-            DataElement dataElement = context.getDataElement( dataValue.getDataElement() );
+            DataElement dataElement = context.getBundle().getPreheat().get( DataElement.class,
+                dataValue.getDataElement() );
 
             if ( dataElement == null )
             {
@@ -97,7 +98,8 @@ public class EventDataValuesValidationHook
     {
         if ( StringUtils.isNotEmpty( event.getProgramStage() ) )
         {
-            ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
+            ProgramStage programStage = context.getBundle().getPreheat().get( ProgramStage.class,
+                event.getProgramStage() );
             final List<String> mandatoryDataElements = programStage.getProgramStageDataElements()
                 .stream()
                 .filter( ProgramStageDataElement::isCompulsory )
@@ -183,7 +185,8 @@ public class EventDataValuesValidationHook
             return;
         }
 
-        FileResource fileResource = reporter.getValidationContext().getFileResource( dataValue.getValue() );
+        FileResource fileResource = reporter.getValidationContext().getBundle().getPreheat().get( FileResource.class,
+            dataValue.getValue() );
 
         addErrorIfNull( fileResource, reporter, event, E1084, dataValue.getValue() );
         addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, event,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.system.util.ValidationUtils;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
@@ -78,15 +77,14 @@ public class EventDataValuesValidationHook
 
             if ( dataElement == null )
             {
-                addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1304,
-                    dataValue.getDataElement() );
+                addError( reporter, event, TrackerErrorCode.E1304, dataValue.getDataElement() );
                 continue;
             }
 
             validateDataElement( reporter, dataElement, dataValue, programStage, event );
             if ( dataValue.getValue() != null )
             {
-                validateOptionSet( reporter, TrackerType.EVENT, event.getUid(), dataElement, dataValue.getValue() );
+                validateOptionSet( reporter, event, dataElement, dataValue.getValue() );
             }
         }
 
@@ -107,7 +105,7 @@ public class EventDataValuesValidationHook
                 .collect( Collectors.toList() );
             List<String> wrongMandatoryDataValue = validateMandatoryDataValue( programStage, event,
                 mandatoryDataElements );
-            wrongMandatoryDataValue.forEach( de -> addError( reporter, TrackerType.EVENT, event.getUid(), E1303, de ) );
+            wrongMandatoryDataValue.forEach( de -> addError( reporter, event, E1303, de ) );
         }
     }
 
@@ -118,13 +116,13 @@ public class EventDataValuesValidationHook
 
         if ( status != null )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1302, dataElement.getUid(),
+            addError( reporter, event, TrackerErrorCode.E1302, dataElement.getUid(),
                 status );
         }
         else
         {
             validateNullDataValues( reporter, dataElement, programStage, dataValue, event );
-            validateFileNotAlreadyAssigned( reporter, event.getUid(), dataValue, dataElement );
+            validateFileNotAlreadyAssigned( reporter, event, dataValue, dataElement );
         }
     }
 
@@ -144,7 +142,7 @@ public class EventDataValuesValidationHook
 
         if ( optionalPsde.isPresent() )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1076, DataElement.class.getSimpleName(),
+            addError( reporter, event, E1076, DataElement.class.getSimpleName(),
                 dataElement.getUid() );
         }
     }
@@ -165,13 +163,13 @@ public class EventDataValuesValidationHook
         {
             if ( !dataElements.contains( payloadDataElement ) )
             {
-                addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1305, payloadDataElement,
+                addError( reporter, event, TrackerErrorCode.E1305, payloadDataElement,
                     programStage.getUid() );
             }
         }
     }
 
-    private void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, String eventUid, DataValue dataValue,
+    private void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, Event event, DataValue dataValue,
         DataElement dataElement )
     {
         if ( dataValue == null || dataValue.getValue() == null )
@@ -187,8 +185,8 @@ public class EventDataValuesValidationHook
 
         FileResource fileResource = reporter.getValidationContext().getFileResource( dataValue.getValue() );
 
-        addErrorIfNull( fileResource, reporter, TrackerType.EVENT, eventUid, E1084, dataValue.getValue() );
-        addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, TrackerType.EVENT, eventUid,
+        addErrorIfNull( fileResource, reporter, event, E1084, dataValue.getValue() );
+        addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, event,
             E1009, dataValue.getValue() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.security.Authorities;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -68,13 +69,13 @@ public class EventDateValidationHook
 
         if ( event.getOccurredAt() == null && occuredAtDateIsMandatory( event, program ) )
         {
-            addError( reporter, E1031, event );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1031, event );
             return;
         }
 
         if ( event.getScheduledAt() == null && EventStatus.SCHEDULE == event.getStatus() )
         {
-            addError( reporter, E1050, event );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1050, event );
             return;
         }
 
@@ -100,13 +101,13 @@ public class EventDateValidationHook
         {
             if ( event.getCompletedAt() == null )
             {
-                addErrorIfNull( event.getCompletedAt(), reporter, E1042, event );
+                addErrorIfNull( event.getCompletedAt(), reporter, TrackerType.EVENT, event.getUid(), E1042, event );
             }
             else
             {
                 if ( now().isAfter( event.getCompletedAt().plus( ofDays( program.getCompleteEventsExpiryDays() ) ) ) )
                 {
-                    addError( reporter, E1043, event );
+                    addError( reporter, TrackerType.EVENT, event.getUid(), E1043, event );
                 }
             }
         }
@@ -131,7 +132,7 @@ public class EventDateValidationHook
 
         if ( referenceDate == null )
         {
-            addError( reporter, E1046, event );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1046, event );
             return;
         }
 
@@ -139,7 +140,7 @@ public class EventDateValidationHook
 
         if ( referenceDate.isBefore( period.getStartDate().toInstant() ) )
         {
-            addError( reporter, E1047, event );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1047, event );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -46,7 +46,6 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.security.Authorities;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -69,13 +68,13 @@ public class EventDateValidationHook
 
         if ( event.getOccurredAt() == null && occuredAtDateIsMandatory( event, program ) )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1031, event );
+            addError( reporter, event, E1031, event );
             return;
         }
 
         if ( event.getScheduledAt() == null && EventStatus.SCHEDULE == event.getStatus() )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1050, event );
+            addError( reporter, event, E1050, event );
             return;
         }
 
@@ -101,13 +100,13 @@ public class EventDateValidationHook
         {
             if ( event.getCompletedAt() == null )
             {
-                addErrorIfNull( event.getCompletedAt(), reporter, TrackerType.EVENT, event.getUid(), E1042, event );
+                addErrorIfNull( event.getCompletedAt(), reporter, event, E1042, event );
             }
             else
             {
                 if ( now().isAfter( event.getCompletedAt().plus( ofDays( program.getCompleteEventsExpiryDays() ) ) ) )
                 {
-                    addError( reporter, TrackerType.EVENT, event.getUid(), E1043, event );
+                    addError( reporter, event, E1043, event );
                 }
             }
         }
@@ -132,7 +131,7 @@ public class EventDateValidationHook
 
         if ( referenceDate == null )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1046, event );
+            addError( reporter, event, E1046, event );
             return;
         }
 
@@ -140,7 +139,7 @@ public class EventDateValidationHook
 
         if ( referenceDate.isBefore( period.getStartDate().toInstant() ) )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1047, event );
+            addError( reporter, event, E1047, event );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -64,7 +64,7 @@ public class EventDateValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        Program program = context.getProgram( event.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, event.getProgram() );
 
         if ( event.getOccurredAt() == null && occuredAtDateIsMandatory( event, program ) )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.api.client.util.Preconditions.checkNotNull;
 
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -52,7 +53,7 @@ public class EventGeoValidationHook
 
         if ( event.getGeometry() != null )
         {
-            ValidationUtils.validateGeometry( reporter,
+            ValidationUtils.validateGeometry( reporter, TrackerType.EVENT, event.getUid(),
                 event.getGeometry(),
                 programStage.getFeatureType() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
@@ -47,7 +47,7 @@ public class EventGeoValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = context.getBundle().getPreheat().get( ProgramStage.class, event.getProgramStage() );
         checkNotNull( programStage, TrackerImporterAssertErrors.PROGRAM_STAGE_CANT_BE_NULL );
 
         if ( event.getGeometry() != null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.api.client.util.Preconditions.checkNotNull;
 
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
@@ -53,7 +52,7 @@ public class EventGeoValidationHook
 
         if ( event.getGeometry() != null )
         {
-            ValidationUtils.validateGeometry( reporter, TrackerType.EVENT, event.getUid(),
+            ValidationUtils.validateGeometry( reporter, event,
                 event.getGeometry(),
                 programStage.getFeatureType() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -40,6 +41,7 @@ public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        event.setNotes( ValidationUtils.validateNotes( reporter, event.getNotes() ) );
+        event
+            .setNotes( ValidationUtils.validateNotes( reporter, TrackerType.EVENT, event.getUid(), event.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -42,6 +41,6 @@ public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
         event
-            .setNotes( ValidationUtils.validateNotes( reporter, TrackerType.EVENT, event.getUid(), event.getNotes() ) );
+            .setNotes( ValidationUtils.validateNotes( reporter, event, event.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
@@ -69,6 +70,6 @@ public class EventRuleValidationHook
                     .getOrDefault( event.getEvent(), Lists.newArrayList() ).stream() )
             .collect( Collectors.toList() );
 
-        addIssuesToReporter( reporter, programRuleIssues );
+        addIssuesToReporter( reporter, TrackerType.EVENT, event.getUid(), programRuleIssues );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
@@ -70,6 +69,6 @@ public class EventRuleValidationHook
                     .getOrDefault( event.getEvent(), Lists.newArrayList() ).stream() )
             .collect( Collectors.toList() );
 
-        addIssuesToReporter( reporter, TrackerType.EVENT, event.getUid(), programRuleIssues );
+        addIssuesToReporter( reporter, event, programRuleIssues );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -27,13 +27,28 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hisp.dhis.tracker.TrackerType.*;
-import static org.hisp.dhis.tracker.report.TrackerErrorCode.*;
-import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1014;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1022;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1029;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1033;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1041;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1079;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1089;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1115;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1116;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4012;
 import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils.getUidFromRelationshipItem;
 import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils.relationshipItemValueType;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 
@@ -50,7 +65,11 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.domain.*;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.RelationshipItem;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.ReferenceTrackerEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
@@ -83,18 +102,18 @@ public class PreCheckDataRelationsValidationHook
         Program program = context.getProgram( enrollment.getProgram() );
         OrganisationUnit organisationUnit = context.getOrganisationUnit( enrollment.getOrgUnit() );
 
-        addErrorIf( () -> !program.isRegistration(), reporter, E1014, program );
+        addErrorIf( () -> !program.isRegistration(), reporter, ENROLLMENT, enrollment.getUid(), E1014, program );
 
         if ( !programHasOrgUnit( program, organisationUnit, context.getProgramWithOrgUnitsMap() ) )
         {
-            addError( reporter, E1041, organisationUnit, program );
+            addError( reporter, ENROLLMENT, enrollment.getUid(), E1041, organisationUnit, program );
         }
 
         if ( program.getTrackedEntityType() != null
             && !program.getTrackedEntityType().getUid()
                 .equals( getTrackedEntityTypeUidFromEnrollment( context, enrollment ) ) )
         {
-            addError( reporter, E1022, enrollment.getTrackedEntity(), program );
+            addError( reporter, ENROLLMENT, enrollment.getUid(), E1022, enrollment.getTrackedEntity(), program );
         }
     }
 
@@ -109,14 +128,14 @@ public class PreCheckDataRelationsValidationHook
 
         if ( !program.getUid().equals( programStage.getProgram().getUid() ) )
         {
-            addError( reporter, E1089, event, programStage, program );
+            addError( reporter, EVENT, event.getUid(), E1089, event, programStage, program );
         }
 
         if ( program.isRegistration() )
         {
             if ( StringUtils.isEmpty( event.getEnrollment() ) )
             {
-                addError( reporter, E1033, event.getEvent() );
+                addError( reporter, EVENT, event.getUid(), E1033, event.getEvent() );
             }
             else
             {
@@ -124,14 +143,14 @@ public class PreCheckDataRelationsValidationHook
 
                 if ( !program.getUid().equals( programUid ) )
                 {
-                    addError( reporter, E1079, event, program, event.getEnrollment() );
+                    addError( reporter, EVENT, event.getUid(), E1079, event, program, event.getEnrollment() );
                 }
             }
         }
 
         if ( !programHasOrgUnit( program, organisationUnit, context.getProgramWithOrgUnitsMap() ) )
         {
-            addError( reporter, E1029, organisationUnit, program );
+            addError( reporter, EVENT, event.getUid(), E1029, organisationUnit, program );
         }
 
         validateEventCategoryCombo( reporter, event, program );
@@ -140,11 +159,11 @@ public class PreCheckDataRelationsValidationHook
     @Override
     public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
     {
-        validateRelationshipReference( reporter, relationship.getFrom() );
-        validateRelationshipReference( reporter, relationship.getTo() );
+        validateRelationshipReference( reporter, relationship.getUid(), relationship.getFrom() );
+        validateRelationshipReference( reporter, relationship.getUid(), relationship.getTo() );
     }
 
-    private void validateRelationshipReference( ValidationErrorReporter reporter, RelationshipItem item )
+    private void validateRelationshipReference( ValidationErrorReporter reporter, String relUid, RelationshipItem item )
     {
         Optional<String> uid = getUidFromRelationshipItem( item );
         TrackerType trackerType = relationshipItemValueType( item );
@@ -155,21 +174,21 @@ public class PreCheckDataRelationsValidationHook
         {
             if ( uid.isPresent() && !ValidationUtils.trackedEntityInstanceExist( ctx, uid.get() ) )
             {
-                addError( reporter, E4012, trackerType.getName(), uid.get() );
+                addError( reporter, RELATIONSHIP, relUid, E4012, trackerType.getName(), uid.get() );
             }
         }
         else if ( ENROLLMENT.equals( trackerType ) )
         {
             if ( uid.isPresent() && !ValidationUtils.enrollmentExist( ctx, uid.get() ) )
             {
-                addError( reporter, E4012, trackerType.getName(), uid.get() );
+                addError( reporter, RELATIONSHIP, relUid, E4012, trackerType.getName(), uid.get() );
             }
         }
         else if ( EVENT.equals( trackerType ) )
         {
             if ( uid.isPresent() && !ValidationUtils.eventExist( ctx, uid.get() ) )
             {
-                addError( reporter, E4012, trackerType.getName(), uid.get() );
+                addError( reporter, RELATIONSHIP, relUid, E4012, trackerType.getName(), uid.get() );
             }
         }
     }
@@ -202,7 +221,7 @@ public class PreCheckDataRelationsValidationHook
 
         if ( categoryOptionCombo == null )
         {
-            addError( reporter, E1115, event.getAttributeOptionCombo() );
+            addError( reporter, EVENT, event.getUid(), E1115, event.getAttributeOptionCombo() );
         }
         else
         {
@@ -231,7 +250,7 @@ public class PreCheckDataRelationsValidationHook
             Set<String> categoryOptions = TextUtils
                 .splitToArray( attributeCategoryOptions, TextUtils.SEMICOLON );
 
-            categoryOptionCombo = resolveCategoryOptionCombo( reporter,
+            categoryOptionCombo = resolveCategoryOptionCombo( reporter, event.getUid(),
                 categoryCombo, categoryOptions );
 
             reporter.getValidationContext().putCachedEventAOCProgramCC( cacheKey,
@@ -265,7 +284,7 @@ public class PreCheckDataRelationsValidationHook
         return categoryOptionCombo;
     }
 
-    private CategoryOptionCombo resolveCategoryOptionCombo( ValidationErrorReporter reporter,
+    private CategoryOptionCombo resolveCategoryOptionCombo( ValidationErrorReporter reporter, String eventUid,
         CategoryCombo programCategoryCombo, Set<String> attributeCategoryOptions )
     {
         Set<CategoryOption> categoryOptions = new HashSet<>();
@@ -275,7 +294,7 @@ public class PreCheckDataRelationsValidationHook
             CategoryOption categoryOption = reporter.getValidationContext().getCategoryOption( uid );
             if ( categoryOption == null )
             {
-                addError( reporter, E1116, uid );
+                addError( reporter, EVENT, eventUid, E1116, uid );
                 return null;
             }
 
@@ -287,9 +306,8 @@ public class PreCheckDataRelationsValidationHook
 
         if ( attrOptCombo == null )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1117 )
-                .addArg( programCategoryCombo )
-                .addArg( categoryOptions ) );
+            addError( reporter, TrackerType.EVENT, eventUid, TrackerErrorCode.E1117, programCategoryCombo,
+                categoryOptions );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -27,12 +27,22 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hisp.dhis.tracker.report.TrackerErrorCode.*;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1002;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1030;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1032;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1063;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1080;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1081;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1082;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1113;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1114;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4015;
 
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -60,17 +70,20 @@ public class PreCheckExistenceValidationHook
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingTe != null && existingTe.isDeleted() )
         {
-            addError( reporter, E1114, trackedEntity.getTrackedEntity() );
+            addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1114,
+                trackedEntity.getTrackedEntity() );
             return;
         }
 
         if ( existingTe != null && importStrategy.isCreate() )
         {
-            addError( reporter, E1002, trackedEntity.getTrackedEntity() );
+            addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1002,
+                trackedEntity.getTrackedEntity() );
         }
         else if ( existingTe == null && importStrategy.isUpdateOrDelete() )
         {
-            addError( reporter, E1063, trackedEntity.getTrackedEntity() );
+            addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1063,
+                trackedEntity.getTrackedEntity() );
         }
     }
 
@@ -85,17 +98,17 @@ public class PreCheckExistenceValidationHook
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingPi != null && existingPi.isDeleted() )
         {
-            addError( reporter, E1113, enrollment.getEnrollment() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1113, enrollment.getEnrollment() );
             return;
         }
 
         if ( existingPi != null && importStrategy.isCreate() )
         {
-            addError( reporter, E1080, enrollment.getEnrollment() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1080, enrollment.getEnrollment() );
         }
         else if ( existingPi == null && importStrategy.isUpdateOrDelete() )
         {
-            addError( reporter, E1081, enrollment.getEnrollment() );
+            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1081, enrollment.getEnrollment() );
         }
     }
 
@@ -110,17 +123,17 @@ public class PreCheckExistenceValidationHook
         // If the event is soft-deleted no operation is allowed
         if ( existingPsi != null && existingPsi.isDeleted() )
         {
-            addError( reporter, E1082, event.getEvent() );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1082, event.getEvent() );
             return;
         }
 
         if ( existingPsi != null && importStrategy.isCreate() )
         {
-            addError( reporter, E1030, event.getEvent() );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1030, event.getEvent() );
         }
         else if ( existingPsi == null && importStrategy.isUpdateOrDelete() )
         {
-            addError( reporter, E1032, event.getEvent() );
+            addError( reporter, TrackerType.EVENT, event.getUid(), E1032, event.getEvent() );
         }
     }
 
@@ -133,7 +146,8 @@ public class PreCheckExistenceValidationHook
 
         if ( existingRelationship != null )
         {
-            addWarning( reporter, E4015, relationship.getRelationship() );
+            addWarning( reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E4015,
+                relationship.getRelationship() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -70,20 +69,17 @@ public class PreCheckExistenceValidationHook
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingTe != null && existingTe.isDeleted() )
         {
-            addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1114,
-                trackedEntity.getTrackedEntity() );
+            addError( reporter, trackedEntity, E1114, trackedEntity.getTrackedEntity() );
             return;
         }
 
         if ( existingTe != null && importStrategy.isCreate() )
         {
-            addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1002,
-                trackedEntity.getTrackedEntity() );
+            addError( reporter, trackedEntity, E1002, trackedEntity.getTrackedEntity() );
         }
         else if ( existingTe == null && importStrategy.isUpdateOrDelete() )
         {
-            addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1063,
-                trackedEntity.getTrackedEntity() );
+            addError( reporter, trackedEntity, E1063, trackedEntity.getTrackedEntity() );
         }
     }
 
@@ -98,17 +94,17 @@ public class PreCheckExistenceValidationHook
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingPi != null && existingPi.isDeleted() )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1113, enrollment.getEnrollment() );
+            addError( reporter, enrollment, E1113, enrollment.getEnrollment() );
             return;
         }
 
         if ( existingPi != null && importStrategy.isCreate() )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1080, enrollment.getEnrollment() );
+            addError( reporter, enrollment, E1080, enrollment.getEnrollment() );
         }
         else if ( existingPi == null && importStrategy.isUpdateOrDelete() )
         {
-            addError( reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1081, enrollment.getEnrollment() );
+            addError( reporter, enrollment, E1081, enrollment.getEnrollment() );
         }
     }
 
@@ -123,17 +119,17 @@ public class PreCheckExistenceValidationHook
         // If the event is soft-deleted no operation is allowed
         if ( existingPsi != null && existingPsi.isDeleted() )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1082, event.getEvent() );
+            addError( reporter, event, E1082, event.getEvent() );
             return;
         }
 
         if ( existingPsi != null && importStrategy.isCreate() )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1030, event.getEvent() );
+            addError( reporter, event, E1030, event.getEvent() );
         }
         else if ( existingPsi == null && importStrategy.isUpdateOrDelete() )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), E1032, event.getEvent() );
+            addError( reporter, event, E1032, event.getEvent() );
         }
     }
 
@@ -146,7 +142,7 @@ public class PreCheckExistenceValidationHook
 
         if ( existingRelationship != null )
         {
-            addWarning( reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E4015,
+            addWarning( reporter, relationship, E4015,
                 relationship.getRelationship() );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -61,10 +61,9 @@ public class PreCheckExistenceValidationHook
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
-        TrackerImportStrategy importStrategy = context.getStrategy( trackedEntity );
 
-        TrackedEntityInstance existingTe = context
-            .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+        TrackedEntityInstance existingTe = context.getBundle().getPreheat()
+            .getTrackedEntity( context.getBundle().getIdentifier(), trackedEntity.getTrackedEntity() );
 
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingTe != null && existingTe.isDeleted() )
@@ -73,6 +72,7 @@ public class PreCheckExistenceValidationHook
             return;
         }
 
+        TrackerImportStrategy importStrategy = context.getBundle().getStrategy( trackedEntity );
         if ( existingTe != null && importStrategy.isCreate() )
         {
             addError( reporter, trackedEntity, E1002, trackedEntity.getTrackedEntity() );
@@ -87,9 +87,9 @@ public class PreCheckExistenceValidationHook
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
-        TrackerImportStrategy importStrategy = context.getStrategy( enrollment );
 
-        ProgramInstance existingPi = context.getProgramInstance( enrollment.getEnrollment() );
+        ProgramInstance existingPi = context.getBundle().getPreheat()
+            .getEnrollment( context.getBundle().getIdentifier(), enrollment.getEnrollment() );
 
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingPi != null && existingPi.isDeleted() )
@@ -98,6 +98,7 @@ public class PreCheckExistenceValidationHook
             return;
         }
 
+        TrackerImportStrategy importStrategy = context.getBundle().getStrategy( enrollment );
         if ( existingPi != null && importStrategy.isCreate() )
         {
             addError( reporter, enrollment, E1080, enrollment.getEnrollment() );
@@ -112,9 +113,9 @@ public class PreCheckExistenceValidationHook
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
-        TrackerImportStrategy importStrategy = context.getStrategy( event );
 
-        ProgramStageInstance existingPsi = context.getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance existingPsi = context.getBundle().getPreheat()
+            .getEvent( context.getBundle().getIdentifier(), event.getEvent() );
 
         // If the event is soft-deleted no operation is allowed
         if ( existingPsi != null && existingPsi.isDeleted() )
@@ -123,6 +124,7 @@ public class PreCheckExistenceValidationHook
             return;
         }
 
+        TrackerImportStrategy importStrategy = context.getBundle().getStrategy( event );
         if ( existingPsi != null && importStrategy.isCreate() )
         {
             addError( reporter, event, E1030, event.getEvent() );
@@ -138,7 +140,8 @@ public class PreCheckExistenceValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        org.hisp.dhis.relationship.Relationship existingRelationship = context.getRelationship( relationship );
+        org.hisp.dhis.relationship.Relationship existingRelationship = context.getBundle().getPreheat()
+            .getRelationship( context.getBundle().getIdentifier(), relationship );
 
         if ( existingRelationship != null )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1124;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -55,24 +56,31 @@ public class PreCheckMandatoryFieldsValidationHook
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
     {
-        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getTrackedEntityType() ), reporter, E1121,
+        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getTrackedEntityType() ), reporter,
+            TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1121,
             "trackedEntityType" );
-        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getOrgUnit() ), reporter, E1121, ORG_UNIT );
+        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getOrgUnit() ), reporter, TrackerType.TRACKED_ENTITY,
+            trackedEntity.getUid(), E1121, ORG_UNIT );
     }
 
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        addErrorIf( () -> StringUtils.isEmpty( enrollment.getOrgUnit() ), reporter, E1122, ORG_UNIT );
-        addErrorIf( () -> StringUtils.isEmpty( enrollment.getProgram() ), reporter, E1122, "program" );
-        addErrorIf( () -> StringUtils.isEmpty( enrollment.getTrackedEntity() ), reporter, E1122, "trackedEntity" );
+        addErrorIf( () -> StringUtils.isEmpty( enrollment.getOrgUnit() ), reporter, TrackerType.ENROLLMENT,
+            enrollment.getUid(), E1122, ORG_UNIT );
+        addErrorIf( () -> StringUtils.isEmpty( enrollment.getProgram() ), reporter, TrackerType.ENROLLMENT,
+            enrollment.getUid(), E1122, "program" );
+        addErrorIf( () -> StringUtils.isEmpty( enrollment.getTrackedEntity() ), reporter, TrackerType.ENROLLMENT,
+            enrollment.getUid(), E1122, "trackedEntity" );
     }
 
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        addErrorIf( () -> StringUtils.isEmpty( event.getOrgUnit() ), reporter, E1123, ORG_UNIT );
-        addErrorIf( () -> StringUtils.isEmpty( event.getProgramStage() ), reporter, E1123, "programStage" );
+        addErrorIf( () -> StringUtils.isEmpty( event.getOrgUnit() ), reporter, TrackerType.EVENT, event.getUid(), E1123,
+            ORG_UNIT );
+        addErrorIf( () -> StringUtils.isEmpty( event.getProgramStage() ), reporter, TrackerType.EVENT, event.getUid(),
+            E1123, "programStage" );
 
         // TODO remove if once metadata import is fixed
         TrackerImportValidationContext context = reporter.getValidationContext();
@@ -87,22 +95,26 @@ public class PreCheckMandatoryFieldsValidationHook
             // the event itself. This should be
             // fixed in the metadata import. For more see
             // https://jira.dhis2.org/browse/DHIS2-12123
-            addErrorIfNull( programStage.getProgram(), reporter, E1008, event.getProgramStage() );
+            addErrorIfNull( programStage.getProgram(), reporter, TrackerType.EVENT, event.getUid(), E1008,
+                event.getProgramStage() );
             // return since program is not a required field according to our API
             // and the issue is with the missing reference in
             // the DB entry of the program stage and not the payload itself
             return;
         }
 
-        addErrorIf( () -> StringUtils.isEmpty( event.getProgram() ), reporter, E1123, "program" );
+        addErrorIf( () -> StringUtils.isEmpty( event.getProgram() ), reporter, TrackerType.EVENT, event.getUid(), E1123,
+            "program" );
     }
 
     @Override
     public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
     {
-        addErrorIfNull( relationship.getFrom(), reporter, E1124, "from" );
-        addErrorIfNull( relationship.getTo(), reporter, E1124, "to" );
-        addErrorIf( () -> StringUtils.isEmpty( relationship.getRelationshipType() ), reporter, E1124,
+        addErrorIfNull( relationship.getFrom(), reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E1124,
+            "from" );
+        addErrorIfNull( relationship.getTo(), reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E1124, "to" );
+        addErrorIf( () -> StringUtils.isEmpty( relationship.getRelationshipType() ), reporter, TrackerType.RELATIONSHIP,
+            relationship.getUid(), E1124,
             "relationshipType" );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1124;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -56,31 +55,25 @@ public class PreCheckMandatoryFieldsValidationHook
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
     {
-        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getTrackedEntityType() ), reporter,
-            TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1121,
+        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getTrackedEntityType() ), reporter, trackedEntity, E1121,
             "trackedEntityType" );
-        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getOrgUnit() ), reporter, TrackerType.TRACKED_ENTITY,
-            trackedEntity.getUid(), E1121, ORG_UNIT );
+        addErrorIf( () -> StringUtils.isEmpty( trackedEntity.getOrgUnit() ), reporter, trackedEntity, E1121, ORG_UNIT );
     }
 
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        addErrorIf( () -> StringUtils.isEmpty( enrollment.getOrgUnit() ), reporter, TrackerType.ENROLLMENT,
-            enrollment.getUid(), E1122, ORG_UNIT );
-        addErrorIf( () -> StringUtils.isEmpty( enrollment.getProgram() ), reporter, TrackerType.ENROLLMENT,
-            enrollment.getUid(), E1122, "program" );
-        addErrorIf( () -> StringUtils.isEmpty( enrollment.getTrackedEntity() ), reporter, TrackerType.ENROLLMENT,
-            enrollment.getUid(), E1122, "trackedEntity" );
+        addErrorIf( () -> StringUtils.isEmpty( enrollment.getOrgUnit() ), reporter, enrollment, E1122, ORG_UNIT );
+        addErrorIf( () -> StringUtils.isEmpty( enrollment.getProgram() ), reporter, enrollment, E1122, "program" );
+        addErrorIf( () -> StringUtils.isEmpty( enrollment.getTrackedEntity() ), reporter, enrollment, E1122,
+            "trackedEntity" );
     }
 
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        addErrorIf( () -> StringUtils.isEmpty( event.getOrgUnit() ), reporter, TrackerType.EVENT, event.getUid(), E1123,
-            ORG_UNIT );
-        addErrorIf( () -> StringUtils.isEmpty( event.getProgramStage() ), reporter, TrackerType.EVENT, event.getUid(),
-            E1123, "programStage" );
+        addErrorIf( () -> StringUtils.isEmpty( event.getOrgUnit() ), reporter, event, E1123, ORG_UNIT );
+        addErrorIf( () -> StringUtils.isEmpty( event.getProgramStage() ), reporter, event, E1123, "programStage" );
 
         // TODO remove if once metadata import is fixed
         TrackerImportValidationContext context = reporter.getValidationContext();
@@ -95,26 +88,22 @@ public class PreCheckMandatoryFieldsValidationHook
             // the event itself. This should be
             // fixed in the metadata import. For more see
             // https://jira.dhis2.org/browse/DHIS2-12123
-            addErrorIfNull( programStage.getProgram(), reporter, TrackerType.EVENT, event.getUid(), E1008,
-                event.getProgramStage() );
+            addErrorIfNull( programStage.getProgram(), reporter, event, E1008, event.getProgramStage() );
             // return since program is not a required field according to our API
             // and the issue is with the missing reference in
             // the DB entry of the program stage and not the payload itself
             return;
         }
 
-        addErrorIf( () -> StringUtils.isEmpty( event.getProgram() ), reporter, TrackerType.EVENT, event.getUid(), E1123,
-            "program" );
+        addErrorIf( () -> StringUtils.isEmpty( event.getProgram() ), reporter, event, E1123, "program" );
     }
 
     @Override
     public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
     {
-        addErrorIfNull( relationship.getFrom(), reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E1124,
-            "from" );
-        addErrorIfNull( relationship.getTo(), reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E1124, "to" );
-        addErrorIf( () -> StringUtils.isEmpty( relationship.getRelationshipType() ), reporter, TrackerType.RELATIONSHIP,
-            relationship.getUid(), E1124,
+        addErrorIfNull( relationship.getFrom(), reporter, relationship, E1124, "from" );
+        addErrorIfNull( relationship.getTo(), reporter, relationship, E1124, "to" );
+        addErrorIf( () -> StringUtils.isEmpty( relationship.getRelationshipType() ), reporter, relationship, E1124,
             "relationshipType" );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -77,7 +77,7 @@ public class PreCheckMandatoryFieldsValidationHook
 
         // TODO remove if once metadata import is fixed
         TrackerImportValidationContext context = reporter.getValidationContext();
-        ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = context.getBundle().getPreheat().get( ProgramStage.class, event.getProgramStage() );
         if ( programStage != null )
         {
             // Program stages should always have a program! Due to how metadata

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -27,8 +27,14 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hisp.dhis.tracker.report.TrackerErrorCode.*;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1005;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1010;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1011;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1013;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1068;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1069;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1070;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4006;
 import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.trackedEntityInstanceExist;
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -36,6 +42,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -60,13 +67,13 @@ public class PreCheckMetaValidationHook
         OrganisationUnit organisationUnit = context.getOrganisationUnit( tei.getOrgUnit() );
         if ( organisationUnit == null )
         {
-            addError( reporter, TrackerErrorCode.E1049, tei.getOrgUnit() );
+            addError( reporter, TrackerType.TRACKED_ENTITY, tei.getUid(), TrackerErrorCode.E1049, tei.getOrgUnit() );
         }
 
         TrackedEntityType entityType = context.getTrackedEntityType( tei.getTrackedEntityType() );
         if ( entityType == null )
         {
-            addError( reporter, E1005, tei.getTrackedEntityType() );
+            addError( reporter, TrackerType.TRACKED_ENTITY, tei.getUid(), E1005, tei.getTrackedEntityType() );
         }
     }
 
@@ -76,13 +83,15 @@ public class PreCheckMetaValidationHook
         TrackerImportValidationContext context = reporter.getValidationContext();
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( enrollment.getOrgUnit() );
-        addErrorIfNull( organisationUnit, reporter, E1070, enrollment.getOrgUnit() );
+        addErrorIfNull( organisationUnit, reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1070,
+            enrollment.getOrgUnit() );
 
         Program program = context.getProgram( enrollment.getProgram() );
-        addErrorIfNull( program, reporter, E1069, enrollment.getProgram() );
+        addErrorIfNull( program, reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1069,
+            enrollment.getProgram() );
 
         addErrorIf( () -> !trackedEntityInstanceExist( context, enrollment.getTrackedEntity() ),
-            reporter, E1068, enrollment.getTrackedEntity() );
+            reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1068, enrollment.getTrackedEntity() );
     }
 
     @Override
@@ -91,13 +100,13 @@ public class PreCheckMetaValidationHook
         TrackerImportValidationContext context = reporter.getValidationContext();
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( event.getOrgUnit() );
-        addErrorIfNull( organisationUnit, reporter, E1011, event.getOrgUnit() );
+        addErrorIfNull( organisationUnit, reporter, TrackerType.EVENT, event.getUid(), E1011, event.getOrgUnit() );
 
         Program program = context.getProgram( event.getProgram() );
-        addErrorIfNull( program, reporter, E1010, event.getProgram() );
+        addErrorIfNull( program, reporter, TrackerType.EVENT, event.getUid(), E1010, event.getProgram() );
 
         ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
-        addErrorIfNull( programStage, reporter, E1013, event.getProgramStage() );
+        addErrorIfNull( programStage, reporter, TrackerType.EVENT, event.getUid(), E1013, event.getProgramStage() );
     }
 
     @Override
@@ -107,7 +116,8 @@ public class PreCheckMetaValidationHook
 
         RelationshipType relationshipType = context.getRelationShipType( relationship.getRelationshipType() );
 
-        addErrorIfNull( relationshipType, reporter, E4006, relationship.getRelationshipType() );
+        addErrorIfNull( relationshipType, reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E4006,
+            relationship.getRelationshipType() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -63,13 +63,15 @@ public class PreCheckMetaValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        OrganisationUnit organisationUnit = context.getOrganisationUnit( tei.getOrgUnit() );
+        OrganisationUnit organisationUnit = context.getBundle().getPreheat().get( OrganisationUnit.class,
+            tei.getOrgUnit() );
         if ( organisationUnit == null )
         {
             addError( reporter, tei, TrackerErrorCode.E1049, tei.getOrgUnit() );
         }
 
-        TrackedEntityType entityType = context.getTrackedEntityType( tei.getTrackedEntityType() );
+        TrackedEntityType entityType = context.getBundle().getPreheat().get( TrackedEntityType.class,
+            tei.getTrackedEntityType() );
         if ( entityType == null )
         {
             addError( reporter, tei, E1005, tei.getTrackedEntityType() );
@@ -81,10 +83,11 @@ public class PreCheckMetaValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        OrganisationUnit organisationUnit = context.getOrganisationUnit( enrollment.getOrgUnit() );
+        OrganisationUnit organisationUnit = context.getBundle().getPreheat().get( OrganisationUnit.class,
+            enrollment.getOrgUnit() );
         addErrorIfNull( organisationUnit, reporter, enrollment, E1070, enrollment.getOrgUnit() );
 
-        Program program = context.getProgram( enrollment.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, enrollment.getProgram() );
         addErrorIfNull( program, reporter, enrollment, E1069, enrollment.getProgram() );
 
         addErrorIf( () -> !trackedEntityInstanceExist( context, enrollment.getTrackedEntity() ), reporter, enrollment,
@@ -96,13 +99,14 @@ public class PreCheckMetaValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        OrganisationUnit organisationUnit = context.getOrganisationUnit( event.getOrgUnit() );
+        OrganisationUnit organisationUnit = context.getBundle().getPreheat().get( OrganisationUnit.class,
+            event.getOrgUnit() );
         addErrorIfNull( organisationUnit, reporter, event, E1011, event.getOrgUnit() );
 
-        Program program = context.getProgram( event.getProgram() );
+        Program program = context.getBundle().getPreheat().get( Program.class, event.getProgram() );
         addErrorIfNull( program, reporter, event, E1010, event.getProgram() );
 
-        ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = context.getBundle().getPreheat().get( ProgramStage.class, event.getProgramStage() );
         addErrorIfNull( programStage, reporter, event, E1013, event.getProgramStage() );
     }
 
@@ -111,7 +115,8 @@ public class PreCheckMetaValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        RelationshipType relationshipType = context.getRelationShipType( relationship.getRelationshipType() );
+        RelationshipType relationshipType = context.getBundle().getPreheat().get( RelationshipType.class,
+            relationship.getRelationshipType() );
 
         addErrorIfNull( relationshipType, reporter, relationship, E4006, relationship.getRelationshipType() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -67,13 +66,13 @@ public class PreCheckMetaValidationHook
         OrganisationUnit organisationUnit = context.getOrganisationUnit( tei.getOrgUnit() );
         if ( organisationUnit == null )
         {
-            addError( reporter, TrackerType.TRACKED_ENTITY, tei.getUid(), TrackerErrorCode.E1049, tei.getOrgUnit() );
+            addError( reporter, tei, TrackerErrorCode.E1049, tei.getOrgUnit() );
         }
 
         TrackedEntityType entityType = context.getTrackedEntityType( tei.getTrackedEntityType() );
         if ( entityType == null )
         {
-            addError( reporter, TrackerType.TRACKED_ENTITY, tei.getUid(), E1005, tei.getTrackedEntityType() );
+            addError( reporter, tei, E1005, tei.getTrackedEntityType() );
         }
     }
 
@@ -83,15 +82,13 @@ public class PreCheckMetaValidationHook
         TrackerImportValidationContext context = reporter.getValidationContext();
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( enrollment.getOrgUnit() );
-        addErrorIfNull( organisationUnit, reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1070,
-            enrollment.getOrgUnit() );
+        addErrorIfNull( organisationUnit, reporter, enrollment, E1070, enrollment.getOrgUnit() );
 
         Program program = context.getProgram( enrollment.getProgram() );
-        addErrorIfNull( program, reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1069,
-            enrollment.getProgram() );
+        addErrorIfNull( program, reporter, enrollment, E1069, enrollment.getProgram() );
 
-        addErrorIf( () -> !trackedEntityInstanceExist( context, enrollment.getTrackedEntity() ),
-            reporter, TrackerType.ENROLLMENT, enrollment.getUid(), E1068, enrollment.getTrackedEntity() );
+        addErrorIf( () -> !trackedEntityInstanceExist( context, enrollment.getTrackedEntity() ), reporter, enrollment,
+            E1068, enrollment.getTrackedEntity() );
     }
 
     @Override
@@ -100,13 +97,13 @@ public class PreCheckMetaValidationHook
         TrackerImportValidationContext context = reporter.getValidationContext();
 
         OrganisationUnit organisationUnit = context.getOrganisationUnit( event.getOrgUnit() );
-        addErrorIfNull( organisationUnit, reporter, TrackerType.EVENT, event.getUid(), E1011, event.getOrgUnit() );
+        addErrorIfNull( organisationUnit, reporter, event, E1011, event.getOrgUnit() );
 
         Program program = context.getProgram( event.getProgram() );
-        addErrorIfNull( program, reporter, TrackerType.EVENT, event.getUid(), E1010, event.getProgram() );
+        addErrorIfNull( program, reporter, event, E1010, event.getProgram() );
 
         ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
-        addErrorIfNull( programStage, reporter, TrackerType.EVENT, event.getUid(), E1013, event.getProgramStage() );
+        addErrorIfNull( programStage, reporter, event, E1013, event.getProgramStage() );
     }
 
     @Override
@@ -116,8 +113,7 @@ public class PreCheckMetaValidationHook
 
         RelationshipType relationshipType = context.getRelationShipType( relationship.getRelationshipType() );
 
-        addErrorIfNull( relationshipType, reporter, TrackerType.RELATIONSHIP, relationship.getUid(), E4006,
-            relationship.getRelationshipType() );
+        addErrorIfNull( relationshipType, reporter, relationship, E4006, relationship.getRelationshipType() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
@@ -27,12 +27,15 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
-
 import java.util.List;
 
 import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.tracker.domain.*;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -47,54 +50,60 @@ public class PreCheckUidValidationHook
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
     {
-        checkUidFormat( trackedEntity.getTrackedEntity(), reporter, trackedEntity, trackedEntity.getTrackedEntity() );
+        checkUidFormat( trackedEntity.getTrackedEntity(), reporter, trackedEntity, trackedEntity,
+            trackedEntity.getTrackedEntity() );
     }
 
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        checkUidFormat( enrollment.getEnrollment(), reporter, enrollment, enrollment.getEnrollment() );
+        checkUidFormat( enrollment.getEnrollment(), reporter, enrollment, enrollment, enrollment.getEnrollment() );
 
-        validateNotesUid( enrollment.getNotes(), reporter );
+        validateNotesUid( enrollment.getNotes(), reporter, enrollment );
     }
 
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        checkUidFormat( event.getEvent(), reporter, event, event.getEvent() );
+        checkUidFormat( event.getEvent(), reporter, event, event, event.getEvent() );
 
-        validateNotesUid( event.getNotes(), reporter );
+        validateNotesUid( event.getNotes(), reporter, event );
     }
 
     @Override
     public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
     {
-        checkUidFormat( relationship.getRelationship(), reporter, relationship, relationship.getRelationship() );
+        checkUidFormat( relationship.getRelationship(), reporter, relationship, relationship,
+            relationship.getRelationship() );
     }
 
-    private void validateNotesUid( List<Note> notes, ValidationErrorReporter reporter )
+    private void validateNotesUid( List<Note> notes, ValidationErrorReporter reporter, TrackerDto dto )
     {
         for ( Note note : notes )
         {
-            checkUidFormat( note.getNote(), reporter, note, note.getNote() );
+            checkUidFormat( note.getNote(), reporter, dto, note, note.getNote() );
         }
     }
 
     /**
      * Check if the given UID has a valid format.
      *
-     * @param uid a UID
+     * @param checkUid a UID to be checked
      * @param reporter a {@see ValidationErrorReporter} to which the error is
      *        added
+     * @param dto the dto to which the report will be linked to
      * @param args list of arguments for the Error report
      */
-    private void checkUidFormat( String uid, ValidationErrorReporter reporter, Object... args )
+    // TODO once tests pass can I use generics so that I do not have to pass the
+    // dto twice?
+    private void checkUidFormat( String checkUid, ValidationErrorReporter reporter, TrackerDto dto,
+        Object... args )
     {
-        if ( !CodeGenerator.isValidUid( uid ) )
+        if ( !CodeGenerator.isValidUid( checkUid ) )
         {
-            reporter.addError( newReport( TrackerErrorCode.E1048 )
-                .addArg( args[0] )
-                .addArg( args[1] ) );
+            // TODO(TECH-880) how can I leverage this directly in addError
+            addError( reporter, dto.getTrackerType(), dto.getUid(), TrackerErrorCode.E1048, checkUid, args[0],
+                args[1] );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
@@ -94,16 +94,12 @@ public class PreCheckUidValidationHook
      * @param dto the dto to which the report will be linked to
      * @param args list of arguments for the Error report
      */
-    // TODO once tests pass can I use generics so that I do not have to pass the
-    // dto twice?
     private void checkUidFormat( String checkUid, ValidationErrorReporter reporter, TrackerDto dto,
         Object... args )
     {
         if ( !CodeGenerator.isValidUid( checkUid ) )
         {
-            // TODO(TECH-880) how can I leverage this directly in addError
-            addError( reporter, dto.getTrackerType(), dto.getUid(), TrackerErrorCode.E1048, checkUid, args[0],
-                args[1] );
+            addError( reporter, dto, TrackerErrorCode.E1048, checkUid, args[0], args[1] );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -63,7 +64,8 @@ public class PreCheckUpdatableFieldsValidationHook
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
 
         addErrorIf( () -> !trackedEntityInstance.getTrackedEntityType().getUid()
-            .equals( trackedEntity.getTrackedEntityType() ), reporter, E1126, "trackedEntityType" );
+            .equals( trackedEntity.getTrackedEntityType() ), reporter, TrackerType.TRACKED_ENTITY,
+            trackedEntity.getUid(), E1126, "trackedEntityType" );
     }
 
     @Override
@@ -75,8 +77,10 @@ public class PreCheckUpdatableFieldsValidationHook
         Program program = pi.getProgram();
         TrackedEntityInstance trackedEntityInstance = pi.getEntityInstance();
 
-        addErrorIf( () -> !program.getUid().equals( enrollment.getProgram() ), reporter, E1127, "program" );
-        addErrorIf( () -> !trackedEntityInstance.getUid().equals( enrollment.getTrackedEntity() ), reporter, E1127,
+        addErrorIf( () -> !program.getUid().equals( enrollment.getProgram() ), reporter, TrackerType.ENROLLMENT,
+            enrollment.getUid(), E1127, "program" );
+        addErrorIf( () -> !trackedEntityInstance.getUid().equals( enrollment.getTrackedEntity() ), reporter,
+            TrackerType.ENROLLMENT, enrollment.getUid(), E1127,
             "trackedEntity" );
     }
 
@@ -89,10 +93,11 @@ public class PreCheckUpdatableFieldsValidationHook
         ProgramStage programStage = programStageInstance.getProgramStage();
         ProgramInstance programInstance = programStageInstance.getProgramInstance();
 
-        addErrorIf( () -> !event.getProgramStage().equals( programStage.getUid() ), reporter, E1128,
+        addErrorIf( () -> !event.getProgramStage().equals( programStage.getUid() ), reporter, TrackerType.EVENT,
+            event.getUid(), E1128,
             "programStage" );
         addErrorIf( () -> event.getEnrollment() != null && !event.getEnrollment().equals( programInstance.getUid() ),
-            reporter, E1128, "enrollment" );
+            reporter, TrackerType.EVENT, event.getUid(), E1128, "enrollment" );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -59,8 +59,8 @@ public class PreCheckUpdatableFieldsValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        TrackedEntityInstance trackedEntityInstance = context
-            .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+        TrackedEntityInstance trackedEntityInstance = context.getBundle().getPreheat()
+            .getTrackedEntity( context.getBundle().getIdentifier(), trackedEntity.getTrackedEntity() );
 
         addErrorIf( () -> !trackedEntityInstance.getTrackedEntityType().getUid()
             .equals( trackedEntity.getTrackedEntityType() ), reporter, trackedEntity, E1126, "trackedEntityType" );
@@ -71,7 +71,8 @@ public class PreCheckUpdatableFieldsValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        ProgramInstance pi = context.getProgramInstance( enrollment.getEnrollment() );
+        ProgramInstance pi = context.getBundle().getPreheat().getEnrollment( context.getBundle().getIdentifier(),
+            enrollment.getEnrollment() );
         Program program = pi.getProgram();
         TrackedEntityInstance trackedEntityInstance = pi.getEntityInstance();
 
@@ -85,7 +86,8 @@ public class PreCheckUpdatableFieldsValidationHook
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        ProgramStageInstance programStageInstance = context.getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance programStageInstance = context.getBundle().getPreheat()
+            .getEvent( context.getBundle().getIdentifier(), event.getEvent() );
         ProgramStage programStage = programStageInstance.getProgramStage();
         ProgramInstance programInstance = programStageInstance.getProgramInstance();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -37,7 +37,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -64,8 +63,7 @@ public class PreCheckUpdatableFieldsValidationHook
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
 
         addErrorIf( () -> !trackedEntityInstance.getTrackedEntityType().getUid()
-            .equals( trackedEntity.getTrackedEntityType() ), reporter, TrackerType.TRACKED_ENTITY,
-            trackedEntity.getUid(), E1126, "trackedEntityType" );
+            .equals( trackedEntity.getTrackedEntityType() ), reporter, trackedEntity, E1126, "trackedEntityType" );
     }
 
     @Override
@@ -77,11 +75,9 @@ public class PreCheckUpdatableFieldsValidationHook
         Program program = pi.getProgram();
         TrackedEntityInstance trackedEntityInstance = pi.getEntityInstance();
 
-        addErrorIf( () -> !program.getUid().equals( enrollment.getProgram() ), reporter, TrackerType.ENROLLMENT,
-            enrollment.getUid(), E1127, "program" );
-        addErrorIf( () -> !trackedEntityInstance.getUid().equals( enrollment.getTrackedEntity() ), reporter,
-            TrackerType.ENROLLMENT, enrollment.getUid(), E1127,
-            "trackedEntity" );
+        addErrorIf( () -> !program.getUid().equals( enrollment.getProgram() ), reporter, enrollment, E1127, "program" );
+        addErrorIf( () -> !trackedEntityInstance.getUid().equals( enrollment.getTrackedEntity() ), reporter, enrollment,
+            E1127, "trackedEntity" );
     }
 
     @Override
@@ -93,11 +89,10 @@ public class PreCheckUpdatableFieldsValidationHook
         ProgramStage programStage = programStageInstance.getProgramStage();
         ProgramInstance programInstance = programStageInstance.getProgramInstance();
 
-        addErrorIf( () -> !event.getProgramStage().equals( programStage.getUid() ), reporter, TrackerType.EVENT,
-            event.getUid(), E1128,
+        addErrorIf( () -> !event.getProgramStage().equals( programStage.getUid() ), reporter, event, E1128,
             "programStage" );
         addErrorIf( () -> event.getEnrollment() != null && !event.getEnrollment().equals( programInstance.getUid() ),
-            reporter, TrackerType.EVENT, event.getUid(), E1128, "enrollment" );
+            reporter, event, E1128, "enrollment" );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -148,10 +148,6 @@ public class RelationshipsValidationHook
         if ( relationshipItemValueType( item ) == null )
         {
             addError( reporter, relationship, TrackerErrorCode.E4013, relSide, TrackerType.TRACKED_ENTITY.getName() );
-            // TODO(TECH-880) if relationshipItemValueType( item ) == null we
-            // cannot call .getName()
-            // on it below. Can we add another arg to the error report? If not
-            // we have to return here
             return;
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -222,7 +222,8 @@ public class RelationshipsValidationHook
 
     private Optional<String> getTrackedEntityTypeFromTrackedEntity( TrackerImportValidationContext ctx, String uid )
     {
-        final TrackedEntityInstance trackedEntity = ctx.getTrackedEntityInstance( uid );
+        final TrackedEntityInstance trackedEntity = ctx.getBundle().getPreheat()
+            .getTrackedEntity( ctx.getBundle().getIdentifier(), uid );
 
         return trackedEntity != null ? Optional.of( trackedEntity.getTrackedEntityType().getUid() ) : Optional.empty();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -53,11 +53,9 @@ public class RepeatedEventsValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public ValidationErrorReporter validate( TrackerImportValidationContext context )
+    public void validate( ValidationErrorReporter rootReporter, TrackerImportValidationContext context )
     {
         TrackerBundle bundle = context.getBundle();
-
-        ValidationErrorReporter rootReporter = context.getRootReporter();
 
         Map<Pair<String, String>, List<Event>> eventsByEnrollmentAndNotRepeatableProgramStage = bundle.getEvents()
             .stream()
@@ -78,18 +76,17 @@ public class RepeatedEventsValidationHook
                 {
                     final ValidationErrorReporter reporter = new ValidationErrorReporter( context, event );
                     addError( reporter, TrackerErrorCode.E1039, mapEntry.getKey().getLeft() );
-                    context.getRootReporter().merge( reporter );
+                    rootReporter.merge( reporter );
                 }
             }
         }
 
         bundle.getEvents()
-            .forEach( e -> validateNotMultipleEvents( context, e ) );
-
-        return rootReporter;
+            .forEach( e -> validateNotMultipleEvents( rootReporter, context, e ) );
     }
 
-    private void validateNotMultipleEvents( TrackerImportValidationContext context, Event event )
+    private void validateNotMultipleEvents( ValidationErrorReporter rootReporter,
+        TrackerImportValidationContext context, Event event )
     {
         ProgramInstance programInstance = context.getProgramInstance( event.getEnrollment() );
         ProgramStage programStage = context.getProgramStage( event.getProgramStage() );
@@ -102,7 +99,7 @@ public class RepeatedEventsValidationHook
         {
             final ValidationErrorReporter reporter = new ValidationErrorReporter( context, event );
             addError( reporter, TrackerErrorCode.E1039, event.getProgramStage() );
-            context.getRootReporter().merge( reporter );
+            rootReporter.merge( reporter );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
@@ -75,8 +74,7 @@ public class RepeatedEventsValidationHook
             {
                 for ( Event event : mapEntry.getValue() )
                 {
-                    addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1039,
-                        mapEntry.getKey().getLeft() );
+                    addError( reporter, event, TrackerErrorCode.E1039, mapEntry.getKey().getLeft() );
                 }
             }
         }
@@ -97,7 +95,7 @@ public class RepeatedEventsValidationHook
             && !programStage.getRepeatable()
             && context.programStageHasEvents( programStage.getUid(), programInstance.getUid() ) )
         {
-            addError( reporter, TrackerType.EVENT, event.getUid(), TrackerErrorCode.E1039, event.getProgramStage() );
+            addError( reporter, event, TrackerErrorCode.E1039, event.getProgramStage() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -71,7 +72,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
     public TrackedEntityAttributeValidationHook( TrackedAttributeValidationService teAttrService,
         DhisConfigurationProvider dhisConfigurationProvider )
     {
-        super( teAttrService );
+        super( TrackerType.TRACKED_ENTITY, teAttrService );
         checkNotNull( dhisConfigurationProvider );
         this.dhisConfigurationProvider = dhisConfigurationProvider;
     }
@@ -155,10 +156,10 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
             }
 
             validateAttributeValue( reporter, tea, attribute.getValue() );
-            validateAttrValueType( reporter, attribute, tea );
+            validateAttrValueType( reporter, trackedEntity.getUid(), attribute, tea );
             validateOptionSet( reporter, tea, attribute.getValue() );
 
-            validateAttributeUniqueness( reporter, attribute.getValue(), tea, tei, orgUnit );
+            validateAttributeUniqueness( reporter, trackedEntity.getUid(), attribute.getValue(), tea, tei, orgUnit );
 
             validateFileNotAlreadyAssigned( reporter, attribute, valueMap );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -40,7 +40,10 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1112;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ATTRIBUTE_CANT_BE_NULL;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -109,8 +112,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
                 .map( BaseIdentifiableObject::getUid )
                 .filter( mandatoryAttributeUid -> !trackedEntityAttributes.contains( mandatoryAttributeUid ) )
                 .forEach(
-                    attribute -> addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1090,
-                        attribute, trackedEntityType.getUid(),
+                    attribute -> addError( reporter, trackedEntity, E1090, attribute, trackedEntityType.getUid(),
                         trackedEntity.getTrackedEntity() ) );
         }
     }
@@ -137,8 +139,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
 
             if ( tea == null )
             {
-                addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1006,
-                    attribute.getAttribute() );
+                addError( reporter, trackedEntity, E1006, attribute.getAttribute() );
                 continue;
             }
 
@@ -152,31 +153,31 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
                         .findFirst() );
 
                 if ( optionalTea.isPresent() )
-                    addError( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), E1076,
-                        TrackedEntityAttribute.class.getSimpleName(), attribute.getAttribute() );
+                    addError( reporter, trackedEntity, E1076, TrackedEntityAttribute.class.getSimpleName(),
+                        attribute.getAttribute() );
 
                 continue;
             }
 
-            validateAttributeValue( reporter, trackedEntity.getUid(), tea, attribute.getValue() );
+            validateAttributeValue( reporter, trackedEntity, tea, attribute.getValue() );
             validateAttrValueType( reporter, trackedEntity.getUid(), attribute, tea );
-            validateOptionSet( reporter, TrackerType.TRACKED_ENTITY, trackedEntity.getUid(), tea,
+            validateOptionSet( reporter, trackedEntity, tea,
                 attribute.getValue() );
 
             validateAttributeUniqueness( reporter, trackedEntity.getUid(), attribute.getValue(), tea, tei, orgUnit );
 
-            validateFileNotAlreadyAssigned( reporter, trackedEntity.getUid(), attribute, valueMap );
+            validateFileNotAlreadyAssigned( reporter, trackedEntity, attribute, valueMap );
         }
     }
 
-    public void validateAttributeValue( ValidationErrorReporter reporter, String teUid, TrackedEntityAttribute tea,
+    public void validateAttributeValue( ValidationErrorReporter reporter, TrackedEntity te, TrackedEntityAttribute tea,
         String value )
     {
         checkNotNull( tea, TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL );
         checkNotNull( value, TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL );
 
         // Validate value (string) don't exceed the max length
-        addErrorIf( () -> value.length() > Constant.MAX_ATTR_VALUE_LENGTH, reporter, TrackerType.TRACKED_ENTITY, teUid,
+        addErrorIf( () -> value.length() > Constant.MAX_ATTR_VALUE_LENGTH, reporter, te,
             E1077, value,
             Constant.MAX_ATTR_VALUE_LENGTH );
 
@@ -184,16 +185,16 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
         // value to (confidential)
         boolean isConfidential = tea.isConfidentialBool();
         boolean encryptionStatusOk = dhisConfigurationProvider.getEncryptionStatus().isOk();
-        addErrorIf( () -> isConfidential && !encryptionStatusOk, reporter, TrackerType.TRACKED_ENTITY, teUid, E1112,
+        addErrorIf( () -> isConfidential && !encryptionStatusOk, reporter, te, E1112,
             value );
 
         // Uses ValidationUtils to check that the data value corresponds to the
         // data value type set on the attribute
         final String result = dataValueIsValid( value, tea.getValueType() );
-        addErrorIf( () -> result != null, reporter, TrackerType.TRACKED_ENTITY, teUid, E1085, tea, result );
+        addErrorIf( () -> result != null, reporter, te, E1085, tea, result );
     }
 
-    protected void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, String teUid,
+    protected void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, TrackedEntity te,
         Attribute attr, Map<String, TrackedEntityAttributeValue> valueMap )
     {
         checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
@@ -215,8 +216,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
 
         FileResource fileResource = reporter.getValidationContext().getFileResource( attr.getValue() );
 
-        addErrorIfNull( fileResource, reporter, TrackerType.TRACKED_ENTITY, teUid, E1084, attr.getValue() );
-        addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, TrackerType.TRACKED_ENTITY,
-            teUid, E1009, attr.getValue() );
+        addErrorIfNull( fileResource, reporter, te, E1084, attr.getValue() );
+        addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, te, E1009, attr.getValue() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -82,13 +82,15 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
     {
-        TrackedEntityType trackedEntityType = reporter.getValidationContext()
-            .getTrackedEntityType( trackedEntity.getTrackedEntityType() );
+        TrackedEntityType trackedEntityType = reporter.getValidationContext().getBundle().getPreheat()
+            .get( TrackedEntityType.class, trackedEntity.getTrackedEntityType() );
 
         TrackerImportValidationContext context = reporter.getValidationContext();
 
-        TrackedEntityInstance tei = context.getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
-        OrganisationUnit organisationUnit = context.getOrganisationUnit( trackedEntity.getOrgUnit() );
+        TrackedEntityInstance tei = context.getBundle().getPreheat()
+            .getTrackedEntity( context.getBundle().getIdentifier(), trackedEntity.getTrackedEntity() );
+        OrganisationUnit organisationUnit = context.getBundle().getPreheat().get( OrganisationUnit.class,
+            trackedEntity.getOrgUnit() );
 
         validateMandatoryAttributes( reporter, trackedEntity, trackedEntityType );
         validateAttributes( reporter, trackedEntity, tei, organisationUnit, trackedEntityType );
@@ -133,8 +135,8 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
 
         for ( Attribute attribute : trackedEntity.getAttributes() )
         {
-            TrackedEntityAttribute tea = reporter.getValidationContext()
-                .getTrackedEntityAttribute( attribute.getAttribute() );
+            TrackedEntityAttribute tea = reporter.getValidationContext().getBundle().getPreheat()
+                .get( TrackedEntityAttribute.class, attribute.getAttribute() );
 
             if ( tea == null )
             {
@@ -213,7 +215,8 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
             return;
         }
 
-        FileResource fileResource = reporter.getValidationContext().getFileResource( attr.getValue() );
+        FileResource fileResource = reporter.getValidationContext().getBundle().getPreheat().get( FileResource.class,
+            attr.getValue() );
 
         addErrorIfNull( fileResource, reporter, te, E1084, attr.getValue() );
         addErrorIf( () -> fileResource != null && fileResource.isAssigned(), reporter, te, E1009, attr.getValue() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -55,7 +55,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -75,7 +74,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
     public TrackedEntityAttributeValidationHook( TrackedAttributeValidationService teAttrService,
         DhisConfigurationProvider dhisConfigurationProvider )
     {
-        super( TrackerType.TRACKED_ENTITY, teAttrService );
+        super( teAttrService );
         checkNotNull( dhisConfigurationProvider );
         this.dhisConfigurationProvider = dhisConfigurationProvider;
     }
@@ -160,11 +159,11 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
             }
 
             validateAttributeValue( reporter, trackedEntity, tea, attribute.getValue() );
-            validateAttrValueType( reporter, trackedEntity.getUid(), attribute, tea );
+            validateAttrValueType( reporter, trackedEntity, attribute, tea );
             validateOptionSet( reporter, trackedEntity, tea,
                 attribute.getValue() );
 
-            validateAttributeUniqueness( reporter, trackedEntity.getUid(), attribute.getValue(), tea, tei, orgUnit );
+            validateAttributeUniqueness( reporter, trackedEntity, attribute.getValue(), tea, tei, orgUnit );
 
             validateFileNotAlreadyAssigned( reporter, trackedEntity, attribute, valueMap );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -31,9 +31,6 @@ import static com.google.api.client.util.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.tracker.programrule.IssueType.ERROR;
 import static org.hisp.dhis.tracker.programrule.IssueType.WARNING;
-import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1012;
-import static org.hisp.dhis.tracker.report.TrackerErrorReport.newReport;
-import static org.hisp.dhis.tracker.report.TrackerWarningReport.newWarningReport;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.GEOMETRY_CANT_BE_NULL;
 
 import java.util.ArrayList;
@@ -45,11 +42,14 @@ import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ValidationStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.TrackerWarningReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.locationtech.jts.geom.Geometry;
@@ -61,13 +61,19 @@ import com.google.common.collect.Lists;
  */
 public class ValidationUtils
 {
-    static void validateGeometry( ValidationErrorReporter errorReporter, Geometry geometry, FeatureType featureType )
+    static void validateGeometry( ValidationErrorReporter reporter, TrackerType type, String uid, Geometry geometry,
+        FeatureType featureType )
     {
         checkNotNull( geometry, GEOMETRY_CANT_BE_NULL );
 
         if ( featureType == null )
         {
-            errorReporter.addError( newReport( TrackerErrorCode.E1074 ) );
+            TrackerErrorReport error = TrackerErrorReport.builder()
+                .uid( uid )
+                .trackerType( type )
+                .errorCode( TrackerErrorCode.E1074 )
+                .build( reporter.getValidationContext().getBundle() );
+            reporter.addError( error );
             return;
         }
 
@@ -75,11 +81,18 @@ public class ValidationUtils
 
         if ( FeatureType.NONE == featureType || featureType != typeFromName )
         {
-            errorReporter.addError( newReport( E1012 ).addArgs( featureType.name() ) );
+            TrackerErrorReport error = TrackerErrorReport.builder()
+                .uid( uid )
+                .trackerType( type )
+                .errorCode( TrackerErrorCode.E1012 )
+                .addArg( featureType.name() )
+                .build( reporter.getValidationContext().getBundle() );
+            reporter.addError( error );
         }
     }
 
-    protected static List<Note> validateNotes( ValidationErrorReporter reporter, List<Note> notesToCheck )
+    protected static List<Note> validateNotes( ValidationErrorReporter reporter, TrackerType type, String uid,
+        List<Note> notesToCheck )
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
 
@@ -92,7 +105,13 @@ public class ValidationUtils
                 // warning, ignore the note and continue
                 if ( isNotEmpty( note.getNote() ) && context.getNote( note.getNote() ).isPresent() )
                 {
-                    reporter.addWarning( newWarningReport( TrackerErrorCode.E1119 ).addArg( note.getNote() ) );
+                    TrackerWarningReport warning = TrackerWarningReport.builder()
+                        .uid( uid )
+                        .trackerType( type )
+                        .warningCode( TrackerErrorCode.E1119 )
+                        .addArg( note.getNote() )
+                        .build( reporter.getValidationContext().getBundle() );
+                    reporter.addWarning( warning );
                 }
                 else
                 {
@@ -145,7 +164,8 @@ public class ValidationUtils
         }
     }
 
-    public static void addIssuesToReporter( ValidationErrorReporter reporter, List<ProgramRuleIssue> programRuleIssues )
+    public static void addIssuesToReporter( ValidationErrorReporter reporter, TrackerType type, String uid,
+        List<ProgramRuleIssue> programRuleIssues )
     {
         programRuleIssues
             .stream()
@@ -153,7 +173,13 @@ public class ValidationUtils
             .forEach( issue -> {
                 List<String> args = Lists.newArrayList( issue.getRuleUid() );
                 args.addAll( issue.getArgs() );
-                reporter.addError( newReport( issue.getIssueCode() ).addArgs( args.toArray() ) );
+                TrackerErrorReport error = TrackerErrorReport.builder()
+                    .uid( uid )
+                    .trackerType( type )
+                    .errorCode( issue.getIssueCode() )
+                    .addArgs( args.toArray() )
+                    .build( reporter.getValidationContext().getBundle() );
+                reporter.addError( error );
             } );
 
         programRuleIssues
@@ -163,8 +189,13 @@ public class ValidationUtils
                 issue -> {
                     List<String> args = Lists.newArrayList( issue.getRuleUid() );
                     args.addAll( issue.getArgs() );
-                    reporter.addWarning( newWarningReport( issue.getIssueCode() )
-                        .addArgs( args.toArray() ) );
+                    TrackerWarningReport warning = TrackerWarningReport.builder()
+                        .uid( uid )
+                        .trackerType( type )
+                        .warningCode( issue.getIssueCode() )
+                        .addArgs( args.toArray() )
+                        .build( reporter.getValidationContext().getBundle() );
+                    reporter.addWarning( warning );
                 } );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -42,10 +42,10 @@ import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ValidationStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
@@ -61,7 +61,7 @@ import com.google.common.collect.Lists;
  */
 public class ValidationUtils
 {
-    static void validateGeometry( ValidationErrorReporter reporter, TrackerType type, String uid, Geometry geometry,
+    static void validateGeometry( ValidationErrorReporter reporter, TrackerDto dto, Geometry geometry,
         FeatureType featureType )
     {
         checkNotNull( geometry, GEOMETRY_CANT_BE_NULL );
@@ -69,8 +69,8 @@ public class ValidationUtils
         if ( featureType == null )
         {
             TrackerErrorReport error = TrackerErrorReport.builder()
-                .uid( uid )
-                .trackerType( type )
+                .uid( dto.getUid() )
+                .trackerType( dto.getTrackerType() )
                 .errorCode( TrackerErrorCode.E1074 )
                 .build( reporter.getValidationContext().getBundle() );
             reporter.addError( error );
@@ -82,8 +82,8 @@ public class ValidationUtils
         if ( FeatureType.NONE == featureType || featureType != typeFromName )
         {
             TrackerErrorReport error = TrackerErrorReport.builder()
-                .uid( uid )
-                .trackerType( type )
+                .uid( dto.getUid() )
+                .trackerType( dto.getTrackerType() )
                 .errorCode( TrackerErrorCode.E1012 )
                 .addArg( featureType.name() )
                 .build( reporter.getValidationContext().getBundle() );
@@ -91,7 +91,7 @@ public class ValidationUtils
         }
     }
 
-    protected static List<Note> validateNotes( ValidationErrorReporter reporter, TrackerType type, String uid,
+    protected static List<Note> validateNotes( ValidationErrorReporter reporter, TrackerDto dto,
         List<Note> notesToCheck )
     {
         TrackerImportValidationContext context = reporter.getValidationContext();
@@ -106,8 +106,8 @@ public class ValidationUtils
                 if ( isNotEmpty( note.getNote() ) && context.getNote( note.getNote() ).isPresent() )
                 {
                     TrackerWarningReport warning = TrackerWarningReport.builder()
-                        .uid( uid )
-                        .trackerType( type )
+                        .uid( dto.getUid() )
+                        .trackerType( dto.getTrackerType() )
                         .warningCode( TrackerErrorCode.E1119 )
                         .addArg( note.getNote() )
                         .build( reporter.getValidationContext().getBundle() );
@@ -164,7 +164,7 @@ public class ValidationUtils
         }
     }
 
-    public static void addIssuesToReporter( ValidationErrorReporter reporter, TrackerType type, String uid,
+    public static void addIssuesToReporter( ValidationErrorReporter reporter, TrackerDto dto,
         List<ProgramRuleIssue> programRuleIssues )
     {
         programRuleIssues
@@ -174,8 +174,8 @@ public class ValidationUtils
                 List<String> args = Lists.newArrayList( issue.getRuleUid() );
                 args.addAll( issue.getArgs() );
                 TrackerErrorReport error = TrackerErrorReport.builder()
-                    .uid( uid )
-                    .trackerType( type )
+                    .uid( dto.getUid() )
+                    .trackerType( dto.getTrackerType() )
                     .errorCode( issue.getIssueCode() )
                     .addArgs( args.toArray() )
                     .build( reporter.getValidationContext().getBundle() );
@@ -190,8 +190,8 @@ public class ValidationUtils
                     List<String> args = Lists.newArrayList( issue.getRuleUid() );
                     args.addAll( issue.getArgs() );
                     TrackerWarningReport warning = TrackerWarningReport.builder()
-                        .uid( uid )
-                        .trackerType( type )
+                        .uid( dto.getUid() )
+                        .trackerType( dto.getTrackerType() )
                         .warningCode( issue.getIssueCode() )
                         .addArgs( args.toArray() )
                         .build( reporter.getValidationContext().getBundle() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -103,7 +103,8 @@ public class ValidationUtils
             {
                 // If a note having the same UID already exist in the db, raise
                 // warning, ignore the note and continue
-                if ( isNotEmpty( note.getNote() ) && context.getNote( note.getNote() ).isPresent() )
+                if ( isNotEmpty( note.getNote() )
+                    && context.getBundle().getPreheat().getNote( note.getNote() ).isPresent() )
                 {
                     TrackerWarningReport warning = TrackerWarningReport.builder()
                         .uid( dto.getUid() )
@@ -201,16 +202,19 @@ public class ValidationUtils
 
     public static boolean trackedEntityInstanceExist( TrackerImportValidationContext context, String teiUid )
     {
-        return context.getTrackedEntityInstance( teiUid ) != null || context.getReference( teiUid ).isPresent();
+        return context.getBundle().getPreheat().getTrackedEntity( context.getBundle().getIdentifier(), teiUid ) != null
+            || context.getBundle().getPreheat().getReference( teiUid ).isPresent();
     }
 
     public static boolean enrollmentExist( TrackerImportValidationContext context, String enrollmentUid )
     {
-        return context.getProgramInstance( enrollmentUid ) != null || context.getReference( enrollmentUid ).isPresent();
+        return context.getBundle().getPreheat().getEnrollment( context.getBundle().getIdentifier(),
+            enrollmentUid ) != null || context.getBundle().getPreheat().getReference( enrollmentUid ).isPresent();
     }
 
     public static boolean eventExist( TrackerImportValidationContext context, String eventUid )
     {
-        return context.getProgramStageInstance( eventUid ) != null || context.getReference( eventUid ).isPresent();
+        return context.getBundle().getPreheat().getEvent( context.getBundle().getIdentifier(), eventUid ) != null
+            || context.getBundle().getPreheat().getReference( eventUid ).isPresent();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -27,10 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,12 +37,8 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.List;
 
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
-import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,27 +99,5 @@ class DefaultTrackerValidationServiceTest
 
         verify( hook1, times( 1 ) ).validate( any(), any() );
         verify( hook2, times( 1 ) ).validate( any(), any() );
-    }
-
-    @Test
-    void shouldOnlyValidateUntilFirstHookFailsInFailFastMode()
-    {
-        when( bundle.getValidationMode() ).thenReturn( ValidationMode.FAIL_FAST );
-        when( bundle.getUser() ).thenReturn( user );
-        when( user.isSuper() ).thenReturn( false );
-        TrackerErrorReport error = new TrackerErrorReport( "invalid", TrackerErrorCode.E1125, TrackerType.EVENT,
-            "213" );
-        List<TrackerErrorReport> errors = List.of( error );
-        doThrow( new ValidationFailFastException( errors ) ).when( hook1 ).validate( any(), any() );
-        TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
-        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), Collections.emptyList() );
-
-        TrackerValidationReport report = service.validate( bundle );
-
-        verify( hook1, times( 1 ) ).validate( any(), any() );
-        verifyNoInteractions( hook2 );
-        assertTrue( report.hasErrors() );
-        assertEquals( 1, report.getErrorReports().size() );
-        assertEquals( error, report.getErrorReports().get( 0 ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
@@ -136,9 +136,10 @@ class TrackerValidationServiceReportTest
                 if ( invalidEvent.equals( event ) )
                 {
                     reporter.addError(
-                        TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                        TrackerErrorReport.builder()
+                            .errorCode( TrackerErrorCode.E1032 )
                             .trackerType( TrackerType.EVENT )
-                            .uid( event.getUid() ) );
+                            .uid( event.getUid() ).build( reporter.getValidationContext().getBundle() ) );
                 }
             } )
             .build();
@@ -148,9 +149,11 @@ class TrackerValidationServiceReportTest
                 if ( invalidEnrollment.equals( enrollment ) )
                 {
                     reporter.addError(
-                        TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
+                        TrackerErrorReport.builder()
+                            .errorCode( TrackerErrorCode.E1069 )
                             .trackerType( TrackerType.ENROLLMENT )
-                            .uid( enrollment.getUid() ) );
+                            .uid( enrollment.getUid() )
+                            .build( reporter.getValidationContext().getBundle() ) );
                 }
             } )
             .build();
@@ -213,9 +216,10 @@ class TrackerValidationServiceReportTest
                 if ( invalidEvent.equals( event ) )
                 {
                     reporter.addError(
-                        TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                        TrackerErrorReport.builder()
+                            .errorCode( TrackerErrorCode.E1032 )
                             .trackerType( TrackerType.EVENT )
-                            .uid( event.getUid() ) );
+                            .uid( event.getUid() ).build( reporter.getValidationContext().getBundle() ) );
                 }
             } ).build();
         TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
@@ -229,12 +233,7 @@ class TrackerValidationServiceReportTest
             && TrackerType.EVENT == err.getTrackerType()
             && invalidEvent.getUid().equals( err.getUid() ) ) );
 
-        // TODO(TECH-880): Is this intentional? When in FAIL_FAST mode,
-        // reporter.addError() throws a FailFastException
-        // which makes sure we exit early and do not call any more hooks. It
-        // also leads to no call to reporter.merge()
-        // which is what adds DTOs into the invalidDTO list.
-        assertTrue( bundle.getEvents().contains( invalidEvent ) );
+        assertFalse( bundle.getEvents().contains( invalidEvent ) );
         assertTrue( bundle.getEvents().contains( validEvent ) );
 
         verifyNoInteractions( hook2 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
@@ -124,39 +124,39 @@ class TrackerValidationServiceReportTest
         enrollments.add( invalidEnrollment );
 
         TrackerBundle bundle = TrackerBundle.builder()
-                .validationMode( ValidationMode.FULL )
-                .skipRuleEngine( true )
-                .events( events )
-                .enrollments( enrollments )
-                .build();
+            .validationMode( ValidationMode.FULL )
+            .skipRuleEngine( true )
+            .events( events )
+            .enrollments( enrollments )
+            .build();
 
         ValidationHook removeOnError = ValidationHook.builder()
-                .removeOnError( true )
-                .validateEvent( ( reporter, event ) -> {
-                    if ( invalidEvent.equals( event ) )
-                    {
-                        reporter.addError(
-                                TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
-                                        .trackerType( TrackerType.EVENT )
-                                        .uid( event.getUid() ) );
-                    }
-                } )
-                .build();
+            .removeOnError( true )
+            .validateEvent( ( reporter, event ) -> {
+                if ( invalidEvent.equals( event ) )
+                {
+                    reporter.addError(
+                        TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                            .trackerType( TrackerType.EVENT )
+                            .uid( event.getUid() ) );
+                }
+            } )
+            .build();
         ValidationHook doNotRemoveOnError = ValidationHook.builder()
-                .removeOnError( false )
-                .validateEnrollment( ( reporter, enrollment ) -> {
-                    if ( invalidEnrollment.equals( enrollment ) )
-                    {
-                        reporter.addError(
-                                TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
-                                        .trackerType( TrackerType.ENROLLMENT )
-                                        .uid( enrollment.getUid() ) );
-                    }
-                } )
-                .build();
+            .removeOnError( false )
+            .validateEnrollment( ( reporter, enrollment ) -> {
+                if ( invalidEnrollment.equals( enrollment ) )
+                {
+                    reporter.addError(
+                        TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
+                            .trackerType( TrackerType.ENROLLMENT )
+                            .uid( enrollment.getUid() ) );
+                }
+            } )
+            .build();
         TrackerValidationService validationService = new DefaultTrackerValidationService(
-                List.of( removeOnError, doNotRemoveOnError ),
-                Collections.emptyList() );
+            List.of( removeOnError, doNotRemoveOnError ),
+            Collections.emptyList() );
 
         TrackerValidationReport report = validationService.validate( bundle );
 
@@ -219,7 +219,7 @@ class TrackerValidationServiceReportTest
                 }
             } ).build();
         TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
-        TrackerValidationService validationService = new DefaultTrackerValidationService( List.of( hook1,hook2 ),
+        TrackerValidationService validationService = new DefaultTrackerValidationService( List.of( hook1, hook2 ),
             Collections.emptyList() );
 
         TrackerValidationReport report = validationService.validate( bundle );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
@@ -124,39 +124,39 @@ class TrackerValidationServiceReportTest
         enrollments.add( invalidEnrollment );
 
         TrackerBundle bundle = TrackerBundle.builder()
-            .validationMode( ValidationMode.FULL )
-            .skipRuleEngine( true )
-            .events( events )
-            .enrollments( enrollments )
-            .build();
+                .validationMode( ValidationMode.FULL )
+                .skipRuleEngine( true )
+                .events( events )
+                .enrollments( enrollments )
+                .build();
 
         ValidationHook removeOnError = ValidationHook.builder()
-            .removeOnError( true )
-            .validateEvent( ( reporter, event ) -> {
-                if ( invalidEvent.equals( event ) )
-                {
-                    reporter.addError(
-                        TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
-                            .trackerType( TrackerType.EVENT )
-                            .uid( event.getUid() ) );
-                }
-            } )
-            .build();
+                .removeOnError( true )
+                .validateEvent( ( reporter, event ) -> {
+                    if ( invalidEvent.equals( event ) )
+                    {
+                        reporter.addError(
+                                TrackerErrorReport.newReport( TrackerErrorCode.E1032 )
+                                        .trackerType( TrackerType.EVENT )
+                                        .uid( event.getUid() ) );
+                    }
+                } )
+                .build();
         ValidationHook doNotRemoveOnError = ValidationHook.builder()
-            .removeOnError( false )
-            .validateEnrollment( ( reporter, enrollment ) -> {
-                if ( invalidEnrollment.equals( enrollment ) )
-                {
-                    reporter.addError(
-                        TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
-                            .trackerType( TrackerType.ENROLLMENT )
-                            .uid( enrollment.getUid() ) );
-                }
-            } )
-            .build();
+                .removeOnError( false )
+                .validateEnrollment( ( reporter, enrollment ) -> {
+                    if ( invalidEnrollment.equals( enrollment ) )
+                    {
+                        reporter.addError(
+                                TrackerErrorReport.newReport( TrackerErrorCode.E1069 )
+                                        .trackerType( TrackerType.ENROLLMENT )
+                                        .uid( enrollment.getUid() ) );
+                    }
+                } )
+                .build();
         TrackerValidationService validationService = new DefaultTrackerValidationService(
-            List.of( removeOnError, doNotRemoveOnError ),
-            Collections.emptyList() );
+                List.of( removeOnError, doNotRemoveOnError ),
+                Collections.emptyList() );
 
         TrackerValidationReport report = validationService.validate( bundle );
 
@@ -219,7 +219,7 @@ class TrackerValidationServiceReportTest
                 }
             } ).build();
         TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
-        TrackerValidationService validationService = new DefaultTrackerValidationService( List.of( hook1 ),
+        TrackerValidationService validationService = new DefaultTrackerValidationService( List.of( hook1,hook2 ),
             Collections.emptyList() );
 
         TrackerValidationReport report = validationService.validate( bundle );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -95,7 +95,7 @@ class AssignedUserValidationHookTest
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -113,7 +113,7 @@ class AssignedUserValidationHookTest
         event.setAssignedUser( "not_valid_uid" );
         event.setProgramStage( PROGRAM_STAGE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -131,7 +131,7 @@ class AssignedUserValidationHookTest
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         TrackerBundle bundle = TrackerBundle.builder().build();
@@ -153,7 +153,7 @@ class AssignedUserValidationHookTest
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         ProgramStage programStage = new ProgramStage();
@@ -179,7 +179,7 @@ class AssignedUserValidationHookTest
         event.setAssignedUser( USER_ID );
         event.setProgramStage( PROGRAM_STAGE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         ProgramStage programStage = new ProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -147,7 +147,7 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
@@ -175,7 +175,7 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 0 ) );
@@ -201,7 +201,7 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 2 ) );
@@ -227,7 +227,7 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEnrollment( reporter, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -74,6 +75,9 @@ class EnrollmentAttributeValidationHookTest
     private EnrollmentAttributeValidationHook hookToTest;
 
     @Mock
+    private TrackerPreheat preheat;
+
+    @Mock
     private TrackerImportValidationContext validationContext;
 
     @Mock
@@ -81,9 +85,6 @@ class EnrollmentAttributeValidationHookTest
 
     @Mock
     private Program program;
-
-    @Mock
-    private TrackerPreheat preheat;
 
     @Mock
     private TrackedEntityInstance trackedEntityInstance;
@@ -110,10 +111,13 @@ class EnrollmentAttributeValidationHookTest
             false );
         trackedEntityAttribute1.setUid( trackedAttribute1 );
 
-        when( validationContext.getProgram( anyString() ) ).thenReturn( program );
+        when( preheat.<Program> get( eq( Program.class ), anyString() ) )
+            .thenReturn( program );
         when( enrollment.getProgram() ).thenReturn( "program" );
-        when( validationContext.getTrackedEntityAttribute( trackedAttribute ) ).thenReturn( trackedEntityAttribute );
-        when( validationContext.getTrackedEntityAttribute( trackedAttribute1 ) ).thenReturn( trackedEntityAttribute1 );
+        when( preheat.<TrackedEntityAttribute> get( TrackedEntityAttribute.class,
+            trackedAttribute ) ).thenReturn( trackedEntityAttribute );
+        when( preheat.<TrackedEntityAttribute> get( TrackedEntityAttribute.class,
+            trackedAttribute1 ) ).thenReturn( trackedEntityAttribute1 );
 
         String uid = CodeGenerator.generateUid();
         when( enrollment.getUid() ).thenReturn( uid );
@@ -121,9 +125,7 @@ class EnrollmentAttributeValidationHookTest
         when( enrollment.getTrackerType() ).thenCallRealMethod();
         enrollment.setTrackedEntity( trackedEntity );
 
-        TrackerBundle bundle = TrackerBundle.builder().build();
-        bundle.setPreheat( preheat );
-
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( validationContext.getBundle() ).thenReturn( bundle );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -118,6 +118,7 @@ class EnrollmentAttributeValidationHookTest
         String uid = CodeGenerator.generateUid();
         when( enrollment.getUid() ).thenReturn( uid );
         when( enrollment.getEnrollment() ).thenReturn( uid );
+        when( enrollment.getTrackerType() ).thenCallRealMethod();
         enrollment.setTrackedEntity( trackedEntity );
 
         TrackerBundle bundle = TrackerBundle.builder().build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -81,7 +81,7 @@ class EnrollmentDateValidationHookTest
         enrollment.setProgram( CodeGenerator.generateUid() );
         enrollment.setOccurredAt( Instant.now() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
@@ -101,7 +101,7 @@ class EnrollmentDateValidationHookTest
         enrollment.setOccurredAt( dateInTheFuture );
         enrollment.setEnrolledAt( dateInTheFuture );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
@@ -121,7 +121,7 @@ class EnrollmentDateValidationHookTest
         enrollment.setOccurredAt( today );
         enrollment.setEnrolledAt( today );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
@@ -140,7 +140,7 @@ class EnrollmentDateValidationHookTest
         enrollment.setOccurredAt( dateInTheFuture );
         enrollment.setEnrolledAt( dateInTheFuture );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         Program program = new Program();
         program.setSelectEnrollmentDatesInFuture( true );
@@ -161,7 +161,7 @@ class EnrollmentDateValidationHookTest
 
         enrollment.setEnrolledAt( Instant.now() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         Program program = new Program();
         program.setDisplayIncidentDate( true );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +62,9 @@ class EnrollmentDateValidationHookTest
     private EnrollmentDateValidationHook hookToTest;
 
     @Mock
+    private TrackerPreheat preheat;
+
+    @Mock
     private TrackerImportValidationContext validationContext;
 
     @BeforeEach
@@ -68,8 +72,7 @@ class EnrollmentDateValidationHookTest
     {
         hookToTest = new EnrollmentDateValidationHook();
 
-        TrackerBundle bundle = TrackerBundle.builder().build();
-
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( validationContext.getBundle() ).thenReturn( bundle );
     }
 
@@ -83,7 +86,8 @@ class EnrollmentDateValidationHookTest
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
-        when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
+        when( preheat.<Program> get( Program.class, enrollment.getProgram() ) )
+            .thenReturn( new Program() );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
@@ -103,7 +107,8 @@ class EnrollmentDateValidationHookTest
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
-        when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
+        when( preheat.<Program> get( Program.class, enrollment.getProgram() ) )
+            .thenReturn( new Program() );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
@@ -123,7 +128,8 @@ class EnrollmentDateValidationHookTest
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
-        when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
+        when( preheat.<Program> get( Program.class, enrollment.getProgram() ) )
+            .thenReturn( new Program() );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
@@ -145,7 +151,8 @@ class EnrollmentDateValidationHookTest
         Program program = new Program();
         program.setSelectEnrollmentDatesInFuture( true );
         program.setSelectIncidentDatesInFuture( true );
-        when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( program );
+        when( preheat.<Program> get( Program.class, enrollment.getProgram() ) )
+            .thenReturn( program );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
@@ -165,7 +172,8 @@ class EnrollmentDateValidationHookTest
 
         Program program = new Program();
         program.setDisplayIncidentDate( true );
-        when( validationContext.getProgram( enrollment.getProgram() ) ).thenReturn( program );
+        when( preheat.<Program> get( Program.class, enrollment.getProgram() ) )
+            .thenReturn( program );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -88,7 +88,7 @@ class EnrollmentGeoValidationHookTest
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEnrollment( reporter, enrollment );
@@ -105,7 +105,7 @@ class EnrollmentGeoValidationHookTest
         enrollment.setProgram( null );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         assertThrows( NullPointerException.class, () -> this.hookToTest.validateEnrollment( reporter, enrollment ) );
     }
@@ -119,7 +119,7 @@ class EnrollmentGeoValidationHookTest
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         Program program = new Program();
@@ -140,7 +140,7 @@ class EnrollmentGeoValidationHookTest
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         Program program = new Program();
@@ -162,7 +162,7 @@ class EnrollmentGeoValidationHookTest
         enrollment.setProgram( PROGRAM );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         Program program = new Program();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,13 +49,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 /**
  * @author Enrico Colasante
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
 class EnrollmentGeoValidationHookTest
 {
@@ -64,6 +62,9 @@ class EnrollmentGeoValidationHookTest
     private EnrollmentGeoValidationHook hookToTest;
 
     @Mock
+    private TrackerPreheat preheat;
+
+    @Mock
     private TrackerImportValidationContext validationContext;
 
     @BeforeEach
@@ -71,13 +72,8 @@ class EnrollmentGeoValidationHookTest
     {
         hookToTest = new EnrollmentGeoValidationHook();
 
-        TrackerBundle bundle = TrackerBundle.builder().build();
-
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( validationContext.getBundle() ).thenReturn( bundle );
-
-        Program program = new Program();
-        program.setFeatureType( FeatureType.POINT );
-        when( validationContext.getProgram( PROGRAM ) ).thenReturn( program );
     }
 
     @Test
@@ -91,6 +87,11 @@ class EnrollmentGeoValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
+        Program program = new Program();
+        program.setFeatureType( FeatureType.POINT );
+        when( preheat.<Program> get( Program.class, PROGRAM ) )
+            .thenReturn( program );
+
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
         // then
@@ -123,7 +124,8 @@ class EnrollmentGeoValidationHookTest
 
         // when
         Program program = new Program();
-        when( validationContext.getProgram( PROGRAM ) ).thenReturn( program );
+        when( preheat.<Program> get( Program.class, PROGRAM ) )
+            .thenReturn( program );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
@@ -145,7 +147,8 @@ class EnrollmentGeoValidationHookTest
         // when
         Program program = new Program();
         program.setFeatureType( FeatureType.NONE );
-        when( validationContext.getProgram( PROGRAM ) ).thenReturn( program );
+        when( preheat.<Program> get( Program.class, PROGRAM ) )
+            .thenReturn( program );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 
@@ -167,7 +170,8 @@ class EnrollmentGeoValidationHookTest
         // when
         Program program = new Program();
         program.setFeatureType( FeatureType.MULTI_POLYGON );
-        when( validationContext.getProgram( PROGRAM ) ).thenReturn( program );
+        when( preheat.<Program> get( Program.class, PROGRAM ) )
+            .thenReturn( program );
 
         this.hookToTest.validateEnrollment( reporter, enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -114,7 +114,7 @@ class EnrollmentInExistingValidationHookTest
         program.setUid( programUid );
 
         when( validationContext.getProgram( programUid ) ).thenReturn( program );
-        reporter = new ValidationErrorReporter( validationContext, enrollment );
+        reporter = new ValidationErrorReporter( validationContext );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -103,6 +103,7 @@ class EnrollmentInExistingValidationHookTest
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.ACTIVE );
         when( enrollment.getEnrollment() ).thenReturn( enrollmentUid );
         when( enrollment.getUid() ).thenReturn( enrollmentUid );
+        when( enrollment.getTrackerType() ).thenCallRealMethod();
 
         when( validationContext.getTrackedEntityInstance( trackedEntity ) ).thenReturn( trackedEntityInstance );
         when( trackedEntityInstance.getUid() ).thenReturn( trackedEntity );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -92,7 +92,7 @@ class EnrollmentNoteValidationHookTest
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( trackerBundle.getPreheat() ).thenReturn( preheat );
         when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         enrollment.setNotes( Collections.singletonList( note ) );
 
@@ -119,7 +119,7 @@ class EnrollmentNoteValidationHookTest
         when( ctx.getBundle() ).thenReturn( trackerBundle );
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         enrollment.setNotes( Collections.singletonList( note ) );
 
@@ -141,7 +141,7 @@ class EnrollmentNoteValidationHookTest
 
         when( ctx.getBundle() ).thenReturn( trackerBundle );
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         enrollment.setNotes( notes );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Note;
@@ -52,16 +51,10 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 /**
  * @author Enrico Colasante
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
-@ExtendWith( MockitoExtension.class )
 class EnrollmentNoteValidationHookTest
 {
 
@@ -72,11 +65,15 @@ class EnrollmentNoteValidationHookTest
 
     private final BeanRandomizer rnd = BeanRandomizer.create();
 
+    private TrackerImportValidationContext ctx;
+
     @BeforeEach
     public void setUp()
     {
         this.hook = new EnrollmentNoteValidationHook();
         enrollment = rnd.nextObject( Enrollment.class );
+
+        ctx = mock( TrackerImportValidationContext.class );
     }
 
     @Test
@@ -84,14 +81,11 @@ class EnrollmentNoteValidationHookTest
     {
         // Given
         final Note note = rnd.nextObject( Note.class );
-
-        TrackerBundle trackerBundle = mock( TrackerBundle.class );
-        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
         TrackerPreheat preheat = mock( TrackerPreheat.class );
-        when( ctx.getBundle() ).thenReturn( trackerBundle );
-        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        when( trackerBundle.getPreheat() ).thenReturn( preheat );
-        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+
+        when( ctx.getBundle() ).thenReturn( TrackerBundle.builder().preheat( preheat ).build() );
+        when( preheat.getNote( note.getNote() ) )
+            .thenReturn( Optional.of( new TrackedEntityComment() ) );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         enrollment.setNotes( Collections.singletonList( note ) );
@@ -113,12 +107,9 @@ class EnrollmentNoteValidationHookTest
         // Given
         final Note note = rnd.nextObject( Note.class );
         note.setValue( null );
-        TrackerBundle trackerBundle = mock( TrackerBundle.class );
-        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
 
+        TrackerBundle trackerBundle = TrackerBundle.builder().build();
         when( ctx.getBundle() ).thenReturn( trackerBundle );
-        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         enrollment.setNotes( Collections.singletonList( note ) );
@@ -136,11 +127,9 @@ class EnrollmentNoteValidationHookTest
     {
         // Given
         final List<Note> notes = rnd.objects( Note.class, 5 ).collect( Collectors.toList() );
-        TrackerBundle trackerBundle = mock( TrackerBundle.class );
-        TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
+        TrackerPreheat preheat = mock( TrackerPreheat.class );
 
-        when( ctx.getBundle() ).thenReturn( trackerBundle );
-        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        when( ctx.getBundle() ).thenReturn( TrackerBundle.builder().preheat( preheat ).build() );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         enrollment.setNotes( notes );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -157,7 +157,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         when( i18nManager.getI18nFormat() )
             .thenReturn( I18N_FORMAT );
 
-        reporter = new ValidationErrorReporter( validationContext, event );
+        reporter = new ValidationErrorReporter( validationContext );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 import static org.hisp.dhis.category.CategoryOption.DEFAULT_NAME;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
-import static org.hisp.dhis.tracker.ValidationMode.FULL;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1055;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1056;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1057;
@@ -52,11 +51,12 @@ import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.mock.MockI18nFormat;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
-import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -75,6 +75,9 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
 
     @Mock
     private I18nManager i18nManager;
+
+    @Mock
+    private TrackerPreheat preheat;
 
     @Mock
     private TrackerImportValidationContext validationContext;
@@ -142,16 +145,14 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         event.setProgram( program.getUid() );
         event.setOccurredAt( EVENT_INSTANT );
 
-        User user = createUser( 'A' );
-
         TrackerBundle bundle = TrackerBundle.builder()
-            .user( user )
-            .validationMode( FULL )
+            .user( createUser( 'A' ) )
+            .validationMode( ValidationMode.FULL )
+            .preheat( preheat )
             .build();
-
         when( validationContext.getBundle() ).thenReturn( bundle );
 
-        when( validationContext.getProgram( program.getUid() ) )
+        when( validationContext.getBundle().getPreheat().<Program> get( Program.class, program.getUid() ) )
             .thenReturn( program );
 
         when( i18nManager.getI18nFormat() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -122,7 +122,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( getDataValue() ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -138,7 +138,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -154,7 +154,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -171,7 +171,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
         when( validationContext.getDataElement( dataElementUid ) ).thenReturn( null );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -204,7 +204,7 @@ class EventDataValuesValidationHookTest
         when( validationContext.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -236,7 +236,7 @@ class EventDataValuesValidationHookTest
         when( validationContext.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -270,7 +270,7 @@ class EventDataValuesValidationHookTest
             .thenReturn( notPresentDataElement );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -292,7 +292,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -316,7 +316,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -343,7 +343,7 @@ class EventDataValuesValidationHookTest
         when( validationContext.getDataElement( validDataValue.getDataElement() ) ).thenReturn( validDataElement );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -373,7 +373,7 @@ class EventDataValuesValidationHookTest
         when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -405,7 +405,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.ACTIVE );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -415,7 +415,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.COMPLETED );
 
         // When
-        reporter = new ValidationErrorReporter( validationContext, event );
+        reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -446,7 +446,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.ACTIVE );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -455,7 +455,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.COMPLETED );
 
         // When
-        reporter = new ValidationErrorReporter( validationContext, event );
+        reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -485,7 +485,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.SCHEDULE );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -494,7 +494,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.SKIPPED );
 
         // When
-        reporter = new ValidationErrorReporter( validationContext, event );
+        reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -524,7 +524,7 @@ class EventDataValuesValidationHookTest
         when( event.getStatus() ).thenReturn( EventStatus.COMPLETED );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -550,7 +550,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then
@@ -604,7 +604,7 @@ class EventDataValuesValidationHookTest
         when( validationContext.getDataElement( dataElementUid ) ).thenReturn( dataElement );
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue, nullDataValue ) );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         assertFalse( reporter.hasErrors() );
@@ -636,7 +636,7 @@ class EventDataValuesValidationHookTest
         when( validationContext.getDataElement( dataElementUid ) ).thenReturn( dataElement );
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         assertTrue( reporter.hasErrors() );
@@ -660,7 +660,7 @@ class EventDataValuesValidationHookTest
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( validDataValue ) );
 
         // When
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
         hookToTest.validateEvent( reporter, event );
 
         // Then

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -115,7 +115,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
         when( validationContext.getBundle() ).thenReturn( bundle );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -132,7 +132,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( PROGRAM_WITHOUT_REGISTRATION_ID );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -150,7 +150,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setStatus( EventStatus.ACTIVE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -168,7 +168,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setProgram( PROGRAM_WITH_REGISTRATION_ID );
         event.setStatus( EventStatus.COMPLETED );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -187,7 +187,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setOccurredAt( Instant.now() );
         event.setStatus( EventStatus.SCHEDULE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -206,7 +206,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setOccurredAt( now() );
         event.setStatus( EventStatus.COMPLETED );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -226,7 +226,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setCompletedAt( sevenDaysAgo() );
         event.setStatus( EventStatus.COMPLETED );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -246,7 +246,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setScheduledAt( null );
         event.setStatus( EventStatus.SKIPPED );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -265,7 +265,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setOccurredAt( sevenDaysAgo() );
         event.setStatus( EventStatus.ACTIVE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.user.User;
@@ -82,6 +83,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     private EventDateValidationHook hookToTest;
 
     @Mock
+    private TrackerPreheat preheat;
+
+    @Mock
     private TrackerImportValidationContext validationContext;
 
     @BeforeEach
@@ -89,17 +93,14 @@ class EventDateValidationHookTest extends DhisConvenienceTest
     {
         hookToTest = new EventDateValidationHook();
 
-        User user = createUser( 'A' );
-
-        TrackerBundle bundle = TrackerBundle.builder().user( user ).build();
-
+        TrackerBundle bundle = TrackerBundle.builder().user( createUser( 'A' ) ).preheat( preheat ).build();
         when( validationContext.getBundle() ).thenReturn( bundle );
 
-        when( validationContext.getProgram( PROGRAM_WITH_REGISTRATION_ID ) )
+        when( preheat.<Program> get( Program.class, PROGRAM_WITH_REGISTRATION_ID ) )
             .thenReturn( getProgramWithRegistration() );
-
-        when( validationContext.getProgram( PROGRAM_WITHOUT_REGISTRATION_ID ) )
-            .thenReturn( getProgramWithoutRegistration() );
+        when(
+            preheat.<Program> get( Program.class, PROGRAM_WITHOUT_REGISTRATION_ID ) )
+                .thenReturn( getProgramWithoutRegistration() );
     }
 
     @Test
@@ -111,8 +112,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setOccurredAt( now() );
         event.setStatus( EventStatus.ACTIVE );
 
-        TrackerBundle bundle = TrackerBundle.builder().user( getEditExpiredUser() ).build();
-
+        TrackerBundle bundle = TrackerBundle.builder().user( getEditExpiredUser() ).preheat( preheat ).build();
         when( validationContext.getBundle() ).thenReturn( bundle );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -90,7 +90,7 @@ class EventGeoValidationHookTest
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         this.hookToTest.validateEvent( reporter, event );
@@ -107,7 +107,7 @@ class EventGeoValidationHookTest
         event.setProgramStage( null );
         event.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         assertThrows( NullPointerException.class, () -> this.hookToTest.validateEvent( reporter, event ) );
@@ -122,7 +122,7 @@ class EventGeoValidationHookTest
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( new ProgramStage() );
@@ -142,7 +142,7 @@ class EventGeoValidationHookTest
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         ProgramStage programStage = new ProgramStage();
@@ -164,7 +164,7 @@ class EventGeoValidationHookTest
         event.setProgramStage( PROGRAM_STAGE );
         event.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
         ProgramStage programStage = new ProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,13 +51,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 /**
  * @author Enrico Colasante
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
 class EventGeoValidationHookTest
 {
@@ -66,6 +64,9 @@ class EventGeoValidationHookTest
     private EventGeoValidationHook hookToTest;
 
     @Mock
+    private TrackerPreheat preheat;
+
+    @Mock
     private TrackerImportValidationContext validationContext;
 
     @BeforeEach
@@ -73,13 +74,8 @@ class EventGeoValidationHookTest
     {
         hookToTest = new EventGeoValidationHook();
 
-        TrackerBundle bundle = TrackerBundle.builder().build();
-
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( validationContext.getBundle() ).thenReturn( bundle );
-
-        ProgramStage programStage = new ProgramStage();
-        programStage.setFeatureType( FeatureType.POINT );
-        when( validationContext.getProgramStage( PROGRAM_STAGE ) ).thenReturn( programStage );
     }
 
     @Test
@@ -93,6 +89,11 @@ class EventGeoValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
+        ProgramStage programStage = new ProgramStage();
+        programStage.setFeatureType( FeatureType.POINT );
+        when( validationContext.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, PROGRAM_STAGE ) )
+            .thenReturn( programStage );
+
         this.hookToTest.validateEvent( reporter, event );
 
         // then
@@ -125,7 +126,8 @@ class EventGeoValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
 
         // when
-        when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( new ProgramStage() );
+        when( validationContext.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class,
+            event.getProgramStage() ) ).thenReturn( new ProgramStage() );
 
         this.hookToTest.validateEvent( reporter, event );
 
@@ -147,7 +149,8 @@ class EventGeoValidationHookTest
         // when
         ProgramStage programStage = new ProgramStage();
         programStage.setFeatureType( NONE );
-        when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        when( validationContext.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class,
+            event.getProgramStage() ) ).thenReturn( programStage );
 
         this.hookToTest.validateEvent( reporter, event );
 
@@ -169,7 +172,8 @@ class EventGeoValidationHookTest
         // when
         ProgramStage programStage = new ProgramStage();
         programStage.setFeatureType( MULTI_POLYGON );
-        when( validationContext.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        when( validationContext.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class,
+            event.getProgramStage() ) ).thenReturn( programStage );
 
         this.hookToTest.validateEvent( reporter, event );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -92,7 +92,7 @@ class EventNoteValidationHookTest
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( trackerBundle.getPreheat() ).thenReturn( preheat );
         when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         event.setNotes( Collections.singletonList( note ) );
 
@@ -119,7 +119,7 @@ class EventNoteValidationHookTest
         when( ctx.getBundle() ).thenReturn( trackerBundle );
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         event.setNotes( Collections.singletonList( note ) );
 
@@ -141,7 +141,7 @@ class EventNoteValidationHookTest
 
         when( ctx.getBundle() ).thenReturn( trackerBundle );
         when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         event.setNotes( notes );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -42,7 +42,6 @@ import java.util.stream.Collectors;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
@@ -52,16 +51,10 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 /**
  * @author Luciano Fiandesio
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
-@ExtendWith( MockitoExtension.class )
 class EventNoteValidationHookTest
 {
 
@@ -85,13 +78,12 @@ class EventNoteValidationHookTest
         // Given
         final Note note = rnd.nextObject( Note.class );
 
-        TrackerBundle trackerBundle = mock( TrackerBundle.class );
         TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
         TrackerPreheat preheat = mock( TrackerPreheat.class );
-        when( ctx.getBundle() ).thenReturn( trackerBundle );
-        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        when( trackerBundle.getPreheat() ).thenReturn( preheat );
-        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
+        when( ctx.getBundle() ).thenReturn( bundle );
+        when( preheat.getNote( note.getNote() ) )
+            .thenReturn( Optional.of( new TrackedEntityComment() ) );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         event.setNotes( Collections.singletonList( note ) );
@@ -113,12 +105,10 @@ class EventNoteValidationHookTest
         // Given
         final Note note = rnd.nextObject( Note.class );
         note.setValue( null );
-        TrackerBundle trackerBundle = mock( TrackerBundle.class );
         TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
 
-        when( ctx.getBundle() ).thenReturn( trackerBundle );
-        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        when( ctx.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
+        TrackerBundle bundle = TrackerBundle.builder().build();
+        when( ctx.getBundle() ).thenReturn( bundle );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         event.setNotes( Collections.singletonList( note ) );
@@ -136,11 +126,10 @@ class EventNoteValidationHookTest
     {
         // Given
         final List<Note> notes = rnd.objects( Note.class, 5 ).collect( Collectors.toList() );
-        TrackerBundle trackerBundle = mock( TrackerBundle.class );
         TrackerImportValidationContext ctx = mock( TrackerImportValidationContext.class );
 
-        when( ctx.getBundle() ).thenReturn( trackerBundle );
-        when( trackerBundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
+        TrackerBundle bundle = TrackerBundle.builder().preheat( mock( TrackerPreheat.class ) ).build();
+        when( ctx.getBundle() ).thenReturn( bundle );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         event.setNotes( notes );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -227,7 +227,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -245,7 +245,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -264,7 +264,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .orgUnit( ANOTHER_ORG_UNIT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -283,7 +283,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .trackedEntity( ANOTHER_TEI_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -302,7 +302,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .trackedEntity( ANOTHER_TEI_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         when( ctx.getTrackedEntityInstance( ANOTHER_TEI_ID ) ).thenReturn( null );
 
@@ -331,7 +331,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .enrollment( ENROLLMENT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -349,7 +349,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .orgUnit( ANOTHER_ORG_UNIT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -370,7 +370,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -392,7 +392,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .enrollment( ANOTHER_ENROLLMENT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -414,7 +414,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .enrollment( ENROLLMENT_ID )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -440,7 +440,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .relationshipType( relType.getUid() )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, relationship );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateRelationship( reporter, relationship );
 
@@ -481,7 +481,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .relationshipType( relType.getUid() )
             .build();
 
-        reporter = new ValidationErrorReporter( ctx, relationship );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateRelationship( reporter, relationship );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -143,22 +143,25 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         organisationUnit = createOrganisationUnit( 'A' );
         organisationUnit.setUid( ORG_UNIT_ID );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
 
         anotherOrganisationUnit = createOrganisationUnit( 'B' );
         anotherOrganisationUnit.setUid( ANOTHER_ORG_UNIT_ID );
-        when( ctx.getOrganisationUnit( ANOTHER_ORG_UNIT_ID ) ).thenReturn( anotherOrganisationUnit );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ANOTHER_ORG_UNIT_ID ) )
+            .thenReturn( anotherOrganisationUnit );
 
         trackedEntityType = createTrackedEntityType( 'A' );
         trackedEntityType.setUid( TEI_TYPE_ID );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
 
         setupPrograms();
 
         Map<String, List<String>> programWithOrgUnits = Maps.newHashMap();
         programWithOrgUnits.put( PROGRAM_WITH_REGISTRATION_ID, Lists.newArrayList( ORG_UNIT_ID ) );
 
-        when( ctx.getProgramWithOrgUnitsMap() ).thenReturn( programWithOrgUnits );
+        when( preheat.getProgramWithOrgUnitsMap() ).thenReturn( programWithOrgUnits );
     }
 
     private void setupPrograms()
@@ -168,31 +171,36 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         programWithoutRegistration.setProgramType( ProgramType.WITHOUT_REGISTRATION );
         programWithoutRegistration.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
         programWithoutRegistration.setTrackedEntityType( trackedEntityType );
-        when( ctx.getProgram( PROGRAM_WITHOUT_REGISTRATION_ID ) ).thenReturn( programWithoutRegistration );
+        when( preheat.<Program> get( Program.class, PROGRAM_WITHOUT_REGISTRATION_ID ) )
+            .thenReturn( programWithoutRegistration );
 
         programWithRegistration = createProgram( 'B' );
         programWithRegistration.setUid( PROGRAM_WITH_REGISTRATION_ID );
         programWithRegistration.setProgramType( ProgramType.WITH_REGISTRATION );
         programWithRegistration.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
         programWithRegistration.setTrackedEntityType( trackedEntityType );
-        when( ctx.getProgram( PROGRAM_WITH_REGISTRATION_ID ) ).thenReturn( programWithRegistration );
+        when( preheat.<Program> get( Program.class, PROGRAM_WITH_REGISTRATION_ID ) )
+            .thenReturn( programWithRegistration );
     }
 
     private void setupForEvents()
     {
         ProgramStage programStage = createProgramStage( 'A', programWithRegistration );
         programStage.setUid( PROGRAM_STAGE_ID );
-        when( ctx.getProgramStage( PROGRAM_STAGE_ID ) ).thenReturn( programStage );
+        when( preheat.<ProgramStage> get( ProgramStage.class, PROGRAM_STAGE_ID ) )
+            .thenReturn( programStage );
 
         ProgramInstance programInstance = new ProgramInstance();
         programInstance.setUid( ENROLLMENT_ID );
         programInstance.setProgram( programWithRegistration );
-        when( ctx.getProgramInstance( ENROLLMENT_ID ) ).thenReturn( programInstance );
+        when( preheat.getEnrollment( ctx.getBundle().getIdentifier(), ENROLLMENT_ID ) )
+            .thenReturn( programInstance );
 
         ProgramInstance anotherProgramInstance = new ProgramInstance();
         anotherProgramInstance.setUid( ANOTHER_ENROLLMENT_ID );
         anotherProgramInstance.setProgram( programWithoutRegistration );
-        when( ctx.getProgramInstance( ANOTHER_ENROLLMENT_ID ) ).thenReturn( anotherProgramInstance );
+        when( preheat.getEnrollment( ctx.getBundle().getIdentifier(), ANOTHER_ENROLLMENT_ID ) )
+            .thenReturn( anotherProgramInstance );
 
         when( preheat.getDefault( CategoryOptionCombo.class ) ).thenReturn( createCategoryOptionCombo( 'A' ) );
     }
@@ -201,19 +209,22 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     {
         TrackedEntityType anotherTrackedEntityType = createTrackedEntityType( 'B' );
         anotherTrackedEntityType.setUid( ANOTHER_TEI_TYPE_ID );
-        when( ctx.getTrackedEntityType( ANOTHER_TEI_TYPE_ID ) ).thenReturn( anotherTrackedEntityType );
+        when( preheat.<TrackedEntityType> get( TrackedEntityType.class, ANOTHER_TEI_TYPE_ID ) )
+            .thenReturn( anotherTrackedEntityType );
 
         TrackedEntityInstance trackedEntity = createTrackedEntityInstance( organisationUnit );
         trackedEntity.setUid( TEI_ID );
         trackedEntity.setTrackedEntityType( trackedEntityType );
 
-        when( ctx.getTrackedEntityInstance( TEI_ID ) ).thenReturn( trackedEntity );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), TEI_ID ) )
+            .thenReturn( trackedEntity );
 
         TrackedEntityInstance anotherTrackedEntity = createTrackedEntityInstance( organisationUnit );
         anotherTrackedEntity.setUid( ANOTHER_TEI_ID );
         anotherTrackedEntity.setTrackedEntityType( anotherTrackedEntityType );
 
-        when( ctx.getTrackedEntityInstance( ANOTHER_TEI_ID ) ).thenReturn( anotherTrackedEntity );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), ANOTHER_TEI_ID ) )
+            .thenReturn( anotherTrackedEntity );
     }
 
     @Test
@@ -304,7 +315,8 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         reporter = new ValidationErrorReporter( ctx );
 
-        when( ctx.getTrackedEntityInstance( ANOTHER_TEI_ID ) ).thenReturn( null );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), ANOTHER_TEI_ID ) )
+            .thenReturn( null );
 
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( ANOTHER_TEI_ID )
@@ -462,11 +474,13 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         TrackedEntityInstance validTrackedEntity = new TrackedEntityInstance();
         validTrackedEntity.setUid( "validTrackedEntity" );
-        when( ctx.getTrackedEntityInstance( "validTrackedEntity" ) ).thenReturn( validTrackedEntity );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), "validTrackedEntity" ) )
+            .thenReturn( validTrackedEntity );
 
         ReferenceTrackerEntity anotherValidTrackedEntity = new ReferenceTrackerEntity( "anotherValidTrackedEntity",
             null );
-        when( ctx.getReference( "anotherValidTrackedEntity" ) ).thenReturn( Optional.of( anotherValidTrackedEntity ) );
+        when( preheat.getReference( "anotherValidTrackedEntity" ) )
+            .thenReturn( Optional.of( anotherValidTrackedEntity ) );
 
         RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -135,7 +135,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -151,7 +151,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -167,7 +167,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -183,7 +183,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -201,7 +201,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -219,7 +219,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -237,7 +237,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -253,7 +253,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -269,7 +269,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -285,7 +285,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -303,7 +303,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -321,7 +321,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -339,7 +339,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -355,7 +355,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -371,7 +371,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -387,7 +387,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -405,7 +405,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -423,7 +423,7 @@ class PreCheckExistenceValidationHookTest
         // when
         when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -439,7 +439,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, rel );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, rel );
 
         // then
@@ -454,7 +454,7 @@ class PreCheckExistenceValidationHookTest
         Relationship rel = getPayloadRelationship();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, rel );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, rel );
 
         // then

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -45,7 +45,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4015;
 import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.program.ProgramInstance;
@@ -58,6 +57,7 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,6 +101,8 @@ class PreCheckExistenceValidationHookTest
     private final static String RELATIONSHIP_UID = "RelationshipId";
 
     @Mock
+    private TrackerPreheat preheat;
+
     private TrackerBundle bundle;
 
     @Mock
@@ -111,17 +113,24 @@ class PreCheckExistenceValidationHookTest
     {
         validationHook = new PreCheckExistenceValidationHook();
 
+        bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( ctx.getBundle() ).thenReturn( bundle );
-        when( ctx.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getTrackedEntityInstance( SOFT_DELETED_TEI_UID ) ).thenReturn( getSoftDeletedTei() );
-        when( ctx.getTrackedEntityInstance( TEI_UID ) ).thenReturn( getTei() );
-        when( ctx.getProgramInstance( SOFT_DELETED_ENROLLMENT_UID ) ).thenReturn( getSoftDeletedEnrollment() );
-        when( ctx.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
-        when( ctx.getProgramStageInstance( SOFT_DELETED_EVENT_UID ) ).thenReturn( getSoftDeletedEvent() );
-        when( ctx.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
-        when( ctx.getRelationship( getPayloadRelationship() ) ).thenReturn( getRelationship() );
+        when( preheat.getTrackedEntity( bundle.getIdentifier(), SOFT_DELETED_TEI_UID ) )
+            .thenReturn( getSoftDeletedTei() );
+        when( preheat.getTrackedEntity( bundle.getIdentifier(), TEI_UID ) )
+            .thenReturn( getTei() );
+        when(
+            preheat.getEnrollment( bundle.getIdentifier(), SOFT_DELETED_ENROLLMENT_UID ) )
+                .thenReturn( getSoftDeletedEnrollment() );
+        when( preheat.getEnrollment( bundle.getIdentifier(), ENROLLMENT_UID ) )
+            .thenReturn( getEnrollment() );
+        when( preheat.getEvent( bundle.getIdentifier(), SOFT_DELETED_EVENT_UID ) )
+            .thenReturn( getSoftDeletedEvent() );
+        when( preheat.getEvent( bundle.getIdentifier(), EVENT_UID ) )
+            .thenReturn( getEvent() );
+        when(
+            preheat.getRelationship( bundle.getIdentifier(), getPayloadRelationship() ) )
+                .thenReturn( getRelationship() );
     }
 
     @Test
@@ -133,7 +142,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
@@ -151,6 +160,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
@@ -167,6 +177,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
@@ -183,6 +194,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
@@ -199,7 +211,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
@@ -217,7 +229,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.UPDATE );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.UPDATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
@@ -235,7 +247,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
@@ -253,6 +265,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
@@ -269,6 +282,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
@@ -285,6 +299,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
@@ -301,7 +316,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
@@ -319,7 +334,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.UPDATE );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.UPDATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
@@ -337,7 +352,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
@@ -355,6 +370,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
@@ -371,6 +387,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
@@ -387,6 +404,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
@@ -403,7 +421,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
@@ -421,7 +439,7 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         // when
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
+        bundle.setStrategy( event, TrackerImportStrategy.UPDATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -103,7 +103,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .orgUnit( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -118,7 +118,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .orgUnit( null )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "orgUnit" );
@@ -133,7 +133,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .orgUnit( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "trackedEntityType" );
@@ -149,7 +149,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         assertFalse( reporter.hasErrors() );
@@ -165,7 +165,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( null )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "trackedEntity" );
@@ -181,7 +181,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "program" );
@@ -197,7 +197,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "orgUnit" );
@@ -213,7 +213,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         assertFalse( reporter.hasErrors() );
@@ -229,7 +229,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( null )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "program" );
@@ -247,7 +247,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         programStage.setUid( event.getProgramStage() );
         when( ctx.getProgramStage( anyString() ) ).thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         assertTrue( reporter.hasErrors() );
@@ -265,7 +265,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "programStage" );
@@ -281,7 +281,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "orgUnit" );
@@ -301,7 +301,7 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, relationship );
 
         assertFalse( reporter.hasErrors() );
@@ -318,7 +318,7 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "from" );
@@ -335,7 +335,7 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "to" );
@@ -354,7 +354,7 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "relationshipType" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -39,13 +39,12 @@ import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReport
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -61,21 +60,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 /**
  * @author Enrico Colasante
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
 class PreCheckMandatoryFieldsValidationHookTest
 {
 
     private PreCheckMandatoryFieldsValidationHook validationHook;
-
-    @Mock
-    private TrackerBundle bundle;
 
     @Mock
     private TrackerImportValidationContext ctx;
@@ -88,10 +81,8 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         validationHook = new PreCheckMandatoryFieldsValidationHook();
 
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( ctx.getBundle() ).thenReturn( bundle );
-        when( ctx.getBundle().getImportStrategy() ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
-        when( bundle.getPreheat() ).thenReturn( preheat );
     }
 
     @Test
@@ -245,7 +236,8 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
         ProgramStage programStage = new ProgramStage();
         programStage.setUid( event.getProgramStage() );
-        when( ctx.getProgramStage( anyString() ) ).thenReturn( programStage );
+        when( preheat.<ProgramStage> get( eq( ProgramStage.class ), anyString() ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -107,7 +107,7 @@ class PreCheckMetaValidationHookTest
         // given
         TrackedEntity tei = validTei();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, tei );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -125,7 +125,7 @@ class PreCheckMetaValidationHookTest
         // given
         TrackedEntity tei = validTei();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, tei );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) ).thenReturn( new TrackedEntityType() );
@@ -142,7 +142,7 @@ class PreCheckMetaValidationHookTest
         // given
         TrackedEntity tei = validTei();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, tei );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -159,7 +159,7 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -178,7 +178,7 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getReference( TRACKED_ENTITY_UID ) )
@@ -198,7 +198,7 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
@@ -216,7 +216,7 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -234,7 +234,7 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -252,7 +252,7 @@ class PreCheckMetaValidationHookTest
         // given
         Event event = validEvent();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -271,7 +271,7 @@ class PreCheckMetaValidationHookTest
         // given
         Event event = validEvent();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -289,7 +289,7 @@ class PreCheckMetaValidationHookTest
         // given
         Event event = validEvent();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
@@ -307,7 +307,7 @@ class PreCheckMetaValidationHookTest
         // given
         Event event = validEvent();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
@@ -325,7 +325,7 @@ class PreCheckMetaValidationHookTest
         // given
         Relationship relationship = validRelationship();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         when( ctx.getRelationShipType( RELATIONSHIP_TYPE_UID ) ).thenReturn( new RelationshipType() );
@@ -342,7 +342,7 @@ class PreCheckMetaValidationHookTest
         // given
         Relationship relationship = validRelationship();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
         validatorToTest.validateRelationship( reporter, relationship );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -59,6 +59,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.ReferenceTrackerEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,6 +90,9 @@ class PreCheckMetaValidationHookTest
     private PreCheckMetaValidationHook validatorToTest;
 
     @Mock
+    private TrackerPreheat preheat;
+
+    @Mock
     private TrackerImportValidationContext ctx;
 
     @BeforeEach
@@ -96,8 +100,7 @@ class PreCheckMetaValidationHookTest
     {
         validatorToTest = new PreCheckMetaValidationHook();
 
-        TrackerBundle bundle = TrackerBundle.builder().build();
-
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( ctx.getBundle() ).thenReturn( bundle );
     }
 
@@ -110,8 +113,10 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) ).thenReturn( new TrackedEntityType() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.<TrackedEntityType> get( TrackedEntityType.class, TRACKED_ENTITY_TYPE_UID ) )
+            .thenReturn( new TrackedEntityType() );
 
         validatorToTest.validateTrackedEntity( reporter, tei );
 
@@ -128,7 +133,10 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) ).thenReturn( new TrackedEntityType() );
+        when( preheat.<TrackedEntityType> get( TrackedEntityType.class, TRACKED_ENTITY_TYPE_UID ) )
+            .thenReturn( new TrackedEntityType() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( null );
 
         validatorToTest.validateTrackedEntity( reporter, tei );
 
@@ -145,7 +153,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
 
         validatorToTest.validateTrackedEntity( reporter, tei );
 
@@ -162,9 +171,11 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), TRACKED_ENTITY_UID ) )
+            .thenReturn( new TrackedEntityInstance() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -181,10 +192,11 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getReference( TRACKED_ENTITY_UID ) )
+        when( preheat.getReference( TRACKED_ENTITY_UID ) )
             .thenReturn( Optional.of( new ReferenceTrackerEntity( "", "" ) ) );
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -201,8 +213,11 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
-        when( ctx.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), TRACKED_ENTITY_UID ) )
+            .thenReturn( new TrackedEntityInstance() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( null );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -219,8 +234,9 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -237,8 +253,10 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.getTrackedEntity( ctx.getBundle().getIdentifier(), TRACKED_ENTITY_UID ) )
+            .thenReturn( new TrackedEntityInstance() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -255,9 +273,11 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
-        when( ctx.getProgramStage( PROGRAM_STAGE_UID ) ).thenReturn( new ProgramStage() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.<ProgramStage> get( ProgramStage.class, PROGRAM_STAGE_UID ) )
+            .thenReturn( new ProgramStage() );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -274,8 +294,11 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getProgramStage( PROGRAM_STAGE_UID ) ).thenReturn( new ProgramStage() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.<ProgramStage> get( ProgramStage.class, PROGRAM_STAGE_UID ) )
+            .thenReturn( new ProgramStage() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( null );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -292,8 +315,9 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( new OrganisationUnit() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -310,8 +334,11 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getProgram( PROGRAM_UID ) ).thenReturn( new Program() );
-        when( ctx.getProgramStage( PROGRAM_STAGE_UID ) ).thenReturn( new ProgramStage() );
+        when( preheat.<Program> get( Program.class, PROGRAM_UID ) ).thenReturn( new Program() );
+        when( preheat.<ProgramStage> get( ProgramStage.class, PROGRAM_STAGE_UID ) )
+            .thenReturn( new ProgramStage() );
+        when( preheat.<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_UID ) )
+            .thenReturn( null );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -328,7 +355,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
 
         // when
-        when( ctx.getRelationShipType( RELATIONSHIP_TYPE_UID ) ).thenReturn( new RelationshipType() );
+        when( preheat.<RelationshipType> get( RelationshipType.class, RELATIONSHIP_TYPE_UID ) )
+            .thenReturn( new RelationshipType() );
 
         validatorToTest.validateRelationship( reporter, relationship );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -162,7 +162,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -184,7 +184,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -206,7 +206,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -228,7 +228,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -251,7 +251,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -273,7 +273,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -296,7 +296,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         bundle.setUser( deleteTeiAuthorisedUser() );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -318,7 +318,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -340,7 +340,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -364,7 +364,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -385,7 +385,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( false );
-        reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
 
@@ -405,7 +405,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -428,7 +428,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -452,7 +452,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -476,7 +476,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -500,7 +500,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -525,7 +525,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         bundle.setUser( deleteEnrollmentAuthorisedUser() );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -549,7 +549,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( false );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -573,7 +573,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -597,7 +597,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -621,7 +621,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( false );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, enrollment );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
@@ -651,7 +651,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -680,7 +680,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
 
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -706,7 +706,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -732,7 +732,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -764,7 +764,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -796,7 +796,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         bundle.setUser( changeCompletedEventAuthorisedUser() );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -823,7 +823,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -851,7 +851,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -882,7 +882,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( ctx, event );
+        reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -39,6 +39,9 @@ import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReport
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.CodeGenerator;
@@ -156,9 +159,11 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -177,10 +182,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().getTrackedEntity( ctx.getBundle().getIdentifier(), TEI_ID ) )
+            .thenReturn( getTEIWithNoProgramInstances() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -199,10 +207,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -221,10 +232,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -243,11 +257,15 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().getTrackedEntity( ctx.getBundle().getIdentifier(), TEI_ID ) )
+            .thenReturn( getTEIWithNoProgramInstances() );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -266,10 +284,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithDeleteProgramInstances() );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().getTrackedEntity( ctx.getBundle().getIdentifier(), TEI_ID ) )
+            .thenReturn( getTEIWithDeleteProgramInstances() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -288,14 +309,17 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.DELETE );
+        bundle.setUser( deleteTeiAuthorisedUser() );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().getTrackedEntity( ctx.getBundle().getIdentifier(), TEI_ID ) )
+            .thenReturn( getTEIWithProgramInstances() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        bundle.setUser( deleteTeiAuthorisedUser() );
         reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateTrackedEntity( reporter, trackedEntity );
@@ -311,10 +335,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().getTrackedEntity( ctx.getBundle().getIdentifier(), TEI_ID ) )
+            .thenReturn( getTEIWithProgramInstances() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -333,10 +360,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -357,10 +387,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -379,9 +412,11 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .orgUnit( ORG_UNIT_ID )
             .trackedEntityType( TEI_TYPE_ID )
             .build();
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( ctx.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
-        when( ctx.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
+        bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<TrackedEntityType> get( TrackedEntityType.class, TEI_TYPE_ID ) )
+            .thenReturn( trackedEntityType );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( false );
@@ -401,8 +436,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( ctx );
@@ -421,9 +456,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -445,9 +481,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -470,9 +507,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -492,10 +530,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( false );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().getProgramInstanceWithOneOrMoreNonDeletedEvent() )
+            .thenReturn( Collections.emptyList() );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -516,15 +556,17 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( true );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        bundle.setUser( deleteEnrollmentAuthorisedUser() );
+        when( ctx.getBundle().getPreheat().getProgramInstanceWithOneOrMoreNonDeletedEvent() )
+            .thenReturn( List.of( enrollment.getEnrollment() ) );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        bundle.setUser( deleteEnrollmentAuthorisedUser() );
         reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
@@ -541,10 +583,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( false );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().getProgramInstanceWithOneOrMoreNonDeletedEvent() )
+            .thenReturn( Collections.emptyList() );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -565,10 +609,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( true );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().getProgramInstanceWithOneOrMoreNonDeletedEvent() )
+            .thenReturn( List.of( enrollment.getEnrollment() ) );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -590,9 +636,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( aclService.canDataWrite( user, program ) ).thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -614,9 +661,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( enrollment, TrackerImportStrategy.DELETE );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( false );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -638,14 +686,18 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.DELETE );
+        bundle.setStrategy( event, TrackerImportStrategy.DELETE );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( ctx.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().getEvent( ctx.getBundle().getIdentifier(), event.getEvent() ) )
+            .thenReturn( programStageInstance );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( programInstance );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, PS_ID ) ).thenReturn( programStage );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -669,13 +721,15 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -696,11 +750,14 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( getEnrollment( null ) );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -722,11 +779,14 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE_AND_UPDATE );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( getEnrollment( null ) );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -750,15 +810,19 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .program( PROGRAM_ID )
             .status( EventStatus.COMPLETED )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        bundle.setStrategy( event, TrackerImportStrategy.UPDATE );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( ctx.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().getEvent( ctx.getBundle().getIdentifier(), event.getEvent() ) )
+            .thenReturn( programStageInstance );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( programInstance );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -781,21 +845,25 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
+        bundle.setStrategy( event, TrackerImportStrategy.UPDATE );
+        bundle.setUser( changeCompletedEventAuthorisedUser() );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( ctx.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().getEvent( ctx.getBundle().getIdentifier(), event.getEvent() ) )
+            .thenReturn( programStageInstance );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( programInstance );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        bundle.setUser( changeCompletedEventAuthorisedUser() );
         reporter = new ValidationErrorReporter( ctx );
 
         validatorToTest.validateEvent( reporter, event );
@@ -813,11 +881,14 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( getEnrollment( null ) );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -841,11 +912,14 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .program( PROGRAM_ID )
             .status( EventStatus.SCHEDULE )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( ctx.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        bundle.setStrategy( event, TrackerImportStrategy.CREATE );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, event.getProgramStage() ) )
+            .thenReturn( programStage );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( getEnrollment( null ) );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -869,14 +943,18 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .programStage( PS_ID )
             .program( PROGRAM_ID )
             .build();
-        when( ctx.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
+        bundle.setStrategy( event, TrackerImportStrategy.UPDATE );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( ctx.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( ctx.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getBundle().getPreheat().getEvent( ctx.getBundle().getIdentifier(), event.getEvent() ) )
+            .thenReturn( programStageInstance );
+        when( ctx.getBundle().getPreheat().getEnrollment( ctx.getBundle().getIdentifier(), event.getEnrollment() ) )
+            .thenReturn( programInstance );
+        when( ctx.getBundle().getPreheat().<ProgramStage> get( ProgramStage.class, PS_ID ) ).thenReturn( programStage );
+        when( ctx.getBundle().getPreheat().<Program> get( Program.class, PROGRAM_ID ) ).thenReturn( program );
+        when( ctx.getBundle().getPreheat().<OrganisationUnit> get( OrganisationUnit.class, ORG_UNIT_ID ) )
+            .thenReturn( organisationUnit );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -74,7 +74,7 @@ class PreCheckUidValidationHookTest
         // given
         TrackedEntity trackedEntity = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
         assertFalse( reporter.hasErrors() );
     }
@@ -86,7 +86,7 @@ class PreCheckUidValidationHookTest
         TrackedEntity trackedEntity = TrackedEntity.builder().trackedEntity( INVALID_UID )
             .orgUnit( CodeGenerator.generateUid() ).build();
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
         // then
         hasTrackerError( reporter, E1048, TRACKED_ENTITY, trackedEntity.getUid() );
@@ -99,7 +99,7 @@ class PreCheckUidValidationHookTest
         Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
         Enrollment enrollment = Enrollment.builder().enrollment( CodeGenerator.generateUid() )
             .notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
         // then
         assertFalse( reporter.hasErrors() );
@@ -110,7 +110,7 @@ class PreCheckUidValidationHookTest
     {
         // given
         Enrollment enrollment = Enrollment.builder().enrollment( INVALID_UID ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
         // then
         hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
@@ -123,7 +123,7 @@ class PreCheckUidValidationHookTest
         Note note = Note.builder().note( INVALID_UID ).build();
         Enrollment enrollment = Enrollment.builder().enrollment( CodeGenerator.generateUid() )
             .notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
         // then
         hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
@@ -135,7 +135,7 @@ class PreCheckUidValidationHookTest
         // given
         Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
         Event event = Event.builder().event( CodeGenerator.generateUid() ).notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
         // then
         assertFalse( reporter.hasErrors() );
@@ -146,7 +146,7 @@ class PreCheckUidValidationHookTest
     {
         // given
         Event event = Event.builder().event( INVALID_UID ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
         // then
         hasTrackerError( reporter, E1048, EVENT, event.getUid() );
@@ -158,7 +158,7 @@ class PreCheckUidValidationHookTest
         // given
         Note note = Note.builder().note( INVALID_UID ).build();
         Event event = Event.builder().event( CodeGenerator.generateUid() ).notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
         // then
         hasTrackerError( reporter, E1048, EVENT, event.getUid() );
@@ -169,7 +169,7 @@ class PreCheckUidValidationHookTest
     {
         // given
         Relationship relationship = Relationship.builder().relationship( CodeGenerator.generateUid() ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, relationship );
         // then
         assertFalse( reporter.hasErrors() );
@@ -180,7 +180,7 @@ class PreCheckUidValidationHookTest
     {
         // given
         Relationship relationship = Relationship.builder().relationship( INVALID_UID ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, relationship );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateRelationship( reporter, relationship );
         // then
         hasTrackerError( reporter, E1048, RELATIONSHIP, relationship.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -113,7 +113,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         TrackedEntity trackedEntity = validTei();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -128,7 +128,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         trackedEntity.setTrackedEntityType( "NewTrackedEntityTypeId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, trackedEntity );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateTrackedEntity( reporter, trackedEntity );
 
         // then
@@ -142,7 +142,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         Enrollment enrollment = validEnrollment();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -157,7 +157,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         enrollment.setProgram( "NewProgramId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -173,7 +173,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         enrollment.setTrackedEntity( "NewTrackedEntityId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, enrollment );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEnrollment( reporter, enrollment );
 
         // then
@@ -188,7 +188,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         Event event = validEvent();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -203,7 +203,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         event.setProgramStage( "NewProgramStageId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then
@@ -219,7 +219,7 @@ class PreCheckUpdatableFieldsValidationHookTest
         event.setEnrollment( "NewEnrollmentId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx, event );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( ctx );
         validationHook.validateEvent( reporter, event );
 
         // then

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -37,7 +37,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1127;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1128;
 import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.program.Program;
@@ -46,11 +45,11 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,23 +86,22 @@ class PreCheckUpdatableFieldsValidationHookTest
     private TrackerImportValidationContext ctx;
 
     @Mock
-    private TrackerBundle bundle;
+    private TrackerPreheat preheat;
 
     @BeforeEach
     public void setUp()
     {
         validationHook = new PreCheckUpdatableFieldsValidationHook();
 
+        TrackerBundle bundle = TrackerBundle.builder().preheat( preheat ).build();
         when( ctx.getBundle() ).thenReturn( bundle );
-        when( ctx.getBundle().getImportStrategy() ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
 
-        when( ctx.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( ctx.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( ctx.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.UPDATE );
-
-        when( ctx.getTrackedEntityInstance( TRACKED_ENTITY_ID ) ).thenReturn( trackedEntityInstance() );
-        when( ctx.getProgramInstance( ENROLLMENT_ID ) ).thenReturn( programInstance() );
-        when( ctx.getProgramStageInstance( EVENT_ID ) ).thenReturn( programStageInstance() );
+        when( preheat.getTrackedEntity( bundle.getIdentifier(), TRACKED_ENTITY_ID ) )
+            .thenReturn( trackedEntityInstance() );
+        when( preheat.getEnrollment( bundle.getIdentifier(), ENROLLMENT_ID ) )
+            .thenReturn( programInstance() );
+        when( preheat.getEvent( bundle.getIdentifier(), EVENT_ID ) )
+            .thenReturn( programStageInstance() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -138,7 +138,8 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramStageWithEvents() )
             .thenReturn( Lists.newArrayList( Pair.of( event.getProgramStage(), event.getEnrollment() ) ) );
         bundle.setEvents( Lists.newArrayList( event ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = new ValidationErrorReporter(
+            new TrackerImportValidationContext( bundle ) );
 
         validatorToTest.validate( errorReporter, ctx );
 
@@ -158,7 +159,8 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ), notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = new ValidationErrorReporter(
+            new TrackerImportValidationContext( bundle ) );
 
         validatorToTest.validate( errorReporter, ctx );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -115,8 +116,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
 
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        validatorToTest.validate( errorReporter, ctx );
 
         assertTrue( errorReporter.getReportList().isEmpty() );
     }
@@ -136,7 +138,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramStageWithEvents() )
             .thenReturn( Lists.newArrayList( Pair.of( event.getProgramStage(), event.getEnrollment() ) ) );
         bundle.setEvents( Lists.newArrayList( event ) );
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+
+        validatorToTest.validate( errorReporter, ctx );
 
         // then
         assertEquals( 1, errorReporter.getReportList().size() );
@@ -154,8 +158,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ), notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
 
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        validatorToTest.validate( errorReporter, ctx );
 
         assertEquals( 2, errorReporter.getReportList().size() );
         assertThat( errorReporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E1039 ) );
@@ -178,8 +183,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( repeatableEvent( "A" ), repeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
 
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        validatorToTest.validate( errorReporter, ctx );
 
         assertTrue( errorReporter.getReportList().isEmpty() );
     }
@@ -189,11 +195,12 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     {
         Event invalidEvent = notRepeatableEvent( "A" );
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
-        ctx.getRootReporter().getInvalidDTOs().put( EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        errorReporter.getInvalidDTOs().put( TrackerType.EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
 
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        validatorToTest.validate( errorReporter, ctx );
 
         assertTrue( errorReporter.getReportList().isEmpty() );
     }
@@ -207,8 +214,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( eventEnrollmentA, eventEnrollmentB );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
 
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        validatorToTest.validate( errorReporter, ctx );
 
         assertTrue( errorReporter.getReportList().isEmpty() );
     }
@@ -221,8 +229,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( eventProgramA, eventProgramB );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
+        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
 
-        ValidationErrorReporter errorReporter = validatorToTest.validate( ctx );
+        validatorToTest.validate( errorReporter, ctx );
 
         assertTrue( errorReporter.getReportList().isEmpty() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.encryption.EncryptionStatus;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
@@ -45,6 +46,7 @@ import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
@@ -221,13 +223,15 @@ class TrackedEntityAttributeValidationHookTest
             sbString.append( "a" );
         }
 
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter,
+        String teUid = CodeGenerator.generateUid();
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, teUid,
             trackedEntityAttribute, sbString.toString() );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( 1, reporter.getReportList().stream()
-            .filter( e -> e.getErrorCode() == TrackerErrorCode.E1077 ).count() );
+        assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1077.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            teUid.equals( err.getUid() ) ) );
     }
 
     @Test
@@ -237,13 +241,15 @@ class TrackedEntityAttributeValidationHookTest
 
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.NUMBER );
 
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter,
+        String teUid = CodeGenerator.generateUid();
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, teUid,
             trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( 1, reporter.getReportList().stream()
-            .filter( e -> e.getErrorCode() == TrackerErrorCode.E1085 ).count() );
+        assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1085.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            teUid.equals( err.getUid() ) ) );
     }
 
     @Test
@@ -260,13 +266,15 @@ class TrackedEntityAttributeValidationHookTest
         when( validationContext.getTrackedEntityAttribute( anyString() ) ).thenReturn( trackedEntityAttribute );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter,
+        String teUid = CodeGenerator.generateUid();
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, teUid,
             trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( 1, reporter.getReportList().stream()
-            .filter( e -> e.getErrorCode() == TrackerErrorCode.E1112 ).count() );
+        assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1112.equals( err.getErrorCode() ) &&
+            TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
+            teUid.equals( err.getUid() ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -223,15 +223,15 @@ class TrackedEntityAttributeValidationHookTest
             sbString.append( "a" );
         }
 
-        String teUid = CodeGenerator.generateUid();
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, teUid,
+        TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
             trackedEntityAttribute, sbString.toString() );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1077.equals( err.getErrorCode() ) &&
             TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            teUid.equals( err.getUid() ) ) );
+            te.getTrackedEntity().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -241,15 +241,15 @@ class TrackedEntityAttributeValidationHookTest
 
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.NUMBER );
 
-        String teUid = CodeGenerator.generateUid();
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, teUid,
+        TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
             trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1085.equals( err.getErrorCode() ) &&
             TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            teUid.equals( err.getUid() ) ) );
+            te.getTrackedEntity().equals( err.getUid() ) ) );
     }
 
     @Test
@@ -266,15 +266,15 @@ class TrackedEntityAttributeValidationHookTest
         when( validationContext.getTrackedEntityAttribute( anyString() ) ).thenReturn( trackedEntityAttribute );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( validationContext );
-        String teUid = CodeGenerator.generateUid();
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, teUid,
+        TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
+        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
             trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1112.equals( err.getErrorCode() ) &&
             TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
-            teUid.equals( err.getUid() ) ) );
+            te.getTrackedEntity().equals( err.getUid() ) ) );
     }
 
     @Test


### PR DESCRIPTION
## Goal

Remove as much as possible from TrackerImportValidationContext, so we can remove the class in the end. Passing in the TrackerBundle into hooks should be enough.

### Why

TrackerImportValidationContext is a class that serves as a utility. You can see that hooks mostly reach for the TrackerPreheat which is a field on the TrackerBundle. In a few cases, hooks need information from the TrackerBundle itself. An older TODO comment already questioned the TrackerImportValidationContext existence. After the PR is merged TrackerImportValidationContext will still hold a cache that we might be able to move into the TrackerPreheat.

- [ ] based on https://github.com/dhis2/dhis2-core/pull/9523 which should be merged first. Diff will become clear afterward.