### PR TITLE
fix: Missing errorReports when using DELETE strategy and validation fails [ DHIS2-11300 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
@@ -81,5 +81,6 @@ public interface ProgramInstanceMapper extends PreheatMapper<ProgramInstance>
     @Mapping( target = "trackedEntityType" )
     @Mapping( target = "programType" )
     @Mapping( target = "sharing" )
+    @Mapping( target = "accessLevel" )
     Program mapProgram( Program p );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
@@ -80,5 +80,6 @@ public interface ProgramInstanceMapper extends PreheatMapper<ProgramInstance>
     @Mapping( target = "name" )
     @Mapping( target = "trackedEntityType" )
     @Mapping( target = "programType" )
+    @Mapping( target = "sharing" )
     Program mapProgram( Program p );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
@@ -67,6 +67,7 @@ public interface ProgramMapper extends PreheatMapper<Program>
     @Mapping( target = "expiryDays" )
     @Mapping( target = "expiryPeriodType" )
     @Mapping( target = "completeEventsExpiryDays" )
+    @Mapping( target = "sharing" )
     @Mapping( target = "accessLevel" )
     Program map( Program program );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -180,7 +180,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( enrollment, ENROLLMENT_CANT_BE_NULL );
         checkNotNull( program, PROGRAM_CANT_BE_NULL );
 
-        checkEnrollmentOrgUnit( enrollment, context, strategy, program, reporter );
+        checkEnrollmentOrgUnit( reporter, context, strategy, enrollment, program );
 
         if ( strategy.isDelete() )
         {
@@ -205,10 +205,10 @@ public class PreCheckSecurityOwnershipValidationHook
             ownerOrgUnit );
     }
 
