### PR TITLE
test: fix failing analytics test

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Run tests
         run: |
           cd dhis-2/dhis-e2e-test
-          IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up -d
+          IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up --remove-orphans -d
           IMAGE_NAME=$TEST_IMAGE_NAME docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
 
       - name: Upload logs

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/AnalyticsDimensionsTest.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/analytics/AnalyticsDimensionsTest.java
@@ -178,8 +178,9 @@ public class AnalyticsDimensionsTest
 
         analyticsEventActions.query().getDimensionsByDimensionType( trackerProgramStage, "DATA_ELEMENT" )
             .validate()
-            .body( "dimensions", hasSize( greaterThanOrEqualTo( 1 ) ) )
-            .body( "dimensions.id", everyItem( in( dataElements ) ) );
+            .body( "dimensions", hasSize( equalTo( dataElements.size()) ) )
+            .body( "dimensions.id", everyItem( startsWith( trackerProgramStage ) ) )
+            .body( "dimensions.id", everyItem( CustomMatchers.containsOneOf( dataElements )) );
     }
 
     @Test

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/matchers/CustomMatchers.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/matchers/CustomMatchers.java
@@ -57,10 +57,31 @@ public class CustomMatchers
             @Override
             public void describeTo( Description description )
             {
-                description.appendText( "string that starts with one of " + strings.toString());
+                description.appendText( "a string that starts with one of " + strings.toString());
             }
         };
     }
 
+
+    public static TypeSafeDiagnosingMatcher<String> containsOneOf( List<String> strings) {
+        return new TypeSafeDiagnosingMatcher<>()
+        {
+            @Override
+            protected boolean matchesSafely( String item, Description mismatchDescription )
+            {
+                if ( strings != null )
+                {
+                    return strings.stream().anyMatch( item::contains );
+                }
+                return false;
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "a string that contains one of " + strings.toString());
+            }
+        };
+    }
 
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/BaseDimensionalItemObjectMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/BaseDimensionalItemObjectMapper.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.analytics.dimension.DimensionResponse;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.springframework.stereotype.Service;
@@ -48,7 +47,6 @@ public class BaseDimensionalItemObjectMapper extends BaseDimensionMapper
     @Getter
     private final Set<Class<? extends BaseIdentifiableObject>> supportedClasses = Set.of(
         ProgramIndicator.class,
-        DataElement.class,
         TrackedEntityAttribute.class );
 
     @Override


### PR DESCRIPTION
One analytics test has been failing on master for a while. Previously, we returned only data element ids when calling
`/analytics/events/query/dimensions?programStageId=PaOOjwLVW23&filter=dimensionType:eq:DATA_ELEMENT`. Now, we return program stage id as a prefix. 

```
 AnalyticsDimensionsTest.shouldOnlyReturnDataElementsAssociatedWithProgramStage:182 1 expectation failed.
 [36me2e-test_1  |[0m JSON path dimensions.id doesn't match.
 [36me2e-test_1  |[0m Expected: every item is one of {"ZrqtjjveTFc", "BuZ5LGNfGET", "mB2QHw1tU96"}
 [36me2e-test_1  |[0m   Actual: [PaOOjwLVW23.ZrqtjjveTFc, PaOOjwLVW23.BuZ5LGNfGET, PaOOjwLVW23.mB2QHw1tU96]
```

removed  DataElement from BaseDimensionalItemObjectMapper.java since data element now has its own mapper and several mappers supporting data element was the reason why data element dimensions didn't have the program prefix in some cases.