### PR TITLE
feat: support Map<> introspection in Property

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/Property.java
@@ -70,6 +70,16 @@ public class Property implements Ordered, Klass
     private Class<?> itemKlass;
 
     /**
+     * If this property is a map, this is the type of the key.
+     */
+    private Class<?> keyType;
+
+    /**
+     * If this property is a map, this is the type of the value.
+     */
+    private Class<?> valueType;
+
+    /**
      * If this property is a collection, this is the normalized type of the
      * items inside the collection.
      */
@@ -147,6 +157,13 @@ public class Property implements Ordered, Klass
      * @see java.util.Collection
      */
     private boolean collection;
+
+    /**
+     * This property is true if the type of this property is a sub-class of Map.
+     *
+     * @see java.util.Map
+     */
+    private boolean map;
 
     /**
      * This property is true if collection=true and klass points to a
@@ -361,6 +378,30 @@ public class Property implements Ordered, Klass
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Class<?> getKeyType()
+    {
+        return keyType;
+    }
+
+    public void setKeyType( Class<?> keyType )
+    {
+        this.keyType = keyType;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Class<?> getValueType()
+    {
+        return valueType;
+    }
+
+    public void setValueType( Class<?> valueType )
+    {
+        this.valueType = valueType;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public PropertyType getItemPropertyType()
     {
         return itemPropertyType;
@@ -509,6 +550,18 @@ public class Property implements Ordered, Klass
     public void setCollection( boolean collection )
     {
         this.collection = collection;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isMap()
+    {
+        return map;
+    }
+
+    public void setMap( boolean map )
+    {
+        this.map = map;
     }
 
     @JsonProperty
@@ -950,10 +1003,9 @@ public class Property implements Ordered, Klass
     {
         return Objects.hash( klass, propertyType, itemKlass, itemPropertyType, getterMethod, setterMethod, name,
             fieldName, persisted, collectionName,
-            collectionWrapping, description, namespace, attribute, simple, collection, owner, identifiableObject,
-            nameableObject, readable, writable,
-            unique, required, length, max, min, cascade, manyToMany, oneToOne, manyToOne, owningRole, inverseRole,
-            constants, defaultValue );
+            collectionWrapping, description, namespace, attribute, simple, collection, map, owner,
+            identifiableObject, nameableObject, readable, writable, unique, required, length, max, min, cascade,
+            manyToMany, oneToOne, manyToOne, owningRole, inverseRole, constants, defaultValue );
     }
 
     @Override
@@ -987,6 +1039,7 @@ public class Property implements Ordered, Klass
             && Objects.equals( this.attribute, other.attribute )
             && Objects.equals( this.simple, other.simple )
             && Objects.equals( this.collection, other.collection )
+            && Objects.equals( this.map, other.map )
             && Objects.equals( this.owner, other.owner )
             && Objects.equals( this.identifiableObject, other.identifiableObject )
             && Objects.equals( this.nameableObject, other.nameableObject )
@@ -1026,7 +1079,8 @@ public class Property implements Ordered, Klass
             .add( "namespace", namespace )
             .add( "attribute", attribute )
             .add( "simple", simple )
-            .add( "collection", collection )
+            .add( "collectionLike", collection )
+            .add( "mapLike", map )
             .add( "owner", owner )
             .add( "identifiableObject", identifiableObject )
             .add( "nameableObject", nameableObject )

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/JacksonPropertyIntrospector.java
@@ -135,6 +135,7 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector
             initFromDescription( property );
             initFromJacksonXmlProperty( property );
             initCollectionProperty( property );
+            initMapProperty( property );
 
             if ( !property.isCollection() && !hasProperties( property.getGetterMethod().getReturnType() ) )
             {
@@ -291,6 +292,23 @@ public class JacksonPropertyIntrospector implements PropertyIntrospector
             property.setEmbeddedObject( EmbeddedObject.class.isAssignableFrom( klass ) );
             property.setAnalyticalObject( AnalyticalObject.class.isAssignableFrom( klass ) );
         }
+    }
+
+    private void initMapProperty( Property property )
+    {
+        Class<?> returnType = property.getGetterMethod().getReturnType();
+
+        if ( !Map.class.isAssignableFrom( returnType ) )
+        {
+            property.setMap( false );
+            return;
+        }
+
+        property.setMap( true );
+
+        List<Class<?>> actualTypeArguments = ReflectionUtils.getActualTypeArguments( property.getGetterMethod() );
+        property.setKeyType( actualTypeArguments.get( 0 ) );
+        property.setValueType( actualTypeArguments.get( 1 ) );
     }
 
     private static Property createSchemaProperty( Class<?> klass )

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ReflectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ReflectionUtils.java
@@ -576,4 +576,46 @@ public class ReflectionUtils
 
         return innerType.getActualTypeArguments()[0];
     }
+
+    public static List<Class<?>> getActualTypeArguments( Method method )
+    {
+        List<Class<?>> actualTypeArguments = new ArrayList<>();
+        List<ParameterizedType> parameterizedTypes = new ArrayList<>();
+
+        Class<?> klass = method.getReturnType();
+        Type genericReturnType = method.getGenericReturnType();
+
+        if ( klass.getGenericSuperclass() instanceof ParameterizedType )
+        {
+            parameterizedTypes.add( (ParameterizedType) klass.getGenericSuperclass() );
+        }
+
+        for ( Type type : klass.getGenericInterfaces() )
+        {
+            if ( type instanceof ParameterizedType )
+            {
+                parameterizedTypes.add( (ParameterizedType) type );
+            }
+        }
+
+        if ( genericReturnType instanceof ParameterizedType )
+        {
+            parameterizedTypes.add( (ParameterizedType) genericReturnType );
+        }
+
+        for ( ParameterizedType parameterizedType : parameterizedTypes )
+        {
+            Type[] typeArguments = parameterizedType.getActualTypeArguments();
+
+            for ( Type type : typeArguments )
+            {
+                if ( type instanceof Class<?> )
+                {
+                    actualTypeArguments.add( (Class<?>) type );
+                }
+            }
+        }
+
+        return actualTypeArguments;
+    }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ReflectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ReflectionUtils.java
@@ -577,6 +577,17 @@ public class ReflectionUtils
         return innerType.getActualTypeArguments()[0];
     }
 
+    /**
+     * Get type parameters from a Method. This is mostly useful for getting
+     * return types from methods which returns a generic map for example.
+     *
+     * This method does not guarantee the correct order of parameters. It will
+     * take the super classes / interfaces first, then add the types of the
+     * concrete class.
+     *
+     * @param method Method to return parameter types for
+     * @return List of resolved parameters
+     */
     public static List<Class<?>> getActualTypeArguments( Method method )
     {
         List<Class<?>> actualTypeArguments = new ArrayList<>();

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ReflectionUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ReflectionUtilsTest.java
@@ -27,13 +27,27 @@
  */
 package org.hisp.dhis.system.util;
 
-import static org.hisp.dhis.system.util.ReflectionUtils.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hisp.dhis.system.util.ReflectionUtils.getClassName;
+import static org.hisp.dhis.system.util.ReflectionUtils.getId;
+import static org.hisp.dhis.system.util.ReflectionUtils.getProperty;
+import static org.hisp.dhis.system.util.ReflectionUtils.isCollection;
+import static org.hisp.dhis.system.util.ReflectionUtils.setProperty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.dataelement.DataElement;
@@ -45,7 +59,6 @@ import org.junit.jupiter.api.Test;
  */
 class ReflectionUtilsTest
 {
-
     private DataElement dataElementA;
 
     @BeforeEach
@@ -100,4 +113,63 @@ class ReflectionUtilsTest
         assertTrue( isCollection( colC ) );
         assertFalse( isCollection( dataElementA ) );
     }
+
+    @Test
+    void testGetActualTypeArguments1()
+    {
+        Method method = org.springframework.util.ReflectionUtils.findMethod( Simple.class, "getStringIntegerMap" );
+        assertNotNull( method );
+
+        List<Class<?>> actualTypeArguments = ReflectionUtils.getActualTypeArguments( method );
+        assertFalse( actualTypeArguments.isEmpty() );
+
+        assertEquals( String.class, actualTypeArguments.get( 0 ) );
+        assertEquals( Integer.class, actualTypeArguments.get( 1 ) );
+    }
+
+    @Test
+    void testGetActualTypeArguments2()
+    {
+        Method method = org.springframework.util.ReflectionUtils.findMethod( Simple.class, "getBooleanStringKey" );
+        assertNotNull( method );
+
+        List<Class<?>> actualTypeArguments = ReflectionUtils.getActualTypeArguments( method );
+        assertFalse( actualTypeArguments.isEmpty() );
+
+        assertEquals( String.class, actualTypeArguments.get( 0 ) );
+        assertEquals( Boolean.class, actualTypeArguments.get( 1 ) );
+    }
+
+    @Test
+    void testGetActualTypeArguments3()
+    {
+        Method method = org.springframework.util.ReflectionUtils.findMethod( Simple.class, "getIntegerStringValue" );
+        assertNotNull( method );
+
+        List<Class<?>> actualTypeArguments = ReflectionUtils.getActualTypeArguments( method );
+        assertFalse( actualTypeArguments.isEmpty() );
+
+        assertEquals( String.class, actualTypeArguments.get( 0 ) );
+        assertEquals( Integer.class, actualTypeArguments.get( 1 ) );
+    }
+}
+
+class StringKey<V> extends LinkedHashMap<String, V>
+{
+
+}
+
+class StringValue<K> extends LinkedHashMap<K, String>
+{
+
+}
+
+@Data
+class Simple
+{
+    private Map<String, Integer> stringIntegerMap;
+
+    private StringKey<Boolean> booleanStringKey;
+
+    private StringValue<Integer> integerStringValue;
 }


### PR DESCRIPTION
Add support for `Property.isMap` and adds `Property.keyType` and `Property.valueType`. Useful in a few cases where we are using Maps in our domain model (like for `Sharing.users` and `Sharing.userGroups`)