### PR TITLE
fix: put AOC, CO specific idSchemes in params DHIS2-12282

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.security.jwt;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilder.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilder.java
@@ -34,6 +34,8 @@ import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.ValidationMode.FULL;
 import static org.hisp.dhis.tracker.bundle.TrackerBundleMode.COMMIT;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.TrackerImportParamKey.ATOMIC_MODE_KEY;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.TrackerImportParamKey.CATEGORY_OPTION_COMBO_ID_SCHEME_KEY;
+import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.TrackerImportParamKey.CATEGORY_OPTION_ID_SCHEME_KEY;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.TrackerImportParamKey.DATA_ELEMENT_ID_SCHEME_KEY;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.TrackerImportParamKey.FLUSH_MODE_KEY;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerImportParamsBuilder.TrackerImportParamKey.ID_SCHEME_KEY;
@@ -123,6 +125,8 @@ public class TrackerImportParamsBuilder
             .programIdScheme( bySchemeAndKey( parameters, PROGRAM_ID_SCHEME_KEY, idScheme ) )
             .programStageIdScheme( bySchemeAndKey( parameters, PROGRAM_STAGE_ID_SCHEME_KEY, idScheme ) )
             .dataElementIdScheme( bySchemeAndKey( parameters, DATA_ELEMENT_ID_SCHEME_KEY, idScheme ) )
+            .categoryOptionComboIdScheme( bySchemeAndKey( parameters, CATEGORY_OPTION_COMBO_ID_SCHEME_KEY, idScheme ) )
+            .categoryOptionIdScheme( bySchemeAndKey( parameters, CATEGORY_OPTION_ID_SCHEME_KEY, idScheme ) )
             .build();
     }
 
@@ -192,7 +196,9 @@ public class TrackerImportParamsBuilder
         ORG_UNIT_ID_SCHEME_KEY( "orgUnitIdScheme" ),
         PROGRAM_ID_SCHEME_KEY( "programIdScheme" ),
         PROGRAM_STAGE_ID_SCHEME_KEY( "programStageIdScheme" ),
-        DATA_ELEMENT_ID_SCHEME_KEY( "dataElementIdScheme" );
+        DATA_ELEMENT_ID_SCHEME_KEY( "dataElementIdScheme" ),
+        CATEGORY_OPTION_COMBO_ID_SCHEME_KEY( "categoryOptionComboIdScheme" ),
+        CATEGORY_OPTION_ID_SCHEME_KEY( "categoryOptionIdScheme" );
 
         @Getter
         private final String key;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilderTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/TrackerImportParamsBuilderTest.java
@@ -157,6 +157,26 @@ class TrackerImportParamsBuilderTest
         } );
     }
 
+    @Test
+    void testCategoryOptionComboIdentifier()
+    {
+        Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
+            paramMap.put( "categoryOptionComboIdScheme", Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getIdentifiers().getCategoryOptionComboIdScheme().getIdScheme(), is( e ) );
+        } );
+    }
+
+    @Test
+    void testCategoryOptionIdentifier()
+    {
+        Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
+            paramMap.put( "categoryOptionIdScheme", Collections.singletonList( e.name() ) );
+            TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
+            assertThat( params.getIdentifiers().getCategoryOptionIdScheme().getIdScheme(), is( e ) );
+        } );
+    }
+
     private void assertDefaultParams( TrackerImportParams params )
     {
         assertThat( params.getValidationMode(), is( ValidationMode.FULL ) );


### PR DESCRIPTION
we missed passing the params for

categoryOptionComboIdScheme
categoryOptionIdScheme

to the importer. This was the reason why query params for these metadata
types had no effect on matching in the import process.