### PR TITLE
feat: add enum constants to job parameters info [DHIS2-12637]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -216,59 +217,72 @@ public class DefaultJobConfigurationService
     {
         List<Property> jobParameters = new ArrayList<>();
 
-        Class<?> clazz = jobType.getJobParameters();
+        Class<?> paramsType = jobType.getJobParameters();
 
-        if ( clazz == null )
+        if ( paramsType == null )
         {
             return jobParameters;
         }
 
-        final Set<PropertyDescriptor> properties = Stream.of( PropertyUtils.getPropertyDescriptors( clazz ) )
+        final Set<PropertyDescriptor> properties = Stream.of( PropertyUtils.getPropertyDescriptors( paramsType ) )
             .filter( pd -> pd.getReadMethod() != null && pd.getWriteMethod() != null )
             .collect( Collectors.toSet() );
 
-        for ( Field field : clazz.getDeclaredFields() )
+        for ( Field field : paramsType.getDeclaredFields() )
         {
             PropertyDescriptor descriptor = properties.stream().filter( pd -> pd.getName().equals( field.getName() ) )
                 .findFirst().orElse( null );
-            if ( descriptor == null || (descriptor.getReadMethod().getAnnotation( JsonProperty.class ) == null
-                && field.getAnnotation( JsonProperty.class ) == null) )
+            if ( isProperty( field, descriptor ) )
             {
-                continue;
+                jobParameters.add( getProperty( jobType, paramsType, field ) );
             }
-            Property property = new Property( Primitives.wrap( field.getType() ), null, null );
-            property.setName( field.getName() );
-            property.setFieldName( TextUtils.getPrettyPropertyName( field.getName() ) );
-
-            try
-            {
-                field.setAccessible( true );
-                property.setDefaultValue( field.get( jobType.getJobParameters().newInstance() ) );
-            }
-            catch ( IllegalAccessException | InstantiationException e )
-            {
-                log.error(
-                    "Fetching default value for JobParameters properties failed for property: " + field.getName(), e );
-            }
-
-            String relativeApiElements = jobType.getRelativeApiElements() != null
-                ? jobType.getRelativeApiElements().get( field.getName() )
-                : "";
-
-            if ( relativeApiElements != null && !relativeApiElements.equals( "" ) )
-            {
-                property.setRelativeApiEndpoint( relativeApiElements );
-            }
-
-            if ( Collection.class.isAssignableFrom( field.getType() ) )
-            {
-                property = setPropertyIfCollection( property, field, clazz );
-            }
-
-            jobParameters.add( property );
         }
 
         return jobParameters;
+    }
+
+    private boolean isProperty( Field field, PropertyDescriptor descriptor )
+    {
+        return !(descriptor == null || (descriptor.getReadMethod().getAnnotation( JsonProperty.class ) == null
+            && field.getAnnotation( JsonProperty.class ) == null));
+    }
+
+    private static Property getProperty( JobType jobType, Class<?> paramsType, Field field )
+    {
+        Class<?> valueType = field.getType();
+        Property property = new Property( Primitives.wrap( valueType ), null, null );
+        property.setName( field.getName() );
+        property.setFieldName( TextUtils.getPrettyPropertyName( field.getName() ) );
+
+        try
+        {
+            field.setAccessible( true );
+            property.setDefaultValue( field.get( jobType.getJobParameters().newInstance() ) );
+        }
+        catch ( IllegalAccessException | InstantiationException e )
+        {
+            log.error(
+                "Fetching default value for JobParameters properties failed for property: " + field.getName(), e );
+        }
+
+        String relativeApiElements = jobType.getRelativeApiElements() != null
+            ? jobType.getRelativeApiElements().get( field.getName() )
+            : "";
+
+        if ( relativeApiElements != null && !relativeApiElements.equals( "" ) )
+        {
+            property.setRelativeApiEndpoint( relativeApiElements );
+        }
+
+        if ( Collection.class.isAssignableFrom( valueType ) )
+        {
+            return setPropertyIfCollection( property, field, paramsType );
+        }
+        if ( valueType.isEnum() )
+        {
+            property.setConstants( getConstants( valueType ) );
+        }
+        return property;
     }
 
     private static Property setPropertyIfCollection( Property property, Field field, Class<?> klass )
@@ -288,8 +302,18 @@ public class DefaultJobConfigurationService
             property.setNameableObject( NameableObject.class.isAssignableFrom( itemKlass ) );
             property.setEmbeddedObject( EmbeddedObject.class.isAssignableFrom( klass ) );
             property.setAnalyticalObject( AnalyticalObject.class.isAssignableFrom( klass ) );
+            if ( itemKlass.isEnum() )
+            {
+                property.setConstants( getConstants( itemKlass ) );
+            }
         }
-
         return property;
+    }
+
+    private static List<String> getConstants( Class<?> enumType )
+    {
+        return Arrays.stream( enumType.getEnumConstants() )
+            .map( e -> ((Enum<?>) e).name() )
+            .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
@@ -134,6 +136,45 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest
         assertTrue( parameters.getBoolean( "sendNotifications" ).booleanValue() );
         assertTrue( parameters.getBoolean( "persistResults" ).booleanValue() );
         assertTrue( parameters.getArray( "validationRuleGroups" ).isEmpty() );
+    }
+
+    @Test
+    void testGetJobTypeInfo()
+    {
+        for ( JsonObject e : GET( "/jobConfigurations/jobTypes" ).content()
+            .getList( "jobTypes", JsonObject.class ) )
+        {
+            if ( e.getString( "jobType" ).string().equals( "ANALYTICS_TABLE" ) )
+            {
+                for ( JsonObject param : e.getList( "jobParameters", JsonObject.class ) )
+                {
+                    if ( param.getString( "name" ).string().equals( "skipTableTypes" ) )
+                    {
+                        assertEquals( List.of( "DATA_VALUE",
+                            "COMPLETENESS",
+                            "COMPLETENESS_TARGET",
+                            "ORG_UNIT_TARGET",
+                            "EVENT",
+                            "ENROLLMENT",
+                            "VALIDATION_RESULT" ), param.getArray( "constants" ).stringValues() );
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void testGetJobTypesExtended()
+    {
+        JsonObject types = GET( "/jobConfigurations/jobTypesExtended" ).content();
+        JsonObject param = types.getObject( "ANALYTICS_TABLE" ).getObject( "skipTableTypes" );
+        assertEquals( List.of( "DATA_VALUE",
+            "COMPLETENESS",
+            "COMPLETENESS_TARGET",
+            "ORG_UNIT_TARGET",
+            "EVENT",
+            "ENROLLMENT",
+            "VALIDATION_RESULT" ), param.getArray( "constants" ).stringValues() );
     }
 
     private JsonObject assertJobConfigurationExists( String jobId, String expectedJobType )


### PR DESCRIPTION
### Summary
After communication with Birk from FE we concluded that it would be good if the job parameter info also contained the constants for enum fields similar to the schema endpoint. 

The reason this isn't already the case is that the extraction of `Property` objects for job parameters is not the same code that the `Schema` uses. It is particularly made for job parameters and just reuses the `Property` class as a container.

This PR adds constants to the `Property` info if
* the value type of the field is an `enum` `Class`, or if
* the field is a collection of `enum` values

### Automatic Testing
Currently (in master) there is only one case of enums being used.
Another one will be added by #9807 for which this feature is intended.