### PR TITLE
fix: ADX export period on endDate DHIS2-12360

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -198,7 +198,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         }
         else if ( params.hasStartEndDate() )
         {
-            hql += "and (pe.startDate >= :startDate and pe.endDate < :endDate) ";
+            hql += "and (pe.startDate >= :startDate and pe.endDate <= :endDate) ";
         }
 
         if ( params.isIncludeDescendantsForOrganisationUnits() )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
@@ -310,6 +310,12 @@ class DataValueServiceTest extends DhisSpringTest
                 .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA ) )
                     .setPeriods( Sets.newHashSet( periodA ) ).setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
                 .size() );
+        assertEquals( 1,
+            dataValueService
+                .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA ) )
+                    .setStartDate( periodA.getStartDate() ).setEndDate( periodA.getEndDate() )
+                    .setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
+                .size() );
     }
 
     @Test


### PR DESCRIPTION
See [DHIS2-12360](https://jira.dhis2.org/browse/DHIS2-12360). With an ADX data value set export specifying start/end dates, a period is not chosen if it ends on the specified end date. This is inconsistent with XML/json data value set exports.

The cause is that `HibernateDataValueStore.getDataValues` was looking for period end dates < the specified endDate, instead of <=. While other places in the code use this method, only ADX uses it with specifying start and end dates instead of specifying a set of periods.

A test was added that fails with the bug and succeeds with the fix.