### PR TITLE
fix: veto CategoryOptionCombo deletion if used by Predictor [DHIS2-10687] (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
@@ -128,6 +128,6 @@ public class PredictorDeletionHandler
     private boolean exists( String sql )
     {
         Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
-        return count == null || count == 0;
+        return count != null && count > 0;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
@@ -32,9 +32,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.Iterator;
 import java.util.List;
 
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.expression.Expression;
 import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
@@ -50,11 +52,14 @@ public class PredictorDeletionHandler
 
     private final PredictorService predictorService;
 
-    public PredictorDeletionHandler( PredictorService predictorService )
+    private final JdbcTemplate jdbcTemplate;
+
+    public PredictorDeletionHandler( PredictorService predictorService, JdbcTemplate jdbcTemplate )
     {
         checkNotNull( predictorService );
 
         this.predictorService = predictorService;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     // -------------------------------------------------------------------------
@@ -112,5 +117,17 @@ public class PredictorDeletionHandler
         }
 
         return null;
+    }
+
+    @Override
+    public String allowDeleteCategoryOptionCombo( CategoryOptionCombo coc )
+    {
+        return exists( "SELECT COUNT(*) FROM predictor where generatoroutputcombo=" + coc.getId() ) ? ERROR : null;
+    }
+
+    private boolean exists( String sql )
+    {
+        Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
+        return count == null || count == 0;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/predictor/PredictorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/predictor/PredictorServiceTest.java
@@ -429,7 +429,7 @@ public class PredictorServiceTest
     }
 
     @Test
-    void testCannotDeleteCategoryOptionComboUsedByPredictor()
+    public void testCannotDeleteCategoryOptionComboUsedByPredictor()
     {
         setUpPredictorGroups();
         DeleteNotAllowedException ex = assertThrows( DeleteNotAllowedException.class,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/predictor/PredictorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/predictor/PredictorServiceTest.java
@@ -27,7 +27,11 @@
  */
 package org.hisp.dhis.predictor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,6 +45,7 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
@@ -421,5 +426,15 @@ public class PredictorServiceTest
         assertEquals( 2, groups.size() );
         assertTrue( groups.contains( predictorGroupA ) );
         assertTrue( groups.contains( predictorGroupB ) );
+    }
+
+    @Test
+    void testCannotDeleteCategoryOptionComboUsedByPredictor()
+    {
+        setUpPredictorGroups();
+        DeleteNotAllowedException ex = assertThrows( DeleteNotAllowedException.class,
+            () -> categoryService.deleteCategoryOptionCombo( altCombo ) );
+        assertEquals( "Object could not be deleted because it is associated with another object: Predictor",
+            ex.getMessage() );
     }
 }


### PR DESCRIPTION
Minimal re-implementation of #9659 in the old deletion handler tech.