### PR TITLE
fix: assign rule action validation update [DHIS2-12033]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -200,8 +200,8 @@ public enum ErrorCode
     E4047( "DataElement `{0}` is not linked to any ProgramStageDataElement for program rule `{1}`" ),
     E4048( "TrackedEntityAttribute `{0}` is not linked to ProgramTrackedEntityAttribute for program rule `{1}`" ),
     E4049( "Property `{0}` requires a valid username, was given `{1}`." ),
-    E4050( "One of the parameters DataElement, TrackedEntityAttribute or ProgramRuleVariable is required for program rule `{0}`" ),
-
+    E4050(
+        "One of the parameters DataElement, TrackedEntityAttribute or ProgramRuleVariable is required for program rule `{0}`" ),
 
     /* ProgramRuleVariable validation */
     E4051( "A program rule variable with name `{0}` and program uid `{1}` already exists" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -200,6 +200,8 @@ public enum ErrorCode
     E4047( "DataElement `{0}` is not linked to any ProgramStageDataElement for program rule `{1}`" ),
     E4048( "TrackedEntityAttribute `{0}` is not linked to ProgramTrackedEntityAttribute for program rule `{1}`" ),
     E4049( "Property `{0}` requires a valid username, was given `{1}`." ),
+    E4050( "One of the parameters DataElement, TrackedEntityAttribute or ProgramRuleVariable is required for program rule `{0}`" ),
+
 
     /* ProgramRuleVariable validation */
     E4051( "A program rule variable with name `{0}` and program uid `{1}` already exists" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -113,6 +113,7 @@ import org.hisp.dhis.external.conf.ConfigurationPropertyFactoryBean;
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.programrule.ProgramRuleActionType;
 import org.hisp.dhis.programrule.action.validation.AlwaysValidProgramRuleActionValidator;
+import org.hisp.dhis.programrule.action.validation.AssignProgramRuleActionValidator;
 import org.hisp.dhis.programrule.action.validation.BaseProgramRuleActionValidator;
 import org.hisp.dhis.programrule.action.validation.HideOptionProgramRuleActionValidator;
 import org.hisp.dhis.programrule.action.validation.HideProgramStageProgramRuleActionValidator;
@@ -405,7 +406,7 @@ public class ServiceConfig
             .put( ProgramRuleActionType.DISPLAYKEYVALUEPAIR,
                 getProgramRuleActionValidatorByClass( AlwaysValidProgramRuleActionValidator.class ) )
             .put( ProgramRuleActionType.ASSIGN,
-                getProgramRuleActionValidatorByClass( BaseProgramRuleActionValidator.class ) )
+                getProgramRuleActionValidatorByClass( AssignProgramRuleActionValidator.class ) )
             .put( ProgramRuleActionType.HIDEFIELD,
                 getProgramRuleActionValidatorByClass( BaseProgramRuleActionValidator.class ) )
             .put( ProgramRuleActionType.CREATEEVENT,

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/AssignProgramRuleActionValidator.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/AssignProgramRuleActionValidator.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.programrule.action.validation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.programrule.ProgramRule;
+import org.hisp.dhis.programrule.ProgramRuleAction;
+import org.hisp.dhis.programrule.ProgramRuleActionValidationResult;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Zubair Asghar
+ */
+
+@Slf4j
+@Component
+public class AssignProgramRuleActionValidator implements ProgramRuleActionValidator
+{
+    @Override
+    public ProgramRuleActionValidationResult validate(ProgramRuleAction programRuleAction, ProgramRuleActionValidationContext validationContext) {
+        ProgramRule rule = validationContext.getProgramRule();
+
+        if ( !programRuleAction.hasDataElement() && !programRuleAction.hasTrackedEntityAttribute() && !programRuleAction.hasContent())
+        {
+            log.debug( String.format( "DataElement or TrackedEntityAttribute or ProgramRuleVariable cannot be null for program rule: %s ",
+                    rule.getName() ) );
+
+            return ProgramRuleActionValidationResult.builder()
+                    .valid( false )
+                    .errorReport( new ErrorReport( ProgramRuleAction.class, ErrorCode.E4050,
+                            rule.getName() ) )
+                    .build();
+        }
+
+        return ProgramRuleActionValidationResult.builder().valid( true ).build();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/AssignProgramRuleActionValidator.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/AssignProgramRuleActionValidator.java
@@ -25,11 +25,10 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package org.hisp.dhis.programrule.action.validation;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.dataelement.DataElement;
+
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.programrule.ProgramRule;
@@ -46,19 +45,23 @@ import org.springframework.stereotype.Component;
 public class AssignProgramRuleActionValidator implements ProgramRuleActionValidator
 {
     @Override
-    public ProgramRuleActionValidationResult validate(ProgramRuleAction programRuleAction, ProgramRuleActionValidationContext validationContext) {
+    public ProgramRuleActionValidationResult validate( ProgramRuleAction programRuleAction,
+        ProgramRuleActionValidationContext validationContext )
+    {
         ProgramRule rule = validationContext.getProgramRule();
 
-        if ( !programRuleAction.hasDataElement() && !programRuleAction.hasTrackedEntityAttribute() && !programRuleAction.hasContent())
+        if ( !programRuleAction.hasDataElement() && !programRuleAction.hasTrackedEntityAttribute()
+            && !programRuleAction.hasContent() )
         {
-            log.debug( String.format( "DataElement or TrackedEntityAttribute or ProgramRuleVariable cannot be null for program rule: %s ",
-                    rule.getName() ) );
+            log.debug( String.format(
+                "DataElement or TrackedEntityAttribute or ProgramRuleVariable cannot be null for program rule: %s ",
+                rule.getName() ) );
 
             return ProgramRuleActionValidationResult.builder()
-                    .valid( false )
-                    .errorReport( new ErrorReport( ProgramRuleAction.class, ErrorCode.E4050,
-                            rule.getName() ) )
-                    .build();
+                .valid( false )
+                .errorReport( new ErrorReport( ProgramRuleAction.class, ErrorCode.E4050,
+                    rule.getName() ) )
+                .build();
         }
 
         return ProgramRuleActionValidationResult.builder().valid( true ).build();


### PR DESCRIPTION
ASSIGN program rule action will pass the validation when any one of the parameters `(DataElement, TrackedEntityAttribute or ProgramRuleVariable) ` is given.