### PR TITLE
feat: Support event headers as GET param [DHIS2-12314]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -53,6 +53,13 @@ public class EnrollmentAnalyticsQueryCriteria
 
     private Set<String> filter;
 
+    /**
+     * This parameter selects the headers to be returned as part of the
+     * response. The implementation for this Set will be LinkedHashSet as the
+     * ordering is important.
+     */
+    private Set<String> headers;
+
     private OrganisationUnitSelectionMode ouMode;
 
     private Set<String> asc;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.common;
 
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
@@ -57,6 +58,8 @@ public class EventDataQueryRequest
     private Set<String> dimension;
 
     private Set<String> filter;
+
+    private Set<String> headers;
 
     private String value;
 
@@ -141,6 +144,7 @@ public class EventDataQueryRequest
         queryRequest.endDate = this.endDate;
         queryRequest.dimension = new HashSet<>( this.dimension );
         queryRequest.filter = new HashSet<>( this.filter );
+        queryRequest.headers = new LinkedHashSet<>( this.headers );
         queryRequest.value = this.value;
         queryRequest.aggregationType = this.aggregationType;
         queryRequest.skipMeta = this.skipMeta;
@@ -201,6 +205,7 @@ public class EventDataQueryRequest
                 .endDate( criteria.getEndDate() )
                 .eventStatus( criteria.getEventStatus() )
                 .filter( criteria.getFilter() )
+                .headers( criteria.getHeaders() )
                 .hierarchyMeta( criteria.isHierarchyMeta() )
                 .includeMetadataDetails( criteria.isIncludeMetadataDetails() )
                 .limit( criteria.getLimit() )
@@ -233,9 +238,9 @@ public class EventDataQueryRequest
             return startDate( criteria.getStartDate() )
                 .timeField( criteria.getTimeField() )
                 .endDate( criteria.getEndDate() )
-                .dimension(
-                    criteria.getDimension() )
+                .dimension( criteria.getDimension() )
                 .filter( criteria.getFilter() )
+                .headers( criteria.getHeaders() )
                 .ouMode( criteria.getOuMode() )
                 .asc( criteria.getAsc() )
                 .desc( criteria.getDesc() )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -81,6 +81,13 @@ public class EventsAnalyticsQueryCriteria
     private Set<String> filter;
 
     /**
+     * This parameter selects the headers to be returned as part of the
+     * response. The implementation for this Set will be LinkedHashSet as the
+     * ordering is important.
+     */
+    private Set<String> headers;
+
+    /**
      * Whether to include names of organisation unit ancestors and hierarchy
      * paths of organisation units in the metadata.
      */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
@@ -501,4 +501,31 @@ public interface Grid
      *        no limit.
      */
     Grid addRows( SqlRowSet rs, int maxLimit );
+
+    /**
+     * This method will keep, in the Grid, only the given list of headers. All
+     * other GridHeaders and respective columns will be removed from the Grid.
+     *
+     * @param headers
+     */
+    void keepOnlyThese( final Set<String> headers );
+
+    /**
+     * Re-order the GridHeaders of current Grid based on the List headers. The
+     * final Grid will have the all its headers defined in the same order as the
+     * given List of headers.
+     *
+     * @param headers
+     * @return a Set of indexes that holds the holds the new order
+     */
+    Set<Integer> repositionHeaders( final Set<String> headers );
+
+    /**
+     * Based on the given column indexes, this method will order the current
+     * columns in the Grid. The new positions of the columns will respect the
+     * new indexes.
+     *
+     * @param newColumnsIndexes
+     */
+    void repositionColumns( final Set<Integer> newColumnsIndexes );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -321,7 +321,8 @@ public enum ErrorCode
     E7226( "Dimension is not a valid query item: `{0}`" ),
     E7227( "Relationship entity type not supported: `{0}`" ),
     E7228( "Fallback coordinate field is invalid: `{0}` " ),
