### PR TITLE
refactor: Create ExpressionParams

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -27,10 +27,17 @@
  */
 package org.hisp.dhis.expression;
 
+import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+
 import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -39,12 +46,6 @@ import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.period.Period;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 
 /**
  * Parameters to evaluate an expression in {@see ExpressionService}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -53,25 +53,31 @@ import org.hisp.dhis.period.Period;
  * @author Jim Grace
  */
 @Getter
-@ToString
-@EqualsAndHashCode
+@ToString( onlyExplicitlyIncluded = true )
+@EqualsAndHashCode( onlyExplicitlyIncluded = true )
 @Builder( toBuilder = true )
 public class ExpressionParams
 {
     /**
      * The expression to parse
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private String expression;
 
     /**
      * The type of expression to parse (Indicator, Predictor, etc.)
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private ParseType parseType;
 
     /**
      * The expected return data type (often but not always determined by the
      * type of expression to parse).
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private DataType dataType;
 
     /**
@@ -91,12 +97,16 @@ public class ExpressionParams
     /**
      * Map of constant values to use in evaluating the expression
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     @Builder.Default
     private Map<String, Constant> constantMap = new HashMap<>();
 
     /**
      * Map of organisation unit counts to use in evaluating the expression
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     @Builder.Default
     private Map<String, Integer> orgUnitCountMap = new HashMap<>();
 
@@ -110,22 +120,30 @@ public class ExpressionParams
     /**
      * The number of calendar days to be used in evaluating the expression
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private Integer days;
 
     /**
      * The missing value strategy (what to do if data values are missing)
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     @Builder.Default
     private MissingValueStrategy missingValueStrategy = NEVER_SKIP;
 
     /**
-     * The current organisaiton unit the expression is being evaluated for
+     * The current organisation unit the expression is being evaluated for
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private OrganisationUnit orgUnit;
 
     /**
      * For predictors, a list of periods in which we will look for sampled data
      */
+    @ToString.Include
+    @EqualsAndHashCode.Include
     private List<Period> samplePeriods;
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.hisp.dhis.analytics.DataType;
+import org.hisp.dhis.common.DimensionalItemId;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.MapMap;
+import org.hisp.dhis.constant.Constant;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.period.Period;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
+
+/**
+ * Parameters to evaluate an expression in {@see ExpressionService}
+ *
+ * @author Jim Grace
+ */
+@Getter
+@ToString
+@EqualsAndHashCode
+@Builder( toBuilder = true )
+public class ExpressionParams
+{
+    /**
+     * The expression to parse
+     */
+    private String expression;
+
+    /**
+     * The type of expression to parse (Indicator, Predictor, etc.)
+     */
+    private ParseType parseType;
+
+    /**
+     * The expected return data type (often but not always determined by the
+     * type of expression to parse).
+     */
+    private DataType dataType;
+
+    /**
+     * A map from a parsed {@see DimensionalItemId} to its equivalent
+     * {@see DimensionalItemObject}
+     */
+    @Builder.Default
+    private Map<DimensionalItemId, DimensionalItemObject> itemMap = new HashMap<>();
+
+    /**
+     * A map from a {@see DimensionalItemObject} to its value to use in
+     * evaluating the expression
+     */
+    @Builder.Default
+    private Map<DimensionalItemObject, Object> valueMap = new HashMap<>();
+
+    /**
+     * Map of constant values to use in evaluating the expression
+     */
+    @Builder.Default
+    private Map<String, Constant> constantMap = new HashMap<>();
+
+    /**
+     * Map of organisation unit counts to use in evaluating the expression
+     */
+    @Builder.Default
+    private Map<String, Integer> orgUnitCountMap = new HashMap<>();
+
+    /**
+     * Map of organisation unit groups to use for testing organisation unit
+     * group membership
+     */
+    @Builder.Default
+    private Map<String, OrganisationUnitGroup> orgUnitGroupMap = new HashMap<>();
+
+    /**
+     * The number of calendar days to be used in evaluating the expression
+     */
+    private Integer days;
+
+    /**
+     * The missing value strategy (what to do if data values are missing)
+     */
+    @Builder.Default
+    private MissingValueStrategy missingValueStrategy = NEVER_SKIP;
+
+    /**
+     * The current organisaiton unit the expression is being evaluated for
+     */
+    private OrganisationUnit orgUnit;
+
+    /**
+     * For predictors, a list of periods in which we will look for sampled data
+     */
+    private List<Period> samplePeriods;
+
+    /**
+     * For predictors, a value map from item to value, for each of the periods
+     * in which data is present
+     */
+    @Builder.Default
+    private MapMap<Period, DimensionalItemObject, Object> periodValueMap = new MapMap<>();
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -35,12 +35,10 @@ import java.util.Set;
 import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.period.Period;
 
@@ -275,59 +273,7 @@ public interface ExpressionService
     /**
      * Generates the calculated value for an expression.
      *
-     * @param expression the expression string.
-     * @param parseType the type of expression to parse.
-     * @return the calculated value.
+     * @param exParams the expression parameters.
      */
-    Object getExpressionValue( String expression, ParseType parseType );
-
-    /**
-     * Generates the calculated numeric value for an expression.
-     *
-     * @param expression the expression string.
-     * @param parseType the type of expression to parse.
-     * @param itemMap map of dimensional item objects to value in expression.
-     * @param valueMap the dimensional item object values to use for
-     *        calculation.
-     * @param constantMap map of constants to use for calculation.
-     * @param orgUnitCountMap the map of organisation unit group member counts.
-     * @param orgUnitGroupMap the map of organisation unit groups.
-     * @param days the number of days to use in the calculation.
-     * @param missingValueStrategy the strategy to use when data values are
-     *        missing when calculating the expression.
-     * @param orgUnit the current organisation unit.
-     * @return the calculated value as a double.
-     */
-    Double getExpressionValue( String expression, ParseType parseType,
-        Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
-        Map<String, Constant> constantMap, Map<String, Integer> orgUnitCountMap,
-        Map<String, OrganisationUnitGroup> orgUnitGroupMap, Integer days,
-        MissingValueStrategy missingValueStrategy, OrganisationUnit orgUnit );
-
-    /**
-     * Generates the calculated value for an expression.
-     *
-     * @param expression the expression string.
-     * @param parseType the type of expression to parse.
-     * @param itemMap map of dimensional item objects to value in expression.
-     * @param valueMap the dimensional item object values to use for
-     *        calculation.
-     * @param constantMap map of constants to use for calculation.
-     * @param orgUnitCountMap the map of organisation unit group member counts.
-     * @param orgUnitGroupMap the map of organisation unit groups.
-     * @param days the number of days to use in the calculation.
-     * @param missingValueStrategy the strategy to use when data values are
-     *        missing when calculating the expression.
-     * @param orgUnit the current organisation unit.
-     * @param samplePeriods periods for samples to aggregate.
-     * @param periodValueMap values for aggregate functions by period.
-     * @param dataType the data type the expression should return.
-     * @return the calculated value.
-     */
-    Object getExpressionValue( String expression, ParseType parseType,
-        Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
-        Map<String, Constant> constantMap, Map<String, Integer> orgUnitCountMap,
-        Map<String, OrganisationUnitGroup> orgUnitGroupMap, Integer days,
-        MissingValueStrategy missingValueStrategy, OrganisationUnit orgUnit, List<Period> samplePeriods,
-        MapMap<Period, DimensionalItemObject, Object> periodValueMap, DataType dataType );
+    Object getExpressionValue( ExpressionParams exParams );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -274,6 +274,7 @@ public interface ExpressionService
      * Generates the calculated value for an expression.
      *
      * @param exParams the expression parameters.
+     * @return the calculated value.
      */
     Object getExpressionValue( ExpressionParams exParams );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -68,10 +68,10 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV_POP;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV_SAMP;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.SUM;
+import static org.hisp.dhis.util.ObjectUtils.firstNonNull;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +93,6 @@ import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.Constant;
@@ -113,7 +112,6 @@ import org.hisp.dhis.expression.function.FunctionOrgUnitGroup;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
@@ -381,11 +379,21 @@ public class DefaultExpressionService
 
         Integer days = periods != null ? getDaysFromPeriods( periods ) : null;
 
-        Double denominatorValue = getExpressionValue( indicator.getDenominator(), INDICATOR_EXPRESSION,
-            itemMap, valueMap, constantMap, orgUnitCountMap, null, days, SKIP_IF_ALL_VALUES_MISSING, null );
+        ExpressionParams exParams = ExpressionParams.builder()
+            .parseType( INDICATOR_EXPRESSION )
+            .itemMap( itemMap )
+            .valueMap( valueMap )
+            .constantMap( constantMap )
+            .orgUnitCountMap( orgUnitCountMap )
+            .days( days )
+            .missingValueStrategy( SKIP_IF_ALL_VALUES_MISSING )
+            .build();
 
-        Double numeratorValue = getExpressionValue( indicator.getNumerator(), INDICATOR_EXPRESSION,
-            itemMap, valueMap, constantMap, orgUnitCountMap, null, days, SKIP_IF_ALL_VALUES_MISSING, null );
+        Double denominatorValue = castDouble( getExpressionValue( exParams.toBuilder()
+            .expression( indicator.getDenominator() ).build() ) );
+
+        Double numeratorValue = castDouble( getExpressionValue( exParams.toBuilder()
+            .expression( indicator.getNumerator() ).build() ) );
 
         if ( denominatorValue != null && denominatorValue != 0d && numeratorValue != null )
         {
@@ -582,54 +590,32 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
-    public Object getExpressionValue( String expression, ParseType parseType )
+    public Object getExpressionValue( ExpressionParams exParams )
     {
-        return getExpressionValue( expression, parseType,
-            new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), null,
-            null, NEVER_SKIP, null, DEFAULT_SAMPLE_PERIODS, new MapMap<>(), parseType.getDataType() );
-    }
-
-    @Override
-    public Double getExpressionValue( String expression, ParseType parseType,
-        Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
-        Map<String, Constant> constantMap, Map<String, Integer> orgUnitCountMap,
-        Map<String, OrganisationUnitGroup> orgUnitGroupMap, Integer days,
-        MissingValueStrategy missingValueStrategy, OrganisationUnit orgUnit )
-    {
-        return castDouble( getExpressionValue( expression, parseType, itemMap, valueMap,
-            constantMap, orgUnitCountMap, orgUnitGroupMap, days, missingValueStrategy, orgUnit,
-            DEFAULT_SAMPLE_PERIODS, new MapMap<>(), parseType.getDataType() ) );
-    }
-
-    @Override
-    public Object getExpressionValue( String expression, ParseType parseType,
-        Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
-        Map<String, Constant> constantMap, Map<String, Integer> orgUnitCountMap,
-        Map<String, OrganisationUnitGroup> orgUnitGroupMap, Integer days,
-        MissingValueStrategy missingValueStrategy, OrganisationUnit orgUnit, List<Period> samplePeriods,
-        MapMap<Period, DimensionalItemObject, Object> periodValueMap, DataType dataType )
-    {
-        if ( isEmpty( expression ) )
+        if ( isEmpty( exParams.getExpression() ) )
         {
             return null;
         }
 
-        CommonExpressionVisitor visitor = newVisitor( parseType, ITEM_EVALUATE,
-            samplePeriods, constantMap, missingValueStrategy );
+        DataType dataType = firstNonNull( exParams.getDataType(), exParams.getParseType().getDataType() );
+        List<Period> samplePeriods = firstNonNull( exParams.getSamplePeriods(), DEFAULT_SAMPLE_PERIODS );
 
-        visitor.setDimItemMap( itemMap );
-        visitor.setItemValueMap( valueMap );
-        visitor.setPeriodItemValueMap( periodValueMap );
-        visitor.setOrgUnitCountMap( orgUnitCountMap );
-        visitor.setOrgUnitGroupMap( orgUnitGroupMap );
-        visitor.setOrganisationUnit( orgUnit );
+        CommonExpressionVisitor visitor = newVisitor( exParams.getParseType(), ITEM_EVALUATE,
+            samplePeriods, exParams.getConstantMap(), exParams.getMissingValueStrategy() );
 
-        if ( days != null )
+        visitor.setDimItemMap( exParams.getItemMap() );
+        visitor.setItemValueMap( exParams.getValueMap() );
+        visitor.setPeriodItemValueMap( exParams.getPeriodValueMap() );
+        visitor.setOrgUnitCountMap( exParams.getOrgUnitCountMap() );
+        visitor.setOrgUnitGroupMap( exParams.getOrgUnitGroupMap() );
+        visitor.setOrganisationUnit( exParams.getOrgUnit() );
+
+        if ( exParams.getDays() != null )
         {
-            visitor.setDays( Double.valueOf( days ) );
+            visitor.setDays( Double.valueOf( exParams.getDays() ) );
         }
 
-        Object value = visit( expression, dataType, visitor, true );
+        Object value = visit( exParams.getExpression(), dataType, visitor, true );
 
         int itemsFound = visitor.getItemsFound();
         int itemValuesFound = visitor.getItemValuesFound();
@@ -639,7 +625,7 @@ public class DefaultExpressionService
             return null;
         }
 
-        switch ( missingValueStrategy )
+        switch ( exParams.getMissingValueStrategy() )
         {
         case SKIP_IF_ANY_VALUE_MISSING:
             if ( itemValuesFound < itemsFound )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 import static org.hisp.dhis.expression.Expression.SEPARATOR;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
@@ -400,8 +401,16 @@ class ExpressionService2Test extends DhisSpringTest
     private Double exprValue( String expression, Map<DimensionalItemId, DimensionalItemObject> itemMap,
         Map<DimensionalItemObject, Object> valueMap, Map<String, Integer> orgUnitCountMap, Integer days )
     {
-        return target.getExpressionValue( expression, INDICATOR_EXPRESSION, itemMap, valueMap,
-            constantMap(), orgUnitCountMap, null, days, NEVER_SKIP, null );
+        return castDouble( target.getExpressionValue( ExpressionParams.builder()
+                .expression( expression )
+                .parseType( INDICATOR_EXPRESSION )
+                .itemMap( itemMap )
+                .valueMap( valueMap )
+                .constantMap( constantMap() )
+                .orgUnitCountMap( orgUnitCountMap )
+                .days( days )
+                .missingValueStrategy( NEVER_SKIP )
+                .build() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -402,15 +402,15 @@ class ExpressionService2Test extends DhisSpringTest
         Map<DimensionalItemObject, Object> valueMap, Map<String, Integer> orgUnitCountMap, Integer days )
     {
         return castDouble( target.getExpressionValue( ExpressionParams.builder()
-                .expression( expression )
-                .parseType( INDICATOR_EXPRESSION )
-                .itemMap( itemMap )
-                .valueMap( valueMap )
-                .constantMap( constantMap() )
-                .orgUnitCountMap( orgUnitCountMap )
-                .days( days )
-                .missingValueStrategy( NEVER_SKIP )
-                .build() ) );
+            .expression( expression )
+            .parseType( INDICATOR_EXPRESSION )
+            .itemMap( itemMap )
+            .valueMap( valueMap )
+            .constantMap( constantMap() )
+            .orgUnitCountMap( orgUnitCountMap )
+            .days( days )
+            .missingValueStrategy( NEVER_SKIP )
+            .build() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -526,18 +526,18 @@ class ExpressionServiceTest extends DhisSpringTest
         Map<DimensionalItemId, DimensionalItemObject> itemMap = new HashMap<>();
         expressionService.getExpressionDimensionalItemMaps( expr, parseType, dataType, itemMap, itemMap );
         Object value = expressionService.getExpressionValue( ExpressionParams.builder()
-                .expression( expr )
-                .parseType( parseType )
-                .dataType( dataType )
-                .itemMap( itemMap )
-                .valueMap( valueMap )
-                .constantMap( constantMap )
-                .orgUnitCountMap( ORG_UNIT_COUNT_MAP )
-                .days( DAYS )
-                .missingValueStrategy( missingValueStrategy )
-                .samplePeriods( TEST_SAMPLE_PERIODS )
-                .periodValueMap( samples )
-                .build() );
+            .expression( expr )
+            .parseType( parseType )
+            .dataType( dataType )
+            .itemMap( itemMap )
+            .valueMap( valueMap )
+            .constantMap( constantMap )
+            .orgUnitCountMap( ORG_UNIT_COUNT_MAP )
+            .days( DAYS )
+            .missingValueStrategy( missingValueStrategy )
+            .samplePeriods( TEST_SAMPLE_PERIODS )
+            .periodValueMap( samples )
+            .build() );
         return result( value, itemMap.values() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -525,8 +525,19 @@ class ExpressionServiceTest extends DhisSpringTest
         }
         Map<DimensionalItemId, DimensionalItemObject> itemMap = new HashMap<>();
         expressionService.getExpressionDimensionalItemMaps( expr, parseType, dataType, itemMap, itemMap );
-        Object value = expressionService.getExpressionValue( expr, parseType, itemMap, valueMap, constantMap,
-            ORG_UNIT_COUNT_MAP, null, DAYS, missingValueStrategy, null, TEST_SAMPLE_PERIODS, samples, dataType );
+        Object value = expressionService.getExpressionValue( ExpressionParams.builder()
+                .expression( expr )
+                .parseType( parseType )
+                .dataType( dataType )
+                .itemMap( itemMap )
+                .valueMap( valueMap )
+                .constantMap( constantMap )
+                .orgUnitCountMap( ORG_UNIT_COUNT_MAP )
+                .days( DAYS )
+                .missingValueStrategy( missingValueStrategy )
+                .samplePeriods( TEST_SAMPLE_PERIODS )
+                .periodValueMap( samples )
+                .build() );
         return result( value, itemMap.values() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.common.OrganisationUnitDescendants.DESCENDANTS;
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
-import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_SAMPLE_PERIODS;
 import static org.hisp.dhis.predictor.PredictionFormatter.formatPrediction;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 
@@ -69,6 +68,7 @@ import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -326,10 +326,20 @@ public class DefaultPredictionService
                         continue;
                     }
 
-                    Object value = expressionService.getExpressionValue( predictor.getGenerator().getExpression(),
-                        PREDICTOR_EXPRESSION, itemMap, c.getValueMap(), constantMap, null, orgUnitGroupMap,
-                        c.getOutputPeriod().getDaysInPeriod(), generator.getMissingValueStrategy(), data.getOrgUnit(),
-                        samplePeriods, c.getPeriodValueMap(), expressionDataType );
+                    Object value = expressionService.getExpressionValue( ExpressionParams.builder()
+                        .expression( predictor.getGenerator().getExpression() )
+                        .parseType( PREDICTOR_EXPRESSION )
+                        .dataType( expressionDataType )
+                        .itemMap( itemMap )
+                        .valueMap( c.getValueMap() )
+                        .constantMap( constantMap )
+                        .orgUnitGroupMap( orgUnitGroupMap )
+                        .days( c.getOutputPeriod().getDaysInPeriod() )
+                        .missingValueStrategy( generator.getMissingValueStrategy() )
+                        .orgUnit( data.getOrgUnit() )
+                        .samplePeriods( samplePeriods )
+                        .periodValueMap( c.getPeriodValueMap() )
+                        .build() );
 
                     if ( value != null || generator.getMissingValueStrategy() == NEVER_SKIP )
                     {
@@ -411,11 +421,18 @@ public class DefaultPredictionService
 
         for ( Period p : allSamplePeriods )
         {
-            if ( aocData.get( p ) != null
-                && Boolean.TRUE == expressionService.getExpressionValue( skipTest.getExpression(),
-                    PREDICTOR_SKIP_TEST, itemMap, aocData.get( p ), constantMap, null, orgUnitGroupMap,
-                    p.getDaysInPeriod(), skipTest.getMissingValueStrategy(), orgUnit,
-                    DEFAULT_SAMPLE_PERIODS, new MapMap<>(), DataType.BOOLEAN ) )
+            if ( aocData.get( p ) != null &&
+                (Boolean) expressionService.getExpressionValue( ExpressionParams.builder()
+                .expression( skipTest.getExpression() )
+                .parseType( PREDICTOR_SKIP_TEST )
+                .itemMap( itemMap )
+                .valueMap( aocData.get( p ) )
+                .constantMap( constantMap )
+                .orgUnitGroupMap( orgUnitGroupMap )
+                .days( p.getDaysInPeriod() )
+                .missingValueStrategy( skipTest.getMissingValueStrategy() )
+                .orgUnit( orgUnit )
+                .build() ) )
             {
                 skippedPeriods.add( p );
             }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -423,16 +423,16 @@ public class DefaultPredictionService
         {
             if ( aocData.get( p ) != null &&
                 (Boolean) expressionService.getExpressionValue( ExpressionParams.builder()
-                .expression( skipTest.getExpression() )
-                .parseType( PREDICTOR_SKIP_TEST )
-                .itemMap( itemMap )
-                .valueMap( aocData.get( p ) )
-                .constantMap( constantMap )
-                .orgUnitGroupMap( orgUnitGroupMap )
-                .days( p.getDaysInPeriod() )
-                .missingValueStrategy( skipTest.getMissingValueStrategy() )
-                .orgUnit( orgUnit )
-                .build() ) )
+                    .expression( skipTest.getExpression() )
+                    .parseType( PREDICTOR_SKIP_TEST )
+                    .itemMap( itemMap )
+                    .valueMap( aocData.get( p ) )
+                    .constantMap( constantMap )
+                    .orgUnitGroupMap( orgUnitGroupMap )
+                    .days( p.getDaysInPeriod() )
+                    .missingValueStrategy( skipTest.getMissingValueStrategy() )
+                    .orgUnit( orgUnit )
+                    .build() ) )
             {
                 skippedPeriods.add( p );
             }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.validation;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 import static org.hisp.dhis.expression.ParseType.SIMPLE_TEST;
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
@@ -56,6 +57,7 @@ import org.hisp.dhis.datavalue.DataExportParams;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.Operator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -354,7 +356,8 @@ public class DataValidationTask
         String test = leftSide
             + ruleX.getRule().getOperator().getMathematicalOperator()
             + rightSide;
-        return !(Boolean) expressionService.getExpressionValue( test, SIMPLE_TEST );
+        return !(Boolean) expressionService.getExpressionValue( ExpressionParams.builder()
+            .expression( test ).parseType( SIMPLE_TEST ).build() );
     }
 
     /**
@@ -494,9 +497,17 @@ public class DataValidationTask
                 values.putAll( nonAocValues );
             }
 
-            Double value = expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION,
-                context.getItemMap(), values, context.getConstantMap(), null, context.getOrgUnitGroupMap(),
-                period.getDaysInPeriod(), expression.getMissingValueStrategy(), orgUnit );
+            Double value = castDouble( expressionService.getExpressionValue( ExpressionParams.builder()
+                .expression( expression.getExpression() )
+                .parseType( VALIDATION_RULE_EXPRESSION )
+                .itemMap( context.getItemMap() )
+                .valueMap( values )
+                .constantMap( context.getConstantMap() )
+                .orgUnitGroupMap( context.getOrgUnitGroupMap() )
+                .days( period.getDaysInPeriod() )
+                .missingValueStrategy( expression.getMissingValueStrategy() )
+                .orgUnit( orgUnit )
+                .build() ) );
 
             if ( MathUtils.isValidDouble( value ) )
             {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/AnalyticsValidationServiceTest.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.mock.MockAnalyticsService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -391,7 +392,8 @@ class AnalyticsValidationServiceTest extends TransactionalIntegrationTest
         {
             String test = result.getLeftsideValue() + result.getValidationRule().getOperator().getMathematicalOperator()
                 + result.getRightsideValue();
-            assertFalse( (Boolean) expressionService.getExpressionValue( test, SIMPLE_TEST ) );
+            assertFalse( (Boolean) expressionService.getExpressionValue( ExpressionParams.builder()
+                .expression( test ).parseType( SIMPLE_TEST ).build() ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -50,9 +50,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DataExportParams;
@@ -190,7 +188,7 @@ class DataValidationTaskTest
 
         when( expressionService.getExpressionValue( ExpressionParams.builder()
             .expression( "8.4!=-10.0" ).parseType( SIMPLE_TEST ).build() ) )
-            .thenReturn( true );
+                .thenReturn( true );
 
         subject.init( organisationUnits, ctx, analyticsService );
         subject.run();

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -50,7 +50,9 @@ import org.apache.commons.lang3.RandomUtils;
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DataExportParams;
@@ -58,6 +60,7 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.expression.Operator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -160,7 +163,9 @@ class DataValidationTaskTest
 
         ValidationRunContext ctx = ValidationRunContext.newBuilder()
             .withOrgUnits( organisationUnits )
+            .withItemMap( new HashMap<>() )
             .withConstantMap( constantMap )
+            .withOrgUnitGroupMap( new HashMap<>() )
             .withDefaultAttributeCombo( categoryOptionCombo )
             .withPeriodTypeXs( periodTypes )
             .withMaxResults( 500 )
@@ -183,7 +188,9 @@ class DataValidationTaskTest
         mockExpressionService( leftExpression, vals, ctx, 8.4 );
         mockExpressionService( rightExpression, vals, ctx, -10.0 );
 
-        when( expressionService.getExpressionValue( "8.4!=-10.0", SIMPLE_TEST ) ).thenReturn( true );
+        when( expressionService.getExpressionValue( ExpressionParams.builder()
+            .expression( "8.4!=-10.0" ).parseType( SIMPLE_TEST ).build() ) )
+            .thenReturn( true );
 
         subject.init( organisationUnits, ctx, analyticsService );
         subject.run();
@@ -230,17 +237,23 @@ class DataValidationTaskTest
     private void mockExpressionService( Expression expression, Map<DimensionalItemObject, Object> vals,
         ValidationRunContext ctx, Double val )
     {
-        when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, null, vals,
-            ctx.getConstantMap(), null, null, p1.getDaysInPeriod(), expression.getMissingValueStrategy(), ouA ) )
-                .thenReturn( val );
+        ExpressionParams exParams = ExpressionParams.builder()
+            .expression( expression.getExpression() )
+            .parseType( VALIDATION_RULE_EXPRESSION )
+            .valueMap( vals )
+            .constantMap( ctx.getConstantMap() )
+            .missingValueStrategy( expression.getMissingValueStrategy() )
+            .orgUnit( ouA )
+            .build();
 
-        when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, null, vals,
-            ctx.getConstantMap(), null, null, p2.getDaysInPeriod(), expression.getMissingValueStrategy(), ouA ) )
-                .thenReturn( val );
+        when( expressionService.getExpressionValue( exParams.toBuilder().days( p1.getDaysInPeriod() ).build() ) )
+            .thenReturn( val );
 
-        when( expressionService.getExpressionValue( expression.getExpression(), VALIDATION_RULE_EXPRESSION, null, vals,
-            ctx.getConstantMap(), null, null, p3.getDaysInPeriod(), expression.getMissingValueStrategy(), ouA ) )
-                .thenReturn( val );
+        when( expressionService.getExpressionValue( exParams.toBuilder().days( p2.getDaysInPeriod() ).build() ) )
+            .thenReturn( val );
+
+        when( expressionService.getExpressionValue( exParams.toBuilder().days( p3.getDaysInPeriod() ).build() ) )
+            .thenReturn( val );
     }
 
     private ValidationRuleExtended createValidationRuleExtended( Expression left, Expression right, Operator op )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/ValidationServiceTest.java
@@ -72,6 +72,7 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.datavalue.DataValueStore;
 import org.hisp.dhis.expression.Expression;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.mock.MockCurrentUserService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -513,7 +514,8 @@ class ValidationServiceTest extends DhisTest
             {
                 String test = result.getLeftsideValue()
                     + result.getValidationRule().getOperator().getMathematicalOperator() + result.getRightsideValue();
-                assertFalse( (Boolean) expressionService.getExpressionValue( test, SIMPLE_TEST ) );
+                assertFalse( (Boolean) expressionService.getExpressionValue( ExpressionParams.builder()
+                    .expression( test ).parseType( SIMPLE_TEST ).build() ) );
             }
         }
     }


### PR DESCRIPTION
`ExpressionService.getExpressionValue` had 3 overloads with 2, 10, and 13 parameters, respectively.

This PR creates the class `ExpressionParams` to build the parameters for `getExpressionValue`, and reduces the three overloads to a single method `getExpressionValue( ExpressionParams exParams )`.

Mostly the callers were just mechanically refactored to use `ExpressionParams.builder()` to make the calls. However in a couple of cases parameters have been omitted in the call where they are now supplied by default.