### PR TITLE
2.38-DHIS2-12326 Event analytics always returns metadata for all options in option set

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -600,7 +600,7 @@ public class JdbcAnalyticsManager
     {
         Period period = params.getLatestPeriod();
 
-        List<String> cols = Lists.newArrayList( "year", "pestartdate", "peenddate", "level", "daysxvalue", "daysno",
+        List<String> cols = Lists.newArrayList( "year", "pestartdate", "peenddate", "oulevel", "daysxvalue", "daysno",
             "value", "textvalue" );
 
         cols = cols.stream().map( AnalyticsSqlUtils::quote ).collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
@@ -33,7 +33,6 @@ import org.hisp.dhis.analytics.AnalyticsMetaDataKey;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.Grid;
-import org.hisp.dhis.option.Option;
 
 /**
  * This interface is responsible for retrieving aggregated event data. Data will
@@ -141,5 +140,4 @@ public interface EventAnalyticsService
      */
     Rectangle getRectangle( EventQueryParams params );
 
-    List<Option> getItemOptions( Grid grid );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
@@ -33,6 +33,7 @@ import org.hisp.dhis.analytics.AnalyticsMetaDataKey;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.option.Option;
 
 /**
  * This interface is responsible for retrieving aggregated event data. Data will
@@ -139,4 +140,6 @@ public interface EventAnalyticsService
      * @return event clusters as a Grid object.
      */
     Rectangle getRectangle( EventQueryParams params );
+
+    List<Option> getItemOptions( Grid grid );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -339,12 +339,20 @@ public abstract class AbstractAnalyticsService
 
         if ( !params.isSkipData() )
         {
+            // filtering if the rows in grid are there (skipData = false)
             itemOptions.forEach( option -> metadataItemMap.put( option.getUid(),
                 new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
                     option.getCode() ) ) );
         }
         else
         {
+            // filtering if the rows in grid are not there (skipData = true
+            // only)
+            // dimension=Zj7UnCAulEk.K6uUAvq500H:IN:A00;A60;A01 -> IN indicates
+            // there is a filter
+            // the stream contains all options if no filter or only options fit
+            // to the filter
+            // options can be divided by separator <<;>>
             params.getItemOptions().stream()
                 .filter( option -> option != null &&
                     (params.getItems().stream().noneMatch( QueryItem::hasFilter ) ||

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -314,9 +314,38 @@ public abstract class AbstractAnalyticsService
                 new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null,
                     legend.getCode() ) ) );
 
-        itemOptions.forEach( option -> metadataItemMap.put( option.getUid(),
-            new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
-                option.getCode() ) ) );
+        if ( !params.isSkipData() )
+        {
+            params.getItemOptions().stream()
+                .filter( option -> {
+                    if ( option != null )
+                    {
+                        return (params.getItems().stream().noneMatch( QueryItem::hasFilter ) &&
+                            itemOptions.stream().anyMatch( dvo -> dvo.getCode().equalsIgnoreCase( option.getCode() ) )
+                            ||
+                            params.getItems().stream().filter( QueryItem::hasFilter )
+                                .anyMatch( qi -> qi.getFilters().stream()
+                                    .anyMatch( f -> f.getFilter().equalsIgnoreCase( option.getCode() ) ) ));
+                    }
+
+                    return false;
+                } )
+                .forEach( option -> metadataItemMap.put( option.getUid(),
+                    new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
+                        option.getCode() ) ) );
+        }
+        else
+        {
+            params.getItemOptions().stream()
+                .filter( option -> option != null &&
+                    (params.getItems().stream().noneMatch( QueryItem::hasFilter ) ||
+                        params.getItems().stream().filter( QueryItem::hasFilter )
+                            .anyMatch( qi -> qi.getFilters().stream()
+                                .anyMatch( f -> f.getFilter().equalsIgnoreCase( option.getCode() ) ) )) )
+                .forEach( option -> metadataItemMap.put( option.getUid(),
+                    new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
+                        option.getCode() ) ) );
+        }
 
         params.getItemsAndItemFilters().stream()
             .filter( Objects::nonNull )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -257,7 +257,7 @@ public abstract class AbstractAnalyticsService
      * @param grid the Grid instance.
      * @return a list of options.
      */
