### PR TITLE
fix: DataHandler visualizations fix DHIS2-12518

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -990,8 +990,7 @@ public class DataHandler
 
                 if ( hasPeriod( row, periodIndex ) )
                 {
-                    addItemBasedOnPeriodOffset( result, dataIndex, periodIndex, valueIndex, row,
-                        dimensionalItem, basePeriods );
+                    addItemBasedOnPeriodOffset( result, periodIndex, valueIndex, row, dimensionalItem, basePeriods );
                 }
                 else
                 {
@@ -1049,7 +1048,6 @@ public class DataHandler
      * Calculate the dimensional item offset and adds to the give result map.
      *
      * @param result the map where the values will be added to.
-     * @param dataIndex the current grid row data index.
      * @param periodIndex the current grid row period index.
      * @param valueIndex the current grid row value index.
      * @param row the current grid row.
@@ -1061,7 +1059,7 @@ public class DataHandler
      * @return the DimensionalItemObject
      */
     private void addItemBasedOnPeriodOffset( MultiValuedMap<String, DimensionItemObjectValue> result,
-        int dataIndex, int periodIndex, int valueIndex, List<Object> row, DimensionalItemObject dimensionalItemObject,
+        int periodIndex, int valueIndex, List<Object> row, DimensionalItemObject dimensionalItemObject,
         List<DimensionalItemObject> basePeriods )
     {
         if ( row.get( valueIndex ) == null )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -1064,7 +1064,7 @@ public class DataHandler
         int dataIndex, int periodIndex, int valueIndex, List<Object> row, DimensionalItemObject dimensionalItemObject,
         List<DimensionalItemObject> basePeriods )
     {
-        if ( row.get( valueIndex ) == null || !dimensionalItemObject.getUid().equals( row.get( dataIndex ) ) )
+        if ( row.get( valueIndex ) == null )
         {
             return;
         }


### PR DESCRIPTION
Symptom: See [DHIS2-12518](https://jira.dhis2.org/browse/DHIS2-12518). Some visualizations aren't loading and getting a 500 error from the server caused by a NPE.

Cause: In [pull/9671](https://github.com/dhis2/dhis2-core/pull/9671), in `DataHandler#addItemBasedOnPeriodOffset` a test was being made to insure that the `dimensionalItemObject` UID matched the UID in the current grid row. There were two problems with this test:

1. While many common types of `DimensionalItemObject` return a UID, some do not (resulting in the NPE).
2. This test is redundant, since the code in `getAggregatedDataValueMap` that calls `addItemBasedOnPeriodOffset` already filters the dimensionalItems to include only those matching the `DimensionIdentifier` from the grid row. This is done in the construct `for ( DimensionalItemObject dimensionalItem : findDimensionalItems(...`. (The reason why this can return multiple dimensionalItems is that the same DimensionIdentifier may be in items with different periodOffsets.)

Fix: Since this test was both problematic and redundant, the fix was just to remove it. This makes this part of the code function as it did prior to [pull/9671](https://github.com/dhis2/dhis2-core/pull/9671).

Testing: With this fix, the visualizations succeeded that had been identified in [DHIS2-12518](https://jira.dhis2.org/browse/DHIS2-12518) as still having problems.