### PR TITLE
fix: DataHandler fix for dashboard 500 DHIS2-12518

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -993,7 +993,7 @@ public class DataHandler
                     addItemBasedOnPeriodOffset( result, dataIndex, periodIndex, valueIndex, row,
                         dimensionalItem, basePeriods );
                 }
-                else if ( !isPeriodInPeriods( (String) row.get( periodIndex ), basePeriods ) )
+                else
                 {
                     result.put( join( remove( row.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP ),
                         new DimensionItemObjectValue(


### PR DESCRIPTION
Symptom: See [DHIS2-12518](https://jira.dhis2.org/browse/DHIS2-12518). Some dashboard items aren't loading and getting a 500 error from the server.

Cause: In [pull/9671](https://github.com/dhis2/dhis2-core/pull/9671), in `DataHandler#getAggregatedDataValueMap` a test for `isPeriodInPeriods` was erroneously moved from an `if` clause to the `else` clause. It should have been removed altogether.

Testing: With this fix, all dashboard items display on all dashboards without the 500 error.