-    private List<Option> getItemOptions( Grid grid )
+    protected List<Option> getItemOptions( Grid grid )
     {
         List<Option> options = new ArrayList<>();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -315,6 +315,28 @@ public abstract class AbstractAnalyticsService
                 new MetadataItem( legend.getDisplayName(), includeDetails ? legend.getUid() : null,
                     legend.getCode() ) ) );
 
+        addMetadataItems( metadataItemMap, params, itemOptions );
+
+        params.getItemsAndItemFilters().stream()
+            .filter( Objects::nonNull )
+            .forEach( item -> metadataItemMap.put( item.getItemId(),
+                new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
+
+        return metadataItemMap;
+    }
+
+    /**
+     * Add into the MetadataItemMap itemOptions
+     *
+     * @param metadataItemMap MetadataItemMap.
+     * @param params EventQueryParams.
+     * @param itemOptions itemOtion list.
+     */
+    private void addMetadataItems( final Map<String, MetadataItem> metadataItemMap, final EventQueryParams params,
+        final List<Option> itemOptions )
+    {
+        boolean includeDetails = params.isIncludeMetadataDetails();
+
         if ( !params.isSkipData() )
         {
             itemOptions.forEach( option -> metadataItemMap.put( option.getUid(),
@@ -334,13 +356,6 @@ public abstract class AbstractAnalyticsService
                     new MetadataItem( option.getDisplayName(), includeDetails ? option.getUid() : null,
                         option.getCode() ) ) );
         }
-
-        params.getItemsAndItemFilters().stream()
-            .filter( Objects::nonNull )
-            .forEach( item -> metadataItemMap.put( item.getItemId(),
-                new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
-
-        return metadataItemMap;
     }
 
     /**
@@ -370,16 +385,7 @@ public abstract class AbstractAnalyticsService
         {
             if ( item.hasOptionSet() )
             {
-                if ( params.isSkipData() )
-                {
-                    dimensionItems.put( item.getItemId(), item.getOptionSetFilterItemsOrAll() );
-                }
-                else
-                {
-                    dimensionItems.put( item.getItemId(), itemOptions.stream()
-                        .map( BaseIdentifiableObject::getUid )
-                        .collect( Collectors.toList() ) );
-                }
+                dimensionItems.put( item.getItemId(), getDimensionItemUidList( params, item, itemOptions ) );
             }
             else if ( item.hasLegendSet() )
             {
@@ -408,6 +414,28 @@ public abstract class AbstractAnalyticsService
         }
 
         return dimensionItems;
+    }
+
+    /**
+     * Return list of dimension item uids
+     *
+     * @param params EventQueryParams.
+     * @param item QueryItem
+     * @param itemOptions itemOtion list.
+     * @return a list of uids.
+     */
+    private List<String> getDimensionItemUidList( EventQueryParams params, QueryItem item, List<Option> itemOptions )
+    {
+        if ( params.isSkipData() )
+        {
+            return item.getOptionSetFilterItemsOrAll();
+        }
+        else
+        {
+            return itemOptions.stream()
+                .map( BaseIdentifiableObject::getUid )
+                .collect( Collectors.toList() );
+        }
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
@@ -171,7 +171,7 @@ class JdbcAnalyticsManagerTest
     private void assertExpectedSql( String sortOrder )
     {
 
-        String lastAggregationTypeSql = "(select \"year\",\"pestartdate\",\"peenddate\",\"level\",\"daysxvalue\","
+        String lastAggregationTypeSql = "(select \"year\",\"pestartdate\",\"peenddate\",\"oulevel\",\"daysxvalue\","
             + "\"daysno\",\"value\",\"textvalue\",\"dx\",cast('201501' as text) as \"pe\",\"ou\","
             + "row_number() over (partition by dx, ou, co, ao order by peenddate " + sortOrder + ", pestartdate "
             + sortOrder + ") as pe_rank "
@@ -184,7 +184,7 @@ class JdbcAnalyticsManagerTest
     private void assertExpectedLastSql( String sortOrder )
     {
 
-        String lastAggregationTypeSql = "(select \"year\",\"pestartdate\",\"peenddate\",\"level\",\"daysxvalue\","
+        String lastAggregationTypeSql = "(select \"year\",\"pestartdate\",\"peenddate\",\"oulevel\",\"daysxvalue\","
             + "\"daysno\",\"value\",\"textvalue\",\"dx\",cast('201501' as text) as \"pe\",\"ou\","
             + "row_number() over (partition by dx, ou, co, ao order by peenddate " + sortOrder + ", pestartdate "
             + sortOrder + ") as pe_rank "

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -173,9 +173,12 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
             .addFilter( new QueryFilter( QueryOperator.IN, opA.getCode() + OPTION_SEP + opB.getCode() ) );
         EventQueryParams params = new EventQueryParams.Builder().withProgram( prA ).addDimension( periods )
             .addDimension( orgUnits ).addItem( itemLegendSet ).addItem( itemLegendSetFilter ).addItem( item )
-            .addItem( itemFilter ).addItem( itemOptionSet ).addItem( itemOptionSetFilter ).withSkipData( true )
+            .addItem( itemFilter ).addItem( itemOptionSet ).addItem( itemOptionSetFilter ).withSkipData( false )
             .withSkipMeta( false ).withDisplayProperty( DisplayProperty.NAME ).build();
+
         Grid grid = eventAnalyticsService.getAggregatedEventData( params );
+        grid = grid.addRow();
+        grid.getRow( 0 ).add( "OptionSetCodeA" );
         Map<String, Object> metadata = grid.getMetaData();
         assertNotNull( metadata );
         Map<String, Object> dimensionItems = (Map<String, Object>) metadata
@@ -200,10 +203,11 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
             itemsLegendSetFilter.containsAll( IdentifiableObjectUtils.getUids( Sets.newHashSet( leA, leB, leC ) ) ) );
         assertTrue( items.isEmpty() );
         assertTrue( itemsFilter.isEmpty() );
-        assertTrue( !itemsOptionSet.isEmpty() );
-        assertEquals( 2, itemsOptionSetFilter.size() );
-        assertTrue(
-            itemsOptionSetFilter.containsAll( IdentifiableObjectUtils.getUids( Sets.newHashSet( opA, opB ) ) ) );
+        // assertTrue( !itemsOptionSet.isEmpty() );
+        // assertEquals( 0, itemsOptionSetFilter.size() );
+        // assertTrue(
+        // itemsOptionSetFilter.containsAll( IdentifiableObjectUtils.getUids(
+        // Sets.newHashSet( opA, opB ) ) ) );
     }
 
     @Test
@@ -229,10 +233,10 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
         {
             assertNotNull( itemMap.get( legend.getUid() ) );
         }
-        for ( Option option : deE.getOptionSet().getOptions() )
-        {
-            assertNotNull( itemMap.get( option.getUid() ) );
-        }
+        // for ( Option option : deE.getOptionSet().getOptions() )
+        // {
+        // assertNotNull( itemMap.get( option.getUid() ) );
+        // }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -173,12 +173,10 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
             .addFilter( new QueryFilter( QueryOperator.IN, opA.getCode() + OPTION_SEP + opB.getCode() ) );
         EventQueryParams params = new EventQueryParams.Builder().withProgram( prA ).addDimension( periods )
             .addDimension( orgUnits ).addItem( itemLegendSet ).addItem( itemLegendSetFilter ).addItem( item )
-            .addItem( itemFilter ).addItem( itemOptionSet ).addItem( itemOptionSetFilter ).withSkipData( false )
+            .addItem( itemFilter ).addItem( itemOptionSet ).addItem( itemOptionSetFilter ).withSkipData( true )
             .withSkipMeta( false ).withDisplayProperty( DisplayProperty.NAME ).build();
 
         Grid grid = eventAnalyticsService.getAggregatedEventData( params );
-        grid = grid.addRow();
-        grid.getRow( 0 ).add( "OptionSetCodeA" );
         Map<String, Object> metadata = grid.getMetaData();
         assertNotNull( metadata );
         Map<String, Object> dimensionItems = (Map<String, Object>) metadata
@@ -203,11 +201,11 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
             itemsLegendSetFilter.containsAll( IdentifiableObjectUtils.getUids( Sets.newHashSet( leA, leB, leC ) ) ) );
         assertTrue( items.isEmpty() );
         assertTrue( itemsFilter.isEmpty() );
-        // assertTrue( !itemsOptionSet.isEmpty() );
-        // assertEquals( 0, itemsOptionSetFilter.size() );
-        // assertTrue(
-        // itemsOptionSetFilter.containsAll( IdentifiableObjectUtils.getUids(
-        // Sets.newHashSet( opA, opB ) ) ) );
+        assertTrue( !itemsOptionSet.isEmpty() );
+        assertEquals( 2, itemsOptionSetFilter.size() );
+        assertTrue(
+            itemsOptionSetFilter.containsAll( IdentifiableObjectUtils.getUids(
+                Sets.newHashSet( opA, opB ) ) ) );
     }
 
     @Test
@@ -233,10 +231,10 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
         {
             assertNotNull( itemMap.get( legend.getUid() ) );
         }
-        // for ( Option option : deE.getOptionSet().getOptions() )
-        // {
-        // assertNotNull( itemMap.get( option.getUid() ) );
-        // }
+        for ( Option option : deE.getOptionSet().getOptions() )
+        {
+            assertNotNull( itemMap.get( option.getUid() ) );
+        }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static org.hisp.dhis.common.QueryFilter.OPTION_SEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -201,11 +202,10 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
             itemsLegendSetFilter.containsAll( IdentifiableObjectUtils.getUids( Sets.newHashSet( leA, leB, leC ) ) ) );
         assertTrue( items.isEmpty() );
         assertTrue( itemsFilter.isEmpty() );
-        assertTrue( !itemsOptionSet.isEmpty() );
+        assertFalse( itemsOptionSet.isEmpty() );
         assertEquals( 2, itemsOptionSetFilter.size() );
         assertTrue(
-            itemsOptionSetFilter.containsAll( IdentifiableObjectUtils.getUids(
-                Sets.newHashSet( opA, opB ) ) ) );
+            itemsOptionSetFilter.containsAll( IdentifiableObjectUtils.getUids( Sets.newHashSet( opA, opB ) ) ) );
     }
 
     @Test


### PR DESCRIPTION
Current behaviour

When a data element with an option set is requested on /analytics/events/query metadata is returned for all options in the option set. Even when only a few options are specifically requested, e.g. dimension=K6uUAvq500H:IN:A00;A000, metadata for all options are returned.

Example where a single option has been specified. Still metadata for all 14000+ options are returned:
https://play.dhis2.org/dev/api/29/analytics/events/query/eBAyeGv0exc.json?dimension=pe:LAST_3_MONTHS&dimension=ou:ImspTQPwCqd&dimension=Zj7UnCAulEk.K6uUAvq500H:IN:A00&displayProperty=SHORTNAME&outputType=EVENT&desc=eventdate&pageSize=100&page=1

Example request where no options are specified and page size is set to 100. Still metadata for all 14000+ options are returned:
https://play.dhis2.org/dev/api/analytics/events/query/eBAyeGv0exc.json?dimension=pe:LAST_3_MONTHS&dimension=ou:ImspTQPwCqd&dimension=Zj7UnCAulEk.K6uUAvq500H&outputType=EVENT&desc=eventdate&pageSize=100&page=1

Expected behaviour

When e.g. two options are requested, only return metadata for those two. If the dimension is requested without specified options then only return metadata for the options that exist in the (paged) data response.