### PR TITLE
fix: Remove vacuum analyze from index creation job (2.38)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TrackerTrigramIndexJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TrackerTrigramIndexJobParameters.java
@@ -61,10 +61,6 @@ public class TrackerTrigramIndexJobParameters
 
     private boolean skipIndexDeletion = false;
 
-    private boolean runVacuum = false;
-
-    private boolean runAnalyze = false;
-
     @JsonProperty
     @JacksonXmlElementWrapper( localName = "attributes", namespace = DxfNamespaces.DXF_2_0 )
     @JacksonXmlProperty( localName = "attributes", namespace = DxfNamespaces.DXF_2_0 )
@@ -89,30 +85,6 @@ public class TrackerTrigramIndexJobParameters
     public void setSkipIndexDeletion( boolean skipIndexDeletion )
     {
         this.skipIndexDeletion = skipIndexDeletion;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isRunVacuum()
-    {
-        return runVacuum;
-    }
-
-    public void setRunVacuum( boolean runVacuum )
-    {
-        this.runVacuum = runVacuum;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isRunAnalyze()
-    {
-        return runAnalyze;
-    }
-
-    public void setRunAnalyze( boolean runAnalyze )
-    {
-        this.runAnalyze = runAnalyze;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeTableManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeTableManager.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.trackedentityattributevalue;
 
+import java.util.List;
+
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 /**
@@ -39,7 +41,7 @@ public interface TrackedEntityAttributeTableManager
 {
     void createTrigramIndex( TrackedEntityAttribute trackedEntityAttribute );
 
-    void runAnalyze();
+    void dropTrigramIndex( Long trackedEntityAttributeId );
 
-    void runVacuum();
+    List<Long> getAttributeIdsWithTrigramIndexCreated();
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
@@ -86,29 +86,27 @@ public class TrackerTrigramIndexingJob implements Job
         log.info( "Starting Trigram Indexing Job. Attributes Provided to Index: {}", parameters.getAttributes() );
         progress.startingProcess( "Starting Trigram indexing process" );
 
-        Set<TrackedEntityAttribute> allIndexableAttributes = null;
-
         // fetch all indexable attributes only if needed
         if ( !CollectionUtils.isEmpty( parameters.getAttributes() ) || !parameters.isSkipIndexDeletion() )
         {
             log.debug( "Fetching all indexable attributes from db" );
-            allIndexableAttributes = trackedEntityAttributeService
+            Set<TrackedEntityAttribute> allIndexableAttributes = allIndexableAttributes = trackedEntityAttributeService
                 .getAllTrigramIndexableTrackedEntityAttributes();
-        }
 
-        // Trigram index only need to be created if requested in the job
-        // parameters.
-        if ( !CollectionUtils.isEmpty( parameters.getAttributes() ) )
-        {
-            createTrigramIndexesOnIndexableAttributes( progress, parameters, allIndexableAttributes );
-        }
+            // Trigram index only need to be created if requested in the job
+            // parameters.
+            if ( !CollectionUtils.isEmpty( parameters.getAttributes() ) )
+            {
+                createTrigramIndexesOnIndexableAttributes( progress, parameters, allIndexableAttributes );
+            }
 
-        // Obsolete index deletion
-        if ( !parameters.isSkipIndexDeletion() )
-        {
-            removeObsoleteTrigramIndexes( progress, allIndexableAttributes );
-        }
+            // Obsolete index deletion
+            if ( !parameters.isSkipIndexDeletion() )
+            {
+                removeObsoleteTrigramIndexes( progress, allIndexableAttributes );
+            }
 
+        }
         progress.completedProcess( "Job completed" );
         log.info( "Trigram Indexing job completed" );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.trackedentity.job;
 
 import static org.mockito.Mockito.*;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -69,24 +70,37 @@ public class TrackerTrigramIndexingJobTest
         // mock normal run conditions
         when( trackedEntityAttributeService.getAllTrigramIndexableTrackedEntityAttributes() ).thenReturn(
             Collections.emptySet() );
-        doNothing().when( trackedEntityAttributeTableManager ).runAnalyze();
-        doNothing().when( trackedEntityAttributeTableManager ).runVacuum();
+        when( trackedEntityAttributeTableManager.getAttributeIdsWithTrigramIndexCreated() ).thenReturn(
+            Collections.emptyList() );
     }
 
     @Test
-    public void testRunJobWithoutAnyAttributesInJobParameters()
+    public void testRunJobWithoutAnyAttributesInJobParametersAndWithoutAnyObsolete()
     {
         JobConfiguration jobConfiguration = new JobConfiguration();
         TrackerTrigramIndexJobParameters jp = new TrackerTrigramIndexJobParameters();
-        jp.setRunAnalyze( true );
-        jp.setRunVacuum( true );
         jobConfiguration.setJobParameters( jp );
 
         job.execute( jobConfiguration, NoopJobProgress.INSTANCE );
 
-        verify( trackedEntityAttributeTableManager, times( 1 ) ).runAnalyze();
-        verify( trackedEntityAttributeTableManager, times( 1 ) ).runVacuum();
         verify( trackedEntityAttributeTableManager, never() ).createTrigramIndex( any() );
+        verify( trackedEntityAttributeTableManager, never() ).dropTrigramIndex( any() );
+    }
+
+    @Test
+    public void testRunJobWithoutAnyAttributesInJobParametersButWithObsoleteIndexes()
+    {
+        when( trackedEntityAttributeTableManager.getAttributeIdsWithTrigramIndexCreated() ).thenReturn(
+            Arrays.asList( 12l, 13l ) );
+
+        JobConfiguration jobConfiguration = new JobConfiguration();
+        TrackerTrigramIndexJobParameters jp = new TrackerTrigramIndexJobParameters();
+        jobConfiguration.setJobParameters( jp );
+
+        job.execute( jobConfiguration, NoopJobProgress.INSTANCE );
+
+        verify( trackedEntityAttributeTableManager, never() ).createTrigramIndex( any() );
+        verify( trackedEntityAttributeTableManager, times( 2 ) ).dropTrigramIndex( any() );
     }
 
     @Test
@@ -94,19 +108,14 @@ public class TrackerTrigramIndexingJobTest
     {
         when( trackedEntityAttributeService.getAllTrigramIndexableTrackedEntityAttributes() ).thenReturn(
             Collections.singleton( new TrackedEntityAttribute() ) );
-        when( trackedEntityAttributeService.getAllTrigramIndexableTrackedEntityAttributes() ).thenReturn(
-            Collections.emptySet() );
+
         JobConfiguration jobConfiguration = new JobConfiguration();
         TrackerTrigramIndexJobParameters jp = new TrackerTrigramIndexJobParameters();
-        jp.setRunAnalyze( true );
-        jp.setRunVacuum( true );
         jp.setAttributes( Collections.singleton( "aaaa" ) );
         jobConfiguration.setJobParameters( jp );
 
         job.execute( jobConfiguration, NoopJobProgress.INSTANCE );
 
-        verify( trackedEntityAttributeTableManager, times( 1 ) ).runAnalyze();
-        verify( trackedEntityAttributeTableManager, times( 1 ) ).runVacuum();
         verify( trackedEntityAttributeTableManager, never() ).createTrigramIndex( any() );
     }
 
@@ -129,15 +138,11 @@ public class TrackerTrigramIndexingJobTest
         doNothing().when( trackedEntityAttributeTableManager ).createTrigramIndex( any() );
         JobConfiguration jobConfiguration = new JobConfiguration();
         TrackerTrigramIndexJobParameters jp = new TrackerTrigramIndexJobParameters();
-        jp.setRunAnalyze( true );
-        jp.setRunVacuum( true );
         jp.setAttributes( Stream.of( "tea2", "tea3" ).collect( Collectors.toSet() ) );
         jobConfiguration.setJobParameters( jp );
 
         job.execute( jobConfiguration, NoopJobProgress.INSTANCE );
 
-        verify( trackedEntityAttributeTableManager, times( 1 ) ).runAnalyze();
-        verify( trackedEntityAttributeTableManager, times( 1 ) ).runVacuum();
         verify( trackedEntityAttributeTableManager, times( 2 ) ).createTrigramIndex( any() );
     }
 


### PR DESCRIPTION
After discussing with Gintare and Bob, we have decided to remove the vacuum and analyze functionality from the job to make it cleaner. 
This PR also add the logic of identifying obsolete trigram indexes and removing them.