### PR TITLE
fix: Add back a data element with domainType=AGGREGATE

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/resources/setup/metadata.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/setup/metadata.json
@@ -2932,5 +2932,38 @@
       "attributeValues": [],
       "translations": []
     }
+  ],
+  "dataElements": [
+    {
+      "code": "TA_DATE_AND_TIME_DE AGGREGATE",
+      "lastUpdated": "2022-01-07T12:45:47.324",
+      "id": "vbZ5LGNfGET",
+      "created": "2019-02-28T12:49:47.868",
+      "name": "TA Date and time AGGREGATE",
+      "shortName": "TA date and time AGGREGATE",
+      "aggregationType": "SUM",
+      "domainType": "AGGREGATE",
+      "valueType": "BOOLEAN",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "sharing": {
+        "owner": "M5zQapPyTZI",
+        "userGroups": {
+          "OPVIvvXzNTw": {
+            "access": "rw------",
+            "id": "OPVIvvXzNTw"
+          }
+        },
+        "external": false,
+        "public": "rw------",
+        "users": {}
+      },
+      "translations": [],
+      "attributeValues": [],
+      "legendSets": [],
+      "aggregationLevels": []
+    }
   ]
 }


### PR DESCRIPTION
Recently the metadata files were changed, and we end-up with a set of Data Elements of `domainType` **_TRACKER_** only.

The DataItemQuery endpoint only considers Data Elements with `domainType` _**AGGREGATE**_.

This PR adds back a Data Element of type **_AGGREGATE_**, so tests will pass again.
