### PR TITLE
fix: refer and set to property name in user object bundle errors [DHIS2-12336]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -75,12 +75,16 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
     {
         if ( bundle.getImportMode().isCreate() && !ValidationUtils.usernameIsValid( user.getUsername() ) )
         {
-            addReports.accept( new ErrorReport( User.class, ErrorCode.E4049, "Username", user.getUsername() ) );
+            addReports.accept(
+                new ErrorReport( User.class, ErrorCode.E4049, "username", user.getUsername() )
+                    .setErrorProperty( "username" ) );
         }
 
         if ( user.getWhatsApp() != null && !ValidationUtils.validateWhatsapp( user.getWhatsApp() ) )
         {
-            addReports.accept( new ErrorReport( User.class, ErrorCode.E4027, user.getWhatsApp(), "Whatsapp" ) );
+            addReports.accept(
+                new ErrorReport( User.class, ErrorCode.E4027, user.getWhatsApp(), "whatsapp" )
+                    .setErrorProperty( "whatsapp" ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -83,8 +83,8 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
         if ( user.getWhatsApp() != null && !ValidationUtils.validateWhatsapp( user.getWhatsApp() ) )
         {
             addReports.accept(
-                new ErrorReport( User.class, ErrorCode.E4027, user.getWhatsApp(), "whatsapp" )
-                    .setErrorProperty( "whatsapp" ) );
+                new ErrorReport( User.class, ErrorCode.E4027, user.getWhatsApp(), "whatsApp" )
+                    .setErrorProperty( "whatsApp" ) );
         }
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonErrorReport.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonErrorReport.java
@@ -59,6 +59,11 @@ public interface JsonErrorReport extends JsonObject
         return getString( "errorKlass" ).parsedClass();
     }
 
+    default String getErrorProperty()
+    {
+        return getString( "errorProperty" ).string();
+    }
+
     default List<String> getErrorProperties()
     {
         return getArray( "errorProperties" ).stringValues();


### PR DESCRIPTION
Sets the correct property name in the validation errors for `username` and `whatsApp` validation.

Added/extended unit tests to verify.