### PR TITLE
fix: Avoid scientific notation on export [DHIS2-12543]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/OutputFormatter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/OutputFormatter.java
@@ -39,7 +39,7 @@ import java.math.BigDecimal;
  *
  * @author maikel arabori
  */
-class OutputFormatter
+public class OutputFormatter
 {
     private static final int TEN_MILLION = 10000000;
 
@@ -59,7 +59,7 @@ class OutputFormatter
      *         type is not supported or is null it will return the given
      *         parameter object itself
      */
-    static Object maybeFormat( final Object object )
+    public static Object maybeFormat( final Object object )
     {
         if ( object instanceof Double )
         {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -28,24 +28,46 @@
 package org.hisp.dhis.system.grid;
 
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
-import static org.hisp.dhis.system.util.PDFUtils.*;
+import static org.hisp.dhis.common.adapter.OutputFormatter.maybeFormat;
+import static org.hisp.dhis.system.util.PDFUtils.addTableToDocument;
+import static org.hisp.dhis.system.util.PDFUtils.closeDocument;
+import static org.hisp.dhis.system.util.PDFUtils.getEmptyCell;
+import static org.hisp.dhis.system.util.PDFUtils.getItalicCell;
+import static org.hisp.dhis.system.util.PDFUtils.getSubtitleCell;
+import static org.hisp.dhis.system.util.PDFUtils.getTextCell;
+import static org.hisp.dhis.system.util.PDFUtils.getTitleCell;
+import static org.hisp.dhis.system.util.PDFUtils.openDocument;
+import static org.hisp.dhis.system.util.PDFUtils.resetPaddings;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
-import net.sf.jasperreports.engine.*;
+import net.sf.jasperreports.engine.JasperCompileManager;
+import net.sf.jasperreports.engine.JasperExportManager;
+import net.sf.jasperreports.engine.JasperFillManager;
+import net.sf.jasperreports.engine.JasperPrint;
+import net.sf.jasperreports.engine.JasperReport;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
-import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.velocity.VelocityContext;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObjectUtils;
@@ -211,7 +233,7 @@ public class GridUtils
         {
             for ( Object col : row )
             {
-                table.addCell( getTextCell( col ) );
+                table.addCell( getTextCell( maybeFormat( col ) ) );
             }
         }
 
@@ -328,10 +350,10 @@ public class GridUtils
 
             for ( Object column : columns )
             {
-                if ( column != null && MathUtils.isNumeric( String.valueOf( column ) ) )
+                if ( column != null && Number.class.isAssignableFrom( column.getClass() ) )
                 {
-                    xlsRow.createCell( columnIndex++, CellType.NUMERIC )
-                        .setCellValue( Double.parseDouble( String.valueOf( column ) ) );
+                    xlsRow.createCell( columnIndex++, CellType.STRING )
+                        .setCellValue( String.valueOf( maybeFormat( column ) ) );
                 }
                 else
                 {
@@ -373,7 +395,7 @@ public class GridUtils
         {
             for ( Object value : row )
             {
-                csvWriter.write( value != null ? String.valueOf( value ) : StringUtils.EMPTY );
+                csvWriter.write( value != null ? String.valueOf( maybeFormat( value ) ) : StringUtils.EMPTY );
             }
 
             csvWriter.endRecord();
@@ -468,7 +490,7 @@ public class GridUtils
 
             for ( Object field : row )
             {
-                writer.writeElement( ATTR_FIELD, field != null ? String.valueOf( field ) : EMPTY );
+                writer.writeElement( ATTR_FIELD, field != null ? String.valueOf( maybeFormat( field ) ) : EMPTY );
             }
 
             writer.closeElement();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -206,9 +206,8 @@ class AnalyticsControllerTest
         final ResultActions resultActions = mockMvc.perform( get( ENDPOINT + ".xls" )
             .param( "dimension", "dx:fbfJHSPpUQD;cYeuwXTCPkU" )
             .param( "filter", "pe:2014Q1;2014Q2" ) )
-            // .andExpect( content().contentType( "application/xml" ) ) // Note:
-            // we do not
-            // send contentType with xsl payload
+            // .andExpect( content().contentType( "application/xml" ) )
+            // Note: we do not send contentType with xsl payload
             .andExpect( status().isOk() );
 
         // Convert content to Excel sheet
@@ -218,7 +217,7 @@ class AnalyticsControllerTest
         assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 0 ).getStringCellValue(), is( "de1" ) );
         assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 1 ).getStringCellValue(), is( "ou2" ) );
         assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 2 ).getStringCellValue(), is( "pe1" ) );
-        assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 3 ).getNumericCellValue(), is( 3.0 ) );
+        assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 3 ).getStringCellValue(), is( "3" ) );
     }
 
     @Test


### PR DESCRIPTION
This fixes the scientific notation output for large numbers.
Instead of exporting the values using _scientific e notation_, we export numbers in the regular representation. ie:

Instead of outputting this -> `3.456E11`, we will output this -> `345600000000`

This bug shows up during the export of analytics responses.