### PR TITLE
[WIP] feat: Support createdBy and lastUpdatedBy in event analytics

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -82,6 +82,16 @@ public class EnrollmentAnalyticsQueryCriteria
 
     private Set<ProgramStatus> programStatus;
 
+    /**
+     * Created by 'username's.
+     */
+    private Set<String> createdBy;
+
+    /**
+     * Last updated by 'username's.
+     */
+    private Set<String> lastUpdatedBy;
+
     private Integer page;
 
     private Integer pageSize;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -85,6 +85,10 @@ public class EventDataQueryRequest
 
     private Set<EventStatus> eventStatus;
 
+    private Set<String> createdBy;
+
+    private Set<String> lastUpdatedBy;
+
     private Set<ProgramStatus> programStatus;
 
     private boolean collapseDataDimensions;
@@ -157,6 +161,8 @@ public class EventDataQueryRequest
         queryRequest.limit = this.limit;
         queryRequest.outputType = this.outputType;
         queryRequest.eventStatus = this.eventStatus;
+        queryRequest.createdBy = this.createdBy;
+        queryRequest.lastUpdatedBy = this.lastUpdatedBy;
         queryRequest.programStatus = this.programStatus;
         queryRequest.collapseDataDimensions = this.collapseDataDimensions;
         queryRequest.aggregateData = this.aggregateData;
@@ -204,6 +210,8 @@ public class EventDataQueryRequest
                 .displayProperty( criteria.getDisplayProperty() )
                 .endDate( criteria.getEndDate() )
                 .eventStatus( criteria.getEventStatus() )
+                .createdBy( criteria.getCreatedBy() )
+                .lastUpdatedBy( criteria.getLastUpdatedBy() )
                 .filter( criteria.getFilter() )
                 .headers( criteria.getHeaders() )
                 .hierarchyMeta( criteria.isHierarchyMeta() )
@@ -252,6 +260,8 @@ public class EventDataQueryRequest
                 .includeMetadataDetails( criteria.isIncludeMetadataDetails() )
                 .dataIdScheme( criteria.getDataIdScheme() )
                 .programStatus( criteria.getProgramStatus() )
+                .createdBy( criteria.getCreatedBy() )
+                .lastUpdatedBy( criteria.getLastUpdatedBy() )
                 .page( criteria.getPage() )
                 .pageSize( criteria.getPageSize() )
                 .paging( criteria.isPaging() )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -99,6 +99,16 @@ public class EventsAnalyticsQueryCriteria
     private Set<EventStatus> eventStatus;
 
     /**
+     * Created by 'username's.
+     */
+    private Set<String> createdBy;
+
+    /**
+     * Last updated by 'username's.
+     */
+    private Set<String> lastUpdatedBy;
+
+    /**
      * Specify the enrollment status of events to include.
      */
     private Set<ProgramStatus> programStatus;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EnrollmentAnalyticsService.java
@@ -47,6 +47,10 @@ public interface EnrollmentAnalyticsService
 
     String ITEM_STORED_BY = "storedby";
 
+    String ITEM_CREATED_BY = "createdby";
+
+    String ITEM_LAST_UPDATED_BY = "lastupdatedby";
+
     String ITEM_LAST_UPDATED = "lastupdated";
 
     String ITEM_GEOMETRY = "geometry";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventAnalyticsService.java
@@ -54,6 +54,10 @@ public interface EventAnalyticsService
 
     String ITEM_STORED_BY = "storedby";
 
+    String ITEM_CREATED_BY = "createdby";
+
+    String ITEM_LAST_UPDATED_BY = "lastupdatedby";
+
     String ITEM_LAST_UPDATED = "lastupdated";
 
     String ITEM_ENROLLMENT_DATE = "enrollmentdate";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -189,17 +189,17 @@ public class EventQueryParams
     /**
      * Indicates the event status.
      */
-    private Set<EventStatus> eventStatus;
+    private Set<EventStatus> eventStatus = new HashSet<>();
 
     /**
      * Created by 'username's.
      */
