### PR TITLE
fix: Make flyway script idempotent to avoid manual dev db changes (2.38)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_26__Add_Feedback_recipients_to_configuration.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_26__Add_Feedback_recipients_to_configuration.sql
@@ -1,3 +1,4 @@
 alter table "configuration" add column if not exists "systemupdatenotificationrecipientsid" int8 null;
+alter table "configuration" drop constraint if exists fk_configuration_systemupdatenotification_recipients;
 alter table only "configuration"
     add constraint fk_configuration_systemupdatenotification_recipients foreign key (systemupdatenotificationrecipientsid) references usergroup(usergroupid);


### PR DESCRIPTION
The specific script was accidentally first added under the 2.37 folder which was caused to already execute in the play dev db. (https://github.com/dhis2/dhis2-core/pull/9665) The script was now moved to 2.38 which caused the script to execute again and now failing in dev because it is not idempotent. Changed the script to make it idempotent to overcome this situation.
(Another option was to manually update the dev db to clear the offending constraint)