### PR TITLE
test: migrate tests to use junit 5 annotations [TECH-969]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.trackedentity;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.util.List;
@@ -42,7 +41,7 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeTableManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/job/TrackerTrigramIndexingJobTest.java
@@ -43,8 +43,8 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeTableManager;
 import org.hisp.dhis.trackedentityattributevalue.TrackerTrigramIndexingJob;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link TrackerTrigramIndexingJob} using mocks to only test the
@@ -64,7 +64,7 @@ public class TrackerTrigramIndexingJobTest
     private final TrackerTrigramIndexingJob job = new TrackerTrigramIndexingJob( trackedEntityAttributeService,
         trackedEntityAttributeTableManager );
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         // mock normal run conditions


### PR DESCRIPTION
it looks like `org.junit.Test` annotated tests are not executed on GH pipeline.
This PR migrates them to use JUnit 5