### PR TITLE
feat: cached data integrity checks [DHIS2-12599]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -53,6 +54,9 @@ public class DataIntegrityDetails implements Serializable
 {
     @JsonUnwrapped
     private final DataIntegrityCheck check;
+
+    @JsonProperty
+    private final Date finishedTime;
 
     @JsonProperty
     private final List<DataIntegrityIssue> issues;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
@@ -59,6 +59,9 @@ public class DataIntegrityDetails implements Serializable
     private final Date finishedTime;
 
     @JsonProperty
+    private final String error;
+
+    @JsonProperty
     private final List<DataIntegrityIssue> issues;
 
     @Getter

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
@@ -44,8 +44,8 @@ public interface DataIntegrityService
      */
 
     /**
-     * @deprecated Replaced by {@link #getSummaries(Set, JobProgress)} and
-     *             {@link #getDetails(Set, JobProgress)}, kept for backwards
+     * @deprecated Replaced by {@link #getSummaries(Set, long)} and
+     *             {@link #getDetails(Set, long)}, kept for backwards
      *             compatibility until new UI exists
      */
     @Deprecated( since = "2.38", forRemoval = true )
@@ -57,7 +57,11 @@ public interface DataIntegrityService
 
     Collection<DataIntegrityCheck> getDataIntegrityChecks();
 
-    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, JobProgress progress );
+    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout );
 
-    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, JobProgress progress );
+    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout );
+
+    void runSummaryChecks( Set<String> checks, JobProgress progress );
+
+    void runDetailsChecks( Set<String> checks, JobProgress progress );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityStore.java
@@ -25,49 +25,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.json.domain;
-
-import org.hisp.dhis.dataintegrity.DataIntegritySeverity;
-import org.hisp.dhis.jsontree.Expected;
-import org.hisp.dhis.jsontree.JsonObject;
+package org.hisp.dhis.dataintegrity;
 
 /**
- * JSON API equivalent of the
- * {@link org.hisp.dhis.dataintegrity.DataIntegrityCheck}.
+ * Database support for running data integrity checks.
+ * <p>
+ * Mainly this supports the YAML based checks that have SQL in the YAML.
  *
  * @author Jan Bernitt
  */
-public interface JsonDataIntegrityCheck extends JsonObject
+public interface DataIntegrityStore
 {
-    @Expected
-    default String getName()
-    {
-        return getString( "name" ).string();
-    }
+    /**
+     * Runs a query for a {@link DataIntegritySummary}
+     *
+     * @param check the check the SQL belongs to
+     * @param sql the native SQL to run from a YAML declaration
+     * @return the mapped summary
+     */
+    DataIntegritySummary querySummary( DataIntegrityCheck check, String sql );
 
-    default String getSection()
-    {
-        return getString( "section" ).string();
-    }
-
-    default DataIntegritySeverity getSeverity()
-    {
-        return getString( "severity" ).parsed( DataIntegritySeverity::valueOf );
-    }
-
-    default String getDescription()
-    {
-        return getString( "description" ).string();
-    }
-
-    default String getIntroduction()
-    {
-        return getString( "introduction" ).string();
-    }
-
-    default String getRecommendation()
-    {
-        return getString( "recommendation" ).string();
-    }
-
+    /**
+     * Runs a query for a {@link DataIntegrityDetails}.
+     *
+     * @param check the check the SQL belongs to
+     * @param sql the native SQL to run from a YAML declaration
+     * @return the mapped details
+     */
+    DataIntegrityDetails queryDetails( DataIntegrityCheck check, String sql );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
@@ -52,6 +52,9 @@ public class DataIntegritySummary implements Serializable
     private final Date finishedTime;
 
     @JsonProperty
+    private final String error;
+
+    @JsonProperty
     private final int count;
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dataintegrity;
 
 import java.io.Serializable;
+import java.util.Date;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -48,9 +49,12 @@ public class DataIntegritySummary implements Serializable
     private final DataIntegrityCheck check;
 
     @JsonProperty
-    private int count;
+    private final Date finishedTime;
 
     @JsonProperty
-    private Double percentage;
+    private final int count;
+
+    @JsonProperty
+    private final Double percentage;
 
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DataIntegrityJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DataIntegrityJobParameters.java
@@ -52,11 +52,22 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 @JsonDeserialize( using = DataIntegrityJobParametersDeserializer.class )
 public class DataIntegrityJobParameters implements JobParameters
 {
+    public enum DataIntegrityReportType
+    {
+        REPORT,
+        SUMMARY,
+        DETAILS
+    }
+
     private static final long serialVersionUID = 1073997854310838296L;
 
     @JsonProperty( required = false )
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private Set<String> checks;
+
+    @JsonProperty( required = false )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    private DataIntegrityReportType type;
 
     @Override
     public Optional<ErrorReport> validate()

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -519,8 +519,8 @@ public class DefaultDataIntegrityService
             .severity( DataIntegritySeverity.WARNING )
             .section( "Legacy" )
             .description( name.replace( '_', ' ' ) )
-            .runDetailsCheck( c -> new DataIntegrityDetails( c, new Date(), check.get() ) )
-            .runSummaryCheck( c -> new DataIntegritySummary( c, new Date(), check.get().size(), null ) )
+            .runDetailsCheck( c -> new DataIntegrityDetails( c, new Date(), null, check.get() ) )
+            .runSummaryCheck( c -> new DataIntegritySummary( c, new Date(), null, check.get().size(), null ) )
             .build() );
     }
 
