### PR TITLE
fix: downgrades jts to 1.16.1 as jackson-datatype-jts does not support it

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -140,7 +140,7 @@
         <fop.version>2.5</fop.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <geotools.version>26.1</geotools.version>
-        <jts.version>1.18.2</jts.version>
+        <jts.version>1.16.1</jts.version>
 
         <!-- Apache Artemis -->
         <artemis.version>2.19.0</artemis.version>


### PR DESCRIPTION
`jackson-datatype-jts` only supports jts 1.16 and down.