### PR TITLE
feat: add GeoJson metadata attribute value type

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -33,6 +33,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
+import org.geotools.geojson.GeoJSON;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -71,7 +72,8 @@ public enum ValueType
     AGE( Date.class, false ),
     URL( String.class, false ),
     FILE_RESOURCE( String.class, true, FileTypeValueOptions.class ),
-    IMAGE( String.class, false, FileTypeValueOptions.class );
+    IMAGE( String.class, false, FileTypeValueOptions.class ),
+    GEOJSON( GeoJSON.class, false );
 
     public static final Set<ValueType> INTEGER_TYPES = ImmutableSet.of(
         INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE );
@@ -92,7 +94,7 @@ public enum ValueType
         FILE_RESOURCE, IMAGE );
 
     public static final Set<ValueType> GEO_TYPES = ImmutableSet.of(
-        COORDINATE );
+        COORDINATE, GEOJSON );
 
     public static final Set<ValueType> NUMERIC_TYPES = ImmutableSet.<ValueType> builder().addAll(
         INTEGER_TYPES ).addAll( DECIMAL_TYPES ).build();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -242,6 +242,7 @@ public enum ErrorCode
         "This property need to be data element of value type date and belong the program stage." ),
     E6002( "Class name {0} is not supported." ),
     E6003( "Could not patch object with id {0}." ),