-    private Set<String> createdBy;
+    private Set<String> createdBy = new HashSet<>();
 
     /**
      * Last updated by 'username's.
      */
-    private Set<String> lastUpdatedBy;
+    private Set<String> lastUpdatedBy = new HashSet<>();
 
     /**
      * Indicates whether the data dimension items should be collapsed into a

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -192,6 +192,16 @@ public class EventQueryParams
     private Set<EventStatus> eventStatus;
 
     /**
+     * Created by 'username's.
+     */
+    private Set<String> createdBy;
+
+    /**
+     * Last updated by 'username's.
+     */
+    private Set<String> lastUpdatedBy;
+
+    /**
      * Indicates whether the data dimension items should be collapsed into a
      * single dimension.
      */
@@ -313,6 +323,8 @@ public class EventQueryParams
         params.outputType = this.outputType;
         params.outputIdScheme = this.outputIdScheme;
         params.eventStatus = this.eventStatus;
+        params.createdBy = this.createdBy;
+        params.lastUpdatedBy = this.lastUpdatedBy;
         params.collapseDataDimensions = this.collapseDataDimensions;
         params.coordinatesOnly = this.coordinatesOnly;
         params.coordinateOuFallback = this.coordinateOuFallback;
@@ -408,6 +420,9 @@ public class EventQueryParams
         itemFilters.forEach( e -> key.add( "itemFilter", "[" + e.getKey() + "]" ) );
         headers.forEach( header -> key.add( "headers", "[" + header + "]" ) );
         itemProgramIndicators.forEach( e -> key.add( "itemProgramIndicator", e.getUid() ) );
+        eventStatus.forEach( status -> key.add( "eventStatus", "[" + status + "]" ) );
+        createdBy.forEach( username -> key.add( "createdBy", "[" + username + "]" ) );
+        lastUpdatedBy.forEach( username -> key.add( "lastUpdatedBy", "[" + username + "]" ) );
         asc.forEach( e -> e.getUid() );
         desc.forEach( e -> e.getUid() );
 
@@ -422,7 +437,6 @@ public class EventQueryParams
             .addIgnoreNull( "limit", limit )
             .addIgnoreNull( "outputType", outputType )
             .addIgnoreNull( "outputIdScheme", outputIdScheme )
-            .addIgnoreNull( "eventStatus", eventStatus )
             .addIgnoreNull( "collapseDataDimensions", collapseDataDimensions )
             .addIgnoreNull( "coordinatesOnly", coordinatesOnly )
             .addIgnoreNull( "coordinateOuFallback", coordinateOuFallback )
@@ -788,6 +802,16 @@ public class EventQueryParams
         return isNotEmpty( eventStatus );
     }
 
+    public boolean hasCreatedBy()
+    {
+        return isNotEmpty( createdBy );
+    }
+
+    public boolean hasLastUpdatedBy()
+    {
+        return isNotEmpty( lastUpdatedBy );
+    }
+
     public boolean hasValueDimension()
     {
         return value != null;
@@ -986,6 +1010,16 @@ public class EventQueryParams
     public Set<EventStatus> getEventStatus()
     {
         return eventStatus;
+    }
+
+    public Set<String> getCreatedBy()
+    {
+        return createdBy;
+    }
+
+    public Set<String> getLastUpdatedBy()
+    {
+        return lastUpdatedBy;
     }
 
     public boolean isCollapseDataDimensions()
@@ -1329,6 +1363,18 @@ public class EventQueryParams
         public Builder withEventStatuses( Set<EventStatus> eventStatuses )
         {
             this.params.eventStatus = eventStatuses;
+            return this;
+        }
+
+        public Builder withCreatedByUsernames( Set<String> usernames )
+        {
+            this.params.createdBy = usernames;
+            return this;
+        }
+
+        public Builder withLastUpdatedByUsernames( Set<String> usernames )
+        {
+            this.params.lastUpdatedBy = usernames;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
@@ -66,6 +66,10 @@ public class DefaultEnrollmentAnalyticsService
 
     private static final String NAME_STORED_BY = "Stored by";
 
+    private static final String NAME_CREATED_BY = "Created by";
+
+    private static final String NAME_LAST_UPDATED_BY = "Last updated by";
+
     private static final String NAME_LAST_UPDATED = "Last Updated";
 
     private static final String NAME_LONGITUDE = "Longitude";
@@ -118,6 +122,10 @@ public class DefaultEnrollmentAnalyticsService
                 ITEM_INCIDENT_DATE, NAME_INCIDENT_DATE, DATE, false, true ) )
             .addHeader( new GridHeader(
                 ITEM_STORED_BY, NAME_STORED_BY, TEXT, false, true ) )
