### PR TITLE
fix: Exception:OrganisationUnit can't be null - [ DHIS2-12347 ] [ 2.38 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -79,6 +80,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class PreCheckSecurityOwnershipValidationHook
     extends AbstractTrackerDtoValidationHook
 {
@@ -461,9 +463,14 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( user, USER_CANT_BE_NULL );
         checkNotNull( programStage, PROGRAM_STAGE_CANT_BE_NULL );
         checkNotNull( programStage.getProgram(), PROGRAM_CANT_BE_NULL );
-        checkNotNull( eventOrgUnit, ORGANISATION_UNIT_CANT_BE_NULL );
 
-        if ( isCreatableInSearchScope ? !organisationUnitService.isInUserSearchHierarchyCached( user, eventOrgUnit )
+        if ( eventOrgUnit == null )
+        {
+            log.warn( "ProgramStageInstance " + event.getUid()
+                + " has no organisation unit assigned, so we skip user validation" );
+        }
+        else if ( isCreatableInSearchScope
+            ? !organisationUnitService.isInUserSearchHierarchyCached( user, eventOrgUnit )
             : !organisationUnitService.isInUserHierarchyCached( user, eventOrgUnit ) )
         {
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12347

When the org unit is null for psi on DB, we do not validate the user authorization and add a warning.