### PR TITLE
fix: use idScheme in event dataElement checks DHIS2-12282

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -60,7 +60,6 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Service;
 
-import com.google.api.client.util.Lists;
 import com.google.api.client.util.Objects;
 
 /**
@@ -182,20 +181,22 @@ public class EventTrackerConverterService
 
     private List<EventDataValue> getProgramStageInstanceDataValues( TrackerPreheat preheat, Event event )
     {
-        List<EventDataValue> eventDataValues = Lists.newArrayList();
+        List<EventDataValue> eventDataValues = new ArrayList<>();
         ProgramStageInstance programStageInstance = preheat.getEvent( TrackerIdScheme.UID, event.getEvent() );
-        if ( programStageInstance != null )
+        if ( programStageInstance == null )
         {
-            Set<String> dataElements = event.getDataValues()
-                .stream()
-                .map( DataValue::getDataElement )
-                .collect( Collectors.toSet() );
-            for ( EventDataValue eventDataValue : programStageInstance.getEventDataValues() )
+            return eventDataValues;
+        }
+
+        Set<String> dataElements = event.getDataValues()
+            .stream()
+            .map( DataValue::getDataElement )
+            .collect( Collectors.toSet() );
+        for ( EventDataValue eventDataValue : programStageInstance.getEventDataValues() )
+        {
+            if ( !dataElements.contains( eventDataValue.getDataElement() ) )
             {
-                if ( !dataElements.contains( eventDataValue.getDataElement() ) )
-                {
-                    eventDataValues.add( eventDataValue );
-                }
+                eventDataValues.add( eventDataValue );
             }
         }
         return eventDataValues;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -42,10 +42,16 @@ import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.program.*;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
@@ -270,7 +276,10 @@ public class EventTrackerConverterService
             eventDataValue.setCreated( DateUtils.fromInstant( dataValue.getCreatedAt() ) );
             eventDataValue.setLastUpdated( new Date() );
             eventDataValue.setProvidedElsewhere( dataValue.isProvidedElsewhere() );
-            eventDataValue.setDataElement( dataValue.getDataElement() );
+            // ensure dataElement is referred to by UID as multiple
+            // dataElementIdSchemes are supported
+            DataElement dataElement = preheat.get( DataElement.class, dataValue.getDataElement() );
+            eventDataValue.setDataElement( dataElement.getUid() );
             eventDataValue.setLastUpdatedByUserInfo( UserInfoSnapshot.from( preheat.getUser() ) );
 
             User createdBy = preheat.getUsers().get( dataValue.getCreatedBy() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -101,7 +101,8 @@ public class EventDataValuesValidationHook
             final List<String> mandatoryDataElements = programStage.getProgramStageDataElements()
                 .stream()
                 .filter( ProgramStageDataElement::isCompulsory )
-                .map( de -> de.getDataElement().getUid() )
+                .map( de -> context.getIdentifiers().getDataElementIdScheme()
+                    .getIdentifier( de.getDataElement() ) )
                 .collect( Collectors.toList() );
             List<String> missingDataValue = validateMandatoryDataValue( programStage, event,
                 mandatoryDataElements );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -103,9 +103,9 @@ public class EventDataValuesValidationHook
                 .filter( ProgramStageDataElement::isCompulsory )
                 .map( de -> de.getDataElement().getUid() )
                 .collect( Collectors.toList() );
-            List<String> wrongMandatoryDataValue = validateMandatoryDataValue( programStage, event,
+            List<String> missingDataValue = validateMandatoryDataValue( programStage, event,
                 mandatoryDataElements );
-            wrongMandatoryDataValue
+            missingDataValue
                 .forEach( de -> reporter.addError( event, E1303, de ) );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -153,7 +153,8 @@ public class EventDataValuesValidationHook
     {
         final Set<String> dataElements = programStage.getProgramStageDataElements()
             .stream()
-            .map( de -> de.getDataElement().getUid() )
+            .map( de -> reporter.getValidationContext().getIdentifiers().getDataElementIdScheme()
+                .getIdentifier( de.getDataElement() ) )
             .collect( Collectors.toSet() );
 
         Set<String> payloadDataElements = event.getDataValues().stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -30,8 +30,8 @@ package org.hisp.dhis.tracker.converter;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
-import static org.wildfly.common.Assert.assertTrue;
 
 import java.time.Instant;
 import java.util.Collections;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.util.DateUtils;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,16 +81,14 @@ class EventDataValuesValidationHookTest
     public void setUp()
     {
         hook = new EventDataValuesValidationHook();
+
+        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
     }
 
     @Test
     void successValidationWhenDataElementIsValid()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
@@ -101,7 +100,7 @@ class EventDataValuesValidationHookTest
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
-            .dataValues( Set.of( getDataValue() ) ).build();
+            .dataValues( Set.of( dataValue() ) ).build();
 
         hook.validateEvent( reporter, event );
 
@@ -111,12 +110,7 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenCreatedAtIsNull()
     {
-
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
@@ -126,7 +120,7 @@ class EventDataValuesValidationHookTest
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
 
-        DataValue validDataValue = getDataValue();
+        DataValue validDataValue = dataValue();
         validDataValue.setCreatedAt( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
@@ -141,11 +135,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenUpdatedAtIsNull()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
@@ -153,7 +143,7 @@ class EventDataValuesValidationHookTest
         programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
-        DataValue validDataValue = getDataValue();
+        DataValue validDataValue = dataValue();
         validDataValue.setUpdatedAt( null );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
@@ -170,11 +160,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsInvalid()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( null );
 
         ProgramStage programStage = new ProgramStage();
@@ -182,7 +168,7 @@ class EventDataValuesValidationHookTest
         programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
-        DataValue validDataValue = getDataValue();
+        DataValue validDataValue = dataValue();
 
         Event event = Event.builder()
             .programStage( programStage.getUid() )
@@ -199,11 +185,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenAMandatoryDataElementIsMissing()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
@@ -214,7 +196,7 @@ class EventDataValuesValidationHookTest
         mandatoryStageElement1.setCompulsory( true );
         ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
         DataElement mandatoryElement2 = new DataElement();
-        mandatoryElement2.setUid( getDataValue().getDataElement() );
+        mandatoryElement2.setUid( dataValue().getDataElement() );
         mandatoryStageElement2.setDataElement( mandatoryElement2 );
         mandatoryStageElement2.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
@@ -224,7 +206,7 @@ class EventDataValuesValidationHookTest
         Event event = Event.builder()
             .programStage( "PROGRAM_STAGE" )
             .status( EventStatus.COMPLETED )
-            .dataValues( Set.of( getDataValue() ) ).build();
+            .dataValues( Set.of( dataValue() ) ).build();
 
         hook.validateEvent( reporter, event );
 
@@ -235,12 +217,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failSuccessWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
     {
-
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
@@ -251,7 +228,7 @@ class EventDataValuesValidationHookTest
         mandatoryStageElement1.setCompulsory( true );
         ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
         DataElement mandatoryElement2 = new DataElement();
-        mandatoryElement2.setUid( getDataValue().getDataElement() );
+        mandatoryElement2.setUid( dataValue().getDataElement() );
         mandatoryStageElement2.setDataElement( mandatoryElement2 );
         mandatoryStageElement2.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
@@ -262,7 +239,7 @@ class EventDataValuesValidationHookTest
         Event event = Event.builder()
             .programStage( "PROGRAM_STAGE" )
             .status( EventStatus.ACTIVE )
-            .dataValues( Set.of( getDataValue() ) ).build();
+            .dataValues( Set.of( dataValue() ) ).build();
 
         hook.validateEvent( reporter, event );
 
@@ -272,11 +249,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsNotPresentInProgramStage()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
+        DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
         DataElement notPresentDataElement = new DataElement();
@@ -288,20 +261,20 @@ class EventDataValuesValidationHookTest
         ProgramStage programStage = new ProgramStage();
         ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
         DataElement mandatoryElement1 = new DataElement();
-        mandatoryElement1.setUid( getDataValue().getDataElement() );
+        mandatoryElement1.setUid( dataValue().getDataElement() );
         mandatoryStageElement1.setDataElement( mandatoryElement1 );
         mandatoryStageElement1.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1 ) );
         when( context.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
 
-        DataValue notPresentDataValue = getDataValue();
+        DataValue notPresentDataValue = dataValue();
         notPresentDataValue.setDataElement( "de_not_present_in_program_stage" );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
         Event event = Event.builder()
             .programStage( "PROGRAM_STAGE" )
             .status( EventStatus.ACTIVE )
-            .dataValues( Set.of( getDataValue(), notPresentDataValue ) ).build();
+            .dataValues( Set.of( dataValue(), notPresentDataValue ) ).build();
 
         hook.validateEvent( reporter, event );
 
@@ -312,16 +285,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementValueTypeIsNull()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
-        when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
-
-        DataElement invalidDataElement = new DataElement();
-        invalidDataElement.setUid( dataElementUid );
-        invalidDataElement.setValueType( null );
+        DataElement dataElement = dataElement();
+        DataElement invalidDataElement = dataElement( null );
         when( context.getDataElement( dataElementUid ) ).thenReturn( invalidDataElement );
 
         ProgramStage programStage = new ProgramStage();
@@ -333,7 +298,7 @@ class EventDataValuesValidationHookTest
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
-            .dataValues( Set.of( getDataValue() ) )
+            .dataValues( Set.of( dataValue() ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -345,15 +310,11 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsNull()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( "QX4LpiTZmUH" );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.FILE_RESOURCE );
+        DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( "QX4LpiTZmUH" );
         when( context.getFileResource( validDataValue.getValue() ) ).thenReturn( null );
 
         ProgramStage programStage = new ProgramStage();
@@ -378,19 +339,15 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenFileResourceValueIsNullAndDataElementIsNotCompulsory()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.FILE_RESOURCE );
+        DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, false );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.COMPLETED )
@@ -405,20 +362,16 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceValueIsNullAndDataElementIsCompulsory()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
 
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.FILE_RESOURCE );
+        DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.COMPLETED )
@@ -434,13 +387,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnActiveEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
@@ -448,6 +395,8 @@ class EventDataValuesValidationHookTest
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.ACTIVE )
@@ -463,13 +412,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
@@ -477,6 +420,8 @@ class EventDataValuesValidationHookTest
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.COMPLETED )
@@ -492,13 +437,7 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnActiveEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
@@ -506,6 +445,8 @@ class EventDataValuesValidationHookTest
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.ACTIVE )
@@ -520,13 +461,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
@@ -534,6 +469,8 @@ class EventDataValuesValidationHookTest
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.COMPLETED )
@@ -549,19 +486,15 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnScheduledEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SCHEDULE )
@@ -576,19 +509,15 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnSkippedEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -603,19 +532,15 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenDataElementIsNullAndDataElementIsNotCompulsory()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( null );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.TEXT );
+        DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = getProgramStage( validDataElement, programStageUid, false );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( null );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.COMPLETED )
@@ -630,17 +555,13 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsAlreadyAssigned()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
-        validDataValue.setValue( "QX4LpiTZmUH" );
-        DataElement validDataElement = new DataElement();
-        validDataElement.setUid( dataElementUid );
-        validDataElement.setValueType( ValueType.FILE_RESOURCE );
+        DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
         FileResource fileResource = new FileResource();
         fileResource.setAssigned( true );
+        DataValue validDataValue = dataValue();
+        validDataValue.setValue( "QX4LpiTZmUH" );
         when( context.getFileResource( validDataValue.getValue() ) ).thenReturn( fileResource );
 
         ProgramStage programStage = new ProgramStage();
@@ -684,11 +605,9 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationDataElementOptionValueIsValid()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
+        DataValue validDataValue = dataValue();
         validDataValue.setValue( "code" );
-        DataValue nullDataValue = getDataValue();
+        DataValue nullDataValue = dataValue();
         nullDataValue.setValue( null );
 
         OptionSet optionSet = new OptionSet();
@@ -698,9 +617,7 @@ class EventDataValuesValidationHookTest
         option1.setCode( "CODE1" );
         optionSet.setOptions( Arrays.asList( option, option1 ) );
 
-        DataElement dataElement = new DataElement();
-        dataElement.setUid( dataElementUid );
-        dataElement.setValueType( ValueType.TEXT );
+        DataElement dataElement = dataElement();
         dataElement.setOptionSet( optionSet );
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -724,9 +641,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationDataElementOptionValueIsInValid()
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataValue validDataValue = getDataValue();
+        DataValue validDataValue = dataValue();
         validDataValue.setDataElement( dataElementUid );
         validDataValue.setValue( "value" );
 
@@ -737,9 +652,7 @@ class EventDataValuesValidationHookTest
         option1.setCode( "CODE1" );
         optionSet.setOptions( Arrays.asList( option, option1 ) );
 
-        DataElement dataElement = new DataElement();
-        dataElement.setUid( dataElementUid );
-        dataElement.setValueType( ValueType.TEXT );
+        DataElement dataElement = dataElement();
         dataElement.setOptionSet( optionSet );
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -765,23 +678,16 @@ class EventDataValuesValidationHookTest
 
     private void runAndAssertValidationForDataValue( ValueType valueType, String value )
     {
-        when( context.getBundle() ).thenReturn( TrackerBundle.builder().build() );
-
-        DataElement dataElement = new DataElement();
-        dataElement.setValueType( ValueType.TEXT );
-        dataElement.setUid( dataElementUid );
-
-        DataElement invalidDataElement = new DataElement();
-        invalidDataElement.setUid( dataElementUid );
-        invalidDataElement.setValueType( valueType );
+        DataElement invalidDataElement = dataElement( valueType );
         when( context.getDataElement( dataElementUid ) ).thenReturn( invalidDataElement );
 
         ProgramStage programStage = new ProgramStage();
         programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        programStage
+            .setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement() ) ) );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
-        DataValue validDataValue = getDataValue();
+        DataValue validDataValue = dataValue();
         validDataValue.setDataElement( dataElementUid );
         validDataValue.setValue( value );
 
@@ -798,7 +704,24 @@ class EventDataValuesValidationHookTest
         assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
     }
 
-    private DataValue getDataValue()
+    @NotNull
+    private DataElement dataElement( ValueType type )
+    {
+        DataElement dataElement = dataElement();
+        dataElement.setValueType( type );
+        return dataElement;
+    }
+
+    @NotNull
+    private DataElement dataElement()
+    {
+        DataElement dataElement = new DataElement();
+        dataElement.setValueType( ValueType.TEXT );
+        dataElement.setUid( dataElementUid );
+        return dataElement;
+    }
+
+    private DataValue dataValue()
     {
         DataValue dataValue = new DataValue();
         dataValue.setCreatedAt( DateUtils.instantFromDateAsString( "2020-10-10" ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.hisp.dhis.common.ValueType;
@@ -91,12 +90,11 @@ class EventDataValuesValidationHookTest
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -113,9 +111,7 @@ class EventDataValuesValidationHookTest
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
@@ -138,15 +134,13 @@ class EventDataValuesValidationHookTest
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
 
         DataValue validDataValue = dataValue();
         validDataValue.setUpdatedAt( null );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -163,18 +157,15 @@ class EventDataValuesValidationHookTest
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( null );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
-        DataValue validDataValue = dataValue();
+        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
 
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
-            .dataValues( Set.of( validDataValue ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+            .dataValues( Set.of( dataValue() ) ).build();
 
         hook.validateEvent( reporter, event );
 
@@ -203,6 +194,7 @@ class EventDataValuesValidationHookTest
         when( context.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( "PROGRAM_STAGE" )
             .status( EventStatus.COMPLETED )
@@ -234,8 +226,8 @@ class EventDataValuesValidationHookTest
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
         when( context.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
 
-        // TODO difference between this test and above is status == ACTIVE
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( "PROGRAM_STAGE" )
             .status( EventStatus.ACTIVE )
@@ -252,8 +244,7 @@ class EventDataValuesValidationHookTest
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
-        DataElement notPresentDataElement = new DataElement();
-        notPresentDataElement.setValueType( ValueType.TEXT );
+        DataElement notPresentDataElement = dataElement();
         notPresentDataElement.setUid( "de_not_present_in_program_stage" );
         when( context.getDataElement( "de_not_present_in_program_stage" ) )
             .thenReturn( notPresentDataElement );
@@ -267,10 +258,10 @@ class EventDataValuesValidationHookTest
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1 ) );
         when( context.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
 
+        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue notPresentDataValue = dataValue();
         notPresentDataValue.setDataElement( "de_not_present_in_program_stage" );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
         Event event = Event.builder()
             .programStage( "PROGRAM_STAGE" )
             .status( EventStatus.ACTIVE )
@@ -289,12 +280,11 @@ class EventDataValuesValidationHookTest
         DataElement invalidDataElement = dataElement( null );
         when( context.getDataElement( dataElementUid ) ).thenReturn( invalidDataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -313,17 +303,14 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        DataValue validDataValue = dataValue();
-        validDataValue.setValue( "QX4LpiTZmUH" );
+        DataValue validDataValue = dataValue( "QX4LpiTZmUH" );
         when( context.getFileResource( validDataValue.getValue() ) ).thenReturn( null );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage
-            .setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, validDataElement ) ) );
+        ProgramStage programStage = programStage( validDataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -342,10 +329,11 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, false );
+        ProgramStage programStage = programStage( validDataElement, false );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -366,10 +354,11 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -390,11 +379,12 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -415,11 +405,12 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -440,11 +431,12 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -464,11 +456,12 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -489,10 +482,11 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -512,10 +506,11 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, true );
+        ProgramStage programStage = programStage( validDataElement, true );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -535,10 +530,11 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        ProgramStage programStage = getProgramStage( validDataElement, programStageUid, false );
+        ProgramStage programStage = programStage( validDataElement, false );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
@@ -558,19 +554,15 @@ class EventDataValuesValidationHookTest
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
-        FileResource fileResource = new FileResource();
-        fileResource.setAssigned( true );
-        DataValue validDataValue = dataValue();
-        validDataValue.setValue( "QX4LpiTZmUH" );
-        when( context.getFileResource( validDataValue.getValue() ) ).thenReturn( fileResource );
-
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage
-            .setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, validDataElement ) ) );
+        ProgramStage programStage = programStage( validDataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
+        FileResource fileResource = new FileResource();
+        fileResource.setAssigned( true );
+        DataValue validDataValue = dataValue( "QX4LpiTZmUH" );
+        when( context.getFileResource( validDataValue.getValue() ) ).thenReturn( fileResource );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -621,12 +613,11 @@ class EventDataValuesValidationHookTest
         dataElement.setOptionSet( optionSet );
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -641,9 +632,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationDataElementOptionValueIsInValid()
     {
-        DataValue validDataValue = dataValue();
+        DataValue validDataValue = dataValue( "value" );
         validDataValue.setDataElement( dataElementUid );
-        validDataValue.setValue( "value" );
 
         OptionSet optionSet = new OptionSet();
         Option option = new Option();
@@ -656,12 +646,11 @@ class EventDataValuesValidationHookTest
         dataElement.setOptionSet( optionSet );
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage.setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement ) ) );
+        ProgramStage programStage = programStage( dataElement );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -681,17 +670,14 @@ class EventDataValuesValidationHookTest
         DataElement invalidDataElement = dataElement( valueType );
         when( context.getDataElement( dataElementUid ) ).thenReturn( invalidDataElement );
 
-        ProgramStage programStage = new ProgramStage();
-        programStage.setUid( programStageUid );
-        programStage
-            .setProgramStageDataElements( Set.of( new ProgramStageDataElement( programStage, dataElement() ) ) );
+        ProgramStage programStage = programStage( dataElement() );
         when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
 
         DataValue validDataValue = dataValue();
         validDataValue.setDataElement( dataElementUid );
         validDataValue.setValue( value );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
         Event event = Event.builder()
             .programStage( programStage.getUid() )
             .status( EventStatus.SKIPPED )
@@ -721,6 +707,14 @@ class EventDataValuesValidationHookTest
         return dataElement;
     }
 
+    @NotNull
+    private DataValue dataValue( String value )
+    {
+        DataValue dataValue = dataValue();
+        dataValue.setValue( value );
+        return dataValue;
+    }
+
     private DataValue dataValue()
     {
         DataValue dataValue = new DataValue();
@@ -731,32 +725,28 @@ class EventDataValuesValidationHookTest
         return dataValue;
     }
 
-    private ProgramStage getProgramStage( DataElement validDataElement, String programStageUid, boolean compulsory )
+    @NotNull
+    private ProgramStage programStage( DataElement dataElement )
+    {
+        return programStage( dataElement, false );
+    }
+
+    private ProgramStage programStage( DataElement dataElement, boolean compulsory )
     {
         ProgramStage programStage = new ProgramStage();
         programStage.setUid( programStageUid );
         programStage
-            .setProgramStageDataElements( getProgramStageDataElements( validDataElement, programStage, compulsory ) );
+            .setProgramStageDataElements( getProgramStageDataElements( dataElement, programStage, compulsory ) );
 
         return programStage;
     }
 
-    private HashSet<ProgramStageDataElement> getProgramStageDataElements( DataElement validDataElement,
+    private Set<ProgramStageDataElement> getProgramStageDataElements( DataElement dataElement,
         ProgramStage programStage, boolean compulsory )
     {
-        return new HashSet<>()
-        {
-            {
-
-                ProgramStageDataElement programStageDataElement = new ProgramStageDataElement();
-                programStageDataElement.setCompulsory( compulsory );
-                programStageDataElement.setDataElement( validDataElement );
-                programStageDataElement.setProgramStage( programStage );
-
-                add( programStageDataElement );
-
-            }
-        };
+        ProgramStageDataElement programStageDataElement = new ProgramStageDataElement( programStage, dataElement );
+        programStageDataElement.setCompulsory( compulsory );
+        return Set.of( programStageDataElement );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -255,18 +255,18 @@ class EventDataValuesValidationHookTest
         mandatoryStageDataElement.setCompulsory( true );
 
         DataValue notPresentDataValue = getDataValue();
-        notPresentDataValue.setDataElement( "de_not_present_in_progam_stage" );
+        notPresentDataValue.setDataElement( "de_not_present_in_program_stage" );
 
         DataElement notPresentDataElement = new DataElement();
         notPresentDataElement.setValueType( ValueType.TEXT );
-        notPresentDataElement.setUid( "de_not_present_in_progam_stage" );
+        notPresentDataElement.setUid( "de_not_present_in_program_stage" );
 
         programStage.setProgramStageDataElements( Sets.newHashSet( mandatoryStageDataElement ) );
         when( event.getDataValues() ).thenReturn( Sets.newHashSet( getDataValue(), notPresentDataValue ) );
         when( event.getProgramStage() ).thenReturn( "PROGRAM_STAGE" );
         when( event.getStatus() ).thenReturn( EventStatus.ACTIVE );
         when( validationContext.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
-        when( validationContext.getDataElement( "de_not_present_in_progam_stage" ) )
+        when( validationContext.getDataElement( "de_not_present_in_program_stage" ) )
             .thenReturn( notPresentDataElement );
 
         // When
@@ -691,7 +691,7 @@ class EventDataValuesValidationHookTest
     private HashSet<ProgramStageDataElement> getProgramStageDataElements( DataElement validDataElement,
         ProgramStage programStage, boolean compulsory )
     {
-        return new HashSet<ProgramStageDataElement>()
+        return new HashSet<>()
         {
             {
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -55,7 +55,6 @@ import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.TrackerImportValidationContext;
 import org.hisp.dhis.util.DateUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -808,7 +807,6 @@ class EventDataValuesValidationHookTest
         when( context.getIdentifiers() ).thenReturn( params );
     }
 
-    @NotNull
     private DataElement dataElement( ValueType type )
     {
         DataElement dataElement = dataElement();
@@ -816,7 +814,6 @@ class EventDataValuesValidationHookTest
         return dataElement;
     }
 
-    @NotNull
     private DataElement dataElement()
     {
         DataElement dataElement = new DataElement();
@@ -825,7 +822,6 @@ class EventDataValuesValidationHookTest
         return dataElement;
     }
 
-    @NotNull
     private DataValue dataValue( String value )
     {
         DataValue dataValue = dataValue();
@@ -843,7 +839,6 @@ class EventDataValuesValidationHookTest
         return dataValue;
     }
 
-    @NotNull
     private ProgramStage programStage( DataElement dataElement )
     {
         return programStage( dataElement, false );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -89,6 +89,8 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenDataElementIsValid()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -110,6 +112,8 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenCreatedAtIsNull()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -133,6 +137,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenUpdatedAtIsNull()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -156,6 +162,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsInvalid()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( null );
 
@@ -178,6 +186,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenAMandatoryDataElementIsMissing()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -209,8 +219,10 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
-    void failSuccessWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
+    void succeedsWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -241,8 +253,42 @@ class EventDataValuesValidationHookTest
     }
 
     @Test
+    void succeedsWhenMandatoryDataElementIsPartOfProgramStageAndIdSchemeIsSetToCode()
+    {
+        TrackerIdentifierParams params = TrackerIdentifierParams.builder()
+            .idScheme( TrackerIdentifier.CODE )
+            .programIdScheme( TrackerIdentifier.UID )
+            .programStageIdScheme( TrackerIdentifier.UID )
+            .dataElementIdScheme( TrackerIdentifier.CODE )
+            .build();
+        when( context.getIdentifiers() ).thenReturn( params );
+
+        DataElement dataElement = dataElement();
+        dataElement.setCode( "DE_424050" );
+        when( context.getDataElement( dataElement.getCode() ) ).thenReturn( dataElement );
+
+        ProgramStage programStage = programStage( dataElement, true );
+        when( context.getProgramStage( programStageUid ) ).thenReturn( programStage );
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( context );
+
+        DataValue dataValue = dataValue();
+        dataValue.setDataElement( "DE_424050" );
+        Event event = Event.builder()
+            .programStage( programStage.getUid() )
+            .status( EventStatus.COMPLETED )
+            .dataValues( Set.of( dataValue ) ).build();
+
+        hook.validateEvent( reporter, event );
+
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
     void failValidationWhenDataElementIsNotPresentInProgramStage()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( dataElement );
 
@@ -310,6 +356,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementValueTypeIsNull()
     {
+        setUpIdentifiers();
+
         DataElement dataElement = dataElement();
         DataElement invalidDataElement = dataElement( null );
         when( context.getDataElement( dataElementUid ) ).thenReturn( invalidDataElement );
@@ -334,6 +382,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsNull()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -360,6 +410,8 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenFileResourceValueIsNullAndDataElementIsNotCompulsory()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -384,6 +436,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceValueIsNullAndDataElementIsCompulsory()
     {
+        setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
@@ -410,6 +463,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnActiveEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -436,6 +491,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -462,6 +519,8 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnActiveEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -487,6 +546,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -513,6 +574,8 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnScheduledEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -537,6 +600,8 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnSkippedEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -561,6 +626,8 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenDataElementIsNullAndDataElementIsNotCompulsory()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement();
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -585,6 +652,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsAlreadyAssigned()
     {
+        setUpIdentifiers();
+
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( context.getDataElement( dataElementUid ) ).thenReturn( validDataElement );
 
@@ -631,10 +700,10 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationDataElementOptionValueIsValid()
     {
-        DataValue validDataValue = dataValue();
-        validDataValue.setValue( "code" );
-        DataValue nullDataValue = dataValue();
-        nullDataValue.setValue( null );
+        setUpIdentifiers();
+
+        DataValue validDataValue = dataValue( "code" );
+        DataValue nullDataValue = dataValue( null );
 
         OptionSet optionSet = new OptionSet();
         Option option = new Option();
@@ -666,6 +735,8 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationDataElementOptionValueIsInValid()
     {
+        setUpIdentifiers();
+
         DataValue validDataValue = dataValue( "value" );
         validDataValue.setDataElement( dataElementUid );
 
@@ -701,6 +772,8 @@ class EventDataValuesValidationHookTest
 
     private void runAndAssertValidationForDataValue( ValueType valueType, String value )
     {
+        setUpIdentifiers();
+
         DataElement invalidDataElement = dataElement( valueType );
         when( context.getDataElement( dataElementUid ) ).thenReturn( invalidDataElement );
 
@@ -722,6 +795,17 @@ class EventDataValuesValidationHookTest
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
+    }
+
+    private void setUpIdentifiers()
+    {
+        TrackerIdentifierParams params = TrackerIdentifierParams.builder()
+            .idScheme( TrackerIdentifier.UID )
+            .programIdScheme( TrackerIdentifier.UID )
+            .programStageIdScheme( TrackerIdentifier.UID )
+            .dataElementIdScheme( TrackerIdentifier.UID )
+            .build();
+        when( context.getIdentifiers() ).thenReturn( params );
     }
 
     @NotNull


### PR DESCRIPTION
when a user uses a dataElementIdScheme other than UID the NTI validation falsely said
* the payload is missing a mandatory dataElement (mandatory to the program stage)
* the payload contains a dataElement that is not part of the events programStage

This was due to the NTI validation not taking the idScheme into account in the EventDataValuesValidationHook

After the above fixes the ProgramRuleService failed to find the DataElement because it was using the UID instead of the user specified CODE idScheme.

Now the EventTrackerConverterService map EventDataValue.dataElement to UID. It does so by getting the dataElement from the preheat.

At this point EventDataValuesValidationHook already checked whether the
dataElement specified by the user exists by looking in the preheat. If
not found it would add error E1304 'DataElement `{0}` is not a valid
data element' and fail validation. Looking the dataElement up in the
preheat already respects the idScheme.

Lookup the dataElement in the preheat using the user specified identifier.
Use the UID when mapping to an EventDataValue. This means any code using
the EventDataValue.identifier from then on can rely on it being a UID.
The NTI request idScheme is not available in the program rule engine so
any existing code already assumed it was a UID.

* fixes a bug in EventTrackerConverterService that fails to merge new and existing dataValues if the user uses an idScheme other than UID.
* EventDataValuesValidation and EventTrackerConverterServiceTest hook test now uses mockitos strict mode. I removed unnecessary mockito stubbing so tests remain clean in the future. Extracted helpers to make differences between tests clear.