### PR TITLE
chore: use GitHub runners pre-installed JDK

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
 
       - name: Analyse PR

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
 
       - name: Check formatting in core

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
 
       - name: Codeql-init

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
       - name: Build core image
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
 
       - name: Test core
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
 
       - name: Run integration tests
@@ -54,7 +54,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 11
-          distribution: zulu
+          distribution: temurin
           cache: maven
 
       - name: Build analytics with dependencies


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
which is now pre-installed on GitHubs ubuntu runners
https://github.com/actions/virtual-environments/issues/3859
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md\#java

by setting the actions/setup-java distribution to temurin the action will not have to download a JDK and thus
save a few seconds on every jobs 'Setup JDK 11' step

see https://github.com/dhis2/dhis2-core/runs/4919378791?check_suite_focus=true#step:3:41
> Resolved Java 11.0.13+8 from tool-cache