### PR TITLE
chore: make TrackerValidationReport add methods fluent and name Timing TECH-880

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -390,8 +390,9 @@ public class DefaultTrackerImportService
         }
         else if ( originalValidationReport != null && TrackerBundleReportMode.FULL == reportMode )
         {
-            validationReport.addWarnings( originalValidationReport.getWarnings() );
-            validationReport.addTimings( originalValidationReport.getTimings() );
+            validationReport
+                .addWarnings( originalValidationReport.getWarnings() )
+                .addTimings( originalValidationReport.getTimings() );
             importReportBuilder.timingsStats( originalImportReport.getTimingsStats() );
         }
         importReportBuilder.validationReport( validationReport );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -382,15 +382,15 @@ public class DefaultTrackerImportService
         TrackerValidationReport validationReport = new TrackerValidationReport();
         if ( originalValidationReport != null )
         {
-            validationReport.addErrors( originalValidationReport.getErrorReports() );
+            validationReport.addErrors( originalValidationReport.getErrors() );
         }
         if ( originalValidationReport != null && TrackerBundleReportMode.WARNINGS == reportMode )
         {
-            validationReport.addWarnings( originalValidationReport.getWarningReports() );
+            validationReport.addWarnings( originalValidationReport.getWarnings() );
         }
         else if ( originalValidationReport != null && TrackerBundleReportMode.FULL == reportMode )
         {
-            validationReport.addWarnings( originalValidationReport.getWarningReports() );
+            validationReport.addWarnings( originalValidationReport.getWarnings() );
             validationReport.addPerfReports( originalValidationReport.getPerformanceReport() );
             importReportBuilder.timingsStats( originalImportReport.getTimingsStats() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -391,7 +391,7 @@ public class DefaultTrackerImportService
         else if ( originalValidationReport != null && TrackerBundleReportMode.FULL == reportMode )
         {
             validationReport.addWarnings( originalValidationReport.getWarnings() );
-            validationReport.addPerfReports( originalValidationReport.getPerformanceReport() );
+            validationReport.addTimings( originalValidationReport.getTimings() );
             importReportBuilder.timingsStats( originalImportReport.getTimingsStats() );
         }
         importReportBuilder.validationReport( validationReport );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
@@ -27,8 +27,10 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -38,13 +40,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
-@Builder
+@RequiredArgsConstructor
+@ToString
+@EqualsAndHashCode
 public class Timing
 {
+    @NonNull
     @JsonProperty
     public String totalTime;
 
+    @NonNull
     @JsonProperty
     public String name;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
@@ -47,9 +47,9 @@ public class Timing
 {
     @NonNull
     @JsonProperty
-    public String totalTime;
+    public final String totalTime;
 
     @NonNull
     @JsonProperty
-    public String name;
+    public final String name;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @Data
 @Builder
-public class TrackerValidationHookTimerReport
+public class Timing
 {
     @JsonProperty
     public String totalTime;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
@@ -81,17 +81,17 @@ public class TrackerValidationReport
 
     public void addValidationReport( TrackerValidationReport report )
     {
-        addErrors( report.getErrorReports() );
-        addWarnings( report.getWarningReports() );
+        addErrors( report.getErrors() );
+        addWarnings( report.getWarnings() );
         addPerfReports( report.getPerformanceReport() );
     }
 
-    public List<TrackerErrorReport> getErrorReports()
+    public List<TrackerErrorReport> getErrors()
     {
         return Collections.unmodifiableList( errorReports );
     }
 
-    public List<TrackerWarningReport> getWarningReports()
+    public List<TrackerWarningReport> getWarnings()
     {
         return Collections.unmodifiableList( warningReports );
     }
@@ -168,7 +168,7 @@ public class TrackerValidationReport
     public long size()
     {
 
-        return this.getErrorReports().stream().map( TrackerErrorReport::getUid ).distinct().count();
+        return this.getErrors().stream().map( TrackerErrorReport::getUid ).distinct().count();
     }
 
     private void addErrorIfNotExisting( TrackerErrorReport error )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
@@ -57,7 +57,7 @@ public class TrackerValidationReport
     private final List<TrackerWarningReport> warningReports;
 
     @JsonIgnore
-    private final List<TrackerValidationHookTimerReport> performanceReport;
+    private final List<Timing> timings;
 
     /*
      * Keeps track of all the invalid Tracker objects (i.e. objects with at
@@ -71,7 +71,7 @@ public class TrackerValidationReport
     {
         this.errorReports = new ArrayList<>();
         this.warningReports = new ArrayList<>();
-        this.performanceReport = new ArrayList<>();
+        this.timings = new ArrayList<>();
         this.invalidDTOs = new HashMap<>();
     }
 
@@ -83,7 +83,7 @@ public class TrackerValidationReport
     {
         addErrors( report.getErrors() );
         addWarnings( report.getWarnings() );
-        addPerfReports( report.getPerformanceReport() );
+        addTimings( report.getTimings() );
     }
 
     public List<TrackerErrorReport> getErrors()
@@ -96,9 +96,9 @@ public class TrackerValidationReport
         return Collections.unmodifiableList( warningReports );
     }
 
-    public List<TrackerValidationHookTimerReport> getPerformanceReport()
+    public List<Timing> getTimings()
     {
-        return Collections.unmodifiableList( performanceReport );
+        return Collections.unmodifiableList( timings );
     }
 
     public void addError( TrackerErrorReport error )
@@ -127,14 +127,14 @@ public class TrackerValidationReport
         }
     }
 
-    public void addPerfReports( List<TrackerValidationHookTimerReport> timerReports )
+    public void addTimings( List<Timing> timings )
     {
-        this.performanceReport.addAll( timerReports );
+        this.timings.addAll( timings );
     }
 
-    public void addPerfReport( TrackerValidationHookTimerReport timerReport )
+    public void addTiming( Timing timing )
     {
-        performanceReport.add( timerReport );
+        timings.add( timing );
     }
 
     public boolean hasErrors()
@@ -157,9 +157,9 @@ public class TrackerValidationReport
         return warningReports.stream().anyMatch( test );
     }
 
-    public boolean hasPerfs()
+    public boolean hasTimings()
     {
-        return !performanceReport.isEmpty();
+        return !timings.isEmpty();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
@@ -101,40 +101,46 @@ public class TrackerValidationReport
         return Collections.unmodifiableList( timings );
     }
 
-    public void addError( TrackerErrorReport error )
+    public TrackerValidationReport addError( TrackerErrorReport error )
     {
         addErrorIfNotExisting( error );
+        return this;
     }
 
-    public void addErrors( List<TrackerErrorReport> errors )
+    public TrackerValidationReport addErrors( List<TrackerErrorReport> errors )
     {
         for ( TrackerErrorReport error : errors )
         {
             addErrorIfNotExisting( error );
         }
+        return this;
     }
 
-    public void addWarning( TrackerWarningReport warning )
+    public TrackerValidationReport addWarning( TrackerWarningReport warning )
     {
         addWarningIfNotExisting( warning );
+        return this;
     }
 
-    public void addWarnings( List<TrackerWarningReport> warnings )
+    public TrackerValidationReport addWarnings( List<TrackerWarningReport> warnings )
     {
         for ( TrackerWarningReport warning : warnings )
         {
             addWarningIfNotExisting( warning );
         }
+        return this;
     }
 
-    public void addTimings( List<Timing> timings )
-    {
-        this.timings.addAll( timings );
-    }
-
-    public void addTiming( Timing timing )
+    public TrackerValidationReport addTiming( Timing timing )
     {
         timings.add( timing );
+        return this;
+    }
+
+    public TrackerValidationReport addTimings( List<Timing> timings )
+    {
+        this.timings.addAll( timings );
+        return this;
     }
 
     public boolean hasErrors()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -36,7 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.report.TrackerValidationHookTimerReport;
+import org.hisp.dhis.tracker.report.Timing;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.user.User;
@@ -100,7 +100,7 @@ public class DefaultTrackerValidationService
 
                 hook.validate( reporter, context );
 
-                validationReport.addPerfReport( TrackerValidationHookTimerReport.builder()
+                validationReport.addTiming( Timing.builder()
                     .name( hook.getClass().getName() )
                     .totalTime( hookTimer.toString() ).build() );
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -111,8 +111,9 @@ public class DefaultTrackerValidationService
         }
         // TODO(TECH-880) can be removed once the ValidationErrorReporter is
         // removed and we only work with TrackerValidationReport
-        validationReport.addErrors( reporter.getReportList() );
-        validationReport.addWarnings( reporter.getWarningsReportList() );
+        validationReport
+            .addErrors( reporter.getReportList() )
+            .addWarnings( reporter.getWarningsReportList() );
 
         removeInvalidObjects( bundle, reporter );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -100,9 +100,9 @@ public class DefaultTrackerValidationService
 
                 hook.validate( reporter, context );
 
-                validationReport.addTiming( Timing.builder()
-                    .name( hook.getClass().getName() )
-                    .totalTime( hookTimer.toString() ).build() );
+                validationReport.addTiming( new Timing(
+                    hook.getClass().getName(),
+                    hookTimer.toString() ) );
             }
         }
         catch ( ValidationFailFastException e )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -140,7 +140,7 @@ public abstract class TrackerTest extends TransactionalIntegrationTest
 
     protected void assertNoImportErrors( TrackerImportReport report )
     {
-        assertTrue( report.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( report.getValidationReport().getErrors().isEmpty() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
@@ -236,7 +236,7 @@ class OwnershipTest extends TrackerTest
         updatedReport = trackerImportService.importTracker( enrollmentParams );
         assertEquals( 1, updatedReport.getStats().getIgnored() );
         assertEquals( TrackerErrorCode.E1102,
-            updatedReport.getValidationReport().getErrorReports().get( 0 ).getErrorCode() );
+            updatedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -253,7 +253,7 @@ class OwnershipTest extends TrackerTest
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
         assertEquals( 1, updatedReport.getStats().getIgnored() );
         assertEquals( TrackerErrorCode.E1102,
-            updatedReport.getValidationReport().getErrorReports().get( 0 ).getErrorCode() );
+            updatedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -270,7 +270,7 @@ class OwnershipTest extends TrackerTest
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
         assertEquals( 1, updatedReport.getStats().getIgnored() );
         assertEquals( TrackerErrorCode.E1102,
-            updatedReport.getValidationReport().getErrorReports().get( 0 ).getErrorCode() );
+            updatedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
     }
 
     private void compareEnrollmentBasicProperties( ProgramInstance pi, Enrollment enrollment )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -132,7 +132,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         TrackerImportReport importReport = trackerImportService.importTracker( params );
         assertEquals( TrackerStatus.ERROR, importReport.getStatus() );
         assertTrue( importReport.getValidationReport().hasErrors() );
-        List<TrackerErrorReport> trackerErrorReports = importReport.getValidationReport().getErrorReports();
+        List<TrackerErrorReport> trackerErrorReports = importReport.getValidationReport().getErrors();
         assertEquals( TrackerErrorCode.E1081, trackerErrorReports.get( 0 ).getErrorCode() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -110,7 +110,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportTeiReport );
         assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
-        assertTrue( trackerImportTeiReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportTeiReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getIgnored() );
@@ -132,7 +132,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportTeiReport );
         assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
-        assertTrue( trackerImportTeiReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportTeiReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 1, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getIgnored() );
@@ -156,7 +156,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportTeiReport );
         assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
-        assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrors().size() );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 1, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 1, trackerImportTeiReport.getStats().getIgnored() );
@@ -178,7 +178,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -200,7 +200,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -212,7 +212,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         trackerImportEnrollmentReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -240,7 +240,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -269,7 +269,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getErrors().size() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -294,7 +294,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEventReport );
         assertEquals( TrackerStatus.OK, trackerImportEventReport.getStatus() );
-        assertTrue( trackerImportEventReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportEventReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEventReport.getStats().getIgnored() );
@@ -324,7 +324,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEventReport );
         assertEquals( TrackerStatus.OK, trackerImportEventReport.getStatus() );
-        assertTrue( trackerImportEventReport.getValidationReport().getErrorReports().isEmpty() );
+        assertTrue( trackerImportEventReport.getValidationReport().getErrors().isEmpty() );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEventReport.getStats().getIgnored() );
@@ -356,7 +356,7 @@ class ReportSummaryIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportEventReport );
         assertEquals( TrackerStatus.OK, trackerImportEventReport.getStatus() );
-        assertEquals( 1, trackerImportEventReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportEventReport.getValidationReport().getErrors().size() );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 1, trackerImportEventReport.getStats().getIgnored() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/params/AtomicModeIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/params/AtomicModeIntegrationTest.java
@@ -114,7 +114,7 @@ class AtomicModeIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportTeiReport );
         assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
-        assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrors().size() );
         assertNotNull( trackedEntityInstanceService.getTrackedEntityInstance( "VALIDTEIAAA" ) );
         assertNull( trackedEntityInstanceService.getTrackedEntityInstance( "INVALIDTEIA" ) );
     }
@@ -131,7 +131,7 @@ class AtomicModeIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportTeiReport );
         assertEquals( TrackerStatus.ERROR, trackerImportTeiReport.getStatus() );
-        assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrors().size() );
         assertNull( trackedEntityInstanceService.getTrackedEntityInstance( "VALIDTEIAAA" ) );
         assertNull( trackedEntityInstanceService.getTrackedEntityInstance( "INVALIDTEIA" ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -166,7 +166,7 @@ class ProgramRuleIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportReport );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 1, trackerImportReport.getValidationReport().getWarningReports().size() );
+        assertEquals( 1, trackerImportReport.getValidationReport().getWarnings().size() );
     }
 
     @Test
@@ -185,7 +185,7 @@ class ProgramRuleIntegrationTest extends TransactionalIntegrationTest
         assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
         assertNotNull( trackerImportEnrollmentReport );
         assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getWarningReports().size() );
+        assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getWarnings().size() );
     }
 
     @Test
@@ -198,7 +198,7 @@ class ProgramRuleIntegrationTest extends TransactionalIntegrationTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportReport );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        List<TrackerWarningReport> warningReports = trackerImportReport.getValidationReport().getWarningReports();
+        List<TrackerWarningReport> warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 4, warningReports.size() );
         assertEquals( 3,
             warningReports.stream().filter( w -> w.getTrackerType().equals( TrackerType.EVENT ) ).count() );
@@ -211,7 +211,7 @@ class ProgramRuleIntegrationTest extends TransactionalIntegrationTest
         trackerImportReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportReport );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        warningReports = trackerImportReport.getValidationReport().getWarningReports();
+        warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 3, warningReports.size() );
         assertEquals( TrackerErrorCode.E1308, warningReports.get( 0 ).getWarningCode() );
         assertEquals(
@@ -224,7 +224,7 @@ class ProgramRuleIntegrationTest extends TransactionalIntegrationTest
         trackerImportReport = trackerImportService.importTracker( params );
         assertNotNull( trackerImportReport );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        warningReports = trackerImportReport.getValidationReport().getWarningReports();
+        warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 3, warningReports.size() );
         assertEquals( TrackerErrorCode.E1308, warningReports.get( 0 ).getWarningCode() );
         assertEquals(

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -80,7 +80,7 @@ class TrackerBundleImportReportTest extends DhisSpringTest
         assertNotNull( report.getValidationReport() );
         assertTrue( report.getValidationReport().hasErrors() );
         assertFalse( report.getValidationReport().hasWarnings() );
-        assertFalse( report.getValidationReport().hasPerfs() );
+        assertFalse( report.getValidationReport().hasTimings() );
         assertNull( report.getTimingsStats() );
     }
 
@@ -95,7 +95,7 @@ class TrackerBundleImportReportTest extends DhisSpringTest
         assertNotNull( report.getValidationReport() );
         assertTrue( report.getValidationReport().hasErrors() );
         assertTrue( report.getValidationReport().hasWarnings() );
-        assertFalse( report.getValidationReport().hasPerfs() );
+        assertFalse( report.getValidationReport().hasTimings() );
         assertNull( report.getTimingsStats() );
     }
 
@@ -110,7 +110,7 @@ class TrackerBundleImportReportTest extends DhisSpringTest
         assertNotNull( report.getValidationReport() );
         assertTrue( report.getValidationReport().hasErrors() );
         assertTrue( report.getValidationReport().hasWarnings() );
-        assertTrue( report.getValidationReport().hasPerfs() );
+        assertTrue( report.getValidationReport().hasTimings() );
         assertNotNull( report.getTimingsStats() );
         assertEquals( "1 sec.", report.getTimingsStats().getProgramRule() );
         assertEquals( "2 sec.", report.getTimingsStats().getCommit() );
@@ -272,7 +272,7 @@ class TrackerBundleImportReportTest extends DhisSpringTest
             new TrackerErrorReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) );
         report.addWarning(
             new TrackerWarningReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) );
-        report.addPerfReport( new TrackerValidationHookTimerReport( "1min", "validation" ) );
+        report.addTiming( new Timing( "1min", "validation" ) );
         return report;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -204,21 +204,21 @@ class TrackerBundleImportReportTest extends DhisSpringTest
             deserializedReportTrackerTypeReport.getObjectReports() );
         assertEquals( serializedReportTrackerTypeReport.getStats(), deserializedReportTrackerTypeReport.getStats() );
         // Verify Validation Report - Error Reports
-        assertEquals( toSerializeReport.getValidationReport().getErrorReports().get( 0 ).getErrorMessage(),
-            deserializedReport.getValidationReport().getErrorReports().get( 0 ).getErrorMessage() );
-        assertEquals( toSerializeReport.getValidationReport().getErrorReports().get( 0 ).getErrorCode(),
-            deserializedReport.getValidationReport().getErrorReports().get( 0 ).getErrorCode() );
-        assertEquals( toSerializeReport.getValidationReport().getErrorReports().get( 0 ).getUid(),
-            deserializedReport.getValidationReport().getErrorReports().get( 0 ).getUid() );
+        assertEquals( toSerializeReport.getValidationReport().getErrors().get( 0 ).getErrorMessage(),
+            deserializedReport.getValidationReport().getErrors().get( 0 ).getErrorMessage() );
+        assertEquals( toSerializeReport.getValidationReport().getErrors().get( 0 ).getErrorCode(),
+            deserializedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
+        assertEquals( toSerializeReport.getValidationReport().getErrors().get( 0 ).getUid(),
+            deserializedReport.getValidationReport().getErrors().get( 0 ).getUid() );
         // Verify Validation Report - Warning Reports
-        assertEquals( toSerializeReport.getValidationReport().getWarningReports().get( 0 ).getWarningMessage(),
-            deserializedReport.getValidationReport().getWarningReports().get( 0 ).getWarningMessage() );
-        assertEquals( toSerializeReport.getValidationReport().getWarningReports().get( 0 ).getWarningCode(),
-            deserializedReport.getValidationReport().getWarningReports().get( 0 ).getWarningCode() );
-        assertEquals( toSerializeReport.getValidationReport().getWarningReports().get( 0 ).getUid(),
-            deserializedReport.getValidationReport().getWarningReports().get( 0 ).getUid() );
-        assertEquals( toSerializeReport.getValidationReport().getWarningReports().get( 0 ).getTrackerType(),
-            deserializedReport.getValidationReport().getWarningReports().get( 0 ).getTrackerType() );
+        assertEquals( toSerializeReport.getValidationReport().getWarnings().get( 0 ).getWarningMessage(),
+            deserializedReport.getValidationReport().getWarnings().get( 0 ).getWarningMessage() );
+        assertEquals( toSerializeReport.getValidationReport().getWarnings().get( 0 ).getWarningCode(),
+            deserializedReport.getValidationReport().getWarnings().get( 0 ).getWarningCode() );
+        assertEquals( toSerializeReport.getValidationReport().getWarnings().get( 0 ).getUid(),
+            deserializedReport.getValidationReport().getWarnings().get( 0 ).getUid() );
+        assertEquals( toSerializeReport.getValidationReport().getWarnings().get( 0 ).getTrackerType(),
+            deserializedReport.getValidationReport().getWarnings().get( 0 ).getTrackerType() );
         // Verify TimingsStats
         assertEquals( toSerializeReport.getTimingsStats().getCommit(),
             deserializedReport.getTimingsStats().getCommit() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -157,10 +157,9 @@ class TrackerBundleImportReportTest extends DhisSpringTest
         TrackerValidationReport tvr = new TrackerValidationReport();
         // Error Reports - Validation Report
         tvr.addError( new TrackerErrorReport( "Could not find OrganisationUnit: ``, linked to Tracked Entity.",
-            TrackerErrorCode.E1049, TRACKED_ENTITY, "BltTZV9HvEZ" ) );
-        // Warning Reports - Validation Report
-        tvr.addWarning( new TrackerWarningReport( "ProgramStage `l8oDIfJJhtg` does not allow user assignment",
-            TrackerErrorCode.E1120, TrackerType.EVENT, "BltTZV9HvEZ" ) );
+            TrackerErrorCode.E1049, TRACKED_ENTITY, "BltTZV9HvEZ" ) )
+            .addWarning( new TrackerWarningReport( "ProgramStage `l8oDIfJJhtg` does not allow user assignment",
+                TrackerErrorCode.E1120, TrackerType.EVENT, "BltTZV9HvEZ" ) );
         // Create the TrackerImportReport
         final Map<TrackerType, Integer> bundleSize = new HashMap<>();
         bundleSize.put( TRACKED_ENTITY, 1 );
@@ -267,13 +266,12 @@ class TrackerBundleImportReportTest extends DhisSpringTest
 
     private TrackerValidationReport createValidationReport()
     {
-        TrackerValidationReport report = new TrackerValidationReport();
-        report.addError(
-            new TrackerErrorReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) );
-        report.addWarning(
-            new TrackerWarningReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) );
-        report.addTiming( new Timing( "1min", "validation" ) );
-        return report;
+        return new TrackerValidationReport()
+            .addError(
+                new TrackerErrorReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) )
+            .addWarning(
+                new TrackerWarningReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) )
+            .addTiming( new Timing( "1min", "validation" ) );
     }
 
     private TrackerBundleReport createBundleReport()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
@@ -148,7 +148,7 @@ class TrackerValidationReportTest
 
         TrackerValidationReport report = new TrackerValidationReport();
 
-        assertFalse( report.hasPerfs() );
+        assertFalse( report.hasTimings() );
     }
 
     @Test
@@ -157,9 +157,9 @@ class TrackerValidationReportTest
 
         TrackerValidationReport report = new TrackerValidationReport();
 
-        report.addPerfReport( new TrackerValidationHookTimerReport( "1min", "validation" ) );
+        report.addTiming( new Timing( "1min", "validation" ) );
 
-        assertTrue( report.hasPerfs() );
+        assertTrue( report.hasTimings() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
@@ -53,13 +53,13 @@ class TrackerValidationReportTest
 
         report.addError( error );
 
-        assertNotNull( report.getErrorReports() );
-        assertEquals( 1, report.getErrorReports().size() );
-        assertContainsOnly( report.getErrorReports(), error );
+        assertNotNull( report.getErrors() );
+        assertEquals( 1, report.getErrors().size() );
+        assertContainsOnly( report.getErrors(), error );
 
         report.addError( error );
 
-        assertEquals( 1, report.getErrorReports().size() );
+        assertEquals( 1, report.getErrors().size() );
     }
 
     @Test
@@ -82,13 +82,13 @@ class TrackerValidationReportTest
 
         report.addWarning( warning );
 
-        assertNotNull( report.getWarningReports() );
-        assertEquals( 1, report.getWarningReports().size() );
-        assertContainsOnly( report.getWarningReports(), warning );
+        assertNotNull( report.getWarnings() );
+        assertEquals( 1, report.getWarnings().size() );
+        assertContainsOnly( report.getWarnings(), warning );
 
         report.addWarning( warning );
 
-        assertEquals( 1, report.getWarningReports().size() );
+        assertEquals( 1, report.getWarnings().size() );
     }
 
     @Test
@@ -219,8 +219,8 @@ class TrackerValidationReportTest
         report.addError( error2 );
         report.addError( error3 );
 
-        assertNotNull( report.getErrorReports() );
-        assertEquals( 3, report.getErrorReports().size() );
+        assertNotNull( report.getErrors() );
+        assertEquals( 3, report.getErrors().size() );
         assertEquals( 2, report.size() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collections;
+import java.util.List;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.tracker.TrackerType;
@@ -63,14 +63,20 @@ class TrackerValidationReportTest
     }
 
     @Test
-    void addErrorsDoesNotAddNull()
+    void addErrorsIfTheyDoNotExist()
     {
 
         TrackerValidationReport report = new TrackerValidationReport();
+        TrackerErrorReport error1 = newError( CodeGenerator.generateUid(), TrackerErrorCode.E1001 );
+        TrackerErrorReport error2 = newError( CodeGenerator.generateUid(), TrackerErrorCode.E1002 );
 
-        report.addErrors( Collections.emptyList() );
+        report.addError( error1 );
 
-        assertFalse( report.hasErrors() );
+        assertContainsOnly( report.getErrors(), error1 );
+
+        report.addErrors( List.of( error1, error2 ) );
+
+        assertContainsOnly( report.getErrors(), error1, error2 );
     }
 
     @Test
@@ -92,14 +98,20 @@ class TrackerValidationReportTest
     }
 
     @Test
-    void addWarningsDoesNotAddNull()
+    void addWarningsIfTheyDoNotExist()
     {
 
         TrackerValidationReport report = new TrackerValidationReport();
+        TrackerWarningReport warning1 = newWarning( CodeGenerator.generateUid(), TrackerErrorCode.E1001 );
+        TrackerWarningReport warning2 = newWarning( CodeGenerator.generateUid(), TrackerErrorCode.E1002 );
 
-        report.addWarnings( Collections.emptyList() );
+        report.addWarning( warning1 );
 
-        assertFalse( report.hasWarnings() );
+        assertContainsOnly( report.getWarnings(), warning1 );
+
+        report.addWarnings( List.of( warning1, warning2 ) );
+
+        assertContainsOnly( report.getWarnings(), warning1, warning2 );
     }
 
     @Test
@@ -215,9 +227,10 @@ class TrackerValidationReportTest
         TrackerErrorReport error2 = newError( error1.getUid(), TrackerErrorCode.E1000 );
         TrackerErrorReport error3 = newError( CodeGenerator.generateUid(), TrackerErrorCode.E1000 );
 
-        report.addError( error1 );
-        report.addError( error2 );
-        report.addError( error3 );
+        report
+            .addError( error1 )
+            .addError( error2 )
+            .addError( error3 );
 
         assertNotNull( report.getErrors() );
         assertEquals( 3, report.getErrors().size() );
@@ -268,11 +281,16 @@ class TrackerValidationReportTest
 
     private TrackerWarningReport newWarning()
     {
-        return newWarning( TrackerErrorCode.E9999 );
+        return newWarning( CodeGenerator.generateUid(), TrackerErrorCode.E9999 );
     }
 
     private TrackerWarningReport newWarning( TrackerErrorCode code )
     {
-        return new TrackerWarningReport( "", code, TrackerType.EVENT, CodeGenerator.generateUid() );
+        return newWarning( CodeGenerator.generateUid(), code );
+    }
+
+    private TrackerWarningReport newWarning( String uid, TrackerErrorCode code )
+    {
+        return new TrackerWarningReport( "", code, TrackerType.EVENT, uid );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
@@ -70,7 +70,7 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
         setUpMetadata( "tracker/tracker_basic_metadata_mandatory_attr.json" );
         TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data_2.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
     }
@@ -83,8 +83,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_with_invalid_option_value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
     }
 
@@ -96,7 +96,7 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_with_valid_option_value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -107,8 +107,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_attr-missing-uuid.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1075 ) ) ) );
     }
 
@@ -120,8 +120,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_attr-missing-value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1076 ) ) ) );
     }
 
@@ -138,8 +138,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
         trackedEntityAttributeService.deleteTrackedEntityAttribute( sTJvSLN7Kcb );
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_attr-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1006 ) ) ) );
     }
 
@@ -151,8 +151,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_attr-missing-mandatory.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1018 ) ) ) );
     }
 
@@ -164,7 +164,7 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -173,21 +173,21 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
         manager.clear();
         params = createBundleFromJson( "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         manager.flush();
         manager.clear();
         params = createBundleFromJson( "tracker/validations/enrollments_te_unique_attr_in_db.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
     }
 
@@ -197,15 +197,15 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
         manager.clear();
         params = createBundleFromJson( "tracker/validations/enrollments_te_unique_attr.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
     }
 
@@ -217,8 +217,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_attr-only-program-attr.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -87,7 +87,7 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 
@@ -98,7 +98,7 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         TrackerImportParams secondParams = createBundleFromJson(
             "tracker/validations/enrollments_te_enrollments-data.json" );
@@ -125,8 +125,8 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 4, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
     }
 
@@ -138,8 +138,8 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_error_non_program_attr.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 3, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 3, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
     }
 
@@ -152,8 +152,8 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getBundleReport().getTypeReportMap().get( TrackerType.ENROLLMENT )
             .getObjectReportMap().values().size() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
     }
 
@@ -166,7 +166,7 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
             TrackerImportParams.class );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
         importProgramStageInstances();
@@ -178,10 +178,10 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         params.setUser( user2 );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
         TrackerImportReport trackerImportDeleteReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportDeleteReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportDeleteReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportDeleteReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportDeleteReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1103 ) ) ) );
-        assertThat( trackerImportDeleteReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportDeleteReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1091 ) ) ) );
     }
 
@@ -191,7 +191,7 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/events-data.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 
@@ -203,13 +203,13 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_double-tei-enrollment_part1.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         TrackerValidationReport validationReport = trackerImportReport.getValidationReport();
-        assertEquals( 0, validationReport.getErrorReports().size() );
+        assertEquals( 0, validationReport.getErrors().size() );
         TrackerImportParams trackerImportParams1 = createBundleFromJson(
             "tracker/validations/enrollments_double-tei-enrollment_part2.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams1 );
         validationReport = trackerImportReport.getValidationReport();
-        assertEquals( 1, validationReport.getErrorReports().size() );
-        assertThat( validationReport.getErrorReports(),
+        assertEquals( 1, validationReport.getErrors().size() );
+        assertThat( validationReport.getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
     }
 
@@ -223,7 +223,7 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_bad-note-no-value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -213,7 +213,7 @@ class EnrollmentSecurityImportValidationTest extends AbstractImportValidationTes
         User user = userService.getUser( ADMIN_USER_UID );
         trackerBundleParams.setUserId( user.getUid() );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 
@@ -226,8 +226,8 @@ class EnrollmentSecurityImportValidationTest extends AbstractImportValidationTes
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 4, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
     }
 
@@ -247,8 +247,8 @@ class EnrollmentSecurityImportValidationTest extends AbstractImportValidationTes
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1104 ) ) ) );
     }
 
@@ -268,8 +268,8 @@ class EnrollmentSecurityImportValidationTest extends AbstractImportValidationTes
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1091 ) ) ) );
     }
 
@@ -289,7 +289,7 @@ class EnrollmentSecurityImportValidationTest extends AbstractImportValidationTes
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -308,8 +308,8 @@ class EnrollmentSecurityImportValidationTest extends AbstractImportValidationTes
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1104 ) ) ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -127,14 +127,14 @@ class EventImportValidationTest extends AbstractImportValidationTest
         User user = userService.getUser( ADMIN_USER_UID );
         trackerImportParams.setUser( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         trackerImportParams = renderService.fromJson(
             new ClassPathResource( "tracker/validations/enrollments_te_enrollments-data.json" ).getInputStream(),
             TrackerImportParams.class );
         trackerImportParams.setUser( user );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 
@@ -146,8 +146,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/events-with_invalid_option_value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
     }
 
@@ -158,7 +158,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/events-with_valid_option_value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -169,7 +169,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -181,11 +181,11 @@ class EventImportValidationTest extends AbstractImportValidationTest
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         trackerBundleParams.setImportStrategy( UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -198,14 +198,14 @@ class EventImportValidationTest extends AbstractImportValidationTest
         trackerImportParams.setUser( user );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 4, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1099 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1104 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1096 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1095 ) ) ) );
     }
 
@@ -218,8 +218,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
         trackerBundleParams.setUser( user );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
     }
 
@@ -232,13 +232,13 @@ class EventImportValidationTest extends AbstractImportValidationTest
             userService.getUser( ADMIN_USER_UID ) );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         trackerImportParams = fromJson( "tracker/validations/events_non-repeatable-programstage_part2.json",
             userService.getUser( ADMIN_USER_UID ) );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1039 ) ) ) );
     }
 
@@ -257,8 +257,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/events_non-default-combo.json" );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1055 ) ) ) );
     }
 
@@ -270,8 +270,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/events_cant-find-cat-opt-combo.json" );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1115 ) ) ) );
     }
 
@@ -283,8 +283,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/events_cant-find-cat-option.json" );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1116 ) ) ) );
     }
 
@@ -296,8 +296,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/events_cant-find-cat-option-combo-set.json" );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1117 ) ) ) );
     }
 
@@ -309,10 +309,10 @@ class EventImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/events_combo-date-wrong.json" );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1056 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1057 ) ) ) );
     }
 
@@ -388,8 +388,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         // When
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1082 ) ) ) );
     }
 
@@ -403,7 +403,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         // Then
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         return trackerImportReport;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -140,14 +140,14 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         User user = userService.getUser( "M5zQapPyTZI" );
         trackerBundleParams.setUser( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         trackerBundleParams = renderService.fromJson(
             new ClassPathResource( "tracker/validations/enrollments_te_enrollments-data.json" ).getInputStream(),
             TrackerImportParams.class );
         trackerBundleParams.setUser( user );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
     }
@@ -244,10 +244,10 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         user.addOrganisationUnit( organisationUnitA );
         manager.update( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1095 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1096 ) ) ) );
     }
 
@@ -259,7 +259,7 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/events_error-no-uncomplete.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         // Change just inserted Event to status COMPLETED...
         ProgramStageInstance zwwuwNp6gVd = programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" );
@@ -281,8 +281,8 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         trackerBundleParams.setUserId( user.getUid() );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1083 ) ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
@@ -127,8 +127,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         assertTrue( fileResource.isAssigned() );
         trackerImportParams = createBundleFromJson( "tracker/validations/te-program_with_tea_fileresource_data2.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1009 ) ) ) );
     }
 
@@ -140,8 +140,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         TrackerImportParams trackerImportParams = createBundleFromJson(
             "tracker/validations/te-program_with_tea_fileresource_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1084 ) ) ) );
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 0, trackedEntityInstances.size() );
@@ -155,8 +155,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         TrackerImportParams trackerImportParams = createBundleFromJson(
             "tracker/validations/te-program_with_tea_too_long_text_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1077 ) ) ) );
     }
 
@@ -170,8 +170,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         H2DhisConfigurationProvider dhisConfigurationProvider = (H2DhisConfigurationProvider) this.dhisConfigurationProvider;
         dhisConfigurationProvider.setEncryptionStatus( EncryptionStatus.MISSING_ENCRYPTION_PASSWORD );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1112 ) ) ) );
     }
 
@@ -187,11 +187,11 @@ class TeTaValidationTest extends AbstractImportValidationTest
             "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         trackerImportParams = createBundleFromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_region.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -204,8 +204,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         trackerImportParams = createBundleFromJson( "tracker/validations/te-program_with_tea_unique_data2.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
     }
 
@@ -217,8 +217,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         TrackerImportParams trackerImportParams = createBundleFromJson(
             "tracker/validations/te-program_with_tea_invalid_format_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1085 ) ) ) );
     }
 
@@ -230,10 +230,10 @@ class TeTaValidationTest extends AbstractImportValidationTest
         TrackerImportParams trackerImportParams = createBundleFromJson(
             "tracker/validations/te-program_with_tea_invalid_image_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1085 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1007 ) ) ) );
     }
 
@@ -245,8 +245,8 @@ class TeTaValidationTest extends AbstractImportValidationTest
         TrackerImportParams trackerImportParams = createBundleFromJson(
             "tracker/validations/te-program_with_tea_invalid_value_isnull.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1076 ) ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
@@ -119,8 +119,8 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/te-with_invalid_option_value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
     }
 
@@ -131,7 +131,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/te-with_valid_option_value.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -141,8 +141,8 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/te-with_unique_attributes.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
     }
 
@@ -153,7 +153,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/te-data_with_different_ou.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 
@@ -167,10 +167,10 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         params.setAtomicMode( AtomicMode.OBJECT );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( 2, trackerImportReport.getStats().getCreated() );
         assertEquals( 1, trackerImportReport.getStats().getIgnored() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             IsCollectionContaining.hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
     }
 
@@ -182,7 +182,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( 3, trackerImportReport.getStats().getCreated() );
         // For some reason teiSearchOrgunits is not created properly from
         // metadata
@@ -198,7 +198,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setAtomicMode( AtomicMode.OBJECT );
         trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( 3, trackerImportReport.getStats().getUpdated() );
     }
 
@@ -210,7 +210,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( 3, trackerImportReport.getStats().getCreated() );
         dbmsManager.clearSession();
         params = createBundleFromJson( "tracker/validations/te-data_with_different_ou.json" );
@@ -219,10 +219,10 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         params.setAtomicMode( AtomicMode.OBJECT );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( 2, trackerImportReport.getStats().getUpdated() );
         assertEquals( 1, trackerImportReport.getStats().getIgnored() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             IsCollectionContaining.hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1003 ) ) ) );
     }
 
@@ -235,8 +235,8 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 13, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 13, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1001 ) ) ) );
     }
 
@@ -252,7 +252,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         injectSecurityContext( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 
@@ -263,7 +263,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/te-data_error_geo-ok.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
 
     @Test
@@ -273,8 +273,8 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/te-data_error_attr-non-existing.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1006 ) ) ) );
     }
 
@@ -285,7 +285,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_te-data.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         importProgramInstances();
         manager.flush();
@@ -297,8 +297,8 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         params.setUser( user2 );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrorReports().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrorReports(),
+        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1100 ) ) ) );
     }
 
@@ -308,7 +308,7 @@ class TrackedEntityImportValidationTest extends AbstractImportValidationTest
         TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrorReports().size() );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationOrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationOrderTest.java
@@ -71,7 +71,7 @@ class TrackerValidationOrderTest extends DhisSpringTest
         TrackerValidationReport report = trackerValidationService.validate( bundle );
 
         assertTrue( report.hasErrors() );
-        assertEquals( 1, report.getErrorReports().size() );
-        assertEquals( E1048, report.getErrorReports().get( 0 ).getErrorCode() );
+        assertEquals( 1, report.getErrors().size() );
+        assertEquals( E1048, report.getErrors().get( 0 ).getErrorCode() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackerValidationServiceReportTest.java
@@ -166,11 +166,11 @@ class TrackerValidationServiceReportTest
         TrackerValidationReport report = validationService.validate( bundle );
 
         assertTrue( report.hasErrors() );
-        assertEquals( 2, report.getErrorReports().size() );
-        assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
+        assertEquals( 2, report.getErrors().size() );
+        assertTrue( report.getErrors().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
             && TrackerType.EVENT == err.getTrackerType()
             && invalidEvent.getUid().equals( err.getUid() ) ) );
-        assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1069 == err.getErrorCode()
+        assertTrue( report.getErrors().stream().anyMatch( err -> TrackerErrorCode.E1069 == err.getErrorCode()
             && TrackerType.ENROLLMENT == err.getTrackerType()
             && invalidEnrollment.getUid().equals( err.getUid() ) ) );
 
@@ -231,7 +231,7 @@ class TrackerValidationServiceReportTest
         TrackerValidationReport report = validationService.validate( bundle );
 
         assertTrue( report.hasErrors() );
-        assertTrue( report.getErrorReports().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
+        assertTrue( report.getErrors().stream().anyMatch( err -> TrackerErrorCode.E1032 == err.getErrorCode()
             && TrackerType.EVENT == err.getTrackerType()
             && invalidEvent.getUid().equals( err.getUid() ) ) );
 
@@ -275,9 +275,9 @@ class TrackerValidationServiceReportTest
         TrackerValidationReport report = validationService.validate( bundle );
 
         assertFalse( report.hasErrors() );
-        assertNotNull( report.getWarningReports() );
-        assertEquals( 1, report.getWarningReports().size() );
-        assertTrue( report.getWarningReports().stream().anyMatch( err -> TrackerErrorCode.E1120 == err.getWarningCode()
+        assertNotNull( report.getWarnings() );
+        assertEquals( 1, report.getWarnings().size() );
+        assertTrue( report.getWarnings().stream().anyMatch( err -> TrackerErrorCode.E1120 == err.getWarningCode()
             && TrackerType.EVENT == err.getTrackerType()
             && validEvent.getUid().equals( err.getUid() ) ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ValidateAndCommitTestUnit.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ValidateAndCommitTestUnit.java
@@ -82,7 +82,7 @@ public class ValidateAndCommitTestUnit
 
         validationReport = trackerValidationService.validate( trackerBundle );
 
-        if ( validationReport.getErrorReports().isEmpty() || forceCommit )
+        if ( validationReport.getErrors().isEmpty() || forceCommit )
         {
             try
             {


### PR DESCRIPTION
* as proposed by @jbee : make the add methods of TrackerValidationReport add methods fluent
* consistently name getters like add methods so getErrors, getWarnings instead of getErrorReports, ...
* rename TrackerValidationHookTimerReport to Timing as that's enough to describe what it represents
* Timing only has 2 fields, so a required arg constructor suffices. The fields are public and exposed in the JSON. I made them final so they cannot be set to something else (at least not without really wanting it).
* added missing test for addErrors, addWarnings