### PR TITLE
fix: periodOffset misses some data [DHIS2-12496]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -75,13 +75,6 @@ public class Period
      */
     private transient String isoPeriod;
 
-    /**
-     * Transient boolean. If true, this Period has been created as a consequence
-     * of a Dimensional Item Object having an Offset Period value higher/lower
-     * than 0
-     */
-    private transient boolean shifted = false;
-
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -410,15 +403,5 @@ public class Period
     public void setPeriodType( PeriodType periodType )
     {
         this.periodType = periodType;
-    }
-
-    public boolean isShifted()
-    {
-        return shifted;
-    }
-
-    public void setShifted( boolean shifted )
-    {
-        this.shifted = shifted;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -102,6 +102,8 @@ public class DefaultQueryPlanner
     {
         queryValidator.validate( params );
 
+        params = PeriodOffsetUtils.addShiftedPeriods( params );
+
         // ---------------------------------------------------------------------
         // Group queries which can be executed together
         // ---------------------------------------------------------------------
@@ -264,8 +266,8 @@ public class DefaultQueryPlanner
         }
         else if ( !params.getPeriods().isEmpty() )
         {
-            ListMap<String, DimensionalItemObject> periodTypePeriodMap = PeriodOffsetUtils
-                .getPeriodTypePeriodMap( params );
+            ListMap<String, DimensionalItemObject> periodTypePeriodMap = PartitionUtils
+                .getPeriodTypePeriodMap( params.getPeriods() );
 
             for ( String periodType : periodTypePeriodMap.keySet() )
             {
@@ -274,7 +276,7 @@ public class DefaultQueryPlanner
                         periodTypePeriodMap.get( periodType ) )
                     .withPeriodType( periodType ).build();
 
-                queries.add( PeriodOffsetUtils.removeOffsetPeriodsIfNotNeeded( query ) );
+                queries.add( query );
             }
         }
         else if ( !params.getFilterPeriods().isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -988,13 +988,12 @@ public class DataHandler
                 // periods from the original Analytics request. The row may
                 // not have a Period if Period is used as filter.
 
-                if ( hasPeriod( row, periodIndex )
-                    && isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
+                if ( hasPeriod( row, periodIndex ) )
                 {
                     addItemBasedOnPeriodOffset( grid, result, dataIndex, periodIndex, valueIndex, row,
-                        dimensionalItem );
+                        dimensionalItem, basePeriods );
                 }
-                else
+                else if ( !isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
                 {
                     result.put( join( remove( row.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP ),
                         new DimensionItemObjectValue(
@@ -1058,24 +1057,30 @@ public class DataHandler
      * @param dimensionalItemObject a dimensional item for the current grid row,
      *        see
      *        {@link org.hisp.dhis.analytics.util.AnalyticsUtils#findDimensionalItems(String, List)}
+     * @param basePeriods the periods from the parameters.
      *
      * @return the DimensionalItemObject
      */
     private void addItemBasedOnPeriodOffset( Grid grid, MultiValuedMap<String, DimensionItemObjectValue> result,
-        int dataIndex, int periodIndex, int valueIndex, List<Object> row, DimensionalItemObject dimensionalItemObject )
+        int dataIndex, int periodIndex, int valueIndex, List<Object> row, DimensionalItemObject dimensionalItemObject,
+        List<DimensionalItemObject> basePeriods )
     {
+        if ( row.get( valueIndex ) == null || !dimensionalItemObject.getUid().equals( (String) row.get( dataIndex ) ) )
+        {
+            return;
+        }
+
         final List<Object> adjustedRow = (dimensionalItemObject.getPeriodOffset() != 0)
-            ? getPeriodOffsetRow( grid, dataIndex, periodIndex, dimensionalItemObject, (String) row.get( periodIndex ),
-                dimensionalItemObject.getPeriodOffset() )
+            ? getPeriodOffsetRow( row, periodIndex, dimensionalItemObject.getPeriodOffset() )
             : row;
 
-        if ( adjustedRow == null || adjustedRow.get( valueIndex ) == null )
+        if ( !isPeriodInPeriods( (String) adjustedRow.get( periodIndex ), basePeriods ) )
         {
             return;
         }
 
         // Key is composed of [uid-period]
-        final String key = join( remove( row.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP );
+        final String key = join( remove( adjustedRow.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP );
 
         final Double value = ((Number) adjustedRow.get( valueIndex )).doubleValue();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -990,7 +990,7 @@ public class DataHandler
 
                 if ( hasPeriod( row, periodIndex ) )
                 {
-                    addItemBasedOnPeriodOffset( grid, result, dataIndex, periodIndex, valueIndex, row,
+                    addItemBasedOnPeriodOffset( result, dataIndex, periodIndex, valueIndex, row,
                         dimensionalItem, basePeriods );
                 }
                 else if ( !isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
@@ -1048,7 +1048,6 @@ public class DataHandler
     /**
      * Calculate the dimensional item offset and adds to the give result map.
      *
-     * @param grid the current Grid.
      * @param result the map where the values will be added to.
      * @param dataIndex the current grid row data index.
      * @param periodIndex the current grid row period index.
@@ -1061,11 +1060,11 @@ public class DataHandler
      *
      * @return the DimensionalItemObject
      */
-    private void addItemBasedOnPeriodOffset( Grid grid, MultiValuedMap<String, DimensionItemObjectValue> result,
+    private void addItemBasedOnPeriodOffset( MultiValuedMap<String, DimensionItemObjectValue> result,
         int dataIndex, int periodIndex, int valueIndex, List<Object> row, DimensionalItemObject dimensionalItemObject,
         List<DimensionalItemObject> basePeriods )
     {
-        if ( row.get( valueIndex ) == null || !dimensionalItemObject.getUid().equals( (String) row.get( dataIndex ) ) )
+        if ( row.get( valueIndex ) == null || !dimensionalItemObject.getUid().equals( row.get( dataIndex ) ) )
         {
             return;
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
@@ -31,6 +31,7 @@ import static java.lang.Math.abs;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -172,41 +173,23 @@ public class PeriodOffsetUtils
     }
 
     /**
-     * Given a Analytics {@link Grid}, this methods tries to extract the row
-     * from the Grid that matches the given {@link DimensionalItemObject} and
-     * offset period. If there is no match, null is returned.
+     * Given an Analytics {@link Grid} row, adjust the date in the row according
+     * to the period offset.
      *
-     * @param grid a {@link Grid} object
-     * @param dataIndex the current grid row data index.
+     * @param row the current grid row
      * @param periodIndex the current grid row period index.
-     * @param dimItem a DimensionalItemObject object
-     * @param isoPeriod a Period, in ISO format (e.g. 202001 - for January 2020)
      * @param offset an offset value
-     * @return a row from the Grid (as List of Object) or null
+     * @return a new row with adjusted date
      */
-    public static List<Object> getPeriodOffsetRow( Grid grid, int dataIndex, int periodIndex,
-        DimensionalItemObject dimItem, String isoPeriod, int offset )
+    public static List<Object> getPeriodOffsetRow( List<Object> row, int periodIndex, int offset )
     {
-        if ( grid == null || dimItem == null )
-        {
-            return null;
-        }
+        String isoPeriod = (String) row.get( periodIndex );
+        Period shifted = shiftPeriod( PeriodType.getPeriodFromIsoString( isoPeriod ), -offset );
 
-        Period shifted = offset != 0 ? shiftPeriod( PeriodType.getPeriodFromIsoString( isoPeriod ), offset )
-            : PeriodType.getPeriodFromIsoString( isoPeriod );
+        List<Object> adjustedRow = new ArrayList<>( row );
+        adjustedRow.set( periodIndex, shifted.getIsoDate() );
 
-        for ( List<Object> row : grid.getRows() )
-        {
-            final String rowUid = (String) row.get( dataIndex );
-            final String rowPeriod = (String) row.get( periodIndex );
-
-            if ( rowUid.equals( dimItem.getUid() ) && rowPeriod.equals( shifted.getIsoDate() ) )
-            {
-                return row;
-            }
-        }
-
-        return null;
+        return adjustedRow;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/PeriodOffsetUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/PeriodOffsetUtilsTest.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.analytics.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -178,7 +177,6 @@ class PeriodOffsetUtilsTest
         grid.addHeader( new GridHeader( DimensionalObject.DATA_X_DIM_ID ) );
         grid.addHeader( new GridHeader( DimensionalObject.ORGUNIT_DIM_ID ) );
         grid.addHeader( new GridHeader( DimensionalObject.PERIOD_DIM_ID ) );
-        int dataIndex = 0;
         int periodIndex = 2;
         grid.addRow();
         grid.addValue( "de1" );
@@ -192,42 +190,20 @@ class PeriodOffsetUtilsTest
         grid.addValue( 5 );
         DataElement dataElement = createDataElement( 0 );
         dataElement.setUid( "de1" );
-        // When
-        final List<Object> row = PeriodOffsetUtils.getPeriodOffsetRow( grid, dataIndex, periodIndex, dataElement,
-            "202001", 1 );
-        // Then
-        assertThat( row, is( notNullValue() ) );
-        assertThat( row, hasSize( 4 ) );
-        assertThat( row.get( 0 ), is( "de1" ) );
-    }
 
-    @Test
-    void verifyGetPeriodOffsetRowNoMatch()
-    {
-        // Given
-        Grid grid = new ListGrid();
-        grid.addHeader( new GridHeader( DimensionalObject.DATA_X_DIM_ID ) );
-        grid.addHeader( new GridHeader( DimensionalObject.ORGUNIT_DIM_ID ) );
-        grid.addHeader( new GridHeader( DimensionalObject.PERIOD_DIM_ID ) );
-        int dataIndex = 0;
-        int periodIndex = 2;
-        grid.addRow();
-        grid.addValue( "de1" );
-        grid.addValue( "ou2" );
-        grid.addValue( "202001" );
-        grid.addValue( 3 );
-        grid.addRow();
-        grid.addValue( "de1" );
-        grid.addValue( "ou3" );
-        grid.addValue( "202002" );
-        grid.addValue( 5 );
-        DataElement dataElement = createDataElement( 0 );
-        dataElement.setUid( "de1" );
         // When
-        final List<Object> row = PeriodOffsetUtils.getPeriodOffsetRow( grid, dataIndex, periodIndex, dataElement,
-            "202003", 1 );
+        final List<Object> row1 = PeriodOffsetUtils.getPeriodOffsetRow( grid.getRow( 0 ), periodIndex, 1 );
         // Then
-        assertThat( row, is( nullValue() ) );
+        assertThat( row1, is( notNullValue() ) );
+        assertThat( row1, hasSize( 4 ) );
+        assertThat( row1.get( periodIndex ), is( "201912" ) );
+
+        // When
+        final List<Object> row2 = PeriodOffsetUtils.getPeriodOffsetRow( grid.getRow( 1 ), periodIndex, -1 );
+        // Then
+        assertThat( row2, is( notNullValue() ) );
+        assertThat( row2, hasSize( 4 ) );
+        assertThat( row2.get( periodIndex ), is( "202003" ) );
     }
 
     private void assertIsoPeriods( List<DimensionalItemObject> periods, String... isoPeriod )


### PR DESCRIPTION
See [DHIS2-12496](https://jira.dhis2.org/browse/DHIS2-12496), especially the screen shots showing the problems and the fixes.

### Problem 1: periodOffset returns offset data only when there is also un-offset data

**The problem:** `DataHandler#getAggregatedDataValueMap` called `DataHandler#addItemBasedOnPeriodOffset` once for each combination of DimensionalItemObject (`dimItem`) and returned data row within the selected reporting periods. If the dimItem had a periodOffset, then this method called `PeriodOffsetUtils#getPeriodOffsetRow`. This method searched through all the returned grid data to find a row with data that matched the dimItem and the offset period. `addItemBasedOnPeriodOffset` then added to the result map a value using the key (including dimItem and period) from the original row, but the value from the offset row.

The problem was that this worked only if there were values for both the reported period and the offset period. If there was no value in the reported period, then the search through the grid for the offset period would not happen.

**The fix:** `DataHandler#getAggregatedDataValueMap` now calls `DataHandler#addItemBasedOnPeriodOffset` for each combination of dimItem and returned data row from the query (including those outside the selected reporting periods). If the dimItem has a periodOffset, it calls `PeriodOffsetUtils#getPeriodOffsetRow`. However this method, instead of looking through the entire grid for the offset period, now takes the given row with the offset period and shifts the period by the negative offset to find the period that the value should be reported for. It then returns a copy of the row with the offset period replaced by the reporting period. `addItemBasedOnPeriodOffset` then adds to the result map a value using both the key and the value from the adjusted row (but it only adds values if the resulting rows are within the selected reporting periods).

This ensures that that all the data desired is returned, shifted or not. Note that a single query row can provide the data value for multiple periodOffsets of the same data element, for example to a dimItem 3 periods later with a periodOffset of -3, and also to a dimItem 4 periods later with a periodOffset of -4.

As well as fixing the problem, these changes made the code smaller, simpler, and faster.

### Problem 2: periodOffset returns data only within selected reporting years

**The problem:** `DefaultQueryPlanner#groupByPeriodType` called `PeriodOffsetUtils#getPeriodTypePeriodMap`. This, in turn, called `PartitionUtils#getPeriodTypePeriodMap` and subsequently added map entries for all the shifted periods.

The problem was that `DefaultQueryPlanner#planQuery` had already called `withTableNameAndPartitions` to determine the analytics table partitions to be queried, before calling `groupByPeriodType`. So, for example, if the query parameters requested 2021 period data only, then only the 2021 partition would be selected. Subsequently, if periodOffsets specified that data should also be fetched from 2020, it was too late. Only the 2021 partition would be used. This resulted in SQL queries that tried to find 2020 periods in the 2021 partition (and of course found no data for these periods):

`select ax."dx"... from analytics_2021... where... ax."monthly" in (... '202012') ...`

Also, after `DefaultQueryPlanner#groupByPeriodType` called `PeriodOffsetUtils#getPeriodTypePeriodMap`, it then called `PeriodOffsetUtils#removeOffsetPeriodsIfNotNeeded`. This method tested to see if there were any DimensionalItemObjects with a periodOffset. If there were none, it removed all shifted periods (where `isShifted()` is true). However this code never did anything, because shifted periods were added to the parameters by `getPeriodTypePeriodMap` only if there were DimensionalItemObjects with a periodOffset. The JavaDoc for `removeOffsetPeriodsIfNotNeeded` claimed that this could happen if a numerator formula used an offset and a denominator formula did not. However, this claim was false as shown both by reading the code and by testing with a suitable numerator and denominator.

**The fix:** `DefaultQueryPlanner#planQuery` now calls a new method `PeriodOffsetUtils#addShiftedPeriods`, which simply adds to (a copy of) the parameters any periods that are needed because of periodOffsets. It does so before calling `withTableNameAndPartitions`, so that any offset periods needed from different partitions will cause those partitions to be included in the SQL queries.

`groupByPeriodType` now calls `PartitionUtils#getPeriodTypePeriodMap` directly, just as it did before periodOffset was initially implemented. This refactor separates adding offset periods from constructing the `periodTypePeriodMap`, which makes the code more modular and hence easier to follow.

`removeOffsetPeriodsIfNotNeeded` was removed since it was not needed. Also, the `Period#shifted` property was removed, since it was only used by `removeOffsetPeriodsIfNotNeeded`.

### Testing

`PeriodOffsetUtilsTest` was changed to correspond to the `PeriodOffsetUtils` refactoring.

I didn't add any new tests to `AnalyticsServiceTest` since the code in this module is rather unruly at present, and since the tests would not demonstrate that the fixes worked. This is because `AnalyticsTestUtils#assertResultGrid` only checks to see that any result values were among the expected. It does not check to see that any expected values were among the results. (When I tried to add this reverse condition in an earlier ticket, some tests from `EventAnalyticsServiceTest` broke because they were testing to see if the same result matched any one of multiple expected values.) I have some ideas in mind for refactoring both `AnalyticsServiceTest` and `EventAnalyticsServiceTest`, when I find the time, to make them much more modular without sacrificing either performance (only one build of analytics) or test granularity (the ability for multiple test cases to fail without the first failure causing the entire test to fail). At the same time, I could add the reverse test condition and fix any tests that take advantage of its current (lack of) function.

The fixed code produced the fixed screenshots shown in  [DHIS2-12496](https://jira.dhis2.org/browse/DHIS2-12496).