### PR TITLE
feat: uid or job type as session ID in logs when running async [DHIS2-12538]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.JobProgress.Process;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
+import org.slf4j.MDC;
 
 /**
  * Base for synchronous or asynchronous {@link SchedulingManager} implementation
@@ -268,6 +269,10 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             // in memory effect only: mark running (dirty)
             configuration.setLastExecutedStatus( JobStatus.RUNNING );
 
+            String identifier = configuration.getUid() != null
+                ? "UID:" + configuration.getUid()
+                : "TYPE:" + configuration.getJobType().name();
+            MDC.put( "sessionId", identifier );
             // run the actual job
             jobService.getJob( type ).execute( configuration, progress );
 
@@ -285,6 +290,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             completedLocally.put( type, runningLocally.remove( type ) );
             runningRemotely.invalidate( type.name() );
             whenRunIsDone( configuration, clock );
+            MDC.remove( "sessionId" );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/RequestIdentifierFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/RequestIdentifierFilter.java
@@ -58,14 +58,14 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class RequestIdentifierFilter
     extends OncePerRequestFilter
 {
-    private final static String SESSION_ID_KEY = "sessionId";
+    private static final String SESSION_ID_KEY = "sessionId";
 
     /**
      * The hash algorithm to use.
      */
-    private final String hashAlgo = "SHA-256";
+    private static final String HASH_ALGO = "SHA-256";
 
-    private final static String IDENTIFIER_PREFIX = "ID";
+    private static final String IDENTIFIER_PREFIX = "ID";
 
     private final boolean enabled;
 
@@ -88,7 +88,7 @@ public class RequestIdentifierFilter
             }
             catch ( NoSuchAlgorithmException e )
             {
-                log.error( String.format( "Invalid Hash algorithm provided (%s)", hashAlgo ), e );
+                log.error( String.format( "Invalid Hash algorithm provided (%s)", HASH_ALGO ), e );
             }
         }
 
@@ -99,7 +99,7 @@ public class RequestIdentifierFilter
         throws NoSuchAlgorithmException
     {
         byte[] data = sessionId.getBytes();
-        MessageDigest digester = MessageDigest.getInstance( hashAlgo );
+        MessageDigest digester = MessageDigest.getInstance( HASH_ALGO );
         digester.update( data );
         return Base64.getEncoder().encodeToString( digester.digest() );
     }


### PR DESCRIPTION
### Summary
When running a job, scheduled or executed ad-hoc/manually, the log with use the job ID as "session ID" in the logs. 
If the job does not have a UID the job-type is used.

Here an example from a manual test run:

    UID:pCXKSlDLDkP * INFO  2022-02-08T16:44:41,827 Create SQL views (NotificationLoggerUtil.java [taskScheduler-2])

I think in some cases the job itself is created ad-hoc (in a controller) in which case it does not have an ID as it never gets stored. Therefore I added a fallback to the job type. I did not test this but this then should look like this:

    TYPE:RESOURCE_TABLE * INFO  2022-02-08T16:44:41,827 Create SQL views (NotificationLoggerUtil.java [taskScheduler-2])

I decided to not use the constant defined in `RequestIdentifierFilter` to avoid the dependency consequences.
Still I did a bit of cleanup in the `RequestIdentifierFilter` which are unrelated other an also being related to the setting of the session ID for the logs.

### Testing
As said I tested this with a manual job.
I created a resource table generation job in the scheduler app and ran it manually.

Then I checked the logs for the `UID:<uid>` to be present as in the below example:

    UID:pCXKSlDLDkP * INFO  2022-02-08T16:44:41,827 Create SQL views (NotificationLoggerUtil.java [taskScheduler-2])
    UID:pCXKSlDLDkP * INFO  2022-02-08T16:44:41,828 Resource tables generated: 00:00:27.008 (NotificationLoggerUtil.java [taskScheduler-2])