### PR TITLE
feat: Add DataElement/TEA support for web_hook notifications[DHIS2-12576]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramStageTemplateVariable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramStageTemplateVariable.java
@@ -58,6 +58,8 @@ public enum ProgramStageTemplateVariable
     PROGRAM_NAME( "program_name" ),
     PROGRAM_STAGE_NAME( "program_stage_name" ),
     ORG_UNIT_NAME( "org_unit_name" ),
+    ORG_UNIT_ID( "org_unit_id" ),
+    ORG_UNIT_CODE( "org_unit_code" ),
     DUE_DATE( "due_date" ),
     DAYS_SINCE_DUE_DATE( "days_since_due_date" ),
     DAYS_UNTIL_DUE_DATE( "days_until_due_date" ),
@@ -89,7 +91,7 @@ public enum ProgramStageTemplateVariable
 
     public static boolean isValidVariableName( String expressionName )
     {
-        return variableNameMap.keySet().contains( expressionName );
+        return variableNameMap.containsKey( expressionName );
     }
 
     public static ProgramStageTemplateVariable fromVariableName( String variableName )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramStageTemplateVariable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramStageTemplateVariable.java
@@ -68,6 +68,8 @@ public enum ProgramStageTemplateVariable
     PROGRAM_ID( "program_id" ),
     EVENT_ORG_UNIT_ID( "event_org_unit_id" ),
     ENROLLMENT_ORG_UNIT_ID( "enrollment_org_unit_id" ),
+    ENROLLMENT_ORG_UNIT_NAME( "enrollment_org_unit_name" ),
+    ENROLLMENT_ORG_UNIT_CODE( "enrollment_org_unit_code" ),
     PROGRAM_STAGE_ID( "program_stage_id" ),
     ENROLLMENT_ID( "enrollment_id" ),
     TRACKED_ENTITY_ID( "tracked_entity_id" );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramTemplateVariable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/notification/ProgramTemplateVariable.java
@@ -61,6 +61,8 @@ public enum ProgramTemplateVariable
     INCIDENT_DATE( "incident_date" ),
     PROGRAM_ID( "program_id" ),
     ENROLLMENT_ORG_UNIT_ID( "enrollment_org_unit_id" ),
+    ENROLLMENT_ORG_UNIT_NAME( "enrollment_org_unit_name" ),
+    ENROLLMENT_ORG_UNIT_CODE( "enrollment_org_unit_code" ),
     ENROLLMENT_ID( "enrollment_id" ),
     TRACKED_ENTITY_ID( "tracked_entity_id" );
 
@@ -83,7 +85,7 @@ public enum ProgramTemplateVariable
 
     public static boolean isValidVariableName( String expressionName )
     {
-        return variableNameMap.keySet().contains( expressionName );
+        return variableNameMap.containsKey( expressionName );
     }
 
     public static ProgramTemplateVariable fromVariableName( String variableName )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramNotificationMessageRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramNotificationMessageRenderer.java
@@ -58,6 +58,8 @@ public class ProgramNotificationMessageRenderer
         .put( ProgramTemplateVariable.INCIDENT_DATE, pi -> formatDate( pi.getIncidentDate() ) )
         .put( ProgramTemplateVariable.DAYS_SINCE_ENROLLMENT_DATE, pi -> daysSince( pi.getEnrollmentDate() ) )
         .put( ProgramTemplateVariable.ENROLLMENT_ORG_UNIT_ID, pi -> pi.getOrganisationUnit().getUid() )
