### PR TITLE
fix: provide data integrity check job configuration parameters metadata [DHIS2-12286]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -29,9 +29,20 @@ package org.hisp.dhis.scheduling;
 
 import java.util.Map;
 
-import org.hisp.dhis.scheduling.parameters.*;
-
-import com.google.common.collect.ImmutableMap;
+import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
+import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
+import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
+import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
+import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
+import org.hisp.dhis.scheduling.parameters.MockJobParameters;
+import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
+import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
+import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
+import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
+import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
+import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 
 /**
  * Enum describing the different jobs in the system. Each job has a key, class,
@@ -46,12 +57,14 @@ import com.google.common.collect.ImmutableMap;
 public enum JobType
 {
     DATA_STATISTICS( false ),
-    DATA_INTEGRITY( true ),
+    DATA_INTEGRITY( true, SchedulingType.CRON, DataIntegrityJobParameters.class,
+        Map.of( "checks", "/api/dataIntegrity" ) ),
     RESOURCE_TABLE( true ),
-    ANALYTICS_TABLE( true, SchedulingType.CRON, AnalyticsJobParameters.class, ImmutableMap.of(
-        "skipTableTypes", "/api/analytics/tableTypes", "skipPrograms", "/api/programs" ) ),
+    ANALYTICS_TABLE( true, SchedulingType.CRON, AnalyticsJobParameters.class, Map.of(
+        "skipTableTypes", "/api/analytics/tableTypes",
+        "skipPrograms", "/api/programs" ) ),
     CONTINUOUS_ANALYTICS_TABLE( true, SchedulingType.FIXED_DELAY,
-        ContinuousAnalyticsJobParameters.class, ImmutableMap.of(
+        ContinuousAnalyticsJobParameters.class, Map.of(
             "skipTableTypes", "/api/analytics/tableTypes" ) ),
     DATA_SYNC( true, SchedulingType.CRON, DataSynchronizationJobParameters.class, null ),
     TRACKER_PROGRAMS_DATA_SYNC( true, SchedulingType.CRON,
@@ -66,17 +79,18 @@ public enum JobType
     PROGRAM_NOTIFICATIONS( true ),
     VALIDATION_RESULTS_NOTIFICATION( false ),
     CREDENTIALS_EXPIRY_ALERT( false ),
-    MONITORING( true, SchedulingType.CRON, MonitoringJobParameters.class, ImmutableMap.of(
-        "relativePeriods", "/api/periodTypes/relativePeriodTypes", "validationRuleGroups",
-        "/api/validationRuleGroups" ) ),
-    PUSH_ANALYSIS( true, SchedulingType.CRON, PushAnalysisJobParameters.class, ImmutableMap.of(
+    MONITORING( true, SchedulingType.CRON, MonitoringJobParameters.class, Map.of(
+        "relativePeriods", "/api/periodTypes/relativePeriodTypes",
+        "validationRuleGroups", "/api/validationRuleGroups" ) ),
+    PUSH_ANALYSIS( true, SchedulingType.CRON, PushAnalysisJobParameters.class, Map.of(
         "pushAnalysis", "/api/pushAnalysis" ) ),
     // TODO: Update API in tracker search optimization job map to reflect actual
     // api url after implementation
-    TRACKER_SEARCH_OPTIMIZATION( true, SchedulingType.CRON, TrackerTrigramIndexJobParameters.class, ImmutableMap.of(
+    TRACKER_SEARCH_OPTIMIZATION( true, SchedulingType.CRON, TrackerTrigramIndexJobParameters.class, Map.of(
         "attributes", "/api/trackedEntityAttributes/indexable" ) ),
-    PREDICTOR( true, SchedulingType.CRON, PredictorJobParameters.class, ImmutableMap.of(
-        "predictors", "/api/predictors", "predictorGroups", "/api/predictorGroups" ) ),
+    PREDICTOR( true, SchedulingType.CRON, PredictorJobParameters.class, Map.of(
+        "predictors", "/api/predictors",
+        "predictorGroups", "/api/predictorGroups" ) ),
     DATA_SET_NOTIFICATION( false ),
     REMOVE_USED_OR_EXPIRED_RESERVED_VALUES( false ),
     TRACKER_IMPORT_JOB( false ),

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -86,7 +86,7 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest
         String jobId = assertStatus( HttpStatus.CREATED, POST( "/jobConfigurations",
             "{'name':'test','jobType':'DATA_INTEGRITY','cronExpression':'0 0 12 ? * MON-FRI'}" ) );
         JsonObject parameters = assertJobConfigurationExists( jobId, "DATA_INTEGRITY" );
-        assertFalse( parameters.exists() );
+        assertTrue( parameters.exists() );
     }
 
     @Test


### PR DESCRIPTION
There were two issues here:
1. I missed to declare the parameters class for the `DATA_INTEGRITY` constant in `JobType` enum
2. I used field annotations but the processing of properties in job parameters did only consider method level annotation of `@JsonProperty`

The processing was changed so that it now considers both method and field level annotations. The `@JsonProperty` annotation was purely used as a filter to find the properties that should be included.