### PR TITLE
fix: make local copy for object mapper filter provider

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParams.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParams.java
@@ -43,11 +43,17 @@ import org.apache.commons.lang3.StringUtils;
 @Builder
 public class FieldFilterParams<T>
 {
+    /**
+     * Objects to apply filters on.
+     */
     private final List<T> objects;
 
     @Builder.Default
     private final Set<String> filters = Collections.singleton( "*" );
 
+    /**
+     * Do not include sharing properties (user, sharing, publicAccess, etc).
+     */
     private final boolean skipSharing;
 
     public static <O> FieldFilterParams<O> of( List<O> objects, List<String> filters )

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.fieldfiltering;
 
+import static org.apache.commons.lang3.StringUtils.containsAny;
+import static org.apache.commons.lang3.StringUtils.isAlphanumeric;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -66,6 +70,8 @@ public class FieldFilterParser
         boolean isExclude = false; // token is !, which means do not include
         boolean isPreset = false; // token is :, which means it's a preset
 
+        // simple token parser that both tokenizes and builds up the internal
+        // fields paths.
         for ( int idx = 0; idx < fieldSplit.length; idx++ )
         {
             String token = fieldSplit[idx];
@@ -83,7 +89,7 @@ public class FieldFilterParser
                 {
                     token = fieldSplit[idx];
 
-                    if ( (StringUtils.containsAny( token, ":", "~", "|" )) )
+                    if ( (containsAny( token, ":", "~", "|" )) )
                     {
                         if ( token.equals( ":" ) )
                         {
@@ -204,7 +210,7 @@ public class FieldFilterParser
     {
         String name = fieldNameBuilder.toString();
 
-        if ( !StringUtils.isEmpty( name ) )
+        if ( !isEmpty( name ) )
         {
             FieldPath fieldPath = new FieldPath( name, new ArrayList<>( path ), isExclude, isPreset, transformers );
             fieldPaths.add( fieldPath );
@@ -218,65 +224,64 @@ public class FieldFilterParser
 
     private static boolean isBlockStart( String token )
     {
-        return token != null && StringUtils.containsAny( token, "[", "(" );
+        return token != null && containsAny( token, "[", "(" );
     }
 
     private static boolean isBlockEnd( String token )
     {
-        return token != null && StringUtils.containsAny( token, "]", ")" );
+        return token != null && containsAny( token, "]", ")" );
     }
 
     // please be aware that this also could mean both block start, and parameter
     // start depending on context
     private static boolean isParameterStart( String token )
     {
-        return StringUtils.containsAny( token, "(" );
+        return containsAny( token, "(" );
     }
 
     // please be aware that this also could mean both block end, and parameter
     // end depending on context
     private static boolean isParameterEnd( String token )
     {
-        return StringUtils.containsAny( token, ")" );
+        return containsAny( token, ")" );
     }
 
     private static boolean isParameterSeparator( String token )
     {
-        return StringUtils.containsAny( token, ";" );
+        return containsAny( token, ";" );
     }
 
     private static boolean isFieldSeparator( String token )
     {
-        return StringUtils.containsAny( token, "," );
+        return containsAny( token, "," );
     }
 
     private static boolean isAlphanumericOrSpecial( String token )
     {
-        return StringUtils.isAlphanumeric( token )
-            || StringUtils.containsAny( token, "*", ":", "{", "}", "~", "!", "|" );
+        return isAlphanumeric( token ) || containsAny( token, "*", ":", "{", "}", "~", "!", "|" );
     }
 
     private static boolean isExclude( String token )
     {
-        return StringUtils.containsAny( token, "!" );
+        return containsAny( token, "!" );
     }
 
     private static boolean isPreset( String token )
     {
-        return StringUtils.containsAny( token, ":" );
+        return containsAny( token, ":" );
     }
 
     private static boolean isAllAlias( String token )
     {
         // special case, convert * to all (preset=true)
-        return StringUtils.containsAny( token, "*" );
+        return containsAny( token, "*" );
     }
 
     private static boolean isTransformer( String[] fieldSplit, int idx )
     {
         String token = fieldSplit[idx];
 
-        return StringUtils.containsAny( token, "~", "|" )
+        return containsAny( token, "~", "|" )
             || (fieldSplit.length > 1 && ":".equals( fieldSplit[idx] ) && ":".equals( fieldSplit[idx + 1] ));
     }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -147,6 +147,9 @@ public class FieldFilterService
         return objectMapper;
     }
 
+    /**
+     * Recursively applies FieldTransformers to a Json node.
+     */
     private void applyTransformers( JsonNode node, JsonNode parent, String path,
         Map<String, List<FieldTransformer>> fieldTransformers )
     {

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -106,7 +106,10 @@ public class FieldFilterService
         fieldPathHelper.apply( fieldPaths, HibernateProxyUtils.getRealClass( firstObject ) );
 
         SimpleFilterProvider filterProvider = getSimpleFilterProvider( fieldPaths, params.isSkipSharing() );
-        ObjectMapper objectMapper = jsonMapper.setFilterProvider( filterProvider );
+
+        // only set filter provider on a local copy so that we don't affect
+        // other object mappers (running across other threads)
+        ObjectMapper objectMapper = jsonMapper.copy().setFilterProvider( filterProvider );
 
         Map<String, List<FieldTransformer>> fieldTransformers = getTransformers( fieldPaths );
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
@@ -43,6 +43,11 @@ import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 
 /**
+ * PropertyFilter that supports filtering using FieldPaths, also supports
+ * skipping of all fields related to sharing.
+ *
+ * The filter _must_ be set on the ObjectMapper before serialising an object.
+ *
  * @author Morten Olav Hansen
  */
 @RequiredArgsConstructor
@@ -152,6 +157,9 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
     }
 }
 
+/**
+ * Simple container class used by getPath to handle Maps.
+ */
 @Data
 @RequiredArgsConstructor
 class PathValue

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldTransformer.java
@@ -32,6 +32,9 @@ import org.springframework.core.Ordered;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
+ * Interface for FieldTransformers, used to modify the Jackson Json tree
+ * dynamically (for example renaming of keys).
+ *
  * @author Morten Olav Hansen
  */
 @FunctionalInterface

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsEmptyFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsEmptyFieldTransformer.java
@@ -33,6 +33,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
+ * Field transformer that check if an array is empty or not.
+ *
+ * Usage: "?fields=id,name,dataElementGroups::isEmpty"
+ *
  * @author Morten Olav Hansen
  */
 public class IsEmptyFieldTransformer implements FieldTransformer
@@ -51,6 +55,7 @@ public class IsEmptyFieldTransformer implements FieldTransformer
 
         if ( value.isArray() )
         {
+            // overwrite array node with true/false depending on empty status
             ((ObjectNode) parent).put( fieldName, value.isEmpty() );
         }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsNotEmptyFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/IsNotEmptyFieldTransformer.java
@@ -33,6 +33,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
+ * Field transformer that check if an array is empty or not.
+ *
+ * Usage: "?fields=id,name,dataElementGroups::isNotEmpty"
+ *
  * @author Morten Olav Hansen
  */
 public class IsNotEmptyFieldTransformer implements FieldTransformer
@@ -51,6 +55,7 @@ public class IsNotEmptyFieldTransformer implements FieldTransformer
 
         if ( value.isArray() )
         {
+            // overwrite array node with true/false depending on empty status
             ((ObjectNode) parent).put( fieldName, !value.isEmpty() );
         }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/PluckFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/PluckFieldTransformer.java
@@ -35,6 +35,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
+ * Field transformer that plucks out a property from an array.
+ *
+ * Usage: "?fields=id,name,dataElementGroups::pluck(id)"
+ *
  * @author Morten Olav Hansen
  */
 public class PluckFieldTransformer implements FieldTransformer

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/RenameFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/RenameFieldTransformer.java
@@ -34,6 +34,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
+ * Field transformer that renames property keys.
+ *
+ * Usage: "?fields=id::(i),name::rename(n)"
+ *
  * @author Morten Olav Hansen
  */
 public class RenameFieldTransformer implements FieldTransformer

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/SizeFieldTransformer.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/transformers/SizeFieldTransformer.java
@@ -33,6 +33,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
+ * Field transformer that returns the size of the value of a given key.
+ *
+ * Usage: "?fields=id,name::size,dataElementGroups::size"
+ *
  * @author Morten Olav Hansen
  */
 public class SizeFieldTransformer implements FieldTransformer


### PR DESCRIPTION
Small fix for `FieldFilterService` that makes sure that the `FilterProvider` is set on a fresh copy of `ObjectMapper` (pre-configured for field filtering).