### PR TITLE
fix: return conflict when no lock exception is created for OU-DS combinations [DHIS2-10901]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/LockException.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/LockException.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dataset;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.PrimaryKeyObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 
@@ -41,7 +42,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @JacksonXmlRootElement( localName = "lockException", namespace = DxfNamespaces.DXF_2_0 )
-public class LockException
+public class LockException implements PrimaryKeyObject
 {
     private long id;
 
@@ -74,6 +75,13 @@ public class LockException
         return dataSet.getName() + " (" + organisationUnit.getName() + ", " + period.getName() + ")";
     }
 
+    @Override
+    public String getUid()
+    {
+        return String.valueOf( id );
+    }
+
+    @Override
     public long getId()
     {
         return id;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.lang.String.format;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
@@ -68,13 +69,16 @@ class LockExceptionControllerTest extends DhisControllerConvenienceTest
     {
         String dsId2 = assertStatus( HttpStatus.CREATED,
             POST( "/dataSets/", "{'name':'My data set', 'periodType':'Monthly'}" ) );
-        assertStatus( HttpStatus.NO_CONTENT, POST( "/lockExceptions/?ou={ou}&pe=2021-01&ds={ds}", ouId, dsId2 ) );
+        assertWebMessage( "Conflict", 409, "ERROR",
+            format( "None of the target organisation unit(s) %s is linked to the specified data set: %s",
+                ouId, dsId2 ),
+            POST( "/lockExceptions/?ou={ou}&pe=2021-01&ds={ds}", ouId, dsId2 ).content( HttpStatus.CONFLICT ) );
     }
 
     @Test
     void testAddLockException_NoOrgUnit()
     {
-        assertWebMessage( "Conflict", 409, "ERROR", " OrganisationUnit ID is invalid.",
+        assertWebMessage( "Conflict", 409, "ERROR", "OrganisationUnit ID is invalid.",
             POST( "/lockExceptions/?ou=&pe=2021-01&ds=" + dsId ).content( HttpStatus.CONFLICT ) );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/LockExceptionController.java
@@ -90,7 +90,7 @@ import com.google.common.collect.Lists;
 @Controller
 @RequestMapping( LockExceptionController.RESOURCE_PATH )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-public class LockExceptionController
+public class LockExceptionController extends AbstractGistReadOnlyController<LockException>
 {
     public static final String RESOURCE_PATH = "/lockExceptions";
 
@@ -219,7 +219,6 @@ public class LockExceptionController
 
     @PostMapping
     @ResponseBody
-    @ResponseStatus( HttpStatus.NO_CONTENT )
     public WebMessage addLockException( @RequestParam( "ou" ) String organisationUnitId,
         @RequestParam( "pe" ) String periodId,
         @RequestParam( "ds" ) String dataSetId )
@@ -240,8 +239,6 @@ public class LockExceptionController
             throw new ReadAccessDeniedException( "You don't have the proper permissions to update this object" );
         }
 
-        boolean created = false;
-
         List<String> listOrgUnitIds = new ArrayList<>();
 
         if ( organisationUnitId.startsWith( "[" ) && organisationUnitId.endsWith( "]" ) )
@@ -256,9 +253,10 @@ public class LockExceptionController
 
         if ( listOrgUnitIds.isEmpty() )
         {
-            return conflict( " OrganisationUnit ID is invalid." );
+            return conflict( "OrganisationUnit ID is invalid." );
         }
 
+        boolean added = false;
         for ( String id : listOrgUnitIds )
         {
             OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( id );
@@ -276,15 +274,16 @@ public class LockExceptionController
                 lockException.setDataSet( dataSet );
                 lockException.setPeriod( period );
                 dataSetService.addLockException( lockException );
-                created = true;
+                added = true;
             }
         }
-
-        if ( created )
+        if ( !added )
         {
-            return created( "LockException created successfully." );
+            return conflict( String.format(
+                "None of the target organisation unit(s) %s is linked to the specified data set: %s",
+                String.join( ",", listOrgUnitIds ), dataSetId ) );
         }
-        return null;
+        return created( "LockException created successfully." );
     }
 
     @DeleteMapping


### PR DESCRIPTION
Changes the response behaviour when creating lock exceptions. 
If no OU is linked to the specified DS the response is no longer 204 but 409 with an error message so that the caller understands that nothing had happened. 

This also adds `/gist` API for  `LockException`. Helps looking for what exceptions do exist.