### PR TITLE
fix: ConcurrentModificationException in translationCheck

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ObjectReport.java
@@ -123,7 +123,13 @@ public class ObjectReport implements ErrorReportContainer
 
     public ObjectReport merge( ObjectReport objectReport )
     {
+        if ( objectReport == this )
+        {
+            return this;
+        }
+
         objectReport.forEachErrorReport( this::addErrorReport );
+
         return this;
     }
 
@@ -226,8 +232,7 @@ public class ObjectReport implements ErrorReportContainer
     @Override
     public void forEachErrorReport( Consumer<ErrorReport> reportConsumer )
     {
-        errorReportsByCode.values().stream().flatMap( errors -> errors.stream() )
-            .forEach( errorReport -> reportConsumer.accept( errorReport ) );
+        errorReportsByCode.values().forEach( reports -> reports.forEach( reportConsumer ) );
     }
 
     public boolean isEmpty()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -27,9 +27,8 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -93,12 +92,13 @@ public class TranslationsCheck implements ObjectValidationCheck
             return;
         }
 
-        Map<String, String> mapPropertyLocale = new HashMap<>();
+        Set<String> setPropertyLocales = new HashSet<>();
 
         for ( Translation translation : translations )
         {
-            if ( mapPropertyLocale.containsKey( translation.getProperty() )
-                && mapPropertyLocale.get( translation.getProperty() ).equals( translation.getLocale() ) )
+            String key = String.join( "_", translation.getProperty(), translation.getLocale() );
+
+            if ( setPropertyLocales.contains( key ) )
             {
                 objectReport.addErrorReport(
                     new ErrorReport( Translation.class, ErrorCode.E1106, translation.getProperty(),
@@ -107,7 +107,7 @@ public class TranslationsCheck implements ObjectValidationCheck
             }
             else
             {
-                mapPropertyLocale.put( translation.getProperty(), translation.getLocale() );
+                setPropertyLocales.add( key );
             }
 
             if ( translation.getLocale() == null )
@@ -128,10 +128,11 @@ public class TranslationsCheck implements ObjectValidationCheck
                     new ErrorReport( Translation.class, ErrorCode.E4000, "value" ).setErrorKlass( klass ) );
             }
 
-            if ( objectReport.hasErrorReports() )
-            {
-                addReports.accept( objectReport );
-            }
+        }
+
+        if ( objectReport.hasErrorReports() )
+        {
+            addReports.accept( objectReport );
         }
     }
 }


### PR DESCRIPTION
Fix issue of adding `ObjectReport` inside the for loop of one object's translations which leads to `ConcurrentModificationException`.

Also shorten the translation duplication check to make it clearer. 