### PR TITLE
fix: headless and paging in datastore [DHIS2-12329]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreQuery.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreQuery.java
@@ -334,7 +334,7 @@ public final class DatastoreQuery
         int size = max( 1, min( 1000, params.getInt( "pageSize", 50 ) ) );
         boolean isPaging = params.getBoolean( "paging", true );
         return toBuilder()
-            .headless( isPaging && params.getBoolean( "headless", false ) )
+            .headless( params.getBoolean( "headless", false ) || !isPaging )
             .anyFilter( params.getString( "rootJunction", "AND" ).equalsIgnoreCase( "OR" ) )
             .order( Order.parse( params.getString( "order", KEY_ASC.path ) ) )
             .paging( isPaging )


### PR DESCRIPTION
This was just a logic flip - the goal was to automatically use `headless` when paging is off.