### PR TITLE
fix: Add support for datetime with 9 fraction of a second

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -90,6 +90,7 @@ public class DateUtils
     };
 
     private static final DateTimeParser[] SUPPORTED_DATE_TIME_FORMAT_PARSERS = {
+        DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSSSS" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd'T'HH:mm:ss.SSSSZ" ).getParser(),


### PR DESCRIPTION
This issue might be limited to Windows.

The e2e tests uses Instant.now() for generating datetimes for dummy data. These datetimes include 9 digits for fractions of a second, while the most we support in the core is 7 fractions of a second.

Add support for 9 fractions of a second instead of rewriting the e2e tests, in case this is just happening on Windows.