### PR TITLE
feat: Add predictorGroups/{uid}/run DHIS2-12092

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -164,7 +164,7 @@ public class DefaultPredictionService
         {
             notifier.notify( jobId, NotificationLevel.INFO, "Making predictions", false );
 
-            predictionSummary = predictInternal( startDate, endDate, predictors, predictorGroups );
+            predictionSummary = predictAll( startDate, endDate, predictors, predictorGroups );
 
             notifier.update( jobId, NotificationLevel.INFO, "Prediction done", true )
                 .addJobSummary( jobId, predictionSummary, PredictionSummary.class );
@@ -182,7 +182,8 @@ public class DefaultPredictionService
         return predictionSummary;
     }
 
-    private PredictionSummary predictInternal( Date startDate, Date endDate, List<String> predictors,
+    @Override
+    public PredictionSummary predictAll( Date startDate, Date endDate, List<String> predictors,
         List<String> predictorGroups )
     {
         List<Predictor> predictorList = new ArrayList<>();

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionService.java
@@ -48,7 +48,7 @@ public interface PredictionService
     PredictionSummary predictJob( PredictorJobParameters predictorJobParameters, JobConfiguration jobId );
 
     /**
-     * Executes predictors and/or predictor groups for a date range
+     * Executes predictors and/or predictor groups for a date range in a job
      *
      * @param startDate the start date of the predictor run
      * @param endDate the end date of the predictor run
@@ -59,6 +59,18 @@ public interface PredictionService
      */
     PredictionSummary predictTask( Date startDate, Date endDate,
         List<String> predictors, List<String> predictorGroups, JobConfiguration jobId );
+
+    /**
+     * Executes predictors and/or predictor groups for a date range
+     *
+     * @param startDate the start date of the predictor run
+     * @param endDate the end date of the predictor run
+     * @param predictors predictor(s) to run
+     * @param predictorGroups predictor group(s) to run
+     * @return a summary of what was predicted
+     */
+    PredictionSummary predictAll( Date startDate, Date endDate,
+        List<String> predictors, List<String> predictorGroups );
 
     /**
      * Executes a single predictor for a date range

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PredictorGroupController.java
@@ -27,10 +27,26 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+
+import java.util.Date;
+import java.util.List;
+
+import org.hisp.dhis.dxf2.common.TranslateParams;
+import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.hisp.dhis.predictor.PredictionService;
+import org.hisp.dhis.predictor.PredictionSummary;
 import org.hisp.dhis.predictor.PredictorGroup;
 import org.hisp.dhis.schema.descriptors.PredictorGroupSchemaDescriptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * @author Jim Grace
@@ -40,4 +56,28 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class PredictorGroupController
     extends AbstractCrudController<PredictorGroup>
 {
+    @Autowired
+    private PredictionService predictionService;
+
+    @RequestMapping( value = "/{uid}/run", method = { RequestMethod.POST, RequestMethod.PUT } )
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PREDICTOR_RUN')" )
+    @ResponseBody
+    public WebMessage runPredictorGroup(
+        @PathVariable( "uid" ) String uid,
+        @RequestParam Date startDate,
+        @RequestParam Date endDate,
+        TranslateParams translateParams )
+    {
+        try
+        {
+            PredictionSummary predictionSummary = predictionService.predictAll( startDate, endDate,
+                null, List.of( uid ) );
+
+            return ok( "Generated " + predictionSummary.getPredictions() + " predictions" );
+        }
+        catch ( Exception ex )
+        {
+            return conflict( "Unable to predict from predictor group " + uid, ex.getMessage() );
+        }
+    }
 }


### PR DESCRIPTION
See [DHIS2-12092](https://jira.dhis2.org/browse/DHIS2-12092).

This adds a POST predictor group API endpoint `/predictorGroups/{uid}/run` to allow all predictors in a group to be run immediately.

This provides similar functionality to the API endpoint `/predictors/{uid}/run` that allows an individual predictor to be run immediately.

This code passes the test described in [DHIS2-12092](https://jira.dhis2.org/browse/DHIS2-12092) in the **Testing suggestion** comment.