### PR TITLE
test: remove incorrectly added properties

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/resources/setup/tracker_metadata.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/setup/tracker_metadata.json
@@ -1796,7 +1796,6 @@
       "created": "2022-01-07T11:13:40.871",
       "lastUpdated": "2022-01-07T12:45:47.427",
       "name": "TA AGE",
-      "valueType": "TEXT",
       "id": "bvSo9pP0reO",
       "programRuleVariableSourceType": "TEI_ATTRIBUTE",
       "useCodeForOptionSet": false,

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/programs_with_program_rules.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/programs_with_program_rules.json
@@ -296,7 +296,6 @@
       "name": "TAComment",
       "id": "qXpTPGjuzuc",
       "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
-      "valueType": "TEXT",
       "useCodeForOptionSet": false,
       "program": {
         "id": "uHi4GZJOD3n"
@@ -311,7 +310,6 @@
       "name": "TADiabetes",
       "id": "qByqFfYUSlE",
       "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
-      "valueType": "TEXT",
       "useCodeForOptionSet": false,
       "program": {
         "id": "uHi4GZJOD3n"
@@ -325,7 +323,6 @@
       "name": "TaPlaceOfBirth",
       "displayName": "TaPlaceOfBirth",
       "programRuleVariableSourceType": "DATAELEMENT_CURRENT_EVENT",
-      "valueType": "TEXT",
       "externalAccess": false,
       "useCodeForOptionSet": false,
       "favorite": false,


### PR DESCRIPTION
API test metadata was wrongly updated with #9540 which also hid the bug that required valueType for all programRuleVariables, when it should only be required for **calculated_value** program rule variables. 