### PR TITLE
feat: ProgramStage prefix to dataElement in enrol. response [TECH-972]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -149,15 +149,7 @@ public abstract class AbstractAnalyticsService
             }
             else
             {
-                String uid = item.getItem().getUid();
-
-                if ( item.getItem().getDimensionItemType() == DATA_ELEMENT )
-                {
-                    if ( item.getProgramStage() != null )
-                    {
-                        uid = joinWith( ".", item.getProgramStage().getUid(), uid );
-                    }
-                }
+                final String uid = getItemUid( item );
 
                 final String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
 
@@ -206,6 +198,24 @@ public abstract class AbstractAnalyticsService
         maybeApplyHeaders( params, grid );
 
         return grid;
+    }
+
+    /**
+     * Based on the given item this method returns the correct uid based on
+     * internal rules/requirements.
+     *
+     * @param item the current QueryItem
+     * @return the correct uid based on the item type
+     */
+    private String getItemUid( final QueryItem item )
+    {
+        String uid = item.getItem().getUid();
+
+        if ( item.getItem().getDimensionItemType() == DATA_ELEMENT && item.getProgramStage() != null )
+        {
+            uid = joinWith( ".", item.getProgramStage().getUid(), uid );
+        }
+        return uid;
     }
 
     protected abstract Grid createGridWithHeaders( EventQueryParams params );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -28,11 +28,13 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_NAME_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.PAGER;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
@@ -136,7 +138,6 @@ public abstract class AbstractAnalyticsService
             }
             else if ( hasNonDefaultRepeatableProgramStageOffset( item ) )
             {
-
                 String name = item.getProgramStage().getUid() + "[" + item.getProgramStageOffset() + "]." +
                     item.getItem().getUid();
 
@@ -148,9 +149,19 @@ public abstract class AbstractAnalyticsService
             }
             else
             {
-                String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
+                String uid = item.getItem().getUid();
 
-                grid.addHeader( new GridHeader( item.getItem().getUid(), column, item.getValueType(),
+                if ( item.getItem().getDimensionItemType() == DATA_ELEMENT )
+                {
+                    if ( item.getProgramStage() != null )
+                    {
+                        uid = joinWith( ".", item.getProgramStage().getUid(), uid );
+                    }
+                }
+
+                final String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
+
+                grid.addHeader( new GridHeader( uid, column, item.getValueType(),
                     false, true, item.getOptionSet(), item.getLegendSet() ) );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -150,7 +150,6 @@ public abstract class AbstractAnalyticsService
             else
             {
                 final String uid = getItemUid( item );
-
                 final String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
 
                 grid.addHeader( new GridHeader( uid, column, item.getValueType(),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/jwt/Dhis2JwtAuthenticationManagerResolver.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.security.jwt;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
This PR adds the ProgramStage `uid` as a prefix to the DataElement item in the response of `/analytics/enrollments/query`

GET request example:
```
http://localhost:8080/dhis/api/29/analytics/enrollments/query/IpHINAT79UW.json?dimension=pe:LAST_3_MONTHS&dimension=ou:ImspTQPwCqd&dimension=ZzYYXq4fJie.X8zyunlgUfM&dimension=A03MvHHogjR.X8zyunlgUfM&displayProperty=NAME&outputType=ENROLLMENT&desc=enrollmentdate&pageSize=100&page=1
```

Before this change the response of the request above would look like:

```
{
"name": "X8zyunlgUfM",
"column": "MCH Infant Feeding",
"valueType": "TEXT",
"type": "java.lang.String",
"hidden": false,
"meta": true,
"optionSet": "x31y45jvIQL"
},
{
"name": "X8zyunlgUfM",
"column": "MCH Infant Feeding",
"valueType": "TEXT",
"type": "java.lang.String",
"hidden": false,
"meta": true,
"optionSet": "x31y45jvIQL"
}
```

With this change, this will look like:
```


{
"name": "ZzYYXq4fJie.X8zyunlgUfM",
"column": "MCH Infant Feeding",
"valueType": "TEXT",
"type": "java.lang.String",
"hidden": false,
"meta": true,
"optionSet": "x31y45jvIQL"
},
{
"name": "A03MvHHogjR.X8zyunlgUfM",
"column": "MCH Infant Feeding",
"valueType": "TEXT",
"type": "java.lang.String",
"hidden": false,
"meta": true,
"optionSet": "x31y45jvIQL"
}

```