+            .addHeader( new GridHeader(
+                ITEM_CREATED_BY, NAME_CREATED_BY, TEXT, false, true ) )
+            .addHeader( new GridHeader(
+                ITEM_LAST_UPDATED_BY, NAME_LAST_UPDATED_BY, TEXT, false, true ) )
             .addHeader( new GridHeader(
                 ITEM_LAST_UPDATED, NAME_LAST_UPDATED, DATE, false, true ) )
             .addHeader( new GridHeader(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -130,6 +130,10 @@ public class DefaultEventAnalyticsService
 
     private static final String NAME_STORED_BY = "Stored by";
 
+    private static final String NAME_CREATED_BY = "Created by";
+
+    private static final String NAME_LAST_UPDATED_BY = "Last updated by";
+
     private static final String NAME_LAST_UPDATED = "Last Updated";
 
     private static final String NAME_ENROLLMENT_DATE = "Enrollment date";
@@ -716,6 +720,10 @@ public class DefaultEventAnalyticsService
             .addHeader( new GridHeader( ITEM_EVENT_DATE,
                 LabelMapper.getEventDateLabel( params.getProgramStage(), NAME_EVENT_DATE ), DATE, false, true ) )
             .addHeader( new GridHeader( ITEM_STORED_BY, NAME_STORED_BY, TEXT, false, true ) )
+            .addHeader( new GridHeader(
+                ITEM_CREATED_BY, NAME_CREATED_BY, TEXT, false, true ) )
+            .addHeader( new GridHeader(
+                ITEM_LAST_UPDATED_BY, NAME_LAST_UPDATED_BY, TEXT, false, true ) )
             .addHeader( new GridHeader( ITEM_LAST_UPDATED, NAME_LAST_UPDATED, DATE, false, true ) );
 
         if ( params.getProgram().isRegistration() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -202,6 +202,8 @@ public class DefaultEventDataQueryService
             .withDataIdScheme( request.getDataIdScheme() )
             .withOutputIdScheme( request.getOutputIdScheme() )
             .withEventStatuses( request.getEventStatus() )
+            .withCreatedByUsernames( request.getCreatedBy() )
+            .withLastUpdatedByUsernames( request.getLastUpdatedBy() )
             .withDisplayProperty( request.getDisplayProperty() )
             .withTimeField( request.getTimeField() )
             .withOrgUnitField( request.getOrgUnitField() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.encode;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
@@ -332,20 +333,24 @@ public class JdbcEnrollmentAnalyticsManager
         if ( params.hasProgramStatus() )
         {
             sql += "and enrollmentstatus in ("
-                + params.getProgramStatus().stream().map( p -> "'" + p.name() + "'" ).collect( joining( "," ) ) + ") ";
+                + params.getProgramStatus().stream().map( p -> encode( p.name(), true ) )
+                    .collect( joining( "," ) )
+                + ") ";
         }
 
         if ( params.hasCreatedBy() )
         {
             sql += hlp.whereAnd() + " createdby in ("
-                + params.getCreatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + params.getCreatedBy().stream().map( username -> encode( username, true ) )
+                    .collect( joining( "," ) )
                 + ") ";
         }
 
         if ( params.hasLastUpdatedBy() )
         {
             sql += hlp.whereAnd() + " lastupdatedby in ("
-                + params.getLastUpdatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + params.getLastUpdatedBy().stream().map( username -> encode( username, true ) )
+                    .collect( joining( "," ) )
                 + ") ";
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -94,8 +94,8 @@ public class JdbcEnrollmentAnalyticsManager
     private static final String LIMIT_1 = "limit 1";
 
     private List<String> COLUMNS = Lists.newArrayList( "pi", "tei", "enrollmentdate", "incidentdate",
-        "storedby", "lastupdated", "ST_AsGeoJSON(pigeometry)", "longitude", "latitude", "ouname", "oucode",
-        "enrollmentstatus" );
+        "storedby", "createdby", "lastupdatedby", "lastupdated", "ST_AsGeoJSON(pigeometry)", "longitude", "latitude",
+        "ouname", "oucode", "enrollmentstatus" );
 
     public JdbcEnrollmentAnalyticsManager( JdbcTemplate jdbcTemplate, StatementBuilder statementBuilder,
         ProgramIndicatorService programIndicatorService,
@@ -333,6 +333,20 @@ public class JdbcEnrollmentAnalyticsManager
         {
             sql += "and enrollmentstatus in ("
                 + params.getProgramStatus().stream().map( p -> "'" + p.name() + "'" ).collect( joining( "," ) ) + ") ";
+        }
+
+        if ( params.hasCreatedBy() )
+        {
+            sql += hlp.whereAnd() + " createdby in ("
+                + params.getCreatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + ") ";
+        }
+
+        if ( params.hasLastUpdatedBy() )
+        {
+            sql += hlp.whereAnd() + " lastupdatedby in ("
+                + params.getLastUpdatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + ") ";
         }
 
         if ( params.isCoordinatesOnly() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -331,7 +331,7 @@ public class JdbcEventAnalyticsManager
     protected String getSelectClause( EventQueryParams params )
     {
         ImmutableList.Builder<String> cols = new ImmutableList.Builder<String>()
-            .add( "psi", "ps", "executiondate", "storedby", "lastupdated" );
+            .add( "psi", "ps", "executiondate", "storedby", "createdby", "lastupdatedby", "lastupdated" );
 
         if ( params.getProgram().isRegistration() )
         {
@@ -549,6 +549,20 @@ public class JdbcEventAnalyticsManager
         {
             sql += hlp.whereAnd() + " psistatus in ("
                 + params.getEventStatus().stream().map( e -> "'" + e.name() + "'" ).collect( joining( "," ) ) + ") ";
+        }
+
+        if ( params.hasCreatedBy() )
+        {
+            sql += hlp.whereAnd() + " createdby in ("
+                + params.getCreatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + ") ";
+        }
+
+        if ( params.hasLastUpdatedBy() )
+        {
+            sql += hlp.whereAnd() + " lastupdatedby in ("
+                + params.getLastUpdatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + ") ";
         }
 
         if ( params.isCoordinatesOnly() || params.isGeometryOnly() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_GE
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ORG_UNIT_STRUCT_ALIAS;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.encode;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.AnalyticsDateFilter.SCHEDULED_DATE;
@@ -548,26 +549,29 @@ public class JdbcEventAnalyticsManager
         if ( params.hasProgramStatus() )
         {
             sql += hlp.whereAnd() + " pistatus in ("
-                + params.getProgramStatus().stream().map( p -> "'" + p.name() + "'" ).collect( joining( "," ) ) + ") ";
+                + params.getProgramStatus().stream().map( p -> encode( p.name(), true ) ).collect( joining( "," ) )
+                + ") ";
         }
 
         if ( params.hasEventStatus() )
         {
             sql += hlp.whereAnd() + " psistatus in ("
-                + params.getEventStatus().stream().map( e -> "'" + e.name() + "'" ).collect( joining( "," ) ) + ") ";
+                + params.getEventStatus().stream().map( e -> encode( e.name(), true ) ).collect( joining( "," ) )
+                + ") ";
         }
 
         if ( params.hasCreatedBy() )
         {
             sql += hlp.whereAnd() + " createdby in ("
-                + params.getCreatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + params.getCreatedBy().stream().map( username -> encode( username, true ) ).collect( joining( "," ) )
                 + ") ";
         }
 
         if ( params.hasLastUpdatedBy() )
         {
             sql += hlp.whereAnd() + " lastupdatedby in ("
-                + params.getLastUpdatedBy().stream().map( username -> "'" + username + "'" ).collect( joining( "," ) )
+                + params.getLastUpdatedBy().stream().map( username -> encode( username, true ) )
+                    .collect( joining( "," ) )
                 + ") ";
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -88,6 +88,10 @@ public class JdbcEnrollmentAnalyticsTableManager
 
     public static final String STORED_BY_COL_NAME = "storedby";
 
+    private static final String CREATED_BY_COL_NAME = "createdby";
+
+    private static final String LAST_UPDATED_BY_COL_NAME = "lastupdatedby";
+
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(
         new AnalyticsTableColumn( quote( "pi" ), CHARACTER_11, NOT_NULL, "pi.uid" ),
         new AnalyticsTableColumn( quote( "enrollmentdate" ), TIMESTAMP, "pi.enrollmentdate" ),
@@ -96,6 +100,10 @@ public class JdbcEnrollmentAnalyticsTableManager
             "case pi.status when 'COMPLETED' then pi.enddate end" ),
         new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP, "pi.lastupdated" ),
         new AnalyticsTableColumn( quote( STORED_BY_COL_NAME ), VARCHAR_255, "pi.storedby" ),
+        new AnalyticsTableColumn( quote( CREATED_BY_COL_NAME ), VARCHAR_255,
+            "pi.createdbyuserinfo ->> 'username' as createdby" ),
+        new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_NAME ), VARCHAR_255,
+            "pi.lastupdatedbyuserinfo ->> 'username' as lastupdatedby" ),
         new AnalyticsTableColumn( quote( "enrollmentstatus" ), VARCHAR_50, "pi.status" ),
         new AnalyticsTableColumn( quote( "longitude" ), DOUBLE,
             "CASE WHEN 'POINT' = GeometryType(pi.geometry) THEN ST_X(pi.geometry) ELSE null END" ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -109,7 +109,11 @@ public class JdbcEventAnalyticsTableManager
             databaseInfo, jdbcTemplate );
     }
 
-    public static final String STORED_BY_COL_NAME = "storedby";
+    private static final String STORED_BY_COL_NAME = "storedby";
+
+    private static final String CREATED_BY_COL_NAME = "createdby";
+
+    private static final String LAST_UPDATED_BY_COL_NAME = "lastupdatedby";
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(
         new AnalyticsTableColumn( quote( "psi" ), CHARACTER_11, NOT_NULL, "psi.uid" ),
@@ -124,6 +128,10 @@ public class JdbcEventAnalyticsTableManager
         new AnalyticsTableColumn( quote( "created" ), TIMESTAMP, "psi.created" ),
         new AnalyticsTableColumn( quote( "lastupdated" ), TIMESTAMP, "psi.lastupdated" ),
         new AnalyticsTableColumn( quote( STORED_BY_COL_NAME ), VARCHAR_255, "psi.storedby" ),
+        new AnalyticsTableColumn( quote( CREATED_BY_COL_NAME ), VARCHAR_255,
+            "psi.createdbyuserinfo ->> 'username' as createdby" ),
+        new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_NAME ), VARCHAR_255,
+            "psi.lastupdatedbyuserinfo ->> 'username' as lastupdatedby" ),
         new AnalyticsTableColumn( quote( "pistatus" ), VARCHAR_50, "pi.status" ),
         new AnalyticsTableColumn( quote( "psistatus" ), VARCHAR_50, "psi.status" ),
         new AnalyticsTableColumn( quote( "psigeometry" ), GEOMETRY, "psi.geometry" )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -110,7 +110,8 @@ class EnrollmentAnalyticsManagerTest extends
     @Captor
     private ArgumentCaptor<String> sql;
 
-    private String DEFAULT_COLUMNS = "pi,tei,enrollmentdate,incidentdate,storedby,lastupdated,ST_AsGeoJSON(pigeometry),longitude,latitude,ouname,oucode,enrollmentstatus";
+    private String DEFAULT_COLUMNS = "pi,tei,enrollmentdate,incidentdate,storedby,createdby,lastupdatedby,lastupdated,"
+        + "ST_AsGeoJSON(pigeometry),longitude,latitude,ouname,oucode,enrollmentstatus";
 
     private final String TABLE_NAME = "analytics_enrollment";
 
@@ -236,8 +237,26 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' )" +
-            " and enrollmentstatus in ('ACTIVE','COMPLETED') limit 10001";
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' )"
+            + " and enrollmentstatus in ('ACTIVE','COMPLETED') limit 10001";
+
+        assertSql( sql.getValue(), expected );
+    }
+
+    @Test
+    void verifyGetEventsWithCreatedByAndLastUpdatedByParams()
+    {
+        mockEmptyRowSet();
+
+        EventQueryParams params = createRequestParamsWithCreatedByAndLastUpdatedBy();
+
+        subject.getEnrollments( params, new ListGrid(), 10000 );
+
+        verify( jdbcTemplate ).queryForRowSet( sql.capture() );
+
+        String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
+            + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' )"
+            + " and createdby in ('userA','userB') and lastupdatedby in ('userC','userD') limit 10001";
 
         assertSql( sql.getValue(), expected );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsTest.java
@@ -156,6 +156,20 @@ abstract class EventAnalyticsTest
         return params.build();
     }
 
+    protected EventQueryParams createRequestParamsWithCreatedByAndLastUpdatedBy()
+    {
+        OrganisationUnit ouA = createOrganisationUnit( 'A' );
+        ouA.setPath( "/" + ouA.getUid() );
+        EventQueryParams.Builder params = new EventQueryParams.Builder();
+        params.withPeriods( getList( createPeriod( "2000Q1" ) ), "monthly" );
+        params.withOrganisationUnits( getList( ouA ) );
+        params.withTableName( getTableName() + "_" + programA.getUid() );
+        params.withProgram( programA );
+        params.withCreatedByUsernames( new LinkedHashSet<>( List.of( "userA", "userB" ) ) );
+        params.withLastUpdatedByUsernames( new LinkedHashSet<>( List.of( "userC", "userD" ) ) );
+        return params.build();
+    }
+
     protected EventQueryParams createRequestParams( ProgramStage withProgramStage, ValueType withQueryItemValueType )
     {
         EventQueryParams.Builder params = new EventQueryParams.Builder( _createRequestParams() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -115,8 +115,8 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
     private final static String TABLE_NAME = "analytics_event";
 
-    private final static String DEFAULT_COLUMNS_WITH_REGISTRATION = "psi,ps,executiondate,storedby,lastupdated,"
-        + "enrollmentdate,incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,"
+    private final static String DEFAULT_COLUMNS_WITH_REGISTRATION = "psi,ps,executiondate,storedby,createdby,lastupdatedby,"
+        + "lastupdated,enrollmentdate,incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,"
         + "oucode,pistatus,psistatus";
 
     @BeforeEach
@@ -145,7 +145,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "select psi,ps,executiondate,storedby,lastupdated,ST_AsGeoJSON(psigeometry, 6) as geometry,"
+        String expected = "select psi,ps,executiondate,storedby,createdby,lastupdatedby,lastupdated,ST_AsGeoJSON(psigeometry, 6) as geometry,"
             + "longitude,latitude,ouname,oucode,pistatus,psistatus,ax.\"monthly\",ax.\"ou\"  from "
             + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
@@ -166,9 +166,9 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "select psi,ps,executiondate,storedby,lastupdated,enrollmentdate,incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) "
-            + "as geometry,longitude,latitude,ouname,oucode,pistatus,psistatus,ax.\"monthly\",ax.\"ou\",\""
-            + dataElement.getUid() + "_name"
+        String expected = "select psi,ps,executiondate,storedby,createdby,lastupdatedby,lastupdated,enrollmentdate,"
+            + "incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,oucode,pistatus,"
+            + "psistatus,ax.\"monthly\",ax.\"ou\",\"" + dataElement.getUid() + "_name"
             + "\"  " + "from " + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA') limit 101";
 
@@ -253,6 +253,22 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')" +
             " and pistatus in ('ACTIVE','COMPLETED') and psistatus in ('SCHEDULE') limit 101";
+
+        assertSql( expected, sql.getValue() );
+    }
+
+    @Test
+    void verifyGetEventsWithCreatedByAndLastUpdatedByParams()
+    {
+        mockEmptyRowSet();
+
+        subject.getEvents( createRequestParamsWithCreatedByAndLastUpdatedBy(), createGrid(), 100 );
+
+        verify( jdbcTemplate ).queryForRowSet( sql.capture() );
+
+        String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
+            + " as ax where ax.\"monthly\" in ('2000Q1') and ax.\"uidlevel1\" in ('ouabcdefghA')"
+            + " and createdby in ('userA','userB') and lastupdatedby in ('userC','userD') limit 101";
 
         assertSql( expected, sql.getValue() );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -257,7 +257,7 @@ class JdbcEventAnalyticsTableManagerTest
         new AnalyticsTableAsserter.Builder( tables.get( 0 ) )
             .withTableType( AnalyticsTableType.EVENT )
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() )
-            .withColumnSize( 44 )
+            .withColumnSize( 46 )
             .withDefaultColumns( subject.getFixedColumns() )
             .addColumns( periodColumns )
             .addColumn( categoryA.getUid(), CHARACTER_11, "acs.", categoryA.getCreated() )
@@ -318,7 +318,7 @@ class JdbcEventAnalyticsTableManagerTest
         new AnalyticsTableAsserter.Builder( tables.get( 0 ) )
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() )
             .withTableType( AnalyticsTableType.EVENT )
-            .withColumnSize( 51 )
+            .withColumnSize( 53 )
             .addColumns( periodColumns )
             .addColumn( d1.getUid(), TEXT, toAlias( aliasD1, d1.getUid() ) ) // ValueType.TEXT
             .addColumn( d2.getUid(), DOUBLE, toAlias( aliasD2, d2.getUid() ) ) // ValueType.PERCENTAGE
@@ -374,7 +374,7 @@ class JdbcEventAnalyticsTableManagerTest
         new AnalyticsTableAsserter.Builder( tables.get( 0 ) )
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() )
             .withTableType( AnalyticsTableType.EVENT )
-            .withColumnSize( 46 ).addColumns( periodColumns )
+            .withColumnSize( 48 ).addColumns( periodColumns )
             .addColumn( d1.getUid(), TEXT, toAlias( aliasD1, d1.getUid() ) ) // ValueType.TEXT
             .addColumn( tea1.getUid(), TEXT, String.format( aliasTea1, "ou.uid", tea1.getId(), tea1.getUid() ) )
             // Second Geometry column created from the OU column above


### PR DESCRIPTION
This PR adds support for two new query parameters into events `/query` endpoints. They are:
`createdBy` and `lastUpdatedBy`

`http://localhost:8080/dhis/api/29/analytics/enrollments/query/WSGAb5XwJ3Y.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&displayProperty=NAME&outputType=ENROLLMENT&desc=enrollmentdate&pageSize=10000&page=1&createdBy=admin,system`

`http://localhost:8080/dhis/api/29/analytics/events/query/WSGAb5XwJ3Y.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&stage=edqlbukwRfQ&displayProperty=NAME&outputType=EVENT&desc=eventdate&pageSize=100&page=1&lastUpdatedBy=system`