### PR TITLE
feat: Flush cache on analytics update DHIS2-12072

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.analytics.AnalyticsTableService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.cache.AnalyticsCache;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.message.MessageService;
@@ -69,6 +70,8 @@ public class DefaultAnalyticsTableGenerator
     private final MessageService messageService;
 
     private final SystemSettingManager systemSettingManager;
+
+    private final AnalyticsCache analyticsCache;
 
     // TODO introduce last successful timestamps per table type
 
@@ -139,6 +142,8 @@ public class DefaultAnalyticsTableGenerator
             systemSettingManager.saveSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_RUNTIME,
                 clock.time() );
         }
+
+        analyticsCache.invalidateAll();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/AnalyticsCacheSettingsTest.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.analytics.AnalyticsCacheTtlMode.FIXED;
 import static org.hisp.dhis.analytics.AnalyticsCacheTtlMode.PROGRESSIVE;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_10_MINUTES;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_1_MINUTE;
+import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_TWO_WEEKS;
 import static org.hisp.dhis.common.cache.CacheStrategy.NO_CACHE;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_PROGRESSIVE_TTL_FACTOR;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_TTL_MODE;
@@ -164,7 +165,7 @@ class AnalyticsCacheSettingsTest
     {
         given( CACHE_10_MINUTES );
 
-        assertEquals( CACHE_10_MINUTES.toSeconds().longValue(), analyticsCacheSettings.fixedExpirationTimeOrDefault() );
+        assertEquals( CACHE_TWO_WEEKS.toSeconds().longValue(), analyticsCacheSettings.fixedExpirationTimeOrDefault() );
     }
 
     @Test
@@ -172,8 +173,7 @@ class AnalyticsCacheSettingsTest
     {
         given( NO_CACHE );
 
-        assertEquals( ((CacheStrategy) CACHE_STRATEGY.getDefaultValue()).toSeconds().longValue(),
-            analyticsCacheSettings.fixedExpirationTimeOrDefault() );
+        assertEquals( 0L, analyticsCacheSettings.fixedExpirationTimeOrDefault() );
     }
 
     @Test


### PR DESCRIPTION
See [DHIS2-12072](https://jira.dhis2.org/browse/DHIS2-12072). This PR:
- Always flushes the analytics cache after an analytics update
- Doesn't change how the cache settings affect the browser Cache-Control
- For cache mode `FIXED`, sets the internal analytics cache time to 2 weeks unless the strategy is `NO_CACHE`
- Doesn't change how cache mode `PROGRESSIVE` works

I chose 2 weeks for a fixed cache time instead of infinite, because 2 weeks is likely to be longer than until the next analytics update, and if it isn't (such as on a static demo system) this ensures that all cache entries will eventually age out (including any unpopular ones).

I haven't made more radical changes at this point, like ripping out all the `PROGRESSIVE` caching logic. We could do that later, or we could do that now if you like. (We would also have to take it out of the UI.)