+        .put( ProgramTemplateVariable.ENROLLMENT_ORG_UNIT_NAME, pi -> pi.getOrganisationUnit().getName() )
+        .put( ProgramTemplateVariable.ENROLLMENT_ORG_UNIT_CODE, pi -> pi.getOrganisationUnit().getCode() )
         .put( ProgramTemplateVariable.PROGRAM_ID, pi -> pi.getProgram().getUid() )
         .put( ProgramTemplateVariable.ENROLLMENT_ID, ProgramInstance::getUid )
         .put( ProgramTemplateVariable.TRACKED_ENTITY_ID, pi -> pi.getEntityInstance().getUid() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramStageNotificationMessageRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramStageNotificationMessageRenderer.java
@@ -56,6 +56,8 @@ public class ProgramStageNotificationMessageRenderer
         .put( ProgramStageTemplateVariable.PROGRAM_NAME, psi -> psi.getProgramStage().getProgram().getDisplayName() )
         .put( ProgramStageTemplateVariable.PROGRAM_STAGE_NAME, psi -> psi.getProgramStage().getDisplayName() )
         .put( ProgramStageTemplateVariable.ORG_UNIT_NAME, psi -> psi.getOrganisationUnit().getDisplayName() )
+        .put( ProgramStageTemplateVariable.ORG_UNIT_ID, psi -> psi.getOrganisationUnit().getUid() )
+        .put( ProgramStageTemplateVariable.ORG_UNIT_CODE, psi -> psi.getOrganisationUnit().getCode() )
         .put( ProgramStageTemplateVariable.DUE_DATE, psi -> formatDate( psi.getDueDate() ) )
         .put( ProgramStageTemplateVariable.EVENT_DATE, psi -> formatDate( psi.getExecutionDate() ) )
         .put( ProgramStageTemplateVariable.DAYS_SINCE_DUE_DATE, psi -> daysSince( psi.getDueDate() ) )
@@ -91,7 +93,7 @@ public class ProgramStageNotificationMessageRenderer
     }
 
     @Override
