### PR TITLE
chore: Skip tests for sonarqube check

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -411,7 +411,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <skipTests>false</skipTests>
+                            <skipTests>true</skipTests>
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>${argLine} ${surefireArgLine}</argLine>
                             <excludedGroups>org.hisp.dhis.IntegrationTest</excludedGroups>


### PR DESCRIPTION
After enabling them to allow the reporting of test-coverage, the general feedback is that the check takes such a long time, it's blocking developers waiting for merge pull requests. Until we find a better automated way of reporting test coverage, the tests will be skipped again to speed up the review and merge process.