### PR TITLE
chore: prevent JUnit 4 tests & assertions being merged

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSectionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSectionServiceTest.java
@@ -37,13 +37,13 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author viet@dhis2.org
  */
-public class ProgramSectionServiceTest
+class ProgramSectionServiceTest
     extends DhisSpringTest
 {
     @Autowired
@@ -66,7 +66,7 @@ public class ProgramSectionServiceTest
     }
 
     @Test
-    public void testUpdateWithAuthority()
+    void testUpdateWithAuthority()
     {
         Program program = createProgram( 'A' );
         manager.save( program );
@@ -83,7 +83,7 @@ public class ProgramSectionServiceTest
     }
 
     @Test
-    public void testSaveWithoutAuthority()
+    void testSaveWithoutAuthority()
     {
         Program program = createProgram( 'A' );
         manager.save( program );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSectionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSectionServiceTest.java
@@ -27,14 +27,17 @@
  */
 package org.hisp.dhis.program;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.junit.Assert;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -73,10 +76,10 @@ public class ProgramSectionServiceTest
         manager.save( programSection );
 
         User userA = createUser( "A", "F_PROGRAM_PUBLIC_ADD" );
-        Assert.assertTrue( aclService.canUpdate( userA, programSection ) );
+        assertTrue( aclService.canUpdate( userA, programSection ) );
 
         User userB = createUser( "B" );
-        Assert.assertFalse( aclService.canUpdate( userB, programSection ) );
+        assertFalse( aclService.canUpdate( userB, programSection ) );
     }
 
     @Test
@@ -89,6 +92,6 @@ public class ProgramSectionServiceTest
         ProgramSection programSection = createProgramSection( 'A', program );
         manager.save( programSection );
 
-        Assert.assertNotNull( manager.get( ProgramSection.class, programSection.getId() ) );
+        assertNotNull( manager.get( ProgramSection.class, programSection.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.trackedentity;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Set;
@@ -48,7 +51,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 /**
  * @author Ameen
  */
-public class TrackedEntityAttributeStoreIntegrationTest
+class TrackedEntityAttributeStoreIntegrationTest
     extends
     IntegrationTestBase
 {
@@ -160,7 +163,7 @@ public class TrackedEntityAttributeStoreIntegrationTest
     }
 
     @Test
-    public void testGetAllIndexableAttributes()
+    void testGetAllIndexableAttributes()
     {
         attributeService.addTrackedEntityAttribute( attributeW );
         attributeService.addTrackedEntityAttribute( attributeY );
@@ -190,7 +193,7 @@ public class TrackedEntityAttributeStoreIntegrationTest
     }
 
     @Test
-    public void testCreateTrigramIndex()
+    void testCreateTrigramIndex()
     {
         attributeService.addTrackedEntityAttribute( attributeW );
         trackedEntityAttributeTableManager.createTrigramIndex( attributeW );

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -222,6 +222,7 @@
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
+        <restrict-imports-enforcer.version>2.0.0</restrict-imports-enforcer.version>
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
         <dependency-check-maven.version>6.0.3</dependency-check-maven.version>
         <spotbugs-maven-plugin.version>4.2.0</spotbugs-maven-plugin.version>
@@ -718,6 +719,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>de.skuzzle.enforcer</groupId>
+                        <artifactId>restrict-imports-enforcer-rule</artifactId>
+                        <version>${restrict-imports-enforcer.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -738,6 +746,13 @@
                                 <requireJavaVersion>
                                     <version>${minimum-java.version}</version>
                                 </requireJavaVersion>
+                                <RestrictImports>
+                                    <reason>Write JUnit 5 tests only; JUnit 4 cannot yet be excluded from our dependencies because of testcontainers issue https://github.com/testcontainers/testcontainers-java/issues/970</reason>
+                                    <bannedImports>
+                                        <bannedImport>org.junit.Test</bannedImport>
+                                        <bannedImport>org.junit.Assert.**</bannedImport>
+                                    </bannedImports>
+                                </RestrictImports>
                             </rules>
                         </configuration>
                     </execution>


### PR DESCRIPTION
We only write JUnit 5 tests on master. Support for JUnit 4 has therefore been removed.
https://github.com/testcontainers/testcontainers-java/issues/970 does not allow us to easily remove
JUnit 4 entirely. Fail the build to prevent JUnit 4 tests from being added and not run without us noticing.

* fails for example when using JUnit 4 assertions with error message

```
[INFO] --- maven-enforcer-plugin:3.0.0:enforce (enforce-maven) @ dhis-service-core ---
[WARN] Rule 4: org.apache.maven.plugins.enforcer.RestrictImports failed with message:

Banned imports detected in TEST code:

Reason: Write JUnit 5 tests only; JUnit 4 cannot yet be excluded from our dependencies because of testcontainers issue https://github.com/testcontainers/testcontainers-java/issues/970
        in file: org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
                static org.junit.Assert.*       (Line: 30, Matched by: org.junit.Assert.**)
```
see https://github.com/dhis2/dhis2-core/runs/5182309343?check_suite_focus=true#step:4:882

* fails when adding a JUnit 4 `@Test`

```
Banned imports detected in TEST code:

Reason: Write JUnit 5 tests only; JUnit 4 cannot yet be excluded from our dependencies because of testcontainers issue https://github.com/testcontainers/testcontainers-java/issues/970
	in file: org/hisp/dhis/program/ProgramSectionServiceTest.java
		org.junit.Test            	(Line: 40, Matched by: org.junit.Test)
	in file: org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
		static org.junit.Assert.* 	(Line: 30, Matched by: org.junit.Assert.**)
```

https://github.com/dhis2/dhis2-core/runs/5182966922?check_suite_focus=true#step:4:1220