-    E7229( "Operator '{0}' does not allow missing value" ),
+    E7229( "Operator `{0}` does not allow missing value" ),
+    E7230( "Header param `{0}` does not exist" ),
 
     /* Org unit analytics */
     E7300( "At least one organisation unit must be specified" ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.event;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
@@ -38,6 +39,7 @@ import static org.hisp.dhis.common.FallbackCoordinateFieldType.PSI_GEOMETRY;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -116,6 +118,11 @@ public class EventQueryParams
      * The query item filters.
      */
     private List<QueryItem> itemFilters = new ArrayList<>();
+
+    /**
+     * The headers.
+     */
+    protected Set<String> headers = new LinkedHashSet<>();
 
     /**
      * The dimensional object for which to produce aggregated data.
@@ -269,6 +276,7 @@ public class EventQueryParams
 
         params.dimensions = new ArrayList<>( this.dimensions );
         params.filters = new ArrayList<>( this.filters );
+        params.headers = new LinkedHashSet<>( this.headers );
         params.includeNumDen = this.includeNumDen;
         params.displayProperty = this.displayProperty;
         params.aggregationType = this.aggregationType;
@@ -396,6 +404,7 @@ public class EventQueryParams
 
         items.forEach( e -> key.add( "item", "[" + e.getKey() + "]" ) );
         itemFilters.forEach( e -> key.add( "itemFilter", "[" + e.getKey() + "]" ) );
+        headers.forEach( header -> key.add( "headers", "[" + header + "]" ) );
         itemProgramIndicators.forEach( e -> key.add( "itemProgramIndicator", e.getUid() ) );
         asc.forEach( e -> e.getUid() );
         desc.forEach( e -> e.getUid() );
@@ -820,6 +829,11 @@ public class EventQueryParams
         return getFilterPeriods().size() > 0;
     }
 
+    public boolean hasHeaders()
+    {
+        return isNotEmpty( getHeaders() );
+    }
+
     /**
      * Indicates whether the program of this query requires registration of
      * tracked entity instances.
@@ -889,6 +903,11 @@ public class EventQueryParams
     public List<QueryItem> getItemFilters()
     {
         return itemFilters;
+    }
+
+    public Set<String> getHeaders()
+    {
+        return headers;
     }
 
     public DimensionalItemObject getValue()
@@ -1118,6 +1137,16 @@ public class EventQueryParams
         public Builder addFilter( DimensionalObject filter )
         {
             this.params.addFilter( filter );
+            return this;
+        }
+
+        public Builder withHeaders( Set<String> headers )
+        {
+            if ( isNotEmpty( headers ) )
+            {
+                this.params.headers.addAll( headers );
+            }
+
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -28,7 +28,11 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.*;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_HIERARCHY;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_NAME_HIERARCHY;
+import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.PAGER;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
@@ -49,7 +53,15 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.calendar.Calendar;
-import org.hisp.dhis.common.*;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.MetadataItem;
+import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
@@ -169,12 +181,23 @@ public abstract class AbstractAnalyticsService
             grid.getMetaData().put( PAGER.getKey(), pager );
         }
 
+        maybeApplyHeaders( params, grid );
+
         return grid;
     }
 
     protected abstract Grid createGridWithHeaders( EventQueryParams params );
 
     protected abstract long addEventData( Grid grid, EventQueryParams params );
+
+    private void maybeApplyHeaders( final EventQueryParams params, final Grid grid )
+    {
+        if ( params.hasHeaders() )
+        {
+            grid.keepOnlyThese( params.getHeaders() );
+            grid.repositionColumns( grid.repositionHeaders( params.getHeaders() ) );
+        }
+    }
 
     /**
      * Adds meta data values to the given grid based on the given data query

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -251,6 +251,7 @@ public class DefaultEventDataQueryService
             .withOrgUnitField( request.getOrgUnitField() )
             .withCoordinateField( getCoordinateField( request.getCoordinateField() ) )
             .withFallbackCoordinateField( getFallbackCoordinateField( request.getFallbackCoordinateField() ) )
+            .withHeaders( request.getHeaders() )
             .withPage( request.getPage() )
             .withPageSize( request.getPageSize() )
             .withPaging( request.isPaging() )

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -1104,6 +1104,7 @@ public class ListGrid
      *
      * @param headers
      */
+    @Override
     public void keepOnlyThese( final Set<String> headers )
     {
         final List<String> exclusions = getHeaders().stream().map( GridHeader::getName ).collect( toList() );
@@ -1129,6 +1130,7 @@ public class ListGrid
      * @param headers
      * @return a Set of indexes that holds the holds the new order
      */
+    @Override
     public Set<Integer> repositionHeaders( final Set<String> headers )
     {
         verifyGridState();
@@ -1164,6 +1166,7 @@ public class ListGrid
      *
      * @param newColumnsIndexes
      */
+    @Override
     public void repositionColumns( final Set<Integer> newColumnsIndexes )
     {
         verifyGridState();

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.system.grid;
 
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.feedback.ErrorCode.E7230;
+
 import java.io.Serializable;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -36,6 +39,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +54,9 @@ import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.apache.commons.math3.util.Precision;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.adapter.JacksonRowDataSerializer;
+import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.system.util.MathUtils;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
 import org.springframework.jdbc.support.rowset.SqlRowSetMetaData;
@@ -1091,6 +1097,92 @@ public class ListGrid
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------
+
+    /**
+     * This method will take a Grid and keep only the given list of headers. All
+     * other GridHeaders and respective columns will be removed from the Grid.
+     *
+     * @param headers
+     */
+    public void keepOnlyThese( final Set<String> headers )
+    {
+        final List<String> exclusions = getHeaders().stream().map( GridHeader::getName ).collect( toList() );
+        exclusions.removeAll( headers );
+
+        for ( final String headerToExclude : exclusions )
+        {
+            final int headerIndex = getIndexOfHeader( headerToExclude );
+            final boolean hasHeader = headerIndex != -1;
+
+            if ( hasHeader )
+            {
+                removeColumn( getHeaders().get( headerIndex ) );
+            }
+        }
+    }
+
+    /**
+     * Re-order the GridHeaders of the given Grid based on the List headers. The
+     * final Grid will have the all its headers defined in the same order as the
+     * given List of headers.
+     *
+     * @param headers
+     * @return a Set of indexes that holds the holds the new order
+     */
+    public Set<Integer> repositionHeaders( final Set<String> headers )
+    {
+        verifyGridState();
+
+        final List<String> gridHeaders = getHeaders().stream().map( GridHeader::getName ).collect( toList() );
+        final List<GridHeader> orderedHeaders = new ArrayList<>();
+        final Set<Integer> newColumnIndexes = new LinkedHashSet<>();
+
+        for ( final String header : headers )
+        {
+            if ( gridHeaders.contains( header ) )
+            {
+                final int gridHeaderIndex = getIndexOfHeader( header );
+                orderedHeaders.add( getHeaders().get( gridHeaderIndex ) );
+
+                newColumnIndexes.add( gridHeaderIndex );
+            }
+            else
+            {
+                throw new IllegalQueryException( new ErrorMessage( E7230, header ) );
+            }
+        }
+
+        replaceHeaders( orderedHeaders );
+
+        return newColumnIndexes;
+    }
+
+    /**
+     * Based on the given column indexes, this method will order the current
+     * columns in the Grid. The new positions of the columns will respect the
+     * new indexes.
+     *
+     * @param newColumnsIndexes
+     */
+    public void repositionColumns( final Set<Integer> newColumnsIndexes )
+    {
+        verifyGridState();
+
+        final List<List<Object>> allRows = getRows();
+        final List<Integer> newIndexes = new ArrayList<>( newColumnsIndexes );
+
+        for ( final List<Object> columns : allRows )
+        {
+            final List<Object> orderedColumns = new ArrayList<>();
+            for ( int i = 0; i < columns.size(); i++ )
+            {
+                orderedColumns.add( columns.get( newIndexes.get( i ) ) );
+            }
+
+            columns.clear();
+            columns.addAll( orderedColumns );
+        }
+    }
 
     /**
      * Verifies that all grid rows are of the same length.


### PR DESCRIPTION
This feature is about supporting a new `headers` param in _events endpoints_.
This new param will allow the clients to choose the `headers` they want back as part of the response.
The `headers` ordering in the response will match the same order of the `headers` specified as the URL parameter.
This should work for `/events/query` and `enrollments/query` endpoints.

Examples of **GET** requests using the `headers` parameter:

`http://localhost:8080/dhis/api/29/analytics/events/query/eBAyeGv0exc.json?dimension=pe:LAST_12_MONTHS&dimension=ou:jUb8gELQApl;TEQlaapDQoK;eIQbndfxQMb;Vth0fbpFcsO;PMa2VCrupOd;O6uvpzGd5pu;bL4ooGhyHRQ;kJq2mPyFEHo;fdc6uOvgoji;at6UHUQatSo;lc3eMKXaEfw;qhqAxPSTUXp;jmIPBj66vD6&stage=Zj7UnCAulEk&displayProperty=NAME&outputType=EVENT&desc=eventdate&pageSize=100&page=1&headers=ouname,oucode,storedby`

`http://localhost:8080/dhis/api/29/analytics/enrollments/query/WSGAb5XwJ3Y.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&dimension=edqlbukwRfQ[0].vANAXwtLwcT&dimension=edqlbukwRfQ[-1].vANAXwtLwcT&dimension=edqlbukwRfQ[2].vANAXwtLwcT&stage=edqlbukwRfQ&displayProperty=NAME&outputType=ENROLLMENT&desc=enrollmentdate&pageSize=100&page=1&skipMeta=true&headers=storedby,ouname,edqlbukwRfQ[-1].vANAXwtLwcT,edqlbukwRfQ[2].vANAXwtLwcT,pi,tei,enrollmentdate,incidentdate,vANAXwtLwcT`