@@ -814,7 +814,7 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity summary checks", expandChecks( checks ), progress, summaryCache,
             check -> check.getRunSummaryCheck().apply( check ),
-            ( check, ex ) -> new DataIntegritySummary( check, new Date(), -1, null ) );
+            ( check, ex ) -> new DataIntegritySummary( check, new Date(), ex.getMessage(), -1, null ) );
     }
 
     @Override
@@ -830,8 +830,7 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity details checks", expandChecks( checks ), progress, detailsCache,
             check -> check.getRunDetailsCheck().apply( check ),
-            ( check, ex ) -> new DataIntegrityDetails( check, new Date(),
-                List.of( new DataIntegrityIssue( "", "", ex.getMessage(), List.of() ) ) ) );
+            ( check, ex ) -> new DataIntegrityDetails( check, new Date(), ex.getMessage(), List.of() ) );
     }
 
     private <T> Map<String, T> getCached( Set<String> checks, long timeout, Cache<T> cache )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.dataintegrity;
 
+import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.groupingBy;
@@ -41,6 +42,7 @@ import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -51,6 +53,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -58,11 +61,12 @@ import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.hibernate.SessionFactory;
 import org.hisp.dhis.antlr.ParserException;
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
@@ -105,9 +109,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Lars Helge Overland
  */
 @Slf4j
-@Service( "org.hisp.dhis.dataintegrity.DataIntegrityService" )
+@Service
 @Transactional
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class DefaultDataIntegrityService
     implements DataIntegrityService
 {
@@ -143,7 +147,20 @@ public class DefaultDataIntegrityService
 
     private final ProgramIndicatorService programIndicatorService;
 
-    private final SessionFactory sessionFactory;
+    private final CacheProvider cacheProvider;
+
+    private final DataIntegrityStore dataIntegrityStore;
+
+    private Cache<DataIntegritySummary> summaryCache;
+
+    private Cache<DataIntegrityDetails> detailsCache;
+
+    @PostConstruct
+    public void init()
+    {
+        summaryCache = cacheProvider.createDataIntegritySummaryCache();
+        detailsCache = cacheProvider.createDataIntegrityDetailsCache();
+    }
 
     private static int alphabeticalOrder( DataIntegrityIssue a, DataIntegrityIssue b )
     {
@@ -502,8 +519,8 @@ public class DefaultDataIntegrityService
             .severity( DataIntegritySeverity.WARNING )
             .section( "Legacy" )
             .description( name.replace( '_', ' ' ) )
-            .runDetailsCheck( c -> new DataIntegrityDetails( c, check.get() ) )
-            .runSummaryCheck( c -> new DataIntegritySummary( c, check.get().size(), null ) )
+            .runDetailsCheck( c -> new DataIntegrityDetails( c, new Date(), check.get() ) )
+            .runSummaryCheck( c -> new DataIntegritySummary( c, new Date(), check.get().size(), null ) )
             .build() );
     }
 