-    protected Map<String, String> resolveTrackedEntityAttributeValues( Set<String> attributeKeys,
+    public Map<String, String> resolveTrackedEntityAttributeValues( Set<String> attributeKeys,
         ProgramStageInstance entity )
     {
         if ( attributeKeys.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramStageNotificationMessageRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramStageNotificationMessageRenderer.java
@@ -93,7 +93,7 @@ public class ProgramStageNotificationMessageRenderer
     }
 
     @Override
-    public Map<String, String> resolveTrackedEntityAttributeValues( Set<String> attributeKeys,
+    protected Map<String, String> resolveTrackedEntityAttributeValues( Set<String> attributeKeys,
         ProgramStageInstance entity )
     {
         if ( attributeKeys.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramStageNotificationMessageRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/notification/ProgramStageNotificationMessageRenderer.java
@@ -66,6 +66,10 @@ public class ProgramStageNotificationMessageRenderer
         .put( ProgramStageTemplateVariable.EVENT_ORG_UNIT_ID, psi -> psi.getOrganisationUnit().getUid() )
         .put( ProgramStageTemplateVariable.ENROLLMENT_ORG_UNIT_ID,
             psi -> psi.getProgramInstance().getOrganisationUnit().getUid() )
+        .put( ProgramStageTemplateVariable.ENROLLMENT_ORG_UNIT_NAME,
+            psi -> psi.getProgramInstance().getOrganisationUnit().getName() )
+        .put( ProgramStageTemplateVariable.ENROLLMENT_ORG_UNIT_CODE,
+            psi -> psi.getProgramInstance().getOrganisationUnit().getCode() )
         .put( ProgramStageTemplateVariable.PROGRAM_ID, psi -> psi.getProgramStage().getProgram().getUid() )
         .put( ProgramStageTemplateVariable.PROGRAM_STAGE_ID, psi -> psi.getProgramStage().getUid() )
         .put( ProgramStageTemplateVariable.ENROLLMENT_ID, psi -> psi.getProgramInstance().getUid() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
@@ -31,14 +31,12 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.notification.ProgramNotificationMessageRenderer;
 import org.hisp.dhis.notification.ProgramStageNotificationMessageRenderer;
 import org.hisp.dhis.program.ProgramInstance;
@@ -78,20 +76,16 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
 
     private final RenderService renderService;
 
-    private final ProgramStageNotificationMessageRenderer programStageNotificationMessageRenderer;
-
     public DefaultTrackerNotificationWebHookService( @NonNull ProgramInstanceService programInstanceService,
         @NonNull ProgramStageInstanceService programStageInstanceService,
         @Nonnull RestTemplate restTemplate, @Nonnull RenderService renderService,
-        @Nonnull ProgramNotificationTemplateService templateService,
-        @Nonnull ProgramStageNotificationMessageRenderer programStageNotificationMessageRenderer )
+        @Nonnull ProgramNotificationTemplateService templateService )
     {
         this.programInstanceService = programInstanceService;
         this.programStageInstanceService = programStageInstanceService;
         this.restTemplate = restTemplate;
         this.renderService = renderService;
         this.templateService = templateService;
-        this.programStageNotificationMessageRenderer = programStageNotificationMessageRenderer;
     }
 
     @Override
@@ -109,10 +103,14 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
         List<ProgramNotificationTemplate> templates = templateService
             .getProgramLinkedToWebHookNotifications( instance.getProgram() );
 
-        Map<String, String> payload = new HashMap<>();
+        Map<String, String> requestPayload = new HashMap<>();
         ProgramNotificationMessageRenderer.VARIABLE_RESOLVERS
-            .forEach( ( key, value ) -> payload.put( key.name(), value.apply( instance ) ) );
-        sendPost( templates, renderService.toJsonAsString( payload ) );
+            .forEach( ( key, value ) -> requestPayload.put( key.name(), value.apply( instance ) ) );
+
+        // populate tracked entity attributes
+        instance.getEntityInstance().getTrackedEntityAttributeValues()
+            .forEach( attr -> requestPayload.put( attr.getAttribute().getUid(), attr.getValue() ) );
+        sendPost( templates, renderService.toJsonAsString( requestPayload ) );
     }
 
     @Override
@@ -130,17 +128,19 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
         List<ProgramNotificationTemplate> templates = templateService
             .getProgramStageLinkedToWebHookNotifications( instance.getProgramStage() );
 
-        Map<String, String> standardVariables = new HashMap<>();
+        // populate environment variables
+        Map<String, String> requestPayload = new HashMap<>();
         ProgramStageNotificationMessageRenderer.VARIABLE_RESOLVERS
-            .forEach( ( key, value ) -> standardVariables.put( key.name(), value.apply( instance ) ) );
+            .forEach( ( key, value ) -> requestPayload.put( key.name(), value.apply( instance ) ) );
 
-        Map<String, String> dataElements = programStageNotificationMessageRenderer.resolveTrackedEntityAttributeValues(
-            instance.getEventDataValues().stream().map( EventDataValue::getDataElement ).collect( Collectors.toSet() ),
-            instance );
+        // populate data values
+        instance.getEventDataValues().forEach( dv -> requestPayload.put( dv.getDataElement(), dv.getValue() ) );
 
-        standardVariables.putAll( dataElements );
+        // populate tracked entity attributes
+        instance.getProgramInstance().getEntityInstance().getTrackedEntityAttributeValues()
+            .forEach( attr -> requestPayload.put( attr.getAttribute().getUid(), attr.getValue() ) );
 
-        sendPost( templates, renderService.toJsonAsString( standardVariables ) );
+        sendPost( templates, renderService.toJsonAsString( requestPayload ) );
     }
 
     private void sendPost( List<ProgramNotificationTemplate> templates, String payload )


### PR DESCRIPTION
PR will add support for some additional template variables

```
    ENROLLMENT_ORG_UNIT_NAME( "enrollment_org_unit_name" )
    ENROLLMENT_ORG_UNIT_CODE( "enrollment_org_unit_code" )
```
Besides, that web request payload will now contain data elements and tracked entity attributes depending upon the object the web request was attached to i.e either `ProgramIntance` or `ProgramStageInstance`