### PR TITLE
fix: Add granted authorites to the JWT auth token

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/DhisJwtAuthenticationManagerResolver.java
@@ -156,7 +156,7 @@ public class DhisJwtAuthenticationManagerResolver implements AuthenticationManag
                     mappingClaimKey, mappingValue ) );
             }
 
-            Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
+            Collection<GrantedAuthority> grantedAuthorities = userCredentials.getAuthorities();
 
             return new DhisJwtAuthenticationToken( jwt, grantedAuthorities, mappingValue, userCredentials );
         };


### PR DESCRIPTION
Fixes broken Spring authorization due to granted authorities not being properly populated on the authentication token.
This is not a security vulnerability, this only resulted in users getting less access. In DHIS2 this resulted in making the Spring @PreAuthorize annotation not working properly, but the DHIS2's internal authorization would work as normal. 

Jira: [DHIS2-12593](https://jira.dhis2.org/browse/DHIS2-12593)