-    private void checkEnrollmentOrgUnit( Enrollment enrollment, TrackerImportValidationContext context,
-        TrackerImportStrategy strategy, Program program, ValidationErrorReporter reporter )
+    private void checkEnrollmentOrgUnit( ValidationErrorReporter reporter, TrackerImportValidationContext context,
+        TrackerImportStrategy strategy, Enrollment enrollment, Program program )
     {
-        OrganisationUnit enrollmentOrgUnit = null;
+        OrganisationUnit enrollmentOrgUnit;
 
         if ( strategy.isUpdateOrDelete() )
         {
@@ -494,7 +494,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( programStage, PROGRAM_STAGE_CANT_BE_NULL );
         checkNotNull( programStage.getProgram(), PROGRAM_CANT_BE_NULL );
 
-        checkEventOrgUnitWriteAccess( reporter, event, eventOrgUnit, isCreatableInSearchScope, bundle, user );
+        checkEventOrgUnitWriteAccess( reporter, bundle, event, eventOrgUnit, isCreatableInSearchScope, user );
 
         if ( programStage.getProgram().isWithoutRegistration() )
         {
@@ -519,9 +519,9 @@ public class PreCheckSecurityOwnershipValidationHook
         }
     }
 
-    private void checkEventOrgUnitWriteAccess( ValidationErrorReporter reporter, Event event,
+    private void checkEventOrgUnitWriteAccess( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
         OrganisationUnit eventOrgUnit,
-        boolean isCreatableInSearchScope, TrackerBundle bundle, User user )
+        boolean isCreatableInSearchScope, User user )
     {
         if ( eventOrgUnit == null )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -171,21 +171,16 @@ public class PreCheckSecurityOwnershipValidationHook
         TrackerImportStrategy strategy = context.getStrategy( enrollment );
         TrackerBundle bundle = context.getBundle();
         User user = bundle.getUser();
-        Program program = context.getProgram( enrollment.getProgram() );
+        Program program = strategy.isUpdateOrDelete() ? context.getProgramInstance( enrollment.getEnrollment() )
+            .getProgram() : context.getProgram( enrollment.getProgram() );
         OrganisationUnit ownerOrgUnit = context.getOwnerOrganisationUnit( enrollment.getTrackedEntity(),
             enrollment.getProgram() );
 
         checkNotNull( user, USER_CANT_BE_NULL );
         checkNotNull( enrollment, ENROLLMENT_CANT_BE_NULL );
-        checkNotNull( enrollment.getOrgUnit(), ORGANISATION_UNIT_CANT_BE_NULL );
+        checkNotNull( program, PROGRAM_CANT_BE_NULL );
 
-        // If enrollment is newly created, or going to be deleted, capture scope
-        // has to be checked
-        if ( program.isWithoutRegistration() || strategy.isCreate() || strategy.isDelete() )
-        {
-            checkOrgUnitInCaptureScope( reporter, enrollment,
-                context.getOrganisationUnit( enrollment.getOrgUnit() ) );
-        }
+        checkEnrollmentOrgUnit( enrollment, context, strategy, program, reporter );
 
         if ( strategy.isDelete() )
         {
@@ -206,8 +201,40 @@ public class PreCheckSecurityOwnershipValidationHook
             }
         }
 
-        checkWriteEnrollmentAccess( reporter, enrollment, program, enrollment.getTrackedEntity(),
+        checkWriteEnrollmentAccess( reporter, enrollment, program, context,
             ownerOrgUnit );
+    }
+
+    private void checkEnrollmentOrgUnit( Enrollment enrollment, TrackerImportValidationContext context,
+        TrackerImportStrategy strategy, Program program, ValidationErrorReporter reporter )
+    {
+        OrganisationUnit enrollmentOrgUnit = null;
+
+        if ( strategy.isUpdateOrDelete() )
+        {
+            enrollmentOrgUnit = context.getProgramInstance( enrollment.getEnrollment() )
+                .getOrganisationUnit();
+
+            if ( enrollmentOrgUnit == null )
+            {
+                log.warn( "ProgramInstance " + enrollment.getEnrollment()
+                    + " has no organisation unit assigned, so we skip user validation" );
+                return;
+            }
+        }
+        else
+        {
+            checkNotNull( enrollment.getOrgUnit(), ORGANISATION_UNIT_CANT_BE_NULL );
+            enrollmentOrgUnit = context.getOrganisationUnit( enrollment.getOrgUnit() );
+        }
+
+        // If enrollment is newly created, or going to be deleted, capture scope
+        // has to be checked
+        if ( program.isWithoutRegistration() || strategy.isCreate()
+            || strategy.isDelete() )
+        {
+            checkOrgUnitInCaptureScope( reporter, enrollment, enrollmentOrgUnit );
+        }
     }
 
     @Override
@@ -247,7 +274,6 @@ public class PreCheckSecurityOwnershipValidationHook
         }
         else
         {
-
             validateCreateEvent( reporter, event, user,
                 categoryOptionCombo,
                 programStage,
@@ -434,7 +460,7 @@ public class PreCheckSecurityOwnershipValidationHook
     }
 
     private void checkWriteEnrollmentAccess( ValidationErrorReporter reporter, Enrollment enrollment, Program program,
-        String trackedEntity, OrganisationUnit ownerOrgUnit )
+        TrackerImportValidationContext context, OrganisationUnit ownerOrgUnit )
     {
         TrackerBundle bundle = reporter.getValidationContext().getBundle();
         User user = bundle.getUser();
@@ -446,6 +472,10 @@ public class PreCheckSecurityOwnershipValidationHook
 
         if ( program.isRegistration() )
         {
+            String trackedEntity = context.getStrategy( enrollment ).isDelete()
+                ? context.getProgramInstance( enrollment.getEnrollment() ).getEntityInstance().getUid()
+                : enrollment.getTrackedEntity();
+
             checkNotNull( program.getTrackedEntityType(), TRACKED_ENTITY_TYPE_CANT_BE_NULL );
             checkTeiTypeAndTeiProgramAccess( reporter, enrollment, user, trackedEntity,
                 ownerOrgUnit, program );
@@ -464,25 +494,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( programStage, PROGRAM_STAGE_CANT_BE_NULL );
         checkNotNull( programStage.getProgram(), PROGRAM_CANT_BE_NULL );
 
-        if ( eventOrgUnit == null )
-        {
-            log.warn( "ProgramStageInstance " + event.getUid()
-                + " has no organisation unit assigned, so we skip user validation" );
-        }
-        else if ( isCreatableInSearchScope
-            ? !organisationUnitService.isInUserSearchHierarchyCached( user, eventOrgUnit )
-            : !organisationUnitService.isInUserHierarchyCached( user, eventOrgUnit ) )
-        {
-
-            TrackerErrorReport error = TrackerErrorReport.builder()
-                .uid( event.getUid() )
-                .trackerType( TrackerType.EVENT )
-                .errorCode( TrackerErrorCode.E1000 )
-                .addArg( user )
-                .addArg( eventOrgUnit )
-                .build( bundle );
-            reporter.addError( error );
-        }
+        checkEventOrgUnitWriteAccess( reporter, event, eventOrgUnit, isCreatableInSearchScope, bundle, user );
 
         if ( programStage.getProgram().isWithoutRegistration() )
         {
@@ -504,6 +516,31 @@ public class PreCheckSecurityOwnershipValidationHook
         if ( categoryOptionCombo != null )
         {
             checkWriteCategoryOptionComboAccess( reporter, event, categoryOptionCombo );
+        }
+    }
+
+    private void checkEventOrgUnitWriteAccess( ValidationErrorReporter reporter, Event event,
+        OrganisationUnit eventOrgUnit,
+        boolean isCreatableInSearchScope, TrackerBundle bundle, User user )
+    {
+        if ( eventOrgUnit == null )
+        {
+            log.warn( "ProgramStageInstance " + event.getUid()
+                + " has no organisation unit assigned, so we skip user validation" );
+        }
+        else if ( isCreatableInSearchScope
+            ? !organisationUnitService.isInUserSearchHierarchyCached( user, eventOrgUnit )
+            : !organisationUnitService.isInUserHierarchyCached( user, eventOrgUnit ) )
+        {
+
+            TrackerErrorReport error = TrackerErrorReport.builder()
+                .uid( event.getUid() )
+                .trackerType( TrackerType.EVENT )
+                .errorCode( TrackerErrorCode.E1000 )
+                .addArg( user )
+                .addArg( eventOrgUnit )
+                .build( bundle );
+            reporter.addError( error );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -213,6 +213,30 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
     }
 
+    @Test
+    void testEnrollmentDeleteOk()
+        throws IOException
+    {
+        TrackerImportParams paramsCreate = createBundleFromJson(
+            "tracker/validations/enrollments_te_enrollments-data.json" );
+        paramsCreate.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( paramsCreate );
+        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+
+        manager.flush();
+        manager.clear();
+
+        TrackerImportParams paramsDelete = createBundleFromJson(
+            "tracker/validations/enrollments_te_enrollments-data-delete.json" );
+        paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
+
+        TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
+        assertEquals( 0, trackerImportReportDelete.getValidationReport().getErrors().size() );
+        assertEquals( TrackerStatus.OK, trackerImportReportDelete.getStatus() );
+        assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
+    }
+
     /**
      * Notes with no value are ignored
      */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -395,6 +395,37 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     }
 
     @Test
+    void verifyValidationSuccessForEnrollmentWhenProgramInstanceHasNoOrgUnitAssigned()
+    {
+        Enrollment enrollment = Enrollment.builder()
+            .enrollment( CodeGenerator.generateUid() )
+            .orgUnit( ORG_UNIT_ID )
+            .trackedEntity( TEI_ID )
+            .program( PROGRAM_ID )
+            .build();
+        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.UPDATE );
+
+        ProgramInstance programInstance = getEnrollment( enrollment.getEnrollment() );
+        programInstance.setOrganisationUnit( null );
+
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( programInstance );
+        when( aclService.canDataWrite( user, program ) ).thenReturn( true );
+        when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
+        reporter = new ValidationErrorReporter( ctx );
+
+        validatorToTest.validateEnrollment( reporter, enrollment );
+
+        assertFalse( reporter.hasErrors() );
+
+        when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
+
+        validatorToTest.validateEnrollment( reporter, enrollment );
+
+        assertFalse( reporter.hasErrors() );
+    }
+
+    @Test
     void verifyValidationSuccessForEnrollment()
     {
         Enrollment enrollment = Enrollment.builder()
@@ -448,8 +479,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .program( PROGRAM_ID )
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -496,8 +527,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( false );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -520,8 +551,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( true );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -545,8 +576,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( false );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -569,8 +600,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( ctx.programInstanceHasEvents( enrollment.getEnrollment() ) ).thenReturn( true );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -593,8 +624,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .program( PROGRAM_ID )
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -617,8 +648,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .program( PROGRAM_ID )
             .build();
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( ctx.getProgram( PROGRAM_ID ) ).thenReturn( program );
-        when( ctx.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( ctx.getProgramInstance( enrollment.getEnrollment() ) )
+            .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( false );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -417,12 +417,14 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertFalse( reporter.hasErrors() );
+        verify( organisationUnitService, times( 0 ) ).isInUserHierarchyCached( user, organisationUnit );
 
         when( ctx.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
 
         assertFalse( reporter.hasErrors() );
+        verify( organisationUnitService, times( 0 ) ).isInUserHierarchyCached( user, organisationUnit );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_enrollments-data-delete.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_enrollments-data-delete.json
@@ -1,0 +1,7 @@
+{
+  "enrollments": [
+    {
+      "enrollment": "MNWZ6hnuhSw"
+    }
+  ]
+}


### PR DESCRIPTION
When we delete enrollments, a basic payload with uid is required. All the other info should be retrieved by pre-fetched entities (program, ou, and tei).

For ou, similarly to [12347](https://jira.dhis2.org/browse/DHIS2-12347), we allow ou to be null and log a warning.
Fixed also missing mapper for sharing in program and programinstance