+    E6004( "Attribute `{0}` has invalid GeoJson value." ),
 
     /* File resource */
     E6100( "Filename not present" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/Preheat.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/preheat/Preheat.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.preheat;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,19 +37,25 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserAuthorityGroup;
 import org.hisp.dhis.user.UserCredentials;
+
+import com.google.common.collect.Sets;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -101,6 +108,13 @@ public class Preheat
      * uid => object uid.
      */
     private Map<Class<?>, Map<String, Map<String, String>>> uniqueAttributeValues = new HashMap<>();
+
+    /**
+     * Map of all metadata attributes, mapped by class type.
+     * <p>
+     * Only Class which has attribute will be put into this map.
+     */
+    private Map<Class<? extends IdentifiableObject>, Set<Attribute>> attributesByTargetObjectType = new HashMap<>();
 
     public Preheat()
     {
@@ -439,6 +453,65 @@ public class Preheat
         IdentifiableObject defaultObject = getDefaults().get( getObjectType( object ) );
 
         return defaultObject != null && defaultObject.getUid().equals( object.getUid() );
+    }
+
+    /**
+     * Get list of {@link Attribute} which the given klass has.
+     *
+     * @param klass Class to be used for querying.
+     * @return Set of {@link Attribute} belong to given klass.
+     */
+    public Set<Attribute> getAttributesByClass( Class<? extends IdentifiableObject> klass )
+    {
+        return attributesByTargetObjectType.get( klass );
+    }
+
+    /**
+     * Add given list of {@link Attribute} to map attributesByTargetObjectType.
+     *
+     * @param klass Class which has given list of {@link Attribute}.
+     * @param attributes List of {@link Attribute} to be added.
+     */
+    public void addClassAttributes( Class<? extends IdentifiableObject> klass, Set<Attribute> attributes )
+    {
+        attributesByTargetObjectType.put( klass, attributes );
+    }
+
+    /**
+     * Add given {@link Attribute} to map attributesByTargetObjectType.
+     *
+     * @param klass Class which has given list of {@link Attribute}.
+     * @param attribute {@link Attribute} to be added.
+     */
+    public void addClassAttribute( Class<? extends IdentifiableObject> klass, Attribute attribute )
+    {
+        if ( attributesByTargetObjectType.get( klass ) == null )
+        {
+            attributesByTargetObjectType.put( klass, Sets.newHashSet() );
+        }
+
+        attributesByTargetObjectType.get( klass ).add( attribute );
+    }
+
+    /**
+     * Get Set of all attribute ID of given klass which has given valueType.
+     *
+     * @param klass Class to be used for querying.
+     * @param valueType {@link ValueType} to be used for querying.
+     * @return Set of {@link Attribute} ID.
+     */
+    public Set<String> getAttributeIdsByValueType( Class<? extends IdentifiableObject> klass, ValueType valueType )
+    {
+        Set<Attribute> attributes = attributesByTargetObjectType.get( klass );
+
+        if ( CollectionUtils.isEmpty( attributes ) )
+        {
+            return emptySet();
+        }
+
+        return attributes.stream()
+            .filter( attribute -> attribute.getValueType() == valueType )
+            .map( attribute -> attribute.getUid() ).collect( Collectors.toUnmodifiableSet() );
     }
 
     /*

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -129,6 +129,10 @@
       <groupId>com.vdurmont</groupId>
       <artifactId>semver4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.grundid.opendatalab</groupId>
+      <artifactId>geojson-jackson</artifactId>
+    </dependency>
 
 
     <!-- JClouds -->

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -1016,6 +1016,7 @@ zero_positive_int=Positive or Zero Integer
 coordinate=Coordinate
 negative_integer=Negative Integer
 unit_interval=Unit interval
+geojson=GeoJSON
 percentage=Percentage
 date=Date
 date_time=Date & Time
@@ -1780,7 +1781,6 @@ data_approval_workflow=Data approval workflow
 program_indicator=Program indicator
 program_rule_variable=Program rule variable
 program=Program
-
 #--Various --------------------------------------------------------------------#
 
 manage_my_apps=Manage my apps

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/attribute/AttributeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/attribute/AttributeServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.attribute;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.common.ValueType;
@@ -41,16 +42,13 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class AttributeServiceTest extends DhisSpringTest
 {
-
     @Autowired
     private AttributeService attributeService;
 
     @Test
     void testAddAttribute()
     {
-        Attribute attribute = new Attribute();
-        attribute.setValueType( ValueType.TEXT );
-        attribute.setName( "attribute1" );
+        Attribute attribute = createAttribute( "attribute1", ValueType.TEXT );
         attributeService.addAttribute( attribute );
         attribute = attributeService.getAttribute( attribute.getId() );
         assertNotNull( attribute );
@@ -61,9 +59,7 @@ class AttributeServiceTest extends DhisSpringTest
     @Test
     void testDeleteAttribute()
     {
-        Attribute attribute = new Attribute();
-        attribute.setValueType( ValueType.TEXT );
-        attribute.setName( "attribute1" );
+        Attribute attribute = createAttribute( "attribute1", ValueType.TEXT );
         attributeService.addAttribute( attribute );
         attribute = attributeService.getAttribute( attribute.getId() );
         assertNotNull( attribute );
@@ -76,9 +72,7 @@ class AttributeServiceTest extends DhisSpringTest
     @Test
     void testGetAttribute()
     {
-        Attribute attribute = new Attribute();
-        attribute.setValueType( ValueType.TEXT );
-        attribute.setName( "attribute1" );
+        Attribute attribute = createAttribute( "attribute1", ValueType.TEXT );
         attributeService.addAttribute( attribute );
         attribute = attributeService.getAttribute( attribute.getId() );
         assertNotNull( attribute );
@@ -87,14 +81,22 @@ class AttributeServiceTest extends DhisSpringTest
     @Test
     void testGetAllAttributes()
     {
-        Attribute attribute1 = new Attribute();
-        attribute1.setValueType( ValueType.TEXT );
-        attribute1.setName( "attribute1" );
-        Attribute attribute2 = new Attribute();
-        attribute2.setValueType( ValueType.TEXT );
-        attribute2.setName( "attribute2" );
+        Attribute attribute1 = createAttribute( "attribute1", ValueType.TEXT );
+        Attribute attribute2 = createAttribute( "attribute2", ValueType.TEXT );
         attributeService.addAttribute( attribute1 );
         attributeService.addAttribute( attribute2 );
         assertEquals( 2, attributeService.getAllAttributes().size() );
+    }
+
+    @Test
+    void testGeoJSONAttribute()
+    {
+        Attribute attribute = createAttribute( "attributeGeoJson", ValueType.GEOJSON );
+        attributeService.addAttribute( attribute );
+
+        attribute = attributeService.getAttributeByName( attribute.getName() );
+        assertNotNull( attribute );
+        assertTrue( attribute.getValueType().isGeo() );
+        assertEquals( attribute.getValueType(), ValueType.GEOJSON );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -96,6 +96,7 @@ import org.hisp.dhis.dxf2.events.importer.update.validation.UpdateProgramStageIn
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.CreationCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DeletionCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DuplicateIdsCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.GeoJsonAttributesCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.MandatoryAttributesCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.NotOwnerReferencesCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ReferencesCheck;
@@ -218,7 +219,8 @@ public class ServiceConfig
                 getValidationCheckByClass( UniqueAttributesCheck.class ),
                 getValidationCheckByClass( ReferencesCheck.class ),
                 getValidationCheckByClass( NotOwnerReferencesCheck.class ),
-                getValidationCheckByClass( TranslationsCheck.class ) ),
+                getValidationCheckByClass( TranslationsCheck.class ),
+                getValidationCheckByClass( GeoJsonAttributesCheck.class ) ),
             CREATE, newArrayList(
                 getValidationCheckByClass( DuplicateIdsCheck.class ),
                 getValidationCheckByClass( ValidationHooksCheck.class ),
@@ -231,7 +233,8 @@ public class ServiceConfig
                 getValidationCheckByClass( UniqueAttributesCheck.class ),
                 getValidationCheckByClass( ReferencesCheck.class ),
                 getValidationCheckByClass( NotOwnerReferencesCheck.class ),
-                getValidationCheckByClass( TranslationsCheck.class ) ),
+                getValidationCheckByClass( TranslationsCheck.class ),
+                getValidationCheckByClass( GeoJsonAttributesCheck.class ) ),
             UPDATE, newArrayList(
                 getValidationCheckByClass( DuplicateIdsCheck.class ),
                 getValidationCheckByClass( ValidationHooksCheck.class ),
@@ -244,7 +247,8 @@ public class ServiceConfig
                 getValidationCheckByClass( UniqueAttributesCheck.class ),
                 getValidationCheckByClass( ReferencesCheck.class ),
                 getValidationCheckByClass( NotOwnerReferencesCheck.class ),
-                getValidationCheckByClass( TranslationsCheck.class ) ),
+                getValidationCheckByClass( TranslationsCheck.class ),
+                getValidationCheckByClass( GeoJsonAttributesCheck.class ) ),
             DELETE, newArrayList(
                 getValidationCheckByClass( SecurityCheck.class ),
                 getValidationCheckByClass( DeletionCheck.class ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/IdentifiableObjectBundleHook.java
@@ -122,6 +122,8 @@ public class IdentifiableObjectBundleHook extends AbstractObjectBundleHook<Ident
             }
 
             attributeValue.setAttribute( attribute );
+
+            attributeValue.setValue( attributeValue.getValue().replaceAll( "\\s{2,}", StringUtils.SPACE ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.geojson.Feature;
+import org.geojson.FeatureCollection;
+import org.geojson.GeoJsonObject;
+import org.geojson.GeoJsonObjectVisitor;
+import org.geojson.GeometryCollection;
+import org.geojson.LineString;
+import org.geojson.MultiLineString;
+import org.geojson.MultiPoint;
+import org.geojson.MultiPolygon;
+import org.geojson.Point;
+import org.geojson.Polygon;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.commons.util.DebugUtils;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.schema.Schema;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Contains methods to perform validation on AttributeValues which have
+ * ValueType = GeoJSON
+ *
+ * @author Viet Nguyen
+ */
+@Component
+@Slf4j
+public class GeoJsonAttributesCheck
+    implements ObjectValidationCheck
+{
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public <T extends IdentifiableObject> void check( ObjectBundle bundle, Class<T> klass,
+        List<T> persistedObjects, List<T> nonPersistedObjects,
+        ImportStrategy importStrategy, ValidationContext ctx, Consumer<ObjectReport> addReports )
+    {
+        Schema schema = ctx.getSchemaService().getDynamicSchema( klass );
+        List<T> objects = selectObjects( persistedObjects, nonPersistedObjects, importStrategy );
+
+        if ( objects.isEmpty() || !schema.havePersistedProperty( "attributeValues" ) )
+        {
+            return;
+        }
+
+        Set<String> attributes = bundle.getPreheat().getAttributeIdsByValueType( klass, ValueType.GEOJSON );
+
+        if ( CollectionUtils.isEmpty( attributes ) )
+        {
+            return;
+        }
+
+        for ( T object : objects )
+        {
+            List<ErrorReport> errorReports = checkGeoJsonAttributes( object, attributes );
+
+            if ( !errorReports.isEmpty() )
+            {
+                addReports.accept( createObjectReport( errorReports, object, bundle ) );
+                ctx.markForRemoval( object );
+            }
+        }
+    }
+
+    /**
+     * Check if give object's attributeValues has valueType
+     * {@link ValueType#GEOJSON} and the value is valid.
+     *
+     * @param object The {@link IdentifiableObject} for validating.
+     * @param attributes Set of {@link Attribute} ID which has
+     *        {@link ValueType#GEOJSON} of the current object's Class.
+     * @return List of {@link ErrorReport} if any.
+     */
+    private List<ErrorReport> checkGeoJsonAttributes( IdentifiableObject object, Set<String> attributes )
+    {
+        if ( object == null )
+        {
+            return emptyList();
+        }
+
+        List<ErrorReport> errorReports = new ArrayList<>();
+        object.getAttributeValues().stream()
+            .filter( attributeValue -> attributes.contains( attributeValue.getAttribute().getUid() ) )
+            .forEach( attributeValue -> validateGeoJsonValue( attributeValue, error -> errorReports.add( error ) ) );
+
+        return errorReports;
+    }
+
+    /**
+     * Validate GeoJson String from given attributeValue using Jackson
+     * ObjectMapper.
+     * <p>
+     * If Jackson throws error then create new ErrorReport with ErrorCode.E6004
+     *
+     * @param attributeValue {@link AttributeValue} for validating.
+     * @param addError ErrorReport consumer.
+     */
+    private void validateGeoJsonValue( AttributeValue attributeValue, Consumer<ErrorReport> addError )
+    {
+        try
+        {
+            validateGeoJsonObject( objectMapper.readValue( attributeValue.getValue(), GeoJsonObject.class ),
+                attributeValue.getAttribute().getUid(), addError );
+        }
+        catch ( JsonProcessingException e )
+        {
+            log.error( DebugUtils.getStackTrace( e ) );
+            addError.accept( new ErrorReport( Attribute.class, ErrorCode.E6004, attributeValue.getAttribute().getUid() )
+                .setMainId( attributeValue.getAttribute().getUid() )
+                .setErrorProperty( "value" ) );
+        }
+    }
+
+    /**
+     * Validate given GeoJsonObject using {@link ValidatingGeoJsonVisitor}
+     *
+     * @param geoJsonObject the {@link GeoJsonObject} to be validated.
+     * @param attributeId The {@link Attribute} ID of the current
+     *        {@link AttributeValue}
+     * @param addError {@link Consumer} for adding the {@link ErrorReport} if
+     *        any.
+     */
+    private void validateGeoJsonObject( GeoJsonObject geoJsonObject, String attributeId,
+        Consumer<ErrorReport> addError )
+    {
+        if ( !geoJsonObject.accept( new ValidatingGeoJsonVisitor() ) )
+        {
+            addError.accept( new ErrorReport( Attribute.class, ErrorCode.E6004, attributeId )
+                .setMainId( attributeId )
+                .setErrorProperty( "value" ) );
+        }
+    }
+
+    /**
+     * Contains validator for each GeoJson Object type.
+     */
+    class ValidatingGeoJsonVisitor
+        implements GeoJsonObjectVisitor<Boolean>
+    {
+        @Override
+        public Boolean visit( GeometryCollection geometryCollection )
+        {
+            return isNotEmpty( geometryCollection.getGeometries() );
+        }
+
+        @Override
+        public Boolean visit( FeatureCollection featureCollection )
+        {
+            return isNotEmpty( featureCollection.getFeatures() );
+        }
+
+        @Override
+        public Boolean visit( Point point )
+        {
+            return point.getCoordinates() != null;
+        }
+
+        @Override
+        public Boolean visit( Feature feature )
+        {
+            return feature.getGeometry() != null && feature.getGeometry().accept( new ValidatingGeoJsonVisitor() );
+        }
+
+        @Override
+        public Boolean visit( MultiLineString multiLineString )
+        {
+            return isNotEmpty( multiLineString.getCoordinates() );
+        }
+
+        @Override
+        public Boolean visit( Polygon polygon )
+        {
+            return isNotEmpty( polygon.getCoordinates() );
+        }
+
+        @Override
+        public Boolean visit( MultiPolygon multiPolygon )
+        {
+            return isNotEmpty( multiPolygon.getCoordinates() );
+        }
+
+        @Override
+        public Boolean visit( MultiPoint multiPoint )
+        {
+            return isNotEmpty( multiPoint.getCoordinates() );
+        }
+
+        @Override
+        public Boolean visit( LineString lineString )
+        {
+            return isNotEmpty( lineString.getCoordinates() );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/GeoJsonAttributesCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/GeoJsonAttributesCheckTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.attribute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.GeoJsonAttributesCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationContext;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.preheat.Preheat;
+import org.hisp.dhis.schema.Property;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.collections.Sets;
+
+import com.google.common.collect.Lists;
+
+/**
+ * @author viet@dhis2.org
+ */
+public class GeoJsonAttributesCheckTest
+{
+    private GeoJsonAttributesCheck geoJsonAttributesCheck = new GeoJsonAttributesCheck();
+
+    private OrganisationUnit organisationUnit;
+
+    private ObjectBundle objectBundle;
+
+    private ValidationContext validationContext;
+
+    private Attribute attribute;
+
+    @BeforeEach
+    public void setUpTest()
+    {
+        organisationUnit = new OrganisationUnit();
+        organisationUnit.setName( "A" );
+        attribute = new Attribute();
+        attribute.setUid( "geoJson" );
+        attribute.setName( "geoJson" );
+
+        validationContext = Mockito.mock( ValidationContext.class );
+        Schema schema = new Schema( OrganisationUnit.class, "organisationUnit", "organisationUnits" );
+        Property property = new Property();
+        property.setPersisted( true );
+        schema.getPropertyMap().put( "attributeValues", property );
+        SchemaService schemaService = Mockito.mock( SchemaService.class );
+
+        when( schemaService.getDynamicSchema( OrganisationUnit.class ) ).thenReturn( schema );
+        when( validationContext.getSchemaService() ).thenReturn( schemaService );
+
+        Preheat preheat = Mockito.mock( Preheat.class );
+        when( preheat.getAttributeIdsByValueType( OrganisationUnit.class, ValueType.GEOJSON ) ).thenReturn(
+            Sets.newSet( "geoJson" ) );
+
+        objectBundle = Mockito.mock( ObjectBundle.class );
+        when( objectBundle.getPreheat() ).thenReturn( preheat );
+    }
+
+    @Test
+    public void testValidPolygon()
+    {
+        organisationUnit.getAttributeValues().add( new AttributeValue( attribute, " {\n" +
+            "         \"type\": \"Polygon\",\n" +
+            "         \"coordinates\": [\n" +
+            "             [\n" +
+            "                 [100.0, 0.0],\n" +
+            "                 [101.0, 0.0],\n" +
+            "                 [101.0, 1.0],\n" +
+            "                 [100.0, 1.0],\n" +
+            "                 [100.0, 0.0]\n" +
+            "             ]\n" +
+            "         ]\n" +
+            "     }" ) );
+
+        List<ObjectReport> objectReportList = new ArrayList<>();
+
+        geoJsonAttributesCheck.check( objectBundle, OrganisationUnit.class, Lists.newArrayList( organisationUnit ),
+            Collections
+                .emptyList(),
+            ImportStrategy.CREATE_AND_UPDATE,
+            validationContext, objectReport -> objectReportList.add( objectReport ) );
+
+        assertTrue( CollectionUtils.isEmpty( objectReportList ) );
+    }
+
+    @Test
+    public void testInValidPolygon()
+    {
+        organisationUnit.getAttributeValues().add( new AttributeValue( attribute, " {\n" +
+            "         \"type\": \"Polygon\"     }" ) );
+
+        List<ObjectReport> objectReportList = new ArrayList<>();
+
+        geoJsonAttributesCheck.check( objectBundle, OrganisationUnit.class, Lists.newArrayList( organisationUnit ),
+            Collections
+                .emptyList(),
+            ImportStrategy.CREATE_AND_UPDATE,
+            validationContext, objectReport -> objectReportList.add( objectReport ) );
+
+        assertFalse( CollectionUtils.isEmpty( objectReportList ) );
+        assertEquals( ErrorCode.E6004, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void testInValidPolygonType()
+    {
+        organisationUnit.getAttributeValues().add( new AttributeValue( attribute, " {\n" +
+            "         \"type\": \"PolygonNew\"     }" ) );
+
+        List<ObjectReport> objectReportList = new ArrayList<>();
+
+        geoJsonAttributesCheck.check( objectBundle, OrganisationUnit.class, Lists.newArrayList( organisationUnit ),
+            Collections
+                .emptyList(),
+            ImportStrategy.CREATE_AND_UPDATE,
+            validationContext, objectReport -> objectReportList.add( objectReport ) );
+
+        assertFalse( CollectionUtils.isEmpty( objectReportList ) );
+        assertEquals( ErrorCode.E6004, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void testInvalidPolygonCoordinates()
+    {
+        organisationUnit.getAttributeValues().add( new AttributeValue( attribute, " {\n" +
+            "         \"type\": \"Polygon\",\n" +
+            "         \"test\": [\n" +
+            "             [\n" +
+            "                 [100.0, 0.0],\n" +
+            "                 [101.0, 0.0],\n" +
+            "                 [101.0, 1.0],\n" +
+            "                 [100.0, 1.0],\n" +
+            "                 [100.0, 0.0]\n" +
+            "             ]\n" +
+            "         ]\n" +
+            "     }" ) );
+
+        List<ObjectReport> objectReportList = new ArrayList<>();
+
+        geoJsonAttributesCheck
+            .check( objectBundle, OrganisationUnit.class, Lists.newArrayList( organisationUnit ), Collections
+                .emptyList(), ImportStrategy.CREATE_AND_UPDATE,
+                validationContext, objectReport -> objectReportList.add( objectReport ) );
+        assertFalse( CollectionUtils.isEmpty( objectReportList ) );
+        assertEquals( ErrorCode.E6004, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void testInvalidPolygonCoordinatesValue()
+    {
+        organisationUnit.getAttributeValues().add( new AttributeValue( attribute, " {" +
+            "         \"type\": \"Polygon\"," +
+            "         \"coordinates\": [100.0, 0.0]" +
+            "     }" ) );
+
+        List<ObjectReport> objectReportList = new ArrayList<>();
+
+        geoJsonAttributesCheck
+            .check( objectBundle, OrganisationUnit.class, Lists.newArrayList( organisationUnit ), Collections
+                .emptyList(), ImportStrategy.CREATE_AND_UPDATE,
+                validationContext, objectReport -> objectReportList.add( objectReport ) );
+        assertFalse( CollectionUtils.isEmpty( objectReportList ) );
+        assertEquals( ErrorCode.E6004, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    public void testInvalidFeature()
+    {
+        String geoJson = "{\"type\": \"Feature\", \"geometry\": { \"type\": \"Point\"," +
+            "\"coordinasstes\": [125.6, 10.1] }, \"properties\": { \"name\": \"Dinagat Islands\" } }";
+
+        organisationUnit.getAttributeValues().add( new AttributeValue( attribute, geoJson ) );
+
+        List<ObjectReport> objectReportList = new ArrayList<>();
+
+        geoJsonAttributesCheck
+            .check( objectBundle, OrganisationUnit.class, Lists.newArrayList( organisationUnit ), Collections
+                .emptyList(), ImportStrategy.CREATE_AND_UPDATE,
+                validationContext, objectReport -> objectReportList.add( objectReport ) );
+        assertFalse( CollectionUtils.isEmpty( objectReportList ) );
+        assertEquals( ErrorCode.E6004, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/GeoUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/GeoUtils.java
@@ -263,4 +263,5 @@ public class GeoUtils
     {
         return CoordinateUtils.getCoordinatesFromGeometry( geometry );
     }
+
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -696,6 +696,14 @@ public abstract class DhisConvenienceTest
         return attribute;
     }
 
+    public static Attribute createAttribute( String name, ValueType valueType )
+    {
+        Attribute attribute = new Attribute( name, valueType );
+        attribute.setAutoFields();
+
+        return attribute;
+    }
+
     public static AttributeValue createAttributeValue( Attribute attribute, String value )
     {
         return new AttributeValue( value, attribute );

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -113,6 +113,7 @@
         <jackson-datatype-jts.version>1.0-2.7</jackson-datatype-jts.version>
         <jackson-datatype-hibernate5.version>2.11.2</jackson-datatype-hibernate5.version>
         <classmate.version>1.5.1</classmate.version>
+        <geojson-jackson.version>1.14</geojson-jackson.version>
 
         <!-- JAXB -->
         <jaxb-api.version>2.4.0-b180830.0359</jaxb-api.version>
@@ -1890,6 +1891,12 @@
                 <groupId>com.fasterxml.jackson.datatype</groupId>
                 <artifactId>jackson-datatype-hibernate5</artifactId>
                 <version>${jackson-datatype-hibernate5.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>de.grundid.opendatalab</groupId>
+                <artifactId>geojson-jackson</artifactId>
+                <version>${geojson-jackson.version}</version>
             </dependency>
 
             <!-- GeoTools -->


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12328

- Add `ValueType.GEOJSON`
- User can create new `Attribute` in maintenance app and select valueType = `GeoJSON`
- Currently user can assign `GeoJSON` attribute to all metadata object. Maybe we should consider to validate this and allow only certain object types.
- GeoJson value will be validated by metadata import service. The validations  is based on this [GeoJson specification](https://datatracker.ietf.org/doc/html/rfc7946)


- The attributeValue will be returned from api as below
```json
{
  "attributeValues":
  [
    {
      "value": "{ \"type\": \"Polygon\", \"coordinates\":[ [ [100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0] ], [ [100.8, 0.8], [100.8, 0.2], [100.2, 0.2], [100.2, 0.8], [100.8, 0.8] ] ] }",
      "attribute":
      {
        "id": "nilqrS9TGid"
      }
    },
    {
      "value": "234",
      "attribute":
      {
        "id": "n2xYlNbsfko"
      }
    }
  ]
}
```