### PR TITLE
feat: data elements id in events dimension endpoints are now returned as PS_ID.DE_ID [DHIS2-12569]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/BaseDimensionMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/BaseDimensionMapper.java
@@ -34,7 +34,7 @@ public abstract class BaseDimensionMapper implements DimensionMapper
 {
 
     @Override
-    public DimensionResponse map( BaseIdentifiableObject dimension )
+    public DimensionResponse map( BaseIdentifiableObject dimension, String prefix )
     {
         DimensionResponse mapped = DimensionResponse.builder()
             .id( dimension.getUid() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingService.java
@@ -61,8 +61,6 @@ public class DimensionFilteringAndPagingService
     @NonNull
     private final FieldFilterService fieldFilterService;
 
-    private final DimensionMapperService dimensionMapperService;
-
     private static final Comparator<DimensionResponse> DEFAULT_COMPARATOR = comparing( DimensionResponse::getCreated,
         nullsFirst( naturalOrder() ) );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingService.java
@@ -44,7 +44,6 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionsCriteria;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
@@ -75,12 +74,10 @@ public class DimensionFilteringAndPagingService
         "name", comparing( DimensionResponse::getName, nullsFirst( naturalOrder() ) ) );
 
     public AnalyticsDimensionsPagingWrapper<ObjectNode> pageAndFilter(
-        Collection<BaseIdentifiableObject> dimensions,
+        Collection<DimensionResponse> dimensionResponses,
         DimensionsCriteria dimensionsCriteria,
         List<String> fields )
     {
-        Collection<DimensionResponse> dimensionResponses = dimensionMapperService.toDimensionResponse( dimensions );
-
         AnalyticsDimensionsPagingWrapper<ObjectNode> pagingWrapper = new AnalyticsDimensionsPagingWrapper<>();
 
         List<DimensionResponse> filteredDimensions = filterStream( dimensionResponses.stream(),

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapper.java
@@ -34,12 +34,7 @@ import org.hisp.dhis.hibernate.HibernateProxyUtils;
 
 public interface DimensionMapper
 {
-    DimensionResponse map( BaseIdentifiableObject dimension );
-
-    default DimensionResponse map( BaseIdentifiableObject dimension, String requestParam )
-    {
-        return map( dimension );
-    }
+    DimensionResponse map( BaseIdentifiableObject dimension, String prefix );
 
     Set<Class<? extends BaseIdentifiableObject>> getSupportedClasses();
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapper.java
@@ -36,6 +36,11 @@ public interface DimensionMapper
 {
     DimensionResponse map( BaseIdentifiableObject dimension );
 
+    default DimensionResponse map( BaseIdentifiableObject dimension, String requestParam )
+    {
+        return map( dimension );
+    }
+
     Set<Class<? extends BaseIdentifiableObject>> getSupportedClasses();
 
     default boolean supports( BaseIdentifiableObject dimension )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapperService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapperService.java
@@ -45,17 +45,23 @@ public class DimensionMapperService
 
     public Collection<DimensionResponse> toDimensionResponse( Collection<BaseIdentifiableObject> dimensions )
     {
+        return toDimensionResponse( dimensions, null );
+    }
+
+    public Collection<DimensionResponse> toDimensionResponse( Collection<BaseIdentifiableObject> dimensions,
+        String requestParam )
+    {
         return dimensions.stream()
-            .map( this::toDimensionResponse )
+            .map( bio -> toDimensionResponse( bio, requestParam ) )
             .collect( Collectors.toList() );
     }
 
-    private DimensionResponse toDimensionResponse( BaseIdentifiableObject dimension )
+    private DimensionResponse toDimensionResponse( BaseIdentifiableObject dimension, String requestParam )
     {
         return mappers.stream()
             .filter( dimensionMapper -> dimensionMapper.supports( dimension ) )
             .findFirst()
-            .map( dimensionMapper -> dimensionMapper.map( dimension ) )
+            .map( dimensionMapper -> dimensionMapper.map( dimension, requestParam ) )
             .orElseThrow( () -> new IllegalArgumentException(
                 "Unsupported dimension type: " + getRealClass( dimension ) ) );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapperService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/DimensionMapperService.java
@@ -49,19 +49,19 @@ public class DimensionMapperService
     }
 
     public Collection<DimensionResponse> toDimensionResponse( Collection<BaseIdentifiableObject> dimensions,
-        String requestParam )
+        String prefix )
     {
         return dimensions.stream()
-            .map( bio -> toDimensionResponse( bio, requestParam ) )
+            .map( bio -> toDimensionResponse( bio, prefix ) )
             .collect( Collectors.toList() );
     }
 
-    private DimensionResponse toDimensionResponse( BaseIdentifiableObject dimension, String requestParam )
+    private DimensionResponse toDimensionResponse( BaseIdentifiableObject dimension, String prefix )
     {
         return mappers.stream()
             .filter( dimensionMapper -> dimensionMapper.supports( dimension ) )
             .findFirst()
-            .map( dimensionMapper -> dimensionMapper.map( dimension, requestParam ) )
+            .map( dimensionMapper -> dimensionMapper.map( dimension, prefix ) )
             .orElseThrow( () -> new IllegalArgumentException(
                 "Unsupported dimension type: " + getRealClass( dimension ) ) );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/BaseDimensionalObjectMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/BaseDimensionalObjectMapper.java
@@ -49,9 +49,9 @@ public class BaseDimensionalObjectMapper extends BaseDimensionMapper
         Category.class );
 
     @Override
-    public DimensionResponse map( BaseIdentifiableObject dimension )
+    public DimensionResponse map( BaseIdentifiableObject dimension, String prefix )
     {
-        return super.map( dimension )
+        return super.map( dimension, prefix )
             .withDimensionType( ((BaseDimensionalObject) dimension).getDimensionType().name() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapper.java
@@ -45,13 +45,13 @@ public class DataElementMapper extends BaseDimensionalItemObjectMapper
         DataElement.class );
 
     @Override
-    public DimensionResponse map( BaseIdentifiableObject dimension, String requestParam )
+    public DimensionResponse map( BaseIdentifiableObject dimension, String prefix )
     {
         DataElement dataElement = (DataElement) dimension;
 
-        final DimensionResponse mapped = super.map( dataElement )
+        final DimensionResponse mapped = super.map( dataElement, prefix )
             .withValueType( dataElement.getValueType().name() )
-            .withId( String.join( ".", requestParam, dataElement.getUid() ) );
+            .withId( String.join( ".", prefix, dataElement.getUid() ) );
 
         return Optional.of( dataElement )
             .map( DataElement::getOptionSet )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapper.java
@@ -45,13 +45,13 @@ public class DataElementMapper extends BaseDimensionalItemObjectMapper
         DataElement.class );
 
     @Override
-    public DimensionResponse map( BaseIdentifiableObject dimension )
+    public DimensionResponse map( BaseIdentifiableObject dimension, String requestParam )
     {
         DataElement dataElement = (DataElement) dimension;
 
         final DimensionResponse mapped = super.map( dataElement )
             .withValueType( dataElement.getValueType().name() )
-            .withId( dataElement.getUid() );
+            .withId( String.join( ".", requestParam, dataElement.getUid() ) );
 
         return Optional.of( dataElement )
             .map( DataElement::getOptionSet )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/ProgramStageDataElementMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/ProgramStageDataElementMapper.java
@@ -46,11 +46,11 @@ public class ProgramStageDataElementMapper extends BaseDimensionalItemObjectMapp
         ProgramStageDataElement.class );
 
     @Override
-    public DimensionResponse map( BaseIdentifiableObject dimension )
+    public DimensionResponse map( BaseIdentifiableObject dimension, String prefix )
     {
         ProgramStageDataElement programStageDataElement = (ProgramStageDataElement) dimension;
 
-        final DimensionResponse mapped = super.map( programStageDataElement.getDataElement() )
+        final DimensionResponse mapped = super.map( programStageDataElement.getDataElement(), prefix )
             .withValueType( programStageDataElement.getDataElement().getValueType().name() )
             .withId( getProgramStageDataElementUid( programStageDataElement ) );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -38,6 +38,7 @@ import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.dimension.DimensionFilteringAndPagingService;
+import org.hisp.dhis.analytics.dimension.DimensionMapperService;
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsDimensionsService;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsService;
@@ -88,6 +89,9 @@ public class EnrollmentAnalyticsController
 
     @NotNull
     private EnrollmentAnalyticsDimensionsService enrollmentAnalyticsDimensionsService;
+
+    @NotNull
+    private DimensionMapperService dimensionMapperService;
 
     @PreAuthorize( "hasRole('F_PERFORM_MAINTENANCE')" )
     @GetMapping( value = "/query/{program}/explain", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
@@ -219,7 +223,8 @@ public class EnrollmentAnalyticsController
             CacheStrategy.RESPECT_SYSTEM_SETTING );
         return dimensionFilteringAndPagingService
             .pageAndFilter(
-                enrollmentAnalyticsDimensionsService.getQueryDimensionsByProgramStageId( programId ),
+                dimensionMapperService.toDimensionResponse(
+                    enrollmentAnalyticsDimensionsService.getQueryDimensionsByProgramStageId( programId ) ),
                 dimensionsCriteria,
                 fields );
     }
@@ -236,7 +241,8 @@ public class EnrollmentAnalyticsController
             CacheStrategy.RESPECT_SYSTEM_SETTING );
         return dimensionFilteringAndPagingService
             .pageAndFilter(
-                enrollmentAnalyticsDimensionsService.getAggregateDimensionsByProgramStageId( programId ),
+                dimensionMapperService.toDimensionResponse(
+                    enrollmentAnalyticsDimensionsService.getAggregateDimensionsByProgramStageId( programId ) ),
                 dimensionsCriteria,
                 fields );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -41,6 +41,7 @@ import lombok.NonNull;
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.dimension.DimensionFilteringAndPagingService;
+import org.hisp.dhis.analytics.dimension.DimensionMapperService;
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
 import org.hisp.dhis.analytics.event.EventAnalyticsDimensionsService;
 import org.hisp.dhis.analytics.event.EventAnalyticsService;
@@ -93,6 +94,9 @@ public class EventAnalyticsController
 
     @NotNull
     private final ExecutionPlanStore executionPlanStore;
+
+    @NotNull
+    private final DimensionMapperService dimensionMapperService;
 
     // -------------------------------------------------------------------------
     // Aggregate
@@ -213,7 +217,9 @@ public class EventAnalyticsController
         configResponseForJson( response );
         return dimensionFilteringAndPagingService
             .pageAndFilter(
-                eventAnalyticsDimensionsService.getAggregateDimensionsByProgramStageId( programStageId ),
+                dimensionMapperService.toDimensionResponse(
+                    eventAnalyticsDimensionsService.getAggregateDimensionsByProgramStageId( programStageId ),
+                    programStageId ),
                 dimensionsCriteria,
                 fields );
     }
@@ -379,7 +385,9 @@ public class EventAnalyticsController
         configResponseForJson( response );
         return dimensionFilteringAndPagingService
             .pageAndFilter(
-                eventAnalyticsDimensionsService.getQueryDimensionsByProgramStageId( programStageId ),
+                dimensionMapperService.toDimensionResponse(
+                    eventAnalyticsDimensionsService.getQueryDimensionsByProgramStageId( programStageId ),
+                    programStageId ),
                 dimensionsCriteria,
                 fields );
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingServiceTest.java
@@ -32,8 +32,8 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -52,20 +52,19 @@ public class DimensionFilteringAndPagingServiceTest
 
     private final FieldFilterService fieldFilterService = mock( FieldFilterService.class );
 
-    private final DimensionMapperService dimensionMapperService = mock( DimensionMapperService.class );
-
     private DimensionFilteringAndPagingService service;
+
+    private Collection<DimensionResponse> dimensionResponses;
 
     @Before
     public void setup()
     {
-        service = new DimensionFilteringAndPagingService( fieldFilterService, dimensionMapperService );
+        service = new DimensionFilteringAndPagingService( fieldFilterService );
 
-        List<DimensionResponse> dimensionResponses = IntStream.rangeClosed( 1, 10 )
+        dimensionResponses = IntStream.rangeClosed( 1, 10 )
             .mapToObj( this::buildDimensionResponse )
             .collect( Collectors.toList() );
 
-        when( dimensionMapperService.toDimensionResponse( any() ) ).thenReturn( dimensionResponses );
         when( fieldFilterService.toObjectNodes( any() ) )
             .thenAnswer( invocationOnMock -> {
                 FieldFilterParams<DimensionResponse> argument = invocationOnMock.getArgument( 0 );
@@ -80,7 +79,7 @@ public class DimensionFilteringAndPagingServiceTest
         criteria.setPageSize( 5 );
 
         AnalyticsDimensionsPagingWrapper<ObjectNode> pagingWrapper = service.pageAndFilter(
-            Collections.emptyList(),
+            dimensionResponses,
             criteria,
             Collections.singletonList( "*" ) );
 
@@ -94,7 +93,7 @@ public class DimensionFilteringAndPagingServiceTest
         criteria.setFilter( Set.of( "name:eq:test" ) );
 
         AnalyticsDimensionsPagingWrapper<ObjectNode> pagingWrapper = service.pageAndFilter(
-            Collections.emptyList(),
+            dimensionResponses,
             criteria,
             Collections.singletonList( "*" ) );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionFilteringAndPagingServiceTest.java
@@ -42,8 +42,8 @@ import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
 import org.hisp.dhis.common.DimensionsCriteria;
 import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -56,7 +56,7 @@ public class DimensionFilteringAndPagingServiceTest
 
     private Collection<DimensionResponse> dimensionResponses;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
         service = new DimensionFilteringAndPagingService( fieldFilterService );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionMapperTestSupport.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/DimensionMapperTestSupport.java
@@ -48,12 +48,22 @@ public class DimensionMapperTestSupport
         List<Consumer<T>> instanceSetters,
         List<Pair<Function<DimensionResponse, Object>, Object>> assertingPairs )
     {
+        asserter( dimensionMapper, instanceSupplier, instanceSetters, assertingPairs, null );
+    }
+
+    public static <T extends BaseIdentifiableObject> void asserter(
+        DimensionMapper dimensionMapper,
+        Supplier<T> instanceSupplier,
+        List<Consumer<T>> instanceSetters,
+        List<Pair<Function<DimensionResponse, Object>, Object>> assertingPairs,
+        String prefix )
+    {
 
         T item = getBaseIdentifiableObject( instanceSupplier, instanceSetters );
 
         assertAll( assertingPairs.stream()
             .map( functionObjectPair -> Pair.<Supplier<?>, Object> of(
-                () -> functionObjectPair.getKey().apply( dimensionMapper.map( item ) ),
+                () -> functionObjectPair.getKey().apply( dimensionMapper.map( item, prefix ) ),
                 functionObjectPair.getRight() ) )
             .collect( Collectors.toList() ) );
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/analytics/dimension/mappers/DataElementMapperTest.java
@@ -27,43 +27,35 @@
  */
 package org.hisp.dhis.analytics.dimension.mappers;
 
-import java.util.Set;
+import static org.hisp.dhis.analytics.dimension.DimensionMapperTestSupport.asserter;
 
-import lombok.Getter;
-
-import org.hisp.dhis.analytics.dimension.BaseDimensionMapper;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.analytics.dimension.DimensionResponse;
-import org.hisp.dhis.common.BaseDimensionalItemObject;
-import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
+import org.hisp.dhis.common.DimensionItemType;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.program.ProgramIndicator;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.springframework.stereotype.Service;
+import org.junit.jupiter.api.Test;
 
-@Service
-public class BaseDimensionalItemObjectMapper extends BaseDimensionMapper
+import com.google.common.collect.ImmutableList;
+
+class DataElementMapperTest
 {
 
-    @Getter
-    private final Set<Class<? extends BaseIdentifiableObject>> supportedClasses = Set.of(
-        ProgramIndicator.class,
-        DataElement.class,
-        TrackedEntityAttribute.class );
+    private static final DimensionItemType DIMENSION_ITEM_TYPE = DimensionItemType.DATA_ELEMENT;
 
-    @Override
-    public DimensionResponse map( BaseIdentifiableObject dimension, String prefix )
+    @Test
+    void testDataElementObjectMapperId()
     {
-        BaseDimensionalItemObject baseDimensionalItemObject = (BaseDimensionalItemObject) dimension;
-        DimensionResponse responseWithDimensionType = super.map( dimension, prefix )
-            .withDimensionType( baseDimensionalItemObject.getDimensionItemType().name() );
-        if ( dimension instanceof ValueTypedDimensionalItemObject )
-        {
-            ValueTypedDimensionalItemObject valueTypedDimensionalItemObject = (ValueTypedDimensionalItemObject) dimension;
-            return responseWithDimensionType
-                .withValueType( valueTypedDimensionalItemObject.getValueType().name() );
-        }
-        return responseWithDimensionType;
+        asserter( new DataElementMapper(),
+            DataElement::new,
+            ImmutableList.of(
+                b -> b.setDimensionItemType( DIMENSION_ITEM_TYPE ),
+                b -> b.setValueType( ValueType.TEXT ),
+                b -> b.setUid( "DE_ID" ) ),
+            ImmutableList.of(
+                Pair.of( DimensionResponse::getDimensionType, DIMENSION_ITEM_TYPE ),
+                Pair.of( DimensionResponse::getId, "PROGRAM_STAGE_ID.DE_ID" ) ),
+            "PROGRAM_STAGE_ID" );
     }
 
 }


### PR DESCRIPTION
now **enrollments** dimension endpoint return dimensions of type `DATA_ELEMENT` like this:
```
{
    valueType: "NUMBER",
    dimensionType: "DATA_ELEMENT",
    ...  
    id: "A03MvHHogjR.a3kGcGDCuk6",
    ...
}
```

while **events** one returns `DATA_ELEMENTS` like this:

```
{
    valueType: "TEXT",
    dimensionType: "DATA_ELEMENT",
    ...
    id: "oZg33kd9taw",
    ...
}
```

This pull request formats `id`s in events dimension endpoint in the same format as enrollments, i.e. 
`{program_stage_uid}.{data_element_uid}`