@@ -599,7 +616,8 @@ public class DefaultDataIntegrityService
     @Transactional( readOnly = true )
     public FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress )
     {
-        return new FlattenedDataIntegrityReport( getDetails( checks, progress ) );
+        runDetailsChecks( checks, progress );
+        return new FlattenedDataIntegrityReport( getDetails( checks, -1L ) );
     }
 
     /**
@@ -784,38 +802,96 @@ public class DefaultDataIntegrityService
     }
 
     @Override
-    @Transactional( readOnly = true )
-    public Map<String, DataIntegritySummary> getSummaries( Set<String> checks, JobProgress progress )
+    public Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout )
     {
-        return runDataIntegrityChecks( "Data Integrity summary checks", expandChecks( checks ), progress,
-            check -> check.getRunSummaryCheck().apply( check ) );
+        return getCached( checks, timeout, summaryCache );
+    }
+
+    // OBS! We intentionally do not open the transaction here to have each check
+    // be independent
+    @Override
+    public void runSummaryChecks( Set<String> checks, JobProgress progress )
+    {
+        runDataIntegrityChecks( "Data Integrity summary checks", expandChecks( checks ), progress, summaryCache,
+            check -> check.getRunSummaryCheck().apply( check ),
+            ( check, ex ) -> new DataIntegritySummary( check, new Date(), -1, null ) );
     }
 
     @Override
-    @Transactional( readOnly = true )
-    public Map<String, DataIntegrityDetails> getDetails( Set<String> checks, JobProgress progress )
+    public Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout )
     {
-        return runDataIntegrityChecks( "Data Integrity details checks", expandChecks( checks ), progress,
-            check -> check.getRunDetailsCheck().apply( check ) );
+        return getCached( checks, timeout, detailsCache );
     }
 
-    private <T> Map<String, T> runDataIntegrityChecks( String stageDesc, Set<String> checks, JobProgress progress,
-        Function<DataIntegrityCheck, T> runCheck )
+    // OBS! We intentionally do not open the transaction here to have each check
+    // be independent
+    @Override
+    public void runDetailsChecks( Set<String> checks, JobProgress progress )
+    {
+        runDataIntegrityChecks( "Data Integrity details checks", expandChecks( checks ), progress, detailsCache,
+            check -> check.getRunDetailsCheck().apply( check ),
+            ( check, ex ) -> new DataIntegrityDetails( check, new Date(),
+                List.of( new DataIntegrityIssue( "", "", ex.getMessage(), List.of() ) ) ) );
+    }
+
+    private <T> Map<String, T> getCached( Set<String> checks, long timeout, Cache<T> cache )
+    {
+        Set<String> names = expandChecks( checks );
+        long giveUpTime = currentTimeMillis() + timeout;
+        Map<String, T> resByName = new LinkedHashMap<>();
+        boolean retry = false;
+        do
+        {
+            if ( retry )
+            {
+                try
+                {
+                    Thread.sleep( Math.max( 10, Math.min( 50, (giveUpTime - currentTimeMillis()) / 2 ) ) );
+                }
+                catch ( InterruptedException ex )
+                {
+                    Thread.currentThread().interrupt();
+                    return resByName;
+                }
+            }
+            for ( String name : names )
+            {
+                if ( !resByName.containsKey( name ) )
+                {
+                    cache.get( name ).ifPresent( res -> resByName.put( name, res ) );
+                }
+            }
+            retry = resByName.size() < names.size() && (timeout < 0 || currentTimeMillis() < giveUpTime);
+        }
+        while ( retry );
+        return resByName;
+    }
+
+    private <T> void runDataIntegrityChecks( String stageDesc, Set<String> checks, JobProgress progress,
+        Cache<T> cache, Function<DataIntegrityCheck, T> runCheck,
+        BiFunction<DataIntegrityCheck, RuntimeException, T> createErrorReport )
     {
         progress.startingProcess( "Data Integrity check" );
         progress.startingStage( stageDesc, checks.size() );
-        Map<String, T> checkResults = new LinkedHashMap<>();
         progress.runStage( checks.stream().map( checksByName::get ).filter( Objects::nonNull ),
             DataIntegrityCheck::getDescription,
             check -> {
-                T res = runCheck.apply( check );
+                T res = null;
+                try
+                {
+                    res = runCheck.apply( check );
+                }
+                catch ( RuntimeException ex )
+                {
+                    cache.put( check.getName(), createErrorReport.apply( check, ex ) );
+                    throw ex;
+                }
                 if ( res != null )
                 {
-                    checkResults.put( check.getName(), res );
+                    cache.put( check.getName(), res );
                 }
             } );
         progress.completedProcess( null );
-        return checkResults;
     }
 
     private Set<String> expandChecks( Set<String> names )
@@ -853,46 +929,10 @@ public class DefaultDataIntegrityService
         if ( configurationsAreLoaded.compareAndSet( false, true ) )
         {
             readDataIntegrityYaml( "data-integrity-checks.yaml",
-                check -> checksByName.put( check.getName(), check ), this::querySummary, this::queryDetails );
+                check -> checksByName.put( check.getName(), check ),
+                sql -> check -> dataIntegrityStore.querySummary( check, sql ),
+                sql -> check -> dataIntegrityStore.queryDetails( check, sql ) );
         }
     }
 
-    private Function<DataIntegrityCheck, DataIntegritySummary> querySummary( String sql )
-    {
-        return check -> {
-            Object[] summary = (Object[]) sessionFactory.getCurrentSession()
-                .createNativeQuery( sql ).getSingleResult();
-            return new DataIntegritySummary( check, parseCount( summary[0] ), parsePercentage( summary[1] ) );
-        };
-    }
-
-    private Function<DataIntegrityCheck, DataIntegrityDetails> queryDetails( String sql )
-    {
-        return check -> {
-            @SuppressWarnings( "unchecked" )
-            List<Object[]> rows = sessionFactory.getCurrentSession().createNativeQuery( sql ).list();
-            return new DataIntegrityDetails( check, rows.stream()
-                .map( row -> new DataIntegrityIssue( (String) row[0],
-                    (String) row[1], row.length == 2 ? null : (String) row[2], null ) )
-                .collect( toUnmodifiableList() ) );
-        };
-    }
-
-    private static Double parsePercentage( Object value )
-    {
-        if ( value == null )
-        {
-            return null;
-        }
-        if ( value instanceof String )
-        {
-            return Double.parseDouble( value.toString().replace( "%", "" ) );
-        }
-        return ((Number) value).doubleValue();
-    }
-
-    private static int parseCount( Object value )
-    {
-        return value == null ? 0 : ((Number) value).intValue();
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -62,7 +62,8 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
     {
         Object[] summary = (Object[]) sessionFactory.getCurrentSession()
             .createNativeQuery( sql ).getSingleResult();
-        return new DataIntegritySummary( check, new Date(), parseCount( summary[0] ), parsePercentage( summary[1] ) );
+        return new DataIntegritySummary( check, new Date(), null, parseCount( summary[0] ),
+            parsePercentage( summary[1] ) );
     }
 
     @Override
@@ -71,7 +72,7 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
     {
         @SuppressWarnings( "unchecked" )
         List<Object[]> rows = sessionFactory.getCurrentSession().createNativeQuery( sql ).list();
-        return new DataIntegrityDetails( check, new Date(), rows.stream()
+        return new DataIntegrityDetails( check, new Date(), null, rows.stream()
             .map( row -> new DataIntegrityIssue( (String) row[0],
                 (String) row[1], row.length == 2 ? null : (String) row[2], null ) )
             .collect( toUnmodifiableList() ) );

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataintegrity.hibernate;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
+import org.hisp.dhis.dataintegrity.DataIntegrityStore;
+import org.hisp.dhis.dataintegrity.DataIntegritySummary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * As we want each check to be its own transaction the @{@link Transactional}
+ * annotation is used on the store and not the service level in this case.
+ *
+ * @author Jan Bernitt
+ */
+@Repository
+@AllArgsConstructor
+public class HibernateDataIntegrityStore implements DataIntegrityStore
+{
+
+    private final SessionFactory sessionFactory;
+
+    @Override
+    @Transactional( readOnly = true )
+    public DataIntegritySummary querySummary( DataIntegrityCheck check, String sql )
+    {
+        Object[] summary = (Object[]) sessionFactory.getCurrentSession()
+            .createNativeQuery( sql ).getSingleResult();
+        return new DataIntegritySummary( check, new Date(), parseCount( summary[0] ), parsePercentage( summary[1] ) );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public DataIntegrityDetails queryDetails( DataIntegrityCheck check, String sql )
+    {
+        @SuppressWarnings( "unchecked" )
+        List<Object[]> rows = sessionFactory.getCurrentSession().createNativeQuery( sql ).list();
+        return new DataIntegrityDetails( check, new Date(), rows.stream()
+            .map( row -> new DataIntegrityIssue( (String) row[0],
+                (String) row[1], row.length == 2 ? null : (String) row[2], null ) )
+            .collect( toUnmodifiableList() ) );
+    }
+
+    private static Double parsePercentage( Object value )
+    {
+        if ( value == null )
+        {
+            return null;
+        }
+        if ( value instanceof String )
+        {
+            return Double.parseDouble( value.toString().replace( "%", "" ) );
+        }
+        return ((Number) value).doubleValue();
+    }
+
+    private static int parseCount( Object value )
+    {
+        return value == null ? 0 : ((Number) value).intValue();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -92,6 +92,14 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
 
     private static int parseCount( Object value )
     {
-        return value == null ? 0 : ((Number) value).intValue();
+        if ( value == null )
+        {
+            return 0;
+        }
+        if ( value instanceof String )
+        {
+            return Integer.parseInt( (String) value );
+        }
+        return ((Number) value).intValue();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
+import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters.DataIntegrityReportType;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
@@ -68,8 +69,25 @@ public class DataIntegrityJob implements Job
         Set<String> checks = parameters == null
             ? Set.of()
             : parameters.getChecks();
-        Timer timer = new SystemTimer().start();
 
+        DataIntegrityReportType type = parameters == null ? null : parameters.getType();
+        if ( type == null || type == DataIntegrityReportType.REPORT )
+        {
+            runReport( config, progress, checks );
+        }
+        else if ( type == DataIntegrityReportType.SUMMARY )
+        {
+            dataIntegrityService.runSummaryChecks( checks, progress );
+        }
+        else
+        {
+            dataIntegrityService.runDetailsChecks( checks, progress );
+        }
+    }
+
+    private void runReport( JobConfiguration config, JobProgress progress, Set<String> checks )
+    {
+        Timer timer = new SystemTimer().start();
         notifier.notify(
             config, NotificationLevel.INFO,
             "Starting data integrity job", false );

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_no_options.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_no_options.yaml
@@ -31,10 +31,9 @@ description: Categories with no category options
 section: Categories
 section_order: 2
 summary_sql: >-
-    select 'categories_no_options' as indicator,
-    COUNT(*)::varchar as value,
-    (100 * COUNT(*) / (SELECT COUNT(*) FROM dataelementcategory)) || '%' as percent,
-    'Categories without category options' as description
+    select
+    COUNT(*) as value,
+    (100 * COUNT(*) / (SELECT COUNT(*) FROM dataelementcategory)) as percent
     from dataelementcategory where categoryid
     not in (select distinct categoryid from categories_categoryoptions);
 details_uid: QOI2PBHvksS
@@ -46,7 +45,7 @@ details_sql: >-
 severity: WARNING
 introduction: >
     Categories should always have at least a single category options.
-recommendation: |
+recommendation: >
     Any categories without category options should either be removed from the
     system if they are not in use. Otherwise, appropriate category options
     should be added to the category.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -61,8 +61,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.hibernate.SessionFactory;
 import org.hisp.dhis.antlr.ParserException;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
@@ -217,7 +217,7 @@ class DataIntegrityServiceTest
             programRuleVariableService, dataElementService, indicatorService, dataSetService,
             organisationUnitService, organisationUnitGroupService, validationRuleService, expressionService,
             dataEntryFormService, categoryService, periodService, programIndicatorService,
-            mock( SessionFactory.class ) );
+            mock( CacheProvider.class ), mock( DataIntegrityStore.class ) );
         setUpFixtures();
     }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -27,12 +27,12 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import static java.util.Collections.singletonList;
 import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
@@ -51,8 +51,9 @@ class DataIntegrityYamlReaderTest
     {
         List<DataIntegrityCheck> checks = new ArrayList<>();
         readDataIntegrityYaml( "data-integrity-checks.yaml", checks::add,
-            sql -> check -> new DataIntegritySummary( check, 1, 100d ), sql -> check -> new DataIntegrityDetails( check,
-                singletonList( new DataIntegrityIssue( "id", "name", sql, List.of() ) ) ) );
+            sql -> check -> new DataIntegritySummary( check, new Date(), 1, 100d ),
+            sql -> check -> new DataIntegrityDetails( check, new Date(),
+                List.of( new DataIntegrityIssue( "id", "name", sql, List.of() ) ) ) );
         assertEquals( 1, checks.size() );
         DataIntegrityCheck check = checks.get( 0 );
         assertEquals( "categories_no_options", check.getName() );

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -61,9 +61,9 @@ class DataIntegrityYamlReaderTest
         assertEquals( "Categories", check.getSection() );
         assertEquals( DataIntegritySeverity.WARNING, check.getSeverity() );
         assertEquals( "Categories should always have at least a single category options.", check.getIntroduction() );
-        assertEquals( "Any categories without category options should either be removed from the\n"
-            + "system if they are not in use. Otherwise, appropriate category options\n"
-            + "should be added to the category.", check.getRecommendation() );
+        assertEquals( "Any categories without category options should either be removed from the"
+            + " system if they are not in use. Otherwise, appropriate category options"
+            + " should be added to the category.", check.getRecommendation() );
         assertTrue( check.getRunDetailsCheck().apply( check ).getIssues().get( 0 ).getComment()
             .startsWith( "SELECT uid,name from dataelementcategory" ) );
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -51,8 +51,8 @@ class DataIntegrityYamlReaderTest
     {
         List<DataIntegrityCheck> checks = new ArrayList<>();
         readDataIntegrityYaml( "data-integrity-checks.yaml", checks::add,
-            sql -> check -> new DataIntegritySummary( check, new Date(), 1, 100d ),
-            sql -> check -> new DataIntegrityDetails( check, new Date(),
+            sql -> check -> new DataIntegritySummary( check, new Date(), null, 1, 100d ),
+            sql -> check -> new DataIntegrityDetails( check, new Date(), null,
                 List.of( new DataIntegrityIssue( "id", "name", sql, List.of() ) ) ) );
         assertEquals( 1, checks.size() );
         DataIntegrityCheck check = checks.get( 0 );

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -129,4 +129,8 @@ public interface CacheProvider
     <V> Cache<V> createCompletedJobsInfoCache();
 
     <V> Cache<V> createJobCancelRequestedCache();
+
+    <V> Cache<V> createDataIntegritySummaryCache();
+
+    <V> Cache<V> createDataIntegrityDetailsCache();
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.cache;
 
+import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -127,7 +128,9 @@ public class DefaultCacheProvider
         securityCache,
         runningJobsInfo,
         completedJobsInfo,
-        jobCancelRequested
+        jobCancelRequested,
+        dataIntegritySummaryCache,
+        dataIntegrityDetailsCache
     }
 
     private final Map<String, Cache<?>> allCaches = new ConcurrentHashMap<>();
@@ -597,5 +600,21 @@ public class DefaultCacheProvider
         return registerCache( this.<V> newBuilder()
             .forRegion( Region.jobCancelRequested.name() )
             .expireAfterWrite( 60, SECONDS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createDataIntegritySummaryCache()
+    {
+        return registerCache( this.<V> newBuilder()
+            .forRegion( Region.dataIntegritySummaryCache.name() )
+            .expireAfterWrite( 1, HOURS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createDataIntegrityDetailsCache()
+    {
+        return registerCache( this.<V> newBuilder()
+            .forRegion( Region.dataIntegrityDetailsCache.name() )
+            .expireAfterWrite( 1, HOURS ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.webapi.json.domain;
 
+import java.time.LocalDateTime;
+
 import org.hisp.dhis.jsontree.Expected;
+import org.hisp.dhis.jsontree.JsonDate;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
@@ -40,6 +43,12 @@ import org.hisp.dhis.jsontree.JsonString;
  */
 public interface JsonDataIntegrityDetails extends JsonDataIntegrityCheck
 {
+    @Expected
+    default LocalDateTime getFinishedTime()
+    {
+        return get( "finishedTime", JsonDate.class ).date();
+    }
+
     @Expected
     default JsonList<JsonDataIntegrityIssue> getIssues()
     {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
@@ -49,6 +49,11 @@ public interface JsonDataIntegrityDetails extends JsonDataIntegrityCheck
         return get( "finishedTime", JsonDate.class ).date();
     }
 
+    default String getError()
+    {
+        return getString( "error" ).string( null );
+    }
+
     @Expected
     default JsonList<JsonDataIntegrityIssue> getIssues()
     {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.webapi.json.domain;
 
+import java.time.LocalDateTime;
+
+import org.hisp.dhis.jsontree.Expected;
+import org.hisp.dhis.jsontree.JsonDate;
+
 /**
  * JSON API equivalent of
  * {@link org.hisp.dhis.dataintegrity.DataIntegritySummary}.
@@ -35,6 +40,11 @@ package org.hisp.dhis.webapi.json.domain;
  */
 public interface JsonDataIntegritySummary extends JsonDataIntegrityCheck
 {
+    @Expected
+    default LocalDateTime getFinishedTime()
+    {
+        return get( "finishedTime", JsonDate.class ).date();
+    }
 
     default int getCount()
     {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
@@ -46,6 +46,11 @@ public interface JsonDataIntegritySummary extends JsonDataIntegrityCheck
         return get( "finishedTime", JsonDate.class ).date();
     }
 
+    default String getError()
+    {
+        return getString( "error" ).string( null );
+    }
+
     default int getCount()
     {
         return getNumber( "count" ).intValue();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityReportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityReportControllerTest.java
@@ -188,7 +188,9 @@ class DataIntegrityReportControllerTest extends DhisControllerConvenienceTest
 
     private JsonDataIntegrityReport getDataIntegrityReport( String url )
     {
-        JsonObject response = POST( url ).content().getObject( "response" );
+        HttpResponse httpResponse = POST( url );
+        assertTrue( httpResponse.location().startsWith( "http://localhost/dataIntegrity/details?checks=" ) );
+        JsonObject response = httpResponse.content().getObject( "response" );
         String id = response.getString( "id" ).string();
         String jobType = response.getString( "jobType" ).string();
         return GET( "/system/taskSummaries/{type}/{id}", jobType, id ).content().as( JsonDataIntegrityReport.class );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -46,9 +46,9 @@ import org.hisp.dhis.dataintegrity.DataIntegritySummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
+import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters.DataIntegrityReportType;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -81,9 +81,19 @@ public class DataIntegrityController
         @RequestParam( required = false ) List<String> checks,
         @CurrentUser User currentUser )
     {
+        return runDataIntegrityAsync( checks, currentUser, "runDataIntegrity", DataIntegrityReportType.REPORT )
+            .setLocation( "/dataIntegrity/details?checks=" + toChecksList( checks ) );
+    }
+
+    private WebMessage runDataIntegrityAsync( Collection<String> checks,
+        User currentUser,
+        String description,
+        DataIntegrityReportType type )
+    {
         DataIntegrityJobParameters params = new DataIntegrityJobParameters();
         params.setChecks( toUniformCheckNames( checks ) );
-        JobConfiguration config = new JobConfiguration( "runDataIntegrity", JobType.DATA_INTEGRITY, null,
+        params.setType( type );
+        JobConfiguration config = new JobConfiguration( description, JobType.DATA_INTEGRITY, null,
             params, true, true );
         config.setUserUid( currentUser.getUid() );
         config.setAutoFields();
@@ -105,37 +115,63 @@ public class DataIntegrityController
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @GetMapping( "/summary" )
     @ResponseBody
-    public Map<String, DataIntegritySummary> runAndGetSummaries(
-        @RequestParam( required = false ) Set<String> checks )
+    public Map<String, DataIntegritySummary> getSummaries(
+        @RequestParam( required = false ) Set<String> checks,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
     {
-        return dataIntegrityService.getSummaries( toUniformCheckNames( checks ), NoopJobProgress.INSTANCE );
+        return dataIntegrityService.getSummaries( toUniformCheckNames( checks ), timeout );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @PostMapping( "/summary" )
+    @ResponseBody
+    public WebMessage runSummariesCheck(
+        @RequestParam( required = false ) Set<String> checks,
+        @CurrentUser User currentUser )
+    {
+        return runDataIntegrityAsync( checks, currentUser, "runSummariesCheck", DataIntegrityReportType.SUMMARY )
+            .setLocation( "/dataIntegrity/summary?checks=" + toChecksList( checks ) );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @GetMapping( "/details" )
     @ResponseBody
-    public Map<String, DataIntegrityDetails> runAndGetDetails(
-        @RequestParam( required = false ) Set<String> checks )
+    public Map<String, DataIntegrityDetails> getDetails(
+        @RequestParam( required = false ) Set<String> checks,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
     {
-        return dataIntegrityService.getDetails( toUniformCheckNames( checks ), NoopJobProgress.INSTANCE );
+        return dataIntegrityService.getDetails( toUniformCheckNames( checks ), timeout );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @PostMapping( "/details" )
+    @ResponseBody
+    public WebMessage runDetailsCheck(
+        @RequestParam( required = false ) Set<String> checks,
+        @CurrentUser User currentUser )
+    {
+        return runDataIntegrityAsync( checks, currentUser, "runDetailsCheck", DataIntegrityReportType.DETAILS )
+            .setLocation( "/dataIntegrity/details?checks=" + toChecksList( checks ) );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @GetMapping( "/{check}/summary" )
     @ResponseBody
-    public DataIntegritySummary runAndGetSummary( @PathVariable String check )
+    public DataIntegritySummary getSummary( @PathVariable String check,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
     {
         Set<String> checks = toUniformCheckNames( Set.of( check ) );
-        return dataIntegrityService.getSummaries( checks, NoopJobProgress.INSTANCE ).get( checks.iterator().next() );
+        return dataIntegrityService.getSummaries( checks, timeout ).get( checks.iterator().next() );
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @GetMapping( "/{check}/details" )
     @ResponseBody
-    public DataIntegrityDetails runAndGetDetails( @PathVariable String check )
+    public DataIntegrityDetails getDetails( @PathVariable String check,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
     {
         Set<String> checks = toUniformCheckNames( Set.of( check ) );
-        return dataIntegrityService.getDetails( checks, NoopJobProgress.INSTANCE ).get( checks.iterator().next() );
+        return dataIntegrityService.getDetails( checks, timeout ).get( checks.iterator().next() );
     }
 
     /**
@@ -148,4 +184,8 @@ public class DataIntegrityController
             : checks.stream().map( check -> check.replace( '-', '_' ) ).collect( toUnmodifiableSet() );
     }
 
+    private String toChecksList( Collection<String> checks )
+    {
+        return checks == null || checks.isEmpty() ? "" : String.join( ",", checks );
+    }
 }


### PR DESCRIPTION
### Summary
On high level this adds caching to the data integrity checks.
But this has a number of consequences in the details.

The `GET` API now reads from the cache but does not trigger the checks.
To trigger the checks a `POST` is send to the same URL as reading cache.

As the computation triggered by a `POST` is now asynchronously performed by an ad-hoc scheduled job, calling `GET` directly after is likely not to find the results in the cache yet. Therefore a `timeout` parameter was added to the cache access API so that you can poll with some server side waiting (if wanted).
The idea here was that we could block wait on the cache and return as soon as the data is provided by the asynchronous computation. However, for now I did not implement block wait as the redis cache would not support it. Therefore I made a sleep wait loop trying to find it in the cache every 10-50ms (based on timeout). Since this is a very check operation I made the loop waiting relatively short to avoid long waits without a need for it.

Also the summary and details report got a `Date` field added for the `finishedTime` so that the user can understand how "old" this result is. The cache will hold results up to an hour. After that they outdate and the check must be rerun.

### Running Checks via Jobs
As now all data integrity checks are run from a job the data integrity job needed to be able to run the set of checks for one of 3 outcomes:
* report (legacy support of the old report)
* summary (new summary reports)
* details (new details reports)

This can be understood as a generally useful feature as soon as the job configuration also lets you chose this parameter in the app this means the users can also opt to run legacy or the new summary or details reports. 

For backwards compatibility the new type parameter is not required and when left out will perform the legacy report.

### Transactions
Doing all checks in  single transaction has shown problematic. While this would be nicest for consistency it has severe problems:
* a failing check can cause the transaction to fail and thereby fail all subsequent checks
* we get long running transactions potentially blocking database in significant ways (even read-only)

To avoid these problems transactions are now opened individually. For the programmatic checks this means they open when we call other services which are transnational. Usually this is the case once in these programmatic checks.
For the YAML based checks the transactions are now opened on the store level so that the service can call a spring proxy that has the `@Transactional` annotation. Therefore a new `DataIntegrityStore` and its implementation needed to be extracted from the service.

### Check Bugfix
The first YAML check had bad SQL for the summary check.
The convention is that a summary should return count and possibly a percentage.
The SQL was copied as still contained some text columns added for readability when used directly.  

### Automatic Testing
Existing tests have been adopted to cover the new asynchronous processing.
Luckily this was already setup for the legacy reports.

### Manual Testing
* Start the server and login
* Trigger summary: `POST` http://localhost:8080/api/dataIntegrity/summary
* Check summary: `GET` http://localhost:8080/api/dataIntegrity/summary?timeout=500
* Trigger details: `POST` http://localhost:8080/api/dataIntegrity/details
* Check details: `GET` http://localhost:8080/api/dataIntegrity/details?timeout=500
 
Note that a timeout of 500ms may not be long enough when running all checks like the examples given will do.
You could also test just single checks like:
* Trigger: `POST` http://localhost:8080/api/dataIntegrity/summary?checks=categories-no-options
* Check: `GET` http://localhost:8080/api/dataIntegrity/summary?checks=categories-no-options?timeout=500

### Documentation
https://github.com/dhis2/dhis2-docs/pull/906