### PR TITLE
test: adds await to task summary requests

### DIFF
--- a/dhis-2/dhis-e2e-test/pom.xml
+++ b/dhis-2/dhis-e2e-test/pom.xml
@@ -82,6 +82,11 @@
       <version>2.4.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/SystemActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/SystemActions.java
@@ -70,7 +70,6 @@ public class SystemActions
             .extractList( "completed" ).contains( true );
 
         with()
-            .pollInterval( 1, TimeUnit.SECONDS )
             .atMost( 20, TimeUnit.SECONDS )
             .await().until( () -> taskIsCompleted.call() );
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/SystemActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/SystemActions.java
@@ -27,11 +27,16 @@
  */
 package org.hisp.dhis.actions;
 
-import java.util.List;
-import java.util.logging.Logger;
-
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.dto.ImportSummary;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Awaitility.with;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -46,30 +51,52 @@ public class SystemActions
         super( "/system" );
     }
 
+    public ApiResponse getTask( String taskType, String taskId )
+    {
+        return get( "/tasks/" + taskType + "/" + taskId );
+    }
+
+    /**
+     * Waits until the task is completed and returns a response
+     *
+     * @param taskType
+     * @param taskId
+     * @return
+     */
     public ApiResponse waitUntilTaskCompleted( String taskType, String taskId )
     {
-        logger.info( "Waiting until task " + taskType + " with id " + taskId + "is completed" );
-        ApiResponse response = null;
-        boolean completed = false;
-        while ( !completed )
-        {
-            response = get( "/tasks/" + taskType + "/" + taskId );
-            response.validate().statusCode( 200 );
-            completed = response.extractList( "completed" ).contains( true );
-        }
+        Callable<Boolean> taskIsCompleted = () -> getTask( taskType, taskId )
+            .validateStatus( 200 )
+            .extractList( "completed" ).contains( true );
 
-        logger.info( "Task completed. Message: " + response.extract( "message" ) );
-        return response;
+        with()
+            .pollInterval( 1, TimeUnit.SECONDS )
+            .atMost( 20, TimeUnit.SECONDS )
+            .await().until( () -> taskIsCompleted.call() );
+
+        return getTask( taskType, taskId );
     }
 
     public List<ImportSummary> getTaskSummaries( String taskType, String taskId )
     {
-        return getTaskSummariesResponse( taskType, taskId ).validateStatus( 200 ).getImportSummaries();
+        return waitForTaskSummaries( taskType, taskId ).validateStatus( 200 ).getImportSummaries();
     }
 
-    public ApiResponse getTaskSummariesResponse( String taskType, String taskId )
+    /**
+     * Waits until task summaries are generated and returns the response
+     *
+     * @param taskType
+     * @param taskId
+     * @return
+     */
+    public ApiResponse waitForTaskSummaries( String taskType, String taskId )
     {
-        return get( "/taskSummaries/" + taskType + "/" + taskId );
+        String url = String.format( "/taskSummaries/%s/%s", taskType, taskId );
+
+        await().ignoreExceptions().until( () -> !get( url ).validateStatus( 200 )
+            .getBody().equals( null ) );
+
+        return get( url );
     }
 
 }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/metadata/metadata_import/MetadataImportTest.java
@@ -27,30 +27,8 @@
  */
 package org.hisp.dhis.metadata.metadata_import;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.oneOf;
-import static org.hamcrest.Matchers.stringContainsInOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.hamcrest.Matchers;
 import org.hisp.dhis.ApiTest;
@@ -68,8 +46,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -222,7 +206,7 @@ public class MetadataImportTest
         ApiResponse response = metadataActions.post( metadata, queryParamsBuilder );
         response.validate()
             .statusCode( 200 )
-            .body( not( equalTo( "null" ) ) )
+            .body( notNullValue() )
             .body( "response.name", equalTo( "metadataImport" ) )
             .body( "response.jobType", equalTo( "METADATA_IMPORT" ) );
 
@@ -230,16 +214,15 @@ public class MetadataImportTest
 
         // Validate that job was successful
 
-        response = systemActions.waitUntilTaskCompleted( "METADATA_IMPORT", taskId );
-
-        assertThat( response.extractList( "message" ), hasItem( containsString( "Import:Start" ) ) );
-        assertThat( response.extractList( "message" ), hasItem( containsString( "Import:Done" ) ) );
+        systemActions.waitUntilTaskCompleted( "METADATA_IMPORT", taskId )
+            .validate()
+            .body( "message", hasItem( containsString( "Import:Start" ) ) )
+            .body( "message", hasItem( containsString( "Import:Done" ) ) );
 
         // validate task summaries were created
-        response = systemActions.getTaskSummariesResponse( "METADATA_IMPORT", taskId );
-
-        response.validate().statusCode( 200 )
-            .body( not( equalTo( "null" ) ) )
+        systemActions.waitForTaskSummaries( "METADATA_IMPORT", taskId )
+            .validate()
+            .body( notNullValue() )
             .body( "status", equalTo( "WARNING" ) )
             .body( "typeReports", notNullValue() )
             .rootPath( "typeReports" )
@@ -248,7 +231,6 @@ public class MetadataImportTest
             .body( "objectReports", notNullValue() )
             .body( "objectReports", hasSize( greaterThanOrEqualTo( 1 ) ) )
             .body( "objectReports.errorReports", notNullValue() );
-
     }
 
     @Test
@@ -282,19 +264,16 @@ public class MetadataImportTest
         assertNotNull( taskId, "Task id was not returned" );
         // Validate that job was successful
 
-        response = systemActions.waitUntilTaskCompleted( "METADATA_IMPORT", taskId );
-
-        response.validate()
-            .statusCode( 200 )
+        systemActions.waitUntilTaskCompleted( "METADATA_IMPORT", taskId )
+            .validate()
             .body( "message", notNullValue() )
             .body( "message", hasItem( containsString( "Import:Start" ) ) )
             .body( "message", hasItem( containsString( "Import:Done" ) ) );
 
         // validate task summaries were created
-        response = systemActions.getTaskSummariesResponse( "METADATA_IMPORT", taskId );
-
-        response.validate().statusCode( 200 )
-            .body( not( equalTo( "null" ) ) )
+        systemActions.waitForTaskSummaries( "METADATA_IMPORT", taskId )
+            .validate()
+            .body( notNullValue() )
             .body( "status", equalTo( "OK" ) )
             .body( "typeReports", notNullValue() )
             .rootPath( "typeReports" )


### PR DESCRIPTION
Async data value import test is sometimes flaky due to taskSummaries not being available immediately after the job is completed. Since it sounds like this is well-known behavior, adding a wait for taskSummaries.