### PR TITLE
fix: Program indicator count distinct DHIS2-11327

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -517,6 +517,9 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
 
         String sql = test( "count(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "count(coalesce(\"DataElmentA\"::numeric,0))" ) );
+
+        String sql2 = test( "count(distinct #{ProgrmStagA.DataElmentA})" );
+        assertThat( sql2, is( "count(distinct coalesce(\"DataElmentA\"::numeric,0))" ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorCount.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/VectorCount.java
@@ -48,6 +48,8 @@ public class VectorCount
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return "count(" + visitor.visit( ctx.expr( 0 ) ) + ")";
+        String distinct = ctx.distinct != null ? "distinct " : "";
+
+        return "count(" + distinct + visitor.visit( ctx.expr( 0 ) ) + ")";
     }
 }


### PR DESCRIPTION
See [DHIS2-11327](https://jira.dhis2.org/browse/DHIS2-11327). Allow the user to specify the keyword `distinct` inside the count function for a program indicator with custom aggregation.