### PR TITLE
chore: reduce indirection in DefaultTrackerBundleService

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.bundle;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
@@ -48,6 +49,7 @@ import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
 import org.hisp.dhis.tracker.report.TrackerBundleReport;
+import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.sideeffect.SideEffectHandlerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -113,13 +115,14 @@ public class DefaultTrackerBundleService
         }
 
         Session session = sessionFactory.getCurrentSession();
-        bundleReport.getTypeReportMap().put( TrackerType.TRACKED_ENTITY,
+        Map<TrackerType, TrackerTypeReport> report = bundleReport.getTypeReportMap();
+        report.put( TrackerType.TRACKED_ENTITY,
             commitService.getTrackerPersister().persist( session, bundle ) );
-        bundleReport.getTypeReportMap().put( TrackerType.ENROLLMENT,
+        report.put( TrackerType.ENROLLMENT,
             commitService.getEnrollmentPersister().persist( session, bundle ) );
-        bundleReport.getTypeReportMap().put( TrackerType.EVENT,
+        report.put( TrackerType.EVENT,
             commitService.getEventPersister().persist( session, bundle ) );
-        bundleReport.getTypeReportMap().put( TrackerType.RELATIONSHIP,
+        report.put( TrackerType.RELATIONSHIP,
             commitService.getRelationshipPersister().persist( session, bundle ) );
 
         return bundleReport;
@@ -154,10 +157,11 @@ public class DefaultTrackerBundleService
             return bundleReport;
         }
 
-        bundleReport.getTypeReportMap().put( TrackerType.RELATIONSHIP, deletionService.deleteRelationShips( bundle ) );
-        bundleReport.getTypeReportMap().put( TrackerType.EVENT, deletionService.deleteEvents( bundle ) );
-        bundleReport.getTypeReportMap().put( TrackerType.ENROLLMENT, deletionService.deleteEnrollments( bundle ) );
-        bundleReport.getTypeReportMap().put( TrackerType.TRACKED_ENTITY,
+        Map<TrackerType, TrackerTypeReport> report = bundleReport.getTypeReportMap();
+        report.put( TrackerType.RELATIONSHIP, deletionService.deleteRelationShips( bundle ) );
+        report.put( TrackerType.EVENT, deletionService.deleteEvents( bundle ) );
+        report.put( TrackerType.ENROLLMENT, deletionService.deleteEnrollments( bundle ) );
+        report.put( TrackerType.TRACKED_ENTITY,
             deletionService.deleteTrackedEntityInstances( bundle ) );
 
         return bundleReport;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/DefaultTrackerBundleService.java
@@ -28,15 +28,9 @@
 package org.hisp.dhis.tracker.bundle;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-import javax.annotation.PostConstruct;
 
 import lombok.RequiredArgsConstructor;
 
@@ -54,13 +48,10 @@ import org.hisp.dhis.tracker.job.TrackerSideEffectDataBundle;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
 import org.hisp.dhis.tracker.report.TrackerBundleReport;
-import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.sideeffect.SideEffectHandlerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -88,33 +79,6 @@ public class DefaultTrackerBundleService
     public void setSideEffectHandlers( List<SideEffectHandlerService> sideEffectHandlers )
     {
         this.sideEffectHandlers = sideEffectHandlers;
-    }
-
-    private ImmutableMap<TrackerType, Function<TrackerBundle, TrackerTypeReport>> DELETION_MAPPER;
-
-    private ImmutableMap<TrackerType, BiFunction<Session, TrackerBundle, TrackerTypeReport>> COMMIT_MAPPER;
-
-    @PostConstruct
-    public void initMaps()
-    {
-
-        COMMIT_MAPPER = new ImmutableMap.Builder<TrackerType, BiFunction<Session, TrackerBundle, TrackerTypeReport>>()
-            .put( TrackerType.ENROLLMENT,
-                (( session, bundle ) -> commitService.getEnrollmentPersister().persist( session, bundle )) )
-            .put( TrackerType.EVENT,
-                (( session, bundle ) -> commitService.getEventPersister().persist( session, bundle )) )
-            .put( TrackerType.TRACKED_ENTITY,
-                (( session, bundle ) -> commitService.getTrackerPersister().persist( session, bundle )) )
-            .put( TrackerType.RELATIONSHIP,
-                (( session, bundle ) -> commitService.getRelationshipPersister().persist( session, bundle )) )
-            .build();
-
-        DELETION_MAPPER = new ImmutableMap.Builder<TrackerType, Function<TrackerBundle, TrackerTypeReport>>()
-            .put( TrackerType.ENROLLMENT, deletionService::deleteEnrollments )
-            .put( TrackerType.EVENT, deletionService::deleteEvents )
-            .put( TrackerType.TRACKED_ENTITY, deletionService::deleteTrackedEntityInstances )
-            .put( TrackerType.RELATIONSHIP, deletionService::deleteRelationShips )
-            .build();
     }
 
     @Override
@@ -149,10 +113,14 @@ public class DefaultTrackerBundleService
         }
 
         Session session = sessionFactory.getCurrentSession();
-
-        TrackerType.getOrderedByPriority()
-            .forEach( t -> bundleReport.getTypeReportMap().put( t, COMMIT_MAPPER.get( t )
-                .apply( session, bundle ) ) );
+        bundleReport.getTypeReportMap().put( TrackerType.TRACKED_ENTITY,
+            commitService.getTrackerPersister().persist( session, bundle ) );
+        bundleReport.getTypeReportMap().put( TrackerType.ENROLLMENT,
+            commitService.getEnrollmentPersister().persist( session, bundle ) );
+        bundleReport.getTypeReportMap().put( TrackerType.EVENT,
+            commitService.getEventPersister().persist( session, bundle ) );
+        bundleReport.getTypeReportMap().put( TrackerType.RELATIONSHIP,
+            commitService.getRelationshipPersister().persist( session, bundle ) );
 
         return bundleReport;
     }
@@ -186,9 +154,11 @@ public class DefaultTrackerBundleService
             return bundleReport;
         }
 
-        Stream.of( TrackerType.values() ).sorted( Collections.reverseOrder() )
-            .forEach( t -> bundleReport.getTypeReportMap().put( t, DELETION_MAPPER.get( t )
-                .apply( bundle ) ) );
+        bundleReport.getTypeReportMap().put( TrackerType.RELATIONSHIP, deletionService.deleteRelationShips( bundle ) );
+        bundleReport.getTypeReportMap().put( TrackerType.EVENT, deletionService.deleteEvents( bundle ) );
+        bundleReport.getTypeReportMap().put( TrackerType.ENROLLMENT, deletionService.deleteEnrollments( bundle ) );
+        bundleReport.getTypeReportMap().put( TrackerType.TRACKED_ENTITY,
+            deletionService.deleteTrackedEntityInstances( bundle ) );
 
         return bundleReport;
     }


### PR DESCRIPTION
The pattern we often use of using a map of TrackerTypes to functions
introduces indirection making the code hard to read. We also rely on a
JAVA EE feature @PostConstruct to build the map once all dependencies
have been wired.

In this case the alternative code is straightforward to read. Removing
@PostConstruct makes unit testing also easier: no need for Spring doing
executing the @PostConstruct or us manually calling initMaps after the
constructor.

### To reviewers

I've seen this pattern at least a couple of times in tracker. It feels to smart for me 😅 I always have to re-read/think whats going on even though I've seen the pattern already. I would prefer a more boring, simple style at least in this case.