### PR TITLE
refactor: Simplify CommonExpressionVisitor

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionInfo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionInfo.java
@@ -25,32 +25,47 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.program.variable;
+package org.hisp.dhis.expression;
 
-import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-import org.hisp.dhis.parser.expression.ProgramExpressionParams;
-import org.hisp.dhis.program.AnalyticsType;
+import java.util.HashSet;
+import java.util.Set;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.hisp.dhis.common.DimensionalItemId;
 
 /**
- * Program indicator variable: event date (also used for execution date)
+ * Information parsed from an expression
+ * <p>
+ * This is only information that is gathered from parsing the expression, and
+ * contains no information from any other source such as the database (either
+ * data or metadata). In other words, the same expression string will always
+ * result in the same information here.
  *
  * @author Jim Grace
  */
-public class vEventDate
-    extends ProgramDateVariable
+@Getter
+@Setter
+public class ExpressionInfo
 {
-    @Override
-    public Object getSql( CommonExpressionVisitor visitor )
-    {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+    /**
+     * The dimensional item ids found.
+     */
+    private Set<DimensionalItemId> itemIds = new HashSet<>();
 
-        if ( AnalyticsType.ENROLLMENT == progExParams.getProgramIndicator().getAnalyticsType() )
-        {
-            return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-                null, "executiondate", progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-                progExParams.getProgramIndicator() );
-        }
+    /**
+     * The sampled dimensional item ids found (for predictors).
+     */
+    private Set<DimensionalItemId> sampleItemIds = new HashSet<>();
 
-        return "executiondate";
-    }
+    /**
+     * Ids of org unit groups that will need org unit group member counts.
+     */
+    private Set<String> orgUnitGroupCountIds = new HashSet<>();
+
+    /**
+     * Ids of org unit groups found in orgUnits.groups function.
+     */
+    private Set<String> orgUnitGroupIds = new HashSet<>();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.expression;
 
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
+import static org.hisp.dhis.util.ObjectUtils.firstNonNull;
 
 import java.util.HashMap;
 import java.util.List;
@@ -42,10 +43,10 @@ import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.MapMap;
-import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
 
 /**
  * Parameters to evaluate an expression in {@see ExpressionService}
@@ -95,14 +96,6 @@ public class ExpressionParams
     private Map<DimensionalItemObject, Object> valueMap = new HashMap<>();
 
     /**
-     * Map of constant values to use in evaluating the expression
-     */
-    @ToString.Include
-    @EqualsAndHashCode.Include
-    @Builder.Default
-    private Map<String, Constant> constantMap = new HashMap<>();
-
-    /**
      * Map of organisation unit counts to use in evaluating the expression
      */
     @ToString.Include
@@ -118,11 +111,13 @@ public class ExpressionParams
     private Map<String, OrganisationUnitGroup> orgUnitGroupMap = new HashMap<>();
 
     /**
-     * The number of calendar days to be used in evaluating the expression
+     * The number of calendar days to be used in evaluating the expression.
+     * Defaults to zero for the purpose of expression syntax checking.
      */
     @ToString.Include
     @EqualsAndHashCode.Include
-    private Integer days;
+    @Builder.Default
+    private Integer days = 0;
 
     /**
      * The missing value strategy (what to do if data values are missing)
@@ -140,11 +135,14 @@ public class ExpressionParams
     private OrganisationUnit orgUnit;
 
     /**
-     * For predictors, a list of periods in which we will look for sampled data
+     * For predictors, a list of periods in which we will look for sampled data.
+     * Defaults to a single dummy period when we don't have an actual list of
+     * periods, so we can do syntax checking.
      */
     @ToString.Include
     @EqualsAndHashCode.Include
-    private List<Period> samplePeriods;
+    @Builder.Default
+    private List<Period> samplePeriods = List.of( PeriodType.getPeriodFromIsoString( "19990101" ) );
 
     /**
      * For predictors, a value map from item to value, for each of the periods
@@ -152,4 +150,13 @@ public class ExpressionParams
      */
     @Builder.Default
     private MapMap<Period, DimensionalItemObject, Object> periodValueMap = new MapMap<>();
+
+    // -------------------------------------------------------------------------
+    // Logic
+    // -------------------------------------------------------------------------
+
+    public DataType getDataType()
+    {
+        return firstNonNull( dataType, parseType.getDataType() );
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -64,14 +64,14 @@ public class ExpressionParams
      */
     @ToString.Include
     @EqualsAndHashCode.Include
-    private String expression;
+    private final String expression;
 
     /**
      * The type of expression to parse (Indicator, Predictor, etc.)
      */
     @ToString.Include
     @EqualsAndHashCode.Include
-    private ParseType parseType;
+    private final ParseType parseType;
 
     /**
      * The expected return data type (often but not always determined by the
@@ -79,21 +79,21 @@ public class ExpressionParams
      */
     @ToString.Include
     @EqualsAndHashCode.Include
-    private DataType dataType;
+    private final DataType dataType;
 
     /**
      * A map from a parsed {@see DimensionalItemId} to its equivalent
      * {@see DimensionalItemObject}
      */
     @Builder.Default
-    private Map<DimensionalItemId, DimensionalItemObject> itemMap = new HashMap<>();
+    private final Map<DimensionalItemId, DimensionalItemObject> itemMap = new HashMap<>();
 
     /**
      * A map from a {@see DimensionalItemObject} to its value to use in
      * evaluating the expression
      */
     @Builder.Default
-    private Map<DimensionalItemObject, Object> valueMap = new HashMap<>();
+    private final Map<DimensionalItemObject, Object> valueMap = new HashMap<>();
 
     /**
      * Map of organisation unit counts to use in evaluating the expression
@@ -101,14 +101,14 @@ public class ExpressionParams
     @ToString.Include
     @EqualsAndHashCode.Include
     @Builder.Default
-    private Map<String, Integer> orgUnitCountMap = new HashMap<>();
+    private final Map<String, Integer> orgUnitCountMap = new HashMap<>();
 
     /**
      * Map of organisation unit groups to use for testing organisation unit
      * group membership
      */
     @Builder.Default
-    private Map<String, OrganisationUnitGroup> orgUnitGroupMap = new HashMap<>();
+    private final Map<String, OrganisationUnitGroup> orgUnitGroupMap = new HashMap<>();
 
     /**
      * The number of calendar days to be used in evaluating the expression.
@@ -117,7 +117,7 @@ public class ExpressionParams
     @ToString.Include
     @EqualsAndHashCode.Include
     @Builder.Default
-    private Integer days = 0;
+    private final Integer days = 0;
 
     /**
      * The missing value strategy (what to do if data values are missing)
@@ -125,14 +125,14 @@ public class ExpressionParams
     @ToString.Include
     @EqualsAndHashCode.Include
     @Builder.Default
-    private MissingValueStrategy missingValueStrategy = NEVER_SKIP;
+    private final MissingValueStrategy missingValueStrategy = NEVER_SKIP;
 
     /**
      * The current organisation unit the expression is being evaluated for
      */
     @ToString.Include
     @EqualsAndHashCode.Include
-    private OrganisationUnit orgUnit;
+    private final OrganisationUnit orgUnit;
 
     /**
      * For predictors, a list of periods in which we will look for sampled data.
@@ -142,14 +142,14 @@ public class ExpressionParams
     @ToString.Include
     @EqualsAndHashCode.Include
     @Builder.Default
-    private List<Period> samplePeriods = List.of( PeriodType.getPeriodFromIsoString( "19990101" ) );
+    private final List<Period> samplePeriods = List.of( PeriodType.getPeriodFromIsoString( "19990101" ) );
 
     /**
      * For predictors, a value map from item to value, for each of the periods
      * in which data is present
      */
     @Builder.Default
-    private MapMap<Period, DimensionalItemObject, Object> periodValueMap = new MapMap<>();
+    private final MapMap<Period, DimensionalItemObject, Object> periodValueMap = new MapMap<>();
 
     // -------------------------------------------------------------------------
     // Logic

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -263,10 +263,10 @@ public interface ExpressionService
     /**
      * Generates the calculated value for an expression.
      *
-     * @param exParams the expression parameters.
+     * @param params the expression parameters.
      * @return the calculated value.
      */
-    Object getExpressionValue( ExpressionParams exParams );
+    Object getExpressionValue( ExpressionParams params );
 
     // -------------------------------------------------------------------------
     // Gets a (possibly cached) constant map

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -126,7 +126,7 @@ public interface ExpressionService
      * @param indicators the set of indicators.
      * @return a Set of OrganisationUnitGroups.
      */
-    Set<OrganisationUnitGroup> getIndicatorOrgUnitGroups( Collection<Indicator> indicators );
+    List<OrganisationUnitGroup> getOrgUnitGroupCountGroups( Collection<Indicator> indicators );
 
     /**
      * Generates the calculated value for the given parameters based on the
@@ -136,13 +136,12 @@ public interface ExpressionService
      * @param periods a List of periods for which to calculate the value.
      * @param itemMap map of dimensional item id to object in expression.
      * @param valueMap the map of data values.
-     * @param constantMap the map of constants.
      * @param orgUnitCountMap the map of organisation unit group member counts.
      * @return the calculated value as a double.
      */
     IndicatorValue getIndicatorValueObject( Indicator indicator, List<Period> periods,
         Map<DimensionalItemId, DimensionalItemObject> itemMap, Map<DimensionalItemObject, Object> valueMap,
-        Map<String, Constant> constantMap, Map<String, Integer> orgUnitCountMap );
+        Map<String, Integer> orgUnitCountMap );
 
     /**
      * Substitutes any constants and org unit group member counts in the
@@ -249,15 +248,6 @@ public interface ExpressionService
     Set<DimensionalItemId> getExpressionDimensionalItemIds( String expression, ParseType parseType );
 
     /**
-     * Returns all OrganisationUnitGroups in the given expression.
-     *
-     * @param expression the expression string.
-     * @param parseType the type of expression to parse.
-     * @return a Set of OrganisationUnitGroups in the expression string.
-     */
-    Set<OrganisationUnitGroup> getExpressionOrgUnitGroups( String expression, ParseType parseType );
-
-    /**
      * Returns set of all OrganisationUnitGroup UIDs in the given expression.
      *
      * @param expression the expression string.
@@ -277,4 +267,15 @@ public interface ExpressionService
      * @return the calculated value.
      */
     Object getExpressionValue( ExpressionParams exParams );
+
+    // -------------------------------------------------------------------------
+    // Gets a (possibly cached) constant map
+    // -------------------------------------------------------------------------
+
+    /**
+     * Gets the (possibly cached) constant map.
+     *
+     * @return the constant map.
+     */
+    Map<String, Constant> getConstantMap();
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -109,7 +109,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -140,7 +139,6 @@ import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.ExecutionPlan;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.ReportingRateMetric;
-import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementOperand.TotalType;
@@ -262,8 +260,6 @@ public class DataHandler
                 ? dataSourceParams.getTypedFilterPeriods()
                 : dataSourceParams.getStartEndDatesToSingleList();
 
-            Map<String, Constant> constantMap = constantService.getConstantMap();
-
             // -----------------------------------------------------------------
             // Get indicator values
             // -----------------------------------------------------------------
@@ -285,7 +281,7 @@ public class DataHandler
             {
                 for ( List<DimensionItem> dimensionItems : dimensionItemPermutations )
                 {
-                    IndicatorValue value = getIndicatorValue( filterPeriods, constantMap, itemMap,
+                    IndicatorValue value = getIndicatorValue( filterPeriods, itemMap,
                         permutationOrgUnitTargetMap, permutationDimensionItemValueMap, indicator, dimensionItems );
 
                     addIndicatorValuesToGrid( params, grid, dataSourceParams, indicator, dimensionItems, value );
@@ -299,7 +295,6 @@ public class DataHandler
      * find the respective IndicatorValue.
      *
      * @param filterPeriods the filter periods.
-     * @param constantMap the current constants map.
      *        See @{{@link ConstantService#getConstantMap()}}.
      * @param permutationOrgUnitTargetMap the org unit permutation map. See
      *        {@link #getOrgUnitTargetMap(DataQueryParams, Collection)}.
@@ -314,7 +309,7 @@ public class DataHandler
      *        {@link DataQueryParams#getDimensionItemPermutations()}.
      * @return the IndicatorValue
      */
-    private IndicatorValue getIndicatorValue( List<Period> filterPeriods, Map<String, Constant> constantMap,
+    private IndicatorValue getIndicatorValue( List<Period> filterPeriods,
         Map<DimensionalItemId, DimensionalItemObject> itemMap,
         Map<String, Map<String, Integer>> permutationOrgUnitTargetMap,
         Map<String, List<DimensionItemObjectValue>> permutationDimensionItemValueMap,
@@ -337,7 +332,7 @@ public class DataHandler
             : null;
 
         return expressionService.getIndicatorValueObject( indicator, periods, itemMap,
-            convertToDimItemValueMap( values ), constantMap, orgUnitCountMap );
+            convertToDimItemValueMap( values ), orgUnitCountMap );
     }
 
     /**
@@ -872,7 +867,7 @@ public class DataHandler
     private Map<String, Map<String, Integer>> getOrgUnitTargetMap( DataQueryParams params,
         Collection<Indicator> indicators )
     {
-        Set<OrganisationUnitGroup> orgUnitGroups = expressionService.getIndicatorOrgUnitGroups( indicators );
+        List<OrganisationUnitGroup> orgUnitGroups = expressionService.getOrgUnitGroupCountGroups( indicators );
 
         if ( orgUnitGroups.isEmpty() )
         {
@@ -881,8 +876,7 @@ public class DataHandler
 
         DataQueryParams orgUnitTargetParams = newBuilder( params )
             .pruneToDimensionType( ORGANISATION_UNIT )
-            .addDimension( new BaseDimensionalObject( ORGUNIT_GROUP_DIM_ID,
-                ORGANISATION_UNIT_GROUP, new ArrayList<DimensionalItemObject>( orgUnitGroups ) ) )
+            .addDimension( new BaseDimensionalObject( ORGUNIT_GROUP_DIM_ID, ORGANISATION_UNIT_GROUP, orgUnitGroups ) )
             .withOutputFormat( ANALYTICS )
             .withSkipPartitioning( true )
             .withSkipDataDimensionValidation( true )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -367,7 +367,7 @@ public class DefaultExpressionService
 
         Integer days = periods != null ? getDaysFromPeriods( periods ) : null;
 
-        ExpressionParams exParams = ExpressionParams.builder()
+        ExpressionParams params = ExpressionParams.builder()
             .parseType( INDICATOR_EXPRESSION )
             .itemMap( itemMap )
             .valueMap( valueMap )
@@ -376,10 +376,10 @@ public class DefaultExpressionService
             .missingValueStrategy( SKIP_IF_ALL_VALUES_MISSING )
             .build();
 
-        Double denominatorValue = castDouble( getExpressionValue( exParams.toBuilder()
+        Double denominatorValue = castDouble( getExpressionValue( params.toBuilder()
             .expression( indicator.getDenominator() ).build() ) );
 
-        Double numeratorValue = castDouble( getExpressionValue( exParams.toBuilder()
+        Double numeratorValue = castDouble( getExpressionValue( params.toBuilder()
             .expression( indicator.getNumerator() ).build() ) );
 
         if ( denominatorValue != null && denominatorValue != 0d && numeratorValue != null )
@@ -559,12 +559,12 @@ public class DefaultExpressionService
             return Collections.emptySet();
         }
 
-        ExpressionInfo exInfo = getExpressionInfo( ExpressionParams.builder()
+        ExpressionInfo info = getExpressionInfo( ExpressionParams.builder()
             .expression( expression )
             .parseType( parseType )
             .build() );
 
-        return exInfo.getOrgUnitGroupIds();
+        return info.getOrgUnitGroupIds();
     }
 
     // -------------------------------------------------------------------------
@@ -572,28 +572,28 @@ public class DefaultExpressionService
     // -------------------------------------------------------------------------
 
     @Override
-    public Object getExpressionValue( ExpressionParams exParams )
+    public Object getExpressionValue( ExpressionParams params )
     {
-        if ( isEmpty( exParams.getExpression() ) )
+        if ( isEmpty( params.getExpression() ) )
         {
             return null;
         }
 
-        CommonExpressionVisitor visitor = newVisitor( ITEM_EVALUATE, exParams );
+        CommonExpressionVisitor visitor = newVisitor( ITEM_EVALUATE, params );
 
-        Object value = visit( exParams.getExpression(), exParams.getDataType(), visitor, true );
+        Object value = visit( params.getExpression(), params.getDataType(), visitor, true );
 
-        ExpressionState exState = visitor.getExState();
+        ExpressionState state = visitor.getState();
 
-        int itemsFound = exState.getItemsFound();
-        int itemValuesFound = exState.getItemValuesFound();
+        int itemsFound = state.getItemsFound();
+        int itemValuesFound = state.getItemValuesFound();
 
-        if ( exState.isUnprotectedNullDateFound() )
+        if ( state.isUnprotectedNullDateFound() )
         {
             return null;
         }
 
-        switch ( exParams.getMissingValueStrategy() )
+        switch ( params.getMissingValueStrategy() )
         {
         case SKIP_IF_ANY_VALUE_MISSING:
             if ( itemValuesFound < itemsFound )
@@ -610,7 +610,7 @@ public class DefaultExpressionService
         case NEVER_SKIP:
             if ( value == null )
             {
-                switch ( exParams.getDataType() )
+                switch ( params.getDataType() )
                 {
                 case NUMERIC:
                     return 0d;
@@ -652,12 +652,12 @@ public class DefaultExpressionService
         }
         try
         {
-            ExpressionInfo exInfo = getExpressionInfo( ExpressionParams.builder()
+            ExpressionInfo info = getExpressionInfo( ExpressionParams.builder()
                 .expression( expression )
                 .parseType( INDICATOR_EXPRESSION )
                 .build() );
 
-            return exInfo.getOrgUnitGroupCountIds();
+            return info.getOrgUnitGroupCountIds();
         }
         catch ( ParserException e )
         {
@@ -680,31 +680,31 @@ public class DefaultExpressionService
             return;
         }
 
-        ExpressionInfo exInfo = getExpressionInfo( ExpressionParams.builder()
+        ExpressionInfo info = getExpressionInfo( ExpressionParams.builder()
             .expression( expression )
             .parseType( parseType )
             .build() );
 
-        itemIds.addAll( exInfo.getItemIds() );
-        sampleItemIds.addAll( exInfo.getSampleItemIds() );
+        itemIds.addAll( info.getItemIds() );
+        sampleItemIds.addAll( info.getSampleItemIds() );
     }
 
     /**
      * Gets the information that we need from an expression
      */
-    private ExpressionInfo getExpressionInfo( ExpressionParams exParams )
+    private ExpressionInfo getExpressionInfo( ExpressionParams params )
     {
-        CommonExpressionVisitor visitor = newVisitor( ITEM_GET_EXPRESSION_INFO, exParams );
+        CommonExpressionVisitor visitor = newVisitor( ITEM_GET_EXPRESSION_INFO, params );
 
-        visit( exParams.getExpression(), exParams.getDataType(), visitor, true );
+        visit( params.getExpression(), params.getDataType(), visitor, true );
 
-        return visitor.getExInfo();
+        return visitor.getInfo();
     }
 
     /**
      * Creates a new {@see CommonExpressionVisitor}
      */
-    private CommonExpressionVisitor newVisitor( ExpressionItemMethod itemMethod, ExpressionParams exParams )
+    private CommonExpressionVisitor newVisitor( ExpressionItemMethod itemMethod, ExpressionParams params )
     {
         return CommonExpressionVisitor.builder()
             .idObjectManager( idObjectManager )
@@ -712,9 +712,9 @@ public class DefaultExpressionService
             .statementBuilder( statementBuilder )
             .i18n( i18nManager.getI18n() )
             .constantMap( getConstantMap() )
-            .itemMap( PARSE_TYPE_EXPRESSION_ITEMS.get( exParams.getParseType() ) )
+            .itemMap( PARSE_TYPE_EXPRESSION_ITEMS.get( params.getParseType() ) )
             .itemMethod( itemMethod )
-            .exParams( exParams )
+            .params( params )
             .build();
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
@@ -54,12 +54,12 @@ public class DimItemDataElementAndOperand
                 ctx.uid0.getText(),
                 ctx.uid1 == null ? null : ctx.uid1.getText(),
                 ctx.uid2 == null ? null : ctx.uid2.getText(),
-                ctx.getText(), visitor.getExState().getQueryMods() );
+                ctx.getText(), visitor.getState().getQueryMods() );
         }
         else
         {
             return new DimensionalItemId( DATA_ELEMENT,
-                ctx.uid0.getText(), visitor.getExState().getQueryMods() );
+                ctx.uid0.getText(), visitor.getState().getQueryMods() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
@@ -54,12 +54,12 @@ public class DimItemDataElementAndOperand
                 ctx.uid0.getText(),
                 ctx.uid1 == null ? null : ctx.uid1.getText(),
                 ctx.uid2 == null ? null : ctx.uid2.getText(),
-                ctx.getText(), visitor.getQueryMods() );
+                ctx.getText(), visitor.getExState().getQueryMods() );
         }
         else
         {
             return new DimensionalItemId( DATA_ELEMENT,
-                ctx.uid0.getText(), visitor.getQueryMods() );
+                ctx.uid0.getText(), visitor.getExState().getQueryMods() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemIndicator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemIndicator.java
@@ -45,6 +45,6 @@ public class DimItemIndicator
     public DimensionalItemId getDimensionalItemId( ExprContext ctx,
         CommonExpressionVisitor visitor )
     {
-        return new DimensionalItemId( INDICATOR, ctx.uid0.getText(), visitor.getQueryMods() );
+        return new DimensionalItemId( INDICATOR, ctx.uid0.getText(), visitor.getExState().getQueryMods() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemIndicator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemIndicator.java
@@ -45,6 +45,6 @@ public class DimItemIndicator
     public DimensionalItemId getDimensionalItemId( ExprContext ctx,
         CommonExpressionVisitor visitor )
     {
-        return new DimensionalItemId( INDICATOR, ctx.uid0.getText(), visitor.getExState().getQueryMods() );
+        return new DimensionalItemId( INDICATOR, ctx.uid0.getText(), visitor.getState().getQueryMods() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimensionalItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimensionalItem.java
@@ -68,7 +68,7 @@ public abstract class DimensionalItem
     @Override
     public final Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getExInfo().getItemIds().add( getDimensionalItemId( ctx, visitor ) );
+        visitor.getInfo().getItemIds().add( getDimensionalItemId( ctx, visitor ) );
 
         return DOUBLE_VALUE_IF_NULL;
     }
@@ -78,13 +78,13 @@ public abstract class DimensionalItem
     {
         DimensionalItemId itemId = getDimensionalItemId( ctx, visitor );
 
-        DimensionalItemObject item = visitor.getExParams().getItemMap().get( itemId );
+        DimensionalItemObject item = visitor.getParams().getItemMap().get( itemId );
 
         Object value = (item != null)
-            ? visitor.getExParams().getValueMap().get( item )
+            ? visitor.getParams().getValueMap().get( item )
             : null;
 
-        return visitor.getExState().handleNulls( value, getItemValueType( item ) );
+        return visitor.getState().handleNulls( value, getItemValueType( item ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimensionalItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimensionalItem.java
@@ -66,16 +66,10 @@ public abstract class DimensionalItem
     }
 
     @Override
-    public final Object getItemId( ExprContext ctx, CommonExpressionVisitor visitor )
+    public final Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getItemIds().add( getDimensionalItemId( ctx, visitor ) );
+        visitor.getExInfo().getItemIds().add( getDimensionalItemId( ctx, visitor ) );
 
-        return DOUBLE_VALUE_IF_NULL;
-    }
-
-    @Override
-    public final Object getOrgUnitGroup( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
         return DOUBLE_VALUE_IF_NULL;
     }
 
@@ -84,13 +78,13 @@ public abstract class DimensionalItem
     {
         DimensionalItemId itemId = getDimensionalItemId( ctx, visitor );
 
-        DimensionalItemObject item = visitor.getDimItemMap().get( itemId );
+        DimensionalItemObject item = visitor.getExParams().getItemMap().get( itemId );
 
         Object value = (item != null)
-            ? visitor.getItemValueMap().get( item )
+            ? visitor.getExParams().getValueMap().get( item )
             : null;
 
-        return visitor.handleNulls( value, getItemValueType( item ) );
+        return visitor.getExState().handleNulls( value, getItemValueType( item ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemDays.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemDays.java
@@ -53,7 +53,7 @@ public class ItemDays
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        Integer days = visitor.getExParams().getDays();
+        Integer days = visitor.getParams().getDays();
 
         return days == null ? null : Double.valueOf( days );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemDays.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemDays.java
@@ -53,6 +53,8 @@ public class ItemDays
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.getDays();
+        Integer days = visitor.getExParams().getDays();
+
+        return days == null ? null : Double.valueOf( days );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
@@ -62,7 +62,7 @@ public class ItemOrgUnitGroupCount
     @Override
     public Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getExInfo().getOrgUnitGroupCountIds().add( ctx.uid0.getText() );
+        visitor.getInfo().getOrgUnitGroupCountIds().add( ctx.uid0.getText() );
 
         return DOUBLE_VALUE_IF_NULL;
     }
@@ -70,7 +70,7 @@ public class ItemOrgUnitGroupCount
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        Integer count = visitor.getExParams().getOrgUnitCountMap().get( ctx.uid0.getText() );
+        Integer count = visitor.getParams().getOrgUnitCountMap().get( ctx.uid0.getText() );
 
         if ( count == null ) // Shouldn't happen for a valid expression.
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
@@ -46,8 +46,8 @@ public class ItemOrgUnitGroupCount
     @Override
     public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        OrganisationUnitGroup orgUnitGroup = visitor.getOrganisationUnitGroupService()
-            .getOrganisationUnitGroup( ctx.uid0.getText() );
+        OrganisationUnitGroup orgUnitGroup = visitor.getIdObjectManager()
+            .get( OrganisationUnitGroup.class, ctx.uid0.getText() );
 
         if ( orgUnitGroup == null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemOrgUnitGroupCount.java
@@ -40,7 +40,7 @@ import org.hisp.dhis.parser.expression.ExpressionItem;
  *
  * @author Jim Grace
  */
-public class ItemOrgUnitGroup
+public class ItemOrgUnitGroupCount
     implements ExpressionItem
 {
     @Override
@@ -60,9 +60,9 @@ public class ItemOrgUnitGroup
     }
 
     @Override
-    public Object getOrgUnitGroup( ExprContext ctx, CommonExpressionVisitor visitor )
+    public Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getOrgUnitGroupIds().add( ctx.uid0.getText() );
+        visitor.getExInfo().getOrgUnitGroupCountIds().add( ctx.uid0.getText() );
 
         return DOUBLE_VALUE_IF_NULL;
     }
@@ -70,7 +70,7 @@ public class ItemOrgUnitGroup
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        Integer count = visitor.getOrgUnitCountMap().get( ctx.uid0.getText() );
+        Integer count = visitor.getExParams().getOrgUnitCountMap().get( ctx.uid0.getText() );
 
         if ( count == null ) // Shouldn't happen for a valid expression.
         {
@@ -78,18 +78,5 @@ public class ItemOrgUnitGroup
         }
 
         return count.doubleValue();
-    }
-
-    @Override
-    public Object regenerate( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        Integer count = visitor.getOrgUnitCountMap().get( ctx.uid0.getText() );
-
-        if ( count == null )
-        {
-            return ctx.getText();
-        }
-
-        return count.toString();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
@@ -65,11 +65,13 @@ public class FunctionOrgUnitAncestor
     @Override
     public Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        if ( visitor.getOrganizationUnit() != null )
+        OrganisationUnit orgUnit = visitor.getExParams().getOrgUnit();
+
+        if ( orgUnit != null )
         {
             for ( TerminalNode uid : ctx.UID() )
             {
-                if ( visitor.getOrganizationUnit().getPath().contains( uid.getText() + "/" ) )
+                if ( orgUnit.getPath().contains( uid.getText() + "/" ) )
                 {
                     return true;
                 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
@@ -65,7 +65,7 @@ public class FunctionOrgUnitAncestor
     @Override
     public Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        OrganisationUnit orgUnit = visitor.getExParams().getOrgUnit();
+        OrganisationUnit orgUnit = visitor.getParams().getOrgUnit();
 
         if ( orgUnit != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitAncestor.java
@@ -49,7 +49,7 @@ public class FunctionOrgUnitAncestor
     {
         for ( TerminalNode uid : ctx.UID() )
         {
-            OrganisationUnit orgUnit = visitor.getOrganisationUnitService().getOrganisationUnit( uid.getText() );
+            OrganisationUnit orgUnit = visitor.getIdObjectManager().get( OrganisationUnit.class, uid.getText() );
 
             if ( orgUnit == null )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
@@ -66,9 +67,9 @@ public class FunctionOrgUnitGroup
     }
 
     @Override
-    public Object getOrgUnitGroup( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    public Object getExpressionInfo( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getOrgUnitGroupIds().addAll(
+        visitor.getExInfo().getOrgUnitGroupIds().addAll(
             ctx.UID().stream()
                 .map( TerminalNode::getText )
                 .collect( Collectors.toList() ) );
@@ -79,13 +80,15 @@ public class FunctionOrgUnitGroup
     @Override
     public Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        if ( visitor.getOrganizationUnit() != null )
+        ExpressionParams exParams = visitor.getExParams();
+
+        if ( exParams.getOrgUnit() != null )
         {
             for ( TerminalNode uid : ctx.UID() )
             {
-                OrganisationUnitGroup oug = visitor.getOrgUnitGroupMap().get( uid.getText() );
+                OrganisationUnitGroup oug = exParams.getOrgUnitGroupMap().get( uid.getText() );
 
-                if ( oug != null && oug.getMembers().contains( visitor.getOrganizationUnit() ) )
+                if ( oug != null && oug.getMembers().contains( exParams.getOrgUnit() ) )
                 {
                     return true;
                 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
@@ -69,7 +69,7 @@ public class FunctionOrgUnitGroup
     @Override
     public Object getExpressionInfo( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        visitor.getExInfo().getOrgUnitGroupIds().addAll(
+        visitor.getInfo().getOrgUnitGroupIds().addAll(
             ctx.UID().stream()
                 .map( TerminalNode::getText )
                 .collect( Collectors.toList() ) );
@@ -80,15 +80,15 @@ public class FunctionOrgUnitGroup
     @Override
     public Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        ExpressionParams exParams = visitor.getExParams();
+        ExpressionParams params = visitor.getParams();
 
-        if ( exParams.getOrgUnit() != null )
+        if ( params.getOrgUnit() != null )
         {
             for ( TerminalNode uid : ctx.UID() )
             {
-                OrganisationUnitGroup oug = exParams.getOrgUnitGroupMap().get( uid.getText() );
+                OrganisationUnitGroup oug = params.getOrgUnitGroupMap().get( uid.getText() );
 
-                if ( oug != null && oug.getMembers().contains( exParams.getOrgUnit() ) )
+                if ( oug != null && oug.getMembers().contains( params.getOrgUnit() ) )
                 {
                     return true;
                 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionOrgUnitGroup.java
@@ -52,8 +52,8 @@ public class FunctionOrgUnitGroup
     {
         for ( TerminalNode uid : ctx.UID() )
         {
-            OrganisationUnitGroup orgUnitGroup = visitor.getOrganisationUnitGroupService()
-                .getOrganisationUnitGroup( uid.getText() );
+            OrganisationUnitGroup orgUnitGroup = visitor.getIdObjectManager()
+                .get( OrganisationUnitGroup.class, uid.getText() );
 
             if ( orgUnitGroup == null )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -384,14 +384,14 @@ public class DefaultProgramIndicatorService
     {
         Set<String> uids = getDataElementAndAttributeIdentifiers( expression, programIndicator.getAnalyticsType() );
 
-        ProgramExpressionParams progExParams = ProgramExpressionParams.builder()
+        ProgramExpressionParams params = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
             .dataElementAndAttributeIdentifiers( uids )
             .build();
 
-        CommonExpressionVisitor visitor = newVisitor( ITEM_GET_SQL, progExParams );
+        CommonExpressionVisitor visitor = newVisitor( ITEM_GET_SQL, params );
 
         visitor.setExpressionLiteral( new SqlLiteral() );
 
@@ -484,7 +484,7 @@ public class DefaultProgramIndicatorService
     // Supportive methods
     // -------------------------------------------------------------------------
 
-    private CommonExpressionVisitor newVisitor( ExpressionItemMethod itemMethod, ProgramExpressionParams progExParams )
+    private CommonExpressionVisitor newVisitor( ExpressionItemMethod itemMethod, ProgramExpressionParams params )
     {
         return CommonExpressionVisitor.builder()
             .idObjectManager( idObjectManager )
@@ -496,7 +496,7 @@ public class DefaultProgramIndicatorService
             .constantMap( expressionService.getConstantMap() )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )
-            .progExParams( progExParams )
+            .progParams( params )
             .build();
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
@@ -54,17 +54,10 @@ public abstract class ProgramExpressionItem
     implements ExpressionItem
 {
     @Override
-    public final Object getItemId( ExprContext ctx, CommonExpressionVisitor visitor )
+    public final Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         throw new ParserExceptionWithoutContext(
-            "Internal parsing error: getItemId called for program indicator item " + ctx.getText() );
-    }
-
-    @Override
-    public final Object getOrgUnitGroup( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        throw new ParserExceptionWithoutContext(
-            "Internal parsing error: getOrgUnitGroup called for program indicator item " + ctx.getText() );
+            "Internal parsing error: getExpressionInfo called for program indicator item " + ctx.getText() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
@@ -67,7 +67,7 @@ public class ProgramItemAttribute
 
         String column = visitor.getStatementBuilder().columnQuote( attributeId );
 
-        if ( visitor.getReplaceNulls() )
+        if ( visitor.getExState().isReplaceNulls() )
         {
             TrackedEntityAttribute attribute = visitor.getAttributeService().getTrackedEntityAttribute( attributeId );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
@@ -68,7 +68,7 @@ public class ProgramItemAttribute
 
         String column = visitor.getStatementBuilder().columnQuote( attributeId );
 
-        if ( visitor.getExState().isReplaceNulls() )
+        if ( visitor.getState().isReplaceNulls() )
         {
             TrackedEntityAttribute attribute = visitor.getIdObjectManager()
                 .get( TrackedEntityAttribute.class, attributeId );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
@@ -48,7 +48,8 @@ public class ProgramItemAttribute
     {
         String attributeId = getProgramAttributeId( ctx );
 
-        TrackedEntityAttribute attribute = visitor.getAttributeService().getTrackedEntityAttribute( attributeId );
+        TrackedEntityAttribute attribute = visitor.getIdObjectManager()
+            .get( TrackedEntityAttribute.class, attributeId );
 
         if ( attribute == null )
         {
@@ -69,7 +70,8 @@ public class ProgramItemAttribute
 
         if ( visitor.getExState().isReplaceNulls() )
         {
-            TrackedEntityAttribute attribute = visitor.getAttributeService().getTrackedEntityAttribute( attributeId );
+            TrackedEntityAttribute attribute = visitor.getIdObjectManager()
+                .get( TrackedEntityAttribute.class, attributeId );
 
             if ( attribute == null )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemPsEventdate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemPsEventdate.java
@@ -65,11 +65,11 @@ public class ProgramItemPsEventdate
     @Override
     public final Object getSql( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
             ctx.uid0.getText(), "executiondate",
-            progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-            progExParams.getProgramIndicator() );
+            params.getReportingStartDate(), params.getReportingEndDate(),
+            params.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemPsEventdate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemPsEventdate.java
@@ -27,11 +27,12 @@
  */
 package org.hisp.dhis.program.dataitem;
 
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DATE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DATE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
 import org.hisp.dhis.program.ProgramExpressionItem;
 import org.hisp.dhis.program.ProgramStage;
@@ -64,8 +65,11 @@ public class ProgramItemPsEventdate
     @Override
     public final Object getSql( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
             ctx.uid0.getText(), "executiondate",
-            visitor.getReportingStartDate(), visitor.getReportingEndDate(), visitor.getProgramIndicator() );
+            progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
+            progExParams.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
@@ -63,7 +63,7 @@ public class ProgramItemStageElement
         ProgramStageService stageService = visitor.getProgramStageService();
 
         ProgramStage programStage = stageService.getProgramStage( programStageId );
-        DataElement dataElement = visitor.getDataElementService().getDataElement( dataElementId );
+        DataElement dataElement = visitor.getIdObjectManager().get( DataElement.class, dataElementId );
 
         if ( programStage == null )
         {
@@ -128,7 +128,7 @@ public class ProgramItemStageElement
 
         if ( visitor.getExState().isReplaceNulls() )
         {
-            DataElement dataElement = visitor.getDataElementService().getDataElement( dataElementId );
+            DataElement dataElement = visitor.getIdObjectManager().get( DataElement.class, dataElementId );
 
             if ( dataElement == null )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
@@ -75,7 +75,7 @@ public class ProgramItemStageElement
             throw new ParserExceptionWithoutContext( "Data element " + dataElementId + " not found" );
         }
 
-        if ( isNonDefaultStageOffset( visitor.getExState().getStageOffset() )
+        if ( isNonDefaultStageOffset( visitor.getState().getStageOffset() )
             && !isRepeatableStage( stageService, programStageId ) )
         {
             throw new ParserException( getErrorMessage( programStageId ) );
@@ -98,9 +98,9 @@ public class ProgramItemStageElement
 
         String dataElementId = ctx.uid1.getText();
 
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
-        int stageOffset = visitor.getExState().getStageOffset();
+        int stageOffset = visitor.getState().getStageOffset();
 
         String column;
 
@@ -111,8 +111,8 @@ public class ProgramItemStageElement
                 column = visitor.getStatementBuilder().getProgramIndicatorEventColumnSql( programStageId,
                     Integer.valueOf( stageOffset ).toString(),
                     SqlUtils.quote( dataElementId ),
-                    progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-                    progExParams.getProgramIndicator() );
+                    params.getReportingStartDate(), params.getReportingEndDate(),
+                    params.getProgramIndicator() );
             }
             else
             {
@@ -122,11 +122,11 @@ public class ProgramItemStageElement
         else
         {
             column = visitor.getStatementBuilder().getProgramIndicatorDataValueSelectSql(
-                programStageId, dataElementId, progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-                progExParams.getProgramIndicator() );
+                programStageId, dataElementId, params.getReportingStartDate(), params.getReportingEndDate(),
+                params.getProgramIndicator() );
         }
 
-        if ( visitor.getExState().isReplaceNulls() )
+        if ( visitor.getState().isReplaceNulls() )
         {
             DataElement dataElement = visitor.getIdObjectManager().get( DataElement.class, dataElementId );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.program.ProgramExpressionItem;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
@@ -74,7 +75,7 @@ public class ProgramItemStageElement
             throw new ParserExceptionWithoutContext( "Data element " + dataElementId + " not found" );
         }
 
-        if ( isNonDefaultStageOffset( visitor.getStageOffset() )
+        if ( isNonDefaultStageOffset( visitor.getExState().getStageOffset() )
             && !isRepeatableStage( stageService, programStageId ) )
         {
             throw new ParserException( getErrorMessage( programStageId ) );
@@ -97,7 +98,9 @@ public class ProgramItemStageElement
 
         String dataElementId = ctx.uid1.getText();
 
-        int stageOffset = visitor.getStageOffset();
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
+        int stageOffset = visitor.getExState().getStageOffset();
 
         String column;
 
@@ -108,7 +111,8 @@ public class ProgramItemStageElement
                 column = visitor.getStatementBuilder().getProgramIndicatorEventColumnSql( programStageId,
                     Integer.valueOf( stageOffset ).toString(),
                     SqlUtils.quote( dataElementId ),
-                    visitor.getReportingStartDate(), visitor.getReportingEndDate(), visitor.getProgramIndicator() );
+                    progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
+                    progExParams.getProgramIndicator() );
             }
             else
             {
@@ -118,11 +122,11 @@ public class ProgramItemStageElement
         else
         {
             column = visitor.getStatementBuilder().getProgramIndicatorDataValueSelectSql(
-                programStageId, dataElementId, visitor.getReportingStartDate(), visitor.getReportingEndDate(),
-                visitor.getProgramIndicator() );
+                programStageId, dataElementId, progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
+                progExParams.getProgramIndicator() );
         }
 
-        if ( visitor.getReplaceNulls() )
+        if ( visitor.getExState().isReplaceNulls() )
         {
             DataElement dataElement = visitor.getDataElementService().getDataElement( dataElementId );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Condition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Condition.java
@@ -64,11 +64,11 @@ public class D2Condition
     {
         String testExpression = trimQuotes( ctx.stringLiteral().getText() );
 
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
         String testSql = visitor.getProgramIndicatorService().getAnalyticsSql( testExpression,
-            progExParams.getProgramIndicator(), progExParams.getReportingStartDate(),
-            progExParams.getReportingEndDate() );
+            params.getProgramIndicator(), params.getReportingStartDate(),
+            params.getReportingEndDate() );
 
         String valueIfTrue = visitor.castStringVisit( ctx.expr( 0 ) );
         String valueIfFalse = visitor.castStringVisit( ctx.expr( 1 ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Condition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Condition.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.antlr.AntlrParserUtils.trimQuotes;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.program.ProgramExpressionItem;
 
 /**
@@ -63,8 +64,11 @@ public class D2Condition
     {
         String testExpression = trimQuotes( ctx.stringLiteral().getText() );
 
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
         String testSql = visitor.getProgramIndicatorService().getAnalyticsSql( testExpression,
-            visitor.getProgramIndicator(), visitor.getReportingStartDate(), visitor.getReportingEndDate() );
+            progExParams.getProgramIndicator(), progExParams.getReportingStartDate(),
+            progExParams.getReportingEndDate() );
 
         String valueIfTrue = visitor.castStringVisit( ctx.expr( 0 ) );
         String valueIfFalse = visitor.castStringVisit( ctx.expr( 1 ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Count.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Count.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.program.function;
 
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfCondition.java
@@ -29,10 +29,11 @@ package org.hisp.dhis.program.function;
 
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 import static org.hisp.dhis.antlr.AntlrParserUtils.trimQuotes;
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 
 /**
  * Program indicator function: d2 count if condition
@@ -60,9 +61,11 @@ public class D2CountIfCondition
     {
         String conditionExpression = getConditionalExpression( ctx );
 
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
         String conditionSql = visitor.getProgramIndicatorService().getAnalyticsSql(
-            conditionExpression, visitor.getProgramIndicator(),
-            visitor.getReportingStartDate(), visitor.getReportingEndDate() );
+            conditionExpression, progExParams.getProgramIndicator(),
+            progExParams.getReportingStartDate(), progExParams.getReportingEndDate() );
 
         return conditionSql.substring( 1 );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfCondition.java
@@ -61,11 +61,11 @@ public class D2CountIfCondition
     {
         String conditionExpression = getConditionalExpression( ctx );
 
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
         String conditionSql = visitor.getProgramIndicatorService().getAnalyticsSql(
-            conditionExpression, progExParams.getProgramIndicator(),
-            progExParams.getReportingStartDate(), progExParams.getReportingEndDate() );
+            conditionExpression, params.getProgramIndicator(),
+            params.getReportingStartDate(), params.getReportingEndDate() );
 
         return conditionSql.substring( 1 );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfValue.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfValue.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.program.function;
 
 import static org.hisp.dhis.antlr.AntlrParserUtils.castClass;
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2HasValue.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2HasValue.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.program.function;
 
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_BOOLEAN_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_BOOLEAN_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
@@ -52,13 +52,13 @@ public class D2HasValue
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        boolean savedReplaceNulls = visitor.getReplaceNulls();
+        boolean savedReplaceNulls = visitor.getExState().isReplaceNulls();
 
-        visitor.setReplaceNulls( false );
+        visitor.getExState().setReplaceNulls( false );
 
         String argSql = (String) getProgramArgType( ctx ).getSql( ctx, visitor );
 
-        visitor.setReplaceNulls( savedReplaceNulls );
+        visitor.getExState().setReplaceNulls( savedReplaceNulls );
 
         return "(" + argSql + " is not null)";
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2HasValue.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2HasValue.java
@@ -52,13 +52,13 @@ public class D2HasValue
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        boolean savedReplaceNulls = visitor.getExState().isReplaceNulls();
+        boolean savedReplaceNulls = visitor.getState().isReplaceNulls();
 
-        visitor.getExState().setReplaceNulls( false );
+        visitor.getState().setReplaceNulls( false );
 
         String argSql = (String) getProgramArgType( ctx ).getSql( ctx, visitor );
 
-        visitor.getExState().setReplaceNulls( savedReplaceNulls );
+        visitor.getState().setReplaceNulls( savedReplaceNulls );
 
         return "(" + argSql + " is not null)";
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2RelationshipCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2RelationshipCount.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.program.function;
 
 import static org.hisp.dhis.antlr.AntlrParserUtils.trimQuotes;
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2RelationshipCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2RelationshipCount.java
@@ -51,8 +51,8 @@ public class D2RelationshipCount
         {
             String relationshipId = trimQuotes( ctx.QUOTED_UID().getText() );
 
-            RelationshipType relationshipType = visitor.getRelationshipTypeService()
-                .getRelationshipType( relationshipId );
+            RelationshipType relationshipType = visitor.getIdObjectManager()
+                .get( RelationshipType.class, relationshipId );
 
             if ( relationshipType == null )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Zpvc.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Zpvc.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.program.function;
 
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.commons.util.TextUtils;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramBetweenFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramBetweenFunction.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.program.function;
 
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDate;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramCountFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramCountFunction.java
@@ -34,6 +34,7 @@ import java.util.Date;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.program.ProgramExpressionItem;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.dataitem.ProgramItemStageElement;
@@ -51,11 +52,14 @@ public abstract class ProgramCountFunction
     {
         validateCountFunctionArgs( ctx );
 
-        ProgramIndicator pi = visitor.getProgramIndicator();
         StatementBuilder sb = visitor.getStatementBuilder();
 
-        Date startDate = visitor.getReportingStartDate();
-        Date endDate = visitor.getReportingEndDate();
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
+        ProgramIndicator pi = progExParams.getProgramIndicator();
+
+        Date startDate = progExParams.getReportingStartDate();
+        Date endDate = progExParams.getReportingEndDate();
 
         String programStage = ctx.uid0.getText();
         String dataElement = ctx.uid1.getText();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramCountFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramCountFunction.java
@@ -54,12 +54,12 @@ public abstract class ProgramCountFunction
 
         StatementBuilder sb = visitor.getStatementBuilder();
 
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
-        ProgramIndicator pi = progExParams.getProgramIndicator();
+        ProgramIndicator pi = params.getProgramIndicator();
 
-        Date startDate = progExParams.getReportingStartDate();
-        Date endDate = progExParams.getReportingEndDate();
+        Date startDate = params.getReportingStartDate();
+        Date endDate = params.getReportingEndDate();
 
         String programStage = ctx.uid0.getText();
         String dataElement = ctx.uid1.getText();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramMinMaxFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramMinMaxFunction.java
@@ -33,6 +33,7 @@ import java.util.Date;
 
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.program.AnalyticsType;
 import org.hisp.dhis.program.ProgramExpressionItem;
 import org.hisp.dhis.program.ProgramIndicator;
@@ -52,8 +53,11 @@ public abstract class ProgramMinMaxFunction
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        ProgramIndicator pi = visitor.getProgramIndicator();
         StatementBuilder sb = visitor.getStatementBuilder();
+
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
+        ProgramIndicator pi = progExParams.getProgramIndicator();
 
         String columnName = "";
 
@@ -72,8 +76,8 @@ public abstract class ProgramMinMaxFunction
             return columnName;
         }
 
-        Date startDate = visitor.getReportingStartDate();
-        Date endDate = visitor.getReportingEndDate();
+        Date startDate = progExParams.getReportingStartDate();
+        Date endDate = progExParams.getReportingEndDate();
 
         String eventTableName = "analytics_event_" + pi.getProgram().getUid();
         String programStage = ctx.uid0.getText();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramMinMaxFunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/ProgramMinMaxFunction.java
@@ -55,9 +55,9 @@ public abstract class ProgramMinMaxFunction
     {
         StatementBuilder sb = visitor.getStatementBuilder();
 
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
-        ProgramIndicator pi = progExParams.getProgramIndicator();
+        ProgramIndicator pi = params.getProgramIndicator();
 
         String columnName = "";
 
@@ -76,8 +76,8 @@ public abstract class ProgramMinMaxFunction
             return columnName;
         }
 
-        Date startDate = progExParams.getReportingStartDate();
-        Date endDate = progExParams.getReportingEndDate();
+        Date startDate = params.getReportingStartDate();
+        Date endDate = params.getReportingEndDate();
 
         String eventTableName = "analytics_event_" + pi.getProgram().getUid();
         String programStage = ctx.uid0.getText();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/ProgramDateVariable.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/ProgramDateVariable.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.program.variable;
 
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DATE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DATE_VALUE;
 
 /**
  * Program indicator date variable (uses default date for validity checking)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/ProgramDoubleVariable.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/ProgramDoubleVariable.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.program.variable;
 
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 
 /**
  * Program indicator double variable (uses default double for validity checking)

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodEnd.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodEnd.java
@@ -42,6 +42,6 @@ public class vAnalyticsPeriodEnd
     public Object getSql( CommonExpressionVisitor visitor )
     {
         return visitor.getStatementBuilder().encode( DateUtils.getSqlDateString(
-            visitor.getProgExParams().getReportingEndDate() ) );
+            visitor.getProgParams().getReportingEndDate() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodEnd.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodEnd.java
@@ -41,6 +41,7 @@ public class vAnalyticsPeriodEnd
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        return visitor.getStatementBuilder().encode( DateUtils.getSqlDateString( visitor.getReportingEndDate() ) );
+        return visitor.getStatementBuilder().encode( DateUtils.getSqlDateString(
+            visitor.getProgExParams().getReportingEndDate() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodStart.java
@@ -42,6 +42,6 @@ public class vAnalyticsPeriodStart
     public Object getSql( CommonExpressionVisitor visitor )
     {
         return visitor.getStatementBuilder().encode( DateUtils.getSqlDateString(
-            visitor.getProgExParams().getReportingStartDate() ) );
+            visitor.getProgParams().getReportingStartDate() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodStart.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vAnalyticsPeriodStart.java
@@ -41,6 +41,7 @@ public class vAnalyticsPeriodStart
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        return visitor.getStatementBuilder().encode( DateUtils.getSqlDateString( visitor.getReportingStartDate() ) );
+        return visitor.getStatementBuilder().encode( DateUtils.getSqlDateString(
+            visitor.getProgExParams().getReportingStartDate() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program.variable;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.program.AnalyticsType;
 
 /**
@@ -41,11 +42,13 @@ public class vCreationDate
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        if ( AnalyticsType.ENROLLMENT == visitor.getProgramIndicator().getAnalyticsType() )
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
+        if ( AnalyticsType.ENROLLMENT == progExParams.getProgramIndicator().getAnalyticsType() )
         {
             return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-                null, "created", visitor.getReportingStartDate(),
-                visitor.getReportingEndDate(), visitor.getProgramIndicator() );
+                null, "created", progExParams.getReportingStartDate(),
+                progExParams.getReportingEndDate(), progExParams.getProgramIndicator() );
         }
 
         return "created";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vCreationDate.java
@@ -42,13 +42,13 @@ public class vCreationDate
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
-        if ( AnalyticsType.ENROLLMENT == progExParams.getProgramIndicator().getAnalyticsType() )
+        if ( AnalyticsType.ENROLLMENT == params.getProgramIndicator().getAnalyticsType() )
         {
             return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-                null, "created", progExParams.getReportingStartDate(),
-                progExParams.getReportingEndDate(), progExParams.getProgramIndicator() );
+                null, "created", params.getReportingStartDate(),
+                params.getReportingEndDate(), params.getProgramIndicator() );
         }
 
         return "created";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vDueDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vDueDate.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program.variable;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.program.AnalyticsType;
 
 /**
@@ -41,14 +42,16 @@ public class vDueDate
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        if ( AnalyticsType.EVENT == visitor.getProgramIndicator().getAnalyticsType() )
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
+        if ( AnalyticsType.EVENT == progExParams.getProgramIndicator().getAnalyticsType() )
         {
             return "duedate";
         }
 
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-            null, "duedate", visitor.getReportingStartDate(),
-            visitor.getReportingEndDate(), visitor.getProgramIndicator() );
+            null, "duedate", progExParams.getReportingStartDate(),
+            progExParams.getReportingEndDate(), progExParams.getProgramIndicator() );
 
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vDueDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vDueDate.java
@@ -42,16 +42,16 @@ public class vDueDate
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
-        if ( AnalyticsType.EVENT == progExParams.getProgramIndicator().getAnalyticsType() )
+        if ( AnalyticsType.EVENT == params.getProgramIndicator().getAnalyticsType() )
         {
             return "duedate";
         }
 
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-            null, "duedate", progExParams.getReportingStartDate(),
-            progExParams.getReportingEndDate(), progExParams.getProgramIndicator() );
+            null, "duedate", params.getReportingStartDate(),
+            params.getReportingEndDate(), params.getProgramIndicator() );
 
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentCount.java
@@ -41,7 +41,7 @@ public class vEnrollmentCount
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        if ( visitor.getProgExParams().getProgramIndicator().getAnalyticsType().equals( AnalyticsType.ENROLLMENT ) )
+        if ( visitor.getProgParams().getProgramIndicator().getAnalyticsType().equals( AnalyticsType.ENROLLMENT ) )
         {
             return "pi";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentCount.java
@@ -41,7 +41,7 @@ public class vEnrollmentCount
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        if ( visitor.getProgramIndicator().getAnalyticsType().equals( AnalyticsType.ENROLLMENT ) )
+        if ( visitor.getProgExParams().getProgramIndicator().getAnalyticsType().equals( AnalyticsType.ENROLLMENT ) )
         {
             return "pi";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
@@ -47,7 +47,7 @@ public class vEnrollmentStatus
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        if ( AnalyticsType.EVENT == visitor.getProgExParams().getProgramIndicator().getAnalyticsType() )
+        if ( AnalyticsType.EVENT == visitor.getProgParams().getProgramIndicator().getAnalyticsType() )
         {
             return "pistatus";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEnrollmentStatus.java
@@ -47,7 +47,7 @@ public class vEnrollmentStatus
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        if ( AnalyticsType.EVENT == visitor.getProgramIndicator().getAnalyticsType() )
+        if ( AnalyticsType.EVENT == visitor.getProgExParams().getProgramIndicator().getAnalyticsType() )
         {
             return "pistatus";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventDate.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventDate.java
@@ -42,13 +42,13 @@ public class vEventDate
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
-        if ( AnalyticsType.ENROLLMENT == progExParams.getProgramIndicator().getAnalyticsType() )
+        if ( AnalyticsType.ENROLLMENT == params.getProgramIndicator().getAnalyticsType() )
         {
             return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-                null, "executiondate", progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-                progExParams.getProgramIndicator() );
+                null, "executiondate", params.getReportingStartDate(), params.getReportingEndDate(),
+                params.getProgramIndicator() );
         }
 
         return "executiondate";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventStatus.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.program.variable;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 
 /**
  * @author Zubair Asghar
@@ -43,8 +44,10 @@ public class vEventStatus implements ProgramVariable
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
+        ProgramExpressionParams progExParams = visitor.getProgExParams();
+
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-            null, "psistatus", visitor.getReportingStartDate(), visitor.getReportingEndDate(),
-            visitor.getProgramIndicator() );
+            null, "psistatus", progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
+            progExParams.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventStatus.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vEventStatus.java
@@ -44,10 +44,10 @@ public class vEventStatus implements ProgramVariable
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+        ProgramExpressionParams params = visitor.getProgParams();
 
         return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-            null, "psistatus", progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-            progExParams.getProgramIndicator() );
+            null, "psistatus", params.getReportingStartDate(), params.getReportingEndDate(),
+            params.getProgramIndicator() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageId.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageId.java
@@ -47,6 +47,6 @@ public class vProgramStageId
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        return AnalyticsType.EVENT == visitor.getProgramIndicator().getAnalyticsType() ? "ps" : "''";
+        return AnalyticsType.EVENT == visitor.getProgExParams().getProgramIndicator().getAnalyticsType() ? "ps" : "''";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageId.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageId.java
@@ -47,6 +47,6 @@ public class vProgramStageId
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        return AnalyticsType.EVENT == visitor.getProgExParams().getProgramIndicator().getAnalyticsType() ? "ps" : "''";
+        return AnalyticsType.EVENT == visitor.getProgParams().getProgramIndicator().getAnalyticsType() ? "ps" : "''";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageName.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageName.java
@@ -47,7 +47,7 @@ public class vProgramStageName
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        return AnalyticsType.EVENT == visitor.getProgramIndicator().getAnalyticsType()
+        return AnalyticsType.EVENT == visitor.getProgExParams().getProgramIndicator().getAnalyticsType()
             ? "(select name from programstage where uid = ps)"
             : "''";
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageName.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vProgramStageName.java
@@ -47,7 +47,7 @@ public class vProgramStageName
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
-        return AnalyticsType.EVENT == visitor.getProgExParams().getProgramIndicator().getAnalyticsType()
+        return AnalyticsType.EVENT == visitor.getProgParams().getProgramIndicator().getAnalyticsType()
             ? "(select name from programstage where uid = ps)"
             : "''";
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
@@ -43,7 +43,7 @@ public class vValueCount
     {
         String sql = "nullif(cast((";
 
-        for ( String uid : visitor.getProgExParams().getDataElementAndAttributeIdentifiers() )
+        for ( String uid : visitor.getProgParams().getDataElementAndAttributeIdentifiers() )
         {
             sql += "case when " + visitor.getStatementBuilder().columnQuote( uid )
                 + " is not null then 1 else 0 end + ";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
@@ -43,7 +43,7 @@ public class vValueCount
     {
         String sql = "nullif(cast((";
 
-        for ( String uid : visitor.getDataElementAndAttributeIdentifiers() )
+        for ( String uid : visitor.getProgExParams().getDataElementAndAttributeIdentifiers() )
         {
             sql += "case when " + visitor.getStatementBuilder().columnQuote( uid )
                 + " is not null then 1 else 0 end + ";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
@@ -43,7 +43,7 @@ public class vZeroPosValueCount
     {
         String sql = "nullif(cast((";
 
-        for ( String uid : visitor.getProgExParams().getDataElementAndAttributeIdentifiers() )
+        for ( String uid : visitor.getProgParams().getDataElementAndAttributeIdentifiers() )
         {
             sql += "case when " + visitor.getStatementBuilder().columnQuote( uid ) + " >= 0 then 1 else 0 end + ";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
@@ -43,7 +43,7 @@ public class vZeroPosValueCount
     {
         String sql = "nullif(cast((";
 
-        for ( String uid : visitor.getDataElementAndAttributeIdentifiers() )
+        for ( String uid : visitor.getProgExParams().getDataElementAndAttributeIdentifiers() )
         {
             sql += "case when " + visitor.getStatementBuilder().columnQuote( uid ) + " >= 0 then 1 else 0 end + ";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -78,7 +78,6 @@ import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
-import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.i18n.I18nManager;
@@ -88,8 +87,6 @@ import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramIndicator;
@@ -118,16 +115,7 @@ class ExpressionService2Test extends DhisSpringTest
     private HibernateGenericStore<Expression> hibernateGenericStore;
 
     @Mock
-    private DataElementService dataElementService;
-
-    @Mock
     private ConstantService constantService;
-
-    @Mock
-    private OrganisationUnitService organisationUnitService;
-
-    @Mock
-    private OrganisationUnitGroupService organisationUnitGroupService;
 
     @Mock
     private DimensionService dimensionService;
@@ -253,9 +241,8 @@ class ExpressionService2Test extends DhisSpringTest
     @BeforeEach
     public void setUp()
     {
-        target = new DefaultExpressionService( hibernateGenericStore, dataElementService, constantService,
-            organisationUnitService, organisationUnitGroupService, dimensionService, idObjectManager,
-            statementBuilder, i18nManager, cacheProvider );
+        target = new DefaultExpressionService( hibernateGenericStore, constantService, dimensionService,
+            idObjectManager, statementBuilder, i18nManager, cacheProvider );
 
         categoryOptionA = new CategoryOption( "Under 5" );
         categoryOptionB = new CategoryOption( "Over 5" );
@@ -544,9 +531,9 @@ class ExpressionService2Test extends DhisSpringTest
     @Test
     void testGetExpressionDataElements()
     {
-        when( dataElementService.getDataElement( opA.getDimensionItem().split( "\\." )[0] ) )
+        when( idObjectManager.get( DataElement.class, opA.getDimensionItem().split( "\\." )[0] ) )
             .thenReturn( opA.getDataElement() );
-        when( dataElementService.getDataElement( opB.getDimensionItem().split( "\\." )[0] ) )
+        when( idObjectManager.get( DataElement.class, opB.getDimensionItem().split( "\\." )[0] ) )
             .thenReturn( opB.getDataElement() );
         Set<DataElement> dataElements = target.getExpressionDataElements( expressionA, INDICATOR_EXPRESSION );
 
@@ -554,9 +541,9 @@ class ExpressionService2Test extends DhisSpringTest
         assertThat( dataElements, hasItems( opA.getDataElement(), opB.getDataElement() ) );
 
         // Expression G
-        when( dataElementService.getDataElement( deA.getUid() ) ).thenReturn( deA );
-        when( dataElementService.getDataElement( deB.getUid() ) ).thenReturn( deB );
-        when( dataElementService.getDataElement( deC.getUid() ) ).thenReturn( deC );
+        when( idObjectManager.get( DataElement.class, deA.getUid() ) ).thenReturn( deA );
+        when( idObjectManager.get( DataElement.class, deB.getUid() ) ).thenReturn( deB );
+        when( idObjectManager.get( DataElement.class, deC.getUid() ) ).thenReturn( deC );
 
         dataElements = target.getExpressionDataElements( expressionG, INDICATOR_EXPRESSION );
 
@@ -613,7 +600,7 @@ class ExpressionService2Test extends DhisSpringTest
         when( dimensionService.getDataDimensionalItemObject( getId( opE ) ) ).thenReturn( opE );
         when( dimensionService.getDataDimensionalItemObject( getId( opF ) ) ).thenReturn( opF );
         when( dimensionService.getDataDimensionalItemObject( getId( reportingRate ) ) ).thenReturn( reportingRate );
-        when( organisationUnitGroupService.getOrganisationUnitGroup( groupA.getUid() ) ).thenReturn( groupA );
+        when( idObjectManager.get( OrganisationUnitGroup.class, groupA.getUid() ) ).thenReturn( groupA );
 
         assertTrue( target.expressionIsValid( expressionA, VALIDATION_RULE_EXPRESSION ).isValid() );
         assertTrue( target.expressionIsValid( expressionB, VALIDATION_RULE_EXPRESSION ).isValid() );
@@ -682,7 +669,7 @@ class ExpressionService2Test extends DhisSpringTest
         description = target.getExpressionDescription( expressionE, INDICATOR_EXPRESSION );
         assertThat( description, is( opA.getDisplayName() + "*" + constantA.getDisplayName() ) );
 
-        when( organisationUnitGroupService.getOrganisationUnitGroup( groupA.getUid() ) ).thenReturn( groupA );
+        when( idObjectManager.get( OrganisationUnitGroup.class, groupA.getUid() ) ).thenReturn( groupA );
         description = target.getExpressionDescription( expressionH, INDICATOR_EXPRESSION );
         assertThat( description, is( opA.getDisplayName() + "*" + groupA.getDisplayName() ) );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -66,7 +66,6 @@ import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.DimensionItemType;
@@ -82,9 +81,11 @@ import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.indicator.IndicatorValue;
+import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
@@ -120,9 +121,6 @@ class ExpressionService2Test extends DhisSpringTest
     private DataElementService dataElementService;
 
     @Mock
-    private CategoryService categoryService;
-
-    @Mock
     private ConstantService constantService;
 
     @Mock
@@ -136,6 +134,12 @@ class ExpressionService2Test extends DhisSpringTest
 
     @Mock
     private IdentifiableObjectManager idObjectManager;
+
+    @Mock
+    private StatementBuilder statementBuilder;
+
+    @Autowired
+    private I18nManager i18nManager;
 
     @Autowired
     private CacheProvider cacheProvider;
@@ -250,7 +254,8 @@ class ExpressionService2Test extends DhisSpringTest
     public void setUp()
     {
         target = new DefaultExpressionService( hibernateGenericStore, dataElementService, constantService,
-            organisationUnitService, organisationUnitGroupService, dimensionService, idObjectManager, cacheProvider );
+            organisationUnitService, organisationUnitGroupService, dimensionService, idObjectManager,
+            statementBuilder, i18nManager, cacheProvider );
 
         categoryOptionA = new CategoryOption( "Under 5" );
         categoryOptionB = new CategoryOption( "Over 5" );
@@ -406,11 +411,19 @@ class ExpressionService2Test extends DhisSpringTest
             .parseType( INDICATOR_EXPRESSION )
             .itemMap( itemMap )
             .valueMap( valueMap )
-            .constantMap( constantMap() )
             .orgUnitCountMap( orgUnitCountMap )
             .days( days )
             .missingValueStrategy( NEVER_SKIP )
             .build() ) );
+    }
+
+    private void mockConstantService()
+    {
+        when( constantService.getConstantMap() ).thenReturn(
+            ImmutableMap.<String, Constant> builder()
+                .put( constantA.getUid(), constantA )
+                .put( constantB.getUid(), constantB )
+                .build() );
     }
 
     @Test
@@ -436,11 +449,7 @@ class ExpressionService2Test extends DhisSpringTest
     @Test
     void testGetExpressionDimensionalItemIds()
     {
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         Set<DimensionalItemId> itemIds = target.getExpressionDimensionalItemIds( expressionI, INDICATOR_EXPRESSION );
 
@@ -489,11 +498,7 @@ class ExpressionService2Test extends DhisSpringTest
         when( dimensionService.getDataDimensionalItemObjectMap( itemIds ) ).thenReturn( expectedItemMap );
         when( dimensionService.getDataDimensionalItemObjectMap( sampleIds ) ).thenReturn( expectedSampleMap );
 
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         Map<DimensionalItemId, DimensionalItemObject> resultItemMap = new HashMap<>();
         Map<DimensionalItemId, DimensionalItemObject> resultSampleMap = new HashMap<>();
@@ -523,11 +528,7 @@ class ExpressionService2Test extends DhisSpringTest
 
         when( dimensionService.getDataDimensionalItemObjectMap( itemIds ) ).thenReturn( itemMap );
 
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         Indicator indicator = createIndicator( 'A', null );
         indicator.setNumerator( expressionI );
@@ -602,11 +603,7 @@ class ExpressionService2Test extends DhisSpringTest
     @Test
     void testExpressionIsValid()
     {
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
         when( dimensionService.getDataDimensionalItemObject( getId( deA ) ) ).thenReturn( deA );
         when( dimensionService.getDataDimensionalItemObject( getId( deE ) ) ).thenReturn( deE );
         when( dimensionService.getDataDimensionalItemObject( getId( opA ) ) ).thenReturn( opA );
@@ -672,11 +669,7 @@ class ExpressionService2Test extends DhisSpringTest
     @Test
     void testGetExpressionDescription()
     {
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
         when( dimensionService.getDataDimensionalItemObject( getId( opA ) ) ).thenReturn( opA );
         when( dimensionService.getDataDimensionalItemObject( getId( opB ) ) ).thenReturn( opB );
 
@@ -725,6 +718,8 @@ class ExpressionService2Test extends DhisSpringTest
         Map<String, Integer> orgUnitCountMap = new HashMap<>();
         orgUnitCountMap.put( groupA.getUid(), groupA.getMembers().size() );
 
+        mockConstantService();
+
         assertEquals( 46d, exprValue( expressionA, itemMap, valueMap, null, null ), DELTA );
         assertEquals( 17d, exprValue( expressionD, itemMap, valueMap, null, 5 ), DELTA );
         assertEquals( 24d, exprValue( expressionE, itemMap, valueMap, null, null ), DELTA );
@@ -743,11 +738,7 @@ class ExpressionService2Test extends DhisSpringTest
 
         when( dimensionService.getDataDimensionalItemObjectMap( itemIds ) ).thenReturn( expectedItemMap );
 
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         IndicatorType indicatorType = new IndicatorType( "A", 100, false );
 
@@ -764,7 +755,7 @@ class ExpressionService2Test extends DhisSpringTest
         valueMap.put( new DataElementOperand( deA, coc ), 12d );
 
         IndicatorValue value = target.getIndicatorValueObject( indicatorA, Collections.singletonList( period ),
-            itemMap, valueMap, constantMap(), null );
+            itemMap, valueMap, null );
 
         assertNotNull( value );
         assertEquals( 24d, value.getNumeratorValue(), DELTA );
@@ -787,11 +778,7 @@ class ExpressionService2Test extends DhisSpringTest
 
         when( dimensionService.getDataDimensionalItemObjectMap( itemIds ) ).thenReturn( expectedItemMap );
 
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         IndicatorType indicatorType = new IndicatorType( "A", 100, false );
 
@@ -812,7 +799,7 @@ class ExpressionService2Test extends DhisSpringTest
         valueMap.put( new DataElementOperand( deB, cocA ), 10d );
 
         IndicatorValue value = target.getIndicatorValueObject( indicatorB, Collections.singletonList( period ),
-            itemMap, valueMap, constantMap(), null );
+            itemMap, valueMap, null );
 
         assertNotNull( value );
         assertEquals( 36d, value.getNumeratorValue(), DELTA );
@@ -901,17 +888,39 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    void testGetExpressionOrgUnitGroups()
+    void testGetExpressionOrgUnitGroupCountGroups()
     {
-        when( organisationUnitGroupService.getOrganisationUnitGroup( groupA.getUid() ) ).thenReturn( groupA );
-        Set<OrganisationUnitGroup> groups = target.getExpressionOrgUnitGroups( expressionH, INDICATOR_EXPRESSION );
+        IndicatorType indicatorType = new IndicatorType( "A", 100, false );
+
+        Indicator indicatorA = createIndicator( 'A', indicatorType );
+        indicatorA.setAnnualized( true );
+        indicatorA.setNumerator( expressionG );
+        indicatorA.setDenominator( expressionH );
+
+        when( idObjectManager.getByUid( OrganisationUnitGroup.class, Set.of( groupA.getUid() ) ) )
+            .thenReturn( List.of( groupA ) );
+
+        List<OrganisationUnitGroup> groups = target.getOrgUnitGroupCountGroups( List.of( indicatorA ) );
         assertThat( groups, hasSize( 1 ) );
         assertThat( groups, hasItem( groupA ) );
 
-        groups = target.getExpressionOrgUnitGroups( null, INDICATOR_EXPRESSION );
-
+        groups = target.getOrgUnitGroupCountGroups( null );
         assertNotNull( groups );
         assertThat( groups, hasSize( 0 ) );
+    }
+
+    @Test
+    void testGetExpressionOrgUnitGroupIds()
+    {
+        String expression = "if( orgUnit.group(groupUidABC,groupUidDEF), 1, 0)";
+        Set<String> ids = target.getExpressionOrgUnitGroupIds( expression, PREDICTOR_EXPRESSION );
+        assertThat( ids, hasSize( 2 ) );
+        assertThat( ids, hasItem( "groupUidABC" ) );
+        assertThat( ids, hasItem( "groupUidDEF" ) );
+
+        ids = target.getExpressionOrgUnitGroupIds( null, PREDICTOR_EXPRESSION );
+        assertNotNull( ids );
+        assertThat( ids, hasSize( 0 ) );
     }
 
     @Test
@@ -924,11 +933,7 @@ class ExpressionService2Test extends DhisSpringTest
 
         when( dimensionService.getDataDimensionalItemObjectMap( itemIds ) ).thenReturn( expectedItemMap );
 
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         List<Period> periods = new ArrayList<>( 6 );
 
@@ -957,7 +962,7 @@ class ExpressionService2Test extends DhisSpringTest
             .getIndicatorDimensionalItemMap( Arrays.asList( indicatorA ) );
 
         IndicatorValue value = target.getIndicatorValueObject(
-            indicatorA, periods, itemMap, valueMap, constantMap(), null );
+            indicatorA, periods, itemMap, valueMap, null );
 
         assertNotNull( value );
         assertEquals( 24d, value.getNumeratorValue(), DELTA );
@@ -978,11 +983,7 @@ class ExpressionService2Test extends DhisSpringTest
 
         when( dimensionService.getDataDimensionalItemObjectMap( itemIds ) ).thenReturn( expectedItemMap );
 
-        when( constantService.getConstantMap() ).thenReturn(
-            ImmutableMap.<String, Constant> builder()
-                .put( constantA.getUid(), constantA )
-                .put( constantB.getUid(), constantB )
-                .build() );
+        mockConstantService();
 
         IndicatorType indicatorType = new IndicatorType( "A", 100, false );
 
@@ -1002,7 +1003,7 @@ class ExpressionService2Test extends DhisSpringTest
             .getIndicatorDimensionalItemMap( Arrays.asList( indicatorA ) );
 
         IndicatorValue value = target.getIndicatorValueObject(
-            indicatorA, null, itemMap, valueMap, constantMap(), null );
+            indicatorA, null, itemMap, valueMap, null );
 
         assertNotNull( value );
         assertEquals( 24d, value.getNumeratorValue(), DELTA );
@@ -1031,7 +1032,7 @@ class ExpressionService2Test extends DhisSpringTest
             .getIndicatorDimensionalItemMap( Arrays.asList( indicatorA ) );
 
         IndicatorValue value = target.getIndicatorValueObject(
-            indicatorA, null, itemMap, valueMap, constantMap(), null );
+            indicatorA, null, itemMap, valueMap, null );
 
         assertNull( value );
     }
@@ -1054,15 +1055,8 @@ class ExpressionService2Test extends DhisSpringTest
             .getIndicatorDimensionalItemMap( Arrays.asList( indicatorA ) );
 
         IndicatorValue value = target.getIndicatorValueObject(
-            indicatorA, null, itemMap, valueMap, constantMap(), null );
+            indicatorA, null, itemMap, valueMap, null );
 
         assertNull( value );
-    }
-
-    private Map<String, Constant> constantMap()
-    {
-        Map<String, Constant> constantMap = new HashMap<>();
-        constantMap.put( constantA.getUid(), new Constant( "two", 2.0 ) );
-        return constantMap;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -588,7 +588,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        ProgramExpressionParams progExParams = ProgramExpressionParams.builder()
+        ProgramExpressionParams params = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
@@ -604,7 +604,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
             .i18n( new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )
-            .progExParams( progExParams )
+            .progParams( params )
             .build();
 
         visitor.setExpressionLiteral( exprLiteral );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -51,25 +51,20 @@ import org.hisp.dhis.antlr.Parser;
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.antlr.literal.DefaultLiteral;
 import org.hisp.dhis.common.DimensionService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
-import org.hisp.dhis.dataelement.DataElementService;
-import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItemMethod;
 import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.parser.expression.literal.SqlLiteral;
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,28 +102,13 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     private Date endDate = getDate( 2020, 12, 31 );
 
     @Mock
+    private IdentifiableObjectManager idObjectManager;
+
+    @Mock
     private ProgramIndicatorService programIndicatorService;
 
     @Mock
     private ProgramStageService programStageService;
-
-    @Mock
-    private DataElementService dataElementService;
-
-    @Mock
-    private TrackedEntityAttributeService attributeService;
-
-    @Mock
-    private RelationshipTypeService relationshipTypeService;
-
-    @Mock
-    private OrganisationUnitService organisationUnitService;
-
-    @Mock
-    private OrganisationUnitGroupService organisationUnitGroupService;
-
-    @Mock
-    private ExpressionService expressionService;
 
     @Mock
     private DimensionService dimensionService;
@@ -190,7 +170,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testCondition()
     {
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( programIndicatorService.getAnalyticsSql( anyString(), eq( programIndicator ), eq( startDate ),
             eq( endDate ) ) )
@@ -204,7 +184,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCount()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "d2:count(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "(select count(\"DataElmentA\") " +
@@ -218,7 +198,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCountWithStartEventBoundary()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         setStartEventBoundary();
 
@@ -235,7 +215,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCountWithEndEventBoundary()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         setEndEventBoundary();
 
@@ -252,7 +232,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCountWithStartAndEndEventBoundary()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         setStartAndEndEventBoundary();
 
@@ -269,7 +249,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCountIfCondition()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programIndicatorService.getAnalyticsSql( anyString(), eq( programIndicator ), eq( startDate ),
             eq( endDate ) ) )
                 .thenAnswer( i -> test( (String) i.getArguments()[0] ) );
@@ -285,7 +265,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCountIfValueNumeric()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "d2:countIfValue(#{ProgrmStagA.DataElmentA},55)" );
         assertThat( sql, is( "(select count(\"DataElmentA\") " +
@@ -299,7 +279,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testCountIfValueString()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         dataElementA.setValueType( TEXT );
 
@@ -314,8 +294,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testDaysBetween()
     {
-        when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
-        when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
+        when( idObjectManager.get( DataElement.class, dataElementC.getUid() ) ).thenReturn( dataElementC );
+        when( idObjectManager.get( DataElement.class, dataElementD.getUid() ) ).thenReturn( dataElementD );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( programStageService.getProgramStage( programStageB.getUid() ) ).thenReturn( programStageB );
 
@@ -326,8 +306,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testHasValueDataElement()
     {
-
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
 
         String sql = test( "d2:hasValue(#{ProgrmStagA.DataElmentA})" );
@@ -337,7 +316,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testHasValueAttribute()
     {
-        when( attributeService.getTrackedEntityAttribute( attributeA.getUid() ) ).thenReturn( attributeA );
+        when( idObjectManager.get( TrackedEntityAttribute.class, attributeA.getUid() ) ).thenReturn( attributeA );
 
         String sql = test( "d2:hasValue(A{Attribute0A})" );
         assertThat( sql, is( "(\"Attribute0A\" is not null)" ) );
@@ -346,8 +325,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testMinutesBetween()
     {
-        when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
-        when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
+        when( idObjectManager.get( DataElement.class, dataElementC.getUid() ) ).thenReturn( dataElementC );
+        when( idObjectManager.get( DataElement.class, dataElementD.getUid() ) ).thenReturn( dataElementD );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( programStageService.getProgramStage( programStageB.getUid() ) ).thenReturn( programStageB );
 
@@ -359,8 +338,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testMonthsBetween()
     {
-        when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
-        when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
+        when( idObjectManager.get( DataElement.class, dataElementC.getUid() ) ).thenReturn( dataElementC );
+        when( idObjectManager.get( DataElement.class, dataElementD.getUid() ) ).thenReturn( dataElementD );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( programStageService.getProgramStage( programStageB.getUid() ) ).thenReturn( programStageB );
 
@@ -374,7 +353,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testOizp()
     {
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
 
         String sql = test( "66 + d2:oizp(#{ProgrmStagA.DataElmentA} + 4)" );
@@ -393,7 +372,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testRelationshipCountWithRelationshipId()
     {
-        when( relationshipTypeService.getRelationshipType( relTypeA.getUid() ) ).thenReturn( relTypeA );
+        when( idObjectManager.get( RelationshipType.class, relTypeA.getUid() ) ).thenReturn( relTypeA );
 
         String sql = test( "d2:relationshipCount('RelatnTypeA')" );
         assertThat( sql, is( "(select count(*) from relationship r " +
@@ -405,8 +384,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     @Test
     void testWeeksBetween()
     {
-        when( dataElementService.getDataElement( dataElementC.getUid() ) ).thenReturn( dataElementC );
-        when( dataElementService.getDataElement( dataElementD.getUid() ) ).thenReturn( dataElementD );
+        when( idObjectManager.get( DataElement.class, dataElementC.getUid() ) ).thenReturn( dataElementC );
+        when( idObjectManager.get( DataElement.class, dataElementD.getUid() ) ).thenReturn( dataElementD );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( programStageService.getProgramStage( programStageB.getUid() ) ).thenReturn( programStageB );
 
@@ -454,7 +433,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testZing()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "d2:zing(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "greatest(0,coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -464,7 +443,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testZpvcOneArg()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "d2:zpvc(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "nullif(cast((" +
@@ -476,8 +455,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testZpvcTwoArgs()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
-        when( dataElementService.getDataElement( dataElementB.getUid() ) ).thenReturn( dataElementB );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementB.getUid() ) ).thenReturn( dataElementB );
 
         String sql = test( "d2:zpvc(#{ProgrmStagA.DataElmentA},#{ProgrmStagA.DataElmentB})" );
         assertThat( sql, is( "nullif(cast((" +
@@ -514,7 +493,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorAvg()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "avg(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "avg(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -524,7 +503,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorCount()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "count(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "count(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -537,7 +516,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorMax()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "max(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "max(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -547,7 +526,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorMin()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "min(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "min(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -557,7 +536,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorStddev()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "stddev(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "stddev_samp(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -567,7 +546,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorSum()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "sum(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "sum(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -577,7 +556,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     void testVectorVariance()
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( dataElementService.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
 
         String sql = test( "variance(#{ProgrmStagA.DataElmentA})" );
         assertThat( sql, is( "variance(coalesce(\"DataElmentA\"::numeric,0))" ) );
@@ -617,14 +596,10 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
             .build();
 
         CommonExpressionVisitor visitor = CommonExpressionVisitor.builder()
+            .idObjectManager( idObjectManager )
             .dimensionService( dimensionService )
-            .organisationUnitService( organisationUnitService )
-            .organisationUnitGroupService( organisationUnitGroupService )
             .programIndicatorService( programIndicatorService )
             .programStageService( programStageService )
-            .dataElementService( dataElementService )
-            .attributeService( attributeService )
-            .relationshipTypeService( relationshipTypeService )
             .statementBuilder( statementBuilder )
             .i18n( new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -234,7 +234,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        ProgramExpressionParams progExParams = ProgramExpressionParams.builder()
+        ProgramExpressionParams params = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
@@ -251,7 +251,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
             .constantMap( constantMap )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )
-            .progExParams( progExParams )
+            .progParams( params )
             .build();
 
         visitor.setExpressionLiteral( exprLiteral );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -36,7 +36,6 @@ import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDIC
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -45,15 +44,14 @@ import org.hisp.dhis.antlr.AntlrExprLiteral;
 import org.hisp.dhis.antlr.Parser;
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.antlr.literal.DefaultLiteral;
-import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.common.DimensionService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.relationship.RelationshipTypeService;
-import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,16 +79,13 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     @Mock
     private ProgramStageService programStageService;
 
+    @Mock
+    private IdentifiableObjectManager idObjectManager;
+
+    @Mock
+    private DimensionService dimensionService;
+
     private StatementBuilder statementBuilder;
-
-    @Mock
-    private DataElementService dataElementService;
-
-    @Mock
-    private TrackedEntityAttributeService attributeService;
-
-    @Mock
-    private RelationshipTypeService relationshipTypeService;
 
     private CommonExpressionVisitor subject;
 
@@ -315,16 +310,14 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
             .build();
 
         subject = CommonExpressionVisitor.builder()
-            .itemMap( PROGRAM_INDICATOR_ITEMS )
-            .itemMethod( ITEM_GET_SQL )
-            .constantMap( new HashMap<>() )
+            .idObjectManager( idObjectManager )
+            .dimensionService( dimensionService )
             .programIndicatorService( programIndicatorService )
             .programStageService( programStageService )
-            .dataElementService( dataElementService )
-            .attributeService( attributeService )
-            .relationshipTypeService( relationshipTypeService )
             .statementBuilder( statementBuilder )
             .i18n( new I18n( null, null ) )
+            .itemMap( PROGRAM_INDICATOR_ITEMS )
+            .itemMethod( ITEM_GET_SQL )
             .progExParams( progExParams )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -31,8 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
-import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_SAMPLE_PERIODS;
-import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_GET_SQL;
+import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
 import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -51,6 +50,7 @@ import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ProgramExpressionParams;
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
@@ -307,25 +307,28 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        subject = CommonExpressionVisitor.newBuilder()
-            .withItemMap( PROGRAM_INDICATOR_ITEMS )
-            .withItemMethod( ITEM_GET_SQL )
-            .withConstantMap( new HashMap<>() )
-            .withProgramIndicatorService( programIndicatorService )
-            .withProgramStageService( programStageService )
-            .withDataElementService( dataElementService )
-            .withAttributeService( attributeService )
-            .withRelationshipTypeService( relationshipTypeService )
-            .withStatementBuilder( statementBuilder )
-            .withI18n( new I18n( null, null ) )
-            .withSamplePeriods( DEFAULT_SAMPLE_PERIODS )
-            .buildForProgramIndicatorExpressions();
+        ProgramExpressionParams progExParams = ProgramExpressionParams.builder()
+            .programIndicator( programIndicator )
+            .reportingStartDate( startDate )
+            .reportingEndDate( endDate )
+            .dataElementAndAttributeIdentifiers( dataElementsAndAttributesIdentifiers )
+            .build();
+
+        subject = CommonExpressionVisitor.builder()
+            .itemMap( PROGRAM_INDICATOR_ITEMS )
+            .itemMethod( ITEM_GET_SQL )
+            .constantMap( new HashMap<>() )
+            .programIndicatorService( programIndicatorService )
+            .programStageService( programStageService )
+            .dataElementService( dataElementService )
+            .attributeService( attributeService )
+            .relationshipTypeService( relationshipTypeService )
+            .statementBuilder( statementBuilder )
+            .i18n( new I18n( null, null ) )
+            .progExParams( progExParams )
+            .build();
 
         subject.setExpressionLiteral( exprLiteral );
-        subject.setProgramIndicator( programIndicator );
-        subject.setReportingStartDate( startDate );
-        subject.setReportingEndDate( endDate );
-        subject.setDataElementAndAttributeIdentifiers( dataElementsAndAttributesIdentifiers );
 
         return Parser.visit( expression, subject );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -302,7 +302,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        ProgramExpressionParams progExParams = ProgramExpressionParams.builder()
+        ProgramExpressionParams params = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
@@ -318,7 +318,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
             .i18n( new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( ITEM_GET_SQL )
-            .progExParams( progExParams )
+            .progParams( params )
             .build();
 
         subject.setExpressionLiteral( exprLiteral );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -61,8 +61,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ListMap;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.constant.Constant;
-import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.datavalue.DataValue;
@@ -104,8 +102,6 @@ public class DefaultPredictionService
     implements PredictionService, AnalyticsServiceTarget, CurrentUserServiceTarget
 {
     private final PredictorService predictorService;
-
-    private final ConstantService constantService;
 
     private final ExpressionService expressionService;
 
@@ -257,7 +253,6 @@ public class DefaultPredictionService
         Set<DimensionalItemObject> outputPeriodItems = new HashSet<>( outputPeriodItemMap.values() );
         Set<DimensionalItemObject> sampledItems = new HashSet<>( sampledItemMap.values() );
         Set<DimensionalItemObject> items = new HashSet<>( itemMap.values() );
-        Map<String, Constant> constantMap = constantService.getConstantMap();
         List<Period> outputPeriods = getPeriodsBetweenDates( predictor.getPeriodType(), startDate, endDate );
         Set<Period> existingOutputPeriods = getExistingPeriods( outputPeriods );
         ListMap<Period, Period> samplePeriodsMap = getSamplePeriodsMap( outputPeriods, predictor );
@@ -319,7 +314,7 @@ public class DefaultPredictionService
                     List<Period> samplePeriods = new ArrayList<>( samplePeriodsMap.get( c.getOutputPeriod() ) );
 
                     samplePeriods.removeAll( getSkippedPeriods( allSamplePeriods, itemMap, c.getPeriodValueMap(),
-                        skipTest, constantMap, orgUnitGroupMap, data.getOrgUnit() ) );
+                        skipTest, orgUnitGroupMap, data.getOrgUnit() ) );
 
                     if ( requireData && !dataIsPresent( outputPeriodItems, c.getValueMap(), sampledItems,
                         samplePeriods, c.getPeriodValueMap() ) )
@@ -333,7 +328,6 @@ public class DefaultPredictionService
                         .dataType( expressionDataType )
                         .itemMap( itemMap )
                         .valueMap( c.getValueMap() )
-                        .constantMap( constantMap )
                         .orgUnitGroupMap( orgUnitGroupMap )
                         .days( c.getOutputPeriod().getDaysInPeriod() )
                         .missingValueStrategy( generator.getMissingValueStrategy() )
@@ -410,8 +404,7 @@ public class DefaultPredictionService
      */
     private Set<Period> getSkippedPeriods( Set<Period> allSamplePeriods,
         Map<DimensionalItemId, DimensionalItemObject> itemMap, MapMap<Period, DimensionalItemObject, Object> aocData,
-        Expression skipTest, Map<String, Constant> constantMap, Map<String, OrganisationUnitGroup> orgUnitGroupMap,
-        OrganisationUnit orgUnit )
+        Expression skipTest, Map<String, OrganisationUnitGroup> orgUnitGroupMap, OrganisationUnit orgUnit )
     {
         Set<Period> skippedPeriods = new HashSet<>();
 
@@ -428,7 +421,6 @@ public class DefaultPredictionService
                     .parseType( PREDICTOR_SKIP_TEST )
                     .itemMap( itemMap )
                     .valueMap( aocData.get( p ) )
-                    .constantMap( constantMap )
                     .orgUnitGroupMap( orgUnitGroupMap )
                     .days( p.getDaysInPeriod() )
                     .missingValueStrategy( skipTest.getMissingValueStrategy() )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DataValidationTask.java
@@ -502,7 +502,6 @@ public class DataValidationTask
                 .parseType( VALIDATION_RULE_EXPRESSION )
                 .itemMap( context.getItemMap() )
                 .valueMap( values )
-                .constantMap( context.getConstantMap() )
                 .orgUnitGroupMap( context.getOrgUnitGroupMap() )
                 .days( period.getDaysInPeriod() )
                 .missingValueStrategy( expression.getMissingValueStrategy() )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.SetMap;
-import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -104,8 +103,6 @@ public class DefaultValidationService
 
     private final CategoryService categoryService;
 
-    private final ConstantService constantService;
-
     private final IdentifiableObjectManager idObjectManager;
 
     private final ValidationNotificationService notificationService;
@@ -122,7 +119,7 @@ public class DefaultValidationService
 
     public DefaultValidationService( PeriodService periodService, OrganisationUnitService organisationUnitService,
         ExpressionService expressionService, DimensionService dimensionService, DataValueService dataValueService,
-        CategoryService categoryService, ConstantService constantService, IdentifiableObjectManager idObjectManager,
+        CategoryService categoryService, IdentifiableObjectManager idObjectManager,
         ValidationNotificationService notificationService, ValidationRuleService validationRuleService,
         ApplicationContext applicationContext, ValidationResultService validationResultService,
         AnalyticsService analyticsService, CurrentUserService currentUserService )
@@ -133,7 +130,6 @@ public class DefaultValidationService
         checkNotNull( dimensionService );
         checkNotNull( dataValueService );
         checkNotNull( categoryService );
-        checkNotNull( constantService );
         checkNotNull( idObjectManager );
         checkNotNull( notificationService );
         checkNotNull( validationRuleService );
@@ -148,7 +144,6 @@ public class DefaultValidationService
         this.dimensionService = dimensionService;
         this.dataValueService = dataValueService;
         this.categoryService = categoryService;
-        this.constantService = constantService;
         this.idObjectManager = idObjectManager;
         this.notificationService = notificationService;
         this.validationRuleService = validationRuleService;
@@ -334,7 +329,6 @@ public class DefaultValidationService
         ValidationRunContext.Builder builder = ValidationRunContext.newBuilder()
             .withOrgUnits( orgUnits )
             .withPeriodTypeXs( new ArrayList<>( periodTypeXMap.values() ) )
-            .withConstantMap( constantService.getConstantMap() )
             .withInitialResults( validationResultService
                 .getValidationResults( parameterOrgUnit,
                     parameters.isIncludeOrgUnitDescendants(), parameters.getValidationRules(),

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/ValidationRunContext.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.category.CategoryOptionGroup;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.MapMapMap;
-import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataanalysis.ValidationRuleExpressionDetails;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -69,8 +68,6 @@ public class ValidationRunContext
     private List<OrganisationUnit> orgUnits;
 
     private List<PeriodTypeExtended> periodTypeXs;
-
-    private Map<String, Constant> constantMap;
 
     private Set<CategoryOptionGroup> cogDimensionConstraints;
 
@@ -153,11 +150,6 @@ public class ValidationRunContext
     public List<PeriodTypeExtended> getPeriodTypeXs()
     {
         return periodTypeXs;
-    }
-
-    public Map<String, Constant> getConstantMap()
-    {
-        return constantMap;
     }
 
     public Set<CategoryOptionGroup> getCogDimensionConstraints()
@@ -283,7 +275,6 @@ public class ValidationRunContext
         public ValidationRunContext build()
         {
             Validate.notNull( this.context.periodTypeXs, "Missing required property 'periodTypeXs'" );
-            Validate.notNull( this.context.constantMap, "Missing required property 'constantMap'" );
             Validate.notNull( this.context.orgUnits, "Missing required property 'orgUnits'" );
             Validate.notNull( this.context.defaultAttributeCombo, "Missing required property 'defaultAttributeCombo'" );
 
@@ -316,12 +307,6 @@ public class ValidationRunContext
             List<PeriodTypeExtended> periodTypeXs )
         {
             this.context.periodTypeXs = periodTypeXs;
-            return this;
-        }
-
-        public Builder withConstantMap( Map<String, Constant> constantMap )
-        {
-            this.context.constantMap = constantMap;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -225,7 +225,7 @@ class DataValidationTaskTest
 
     private void mockExpressionService( Expression expression, Map<DimensionalItemObject, Object> vals, Double val )
     {
-        ExpressionParams exParams = ExpressionParams.builder()
+        ExpressionParams params = ExpressionParams.builder()
             .expression( expression.getExpression() )
             .parseType( VALIDATION_RULE_EXPRESSION )
             .valueMap( vals )
@@ -233,13 +233,13 @@ class DataValidationTaskTest
             .orgUnit( ouA )
             .build();
 
-        when( expressionService.getExpressionValue( exParams.toBuilder().days( p1.getDaysInPeriod() ).build() ) )
+        when( expressionService.getExpressionValue( params.toBuilder().days( p1.getDaysInPeriod() ).build() ) )
             .thenReturn( val );
 
-        when( expressionService.getExpressionValue( exParams.toBuilder().days( p2.getDaysInPeriod() ).build() ) )
+        when( expressionService.getExpressionValue( params.toBuilder().days( p2.getDaysInPeriod() ).build() ) )
             .thenReturn( val );
 
-        when( expressionService.getExpressionValue( exParams.toBuilder().days( p3.getDaysInPeriod() ).build() ) )
+        when( expressionService.getExpressionValue( params.toBuilder().days( p3.getDaysInPeriod() ).build() ) )
             .thenReturn( val );
     }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/validation/DataValidationTaskTest.java
@@ -51,7 +51,6 @@ import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DataExportParams;
 import org.hisp.dhis.datavalue.DataValue;
@@ -110,8 +109,6 @@ class DataValidationTaskTest
 
     private Period p3;
 
-    private Map<String, Constant> constantMap;
-
     @BeforeEach
     public void setUp()
     {
@@ -134,10 +131,6 @@ class DataValidationTaskTest
         p1 = createPeriod( "201901" );
         p2 = createPeriod( "201902" );
         p3 = createPeriod( "201903" );
-
-        constantMap = new HashMap<>();
-        constantMap.put( "Gfd3ppDfq8E", new Constant( "a", 5.0 ) );
-        constantMap.put( "bCqvfPR02Im", new Constant( "pi", 3.14 ) );
     }
 
     /**
@@ -162,7 +155,6 @@ class DataValidationTaskTest
         ValidationRunContext ctx = ValidationRunContext.newBuilder()
             .withOrgUnits( organisationUnits )
             .withItemMap( new HashMap<>() )
-            .withConstantMap( constantMap )
             .withOrgUnitGroupMap( new HashMap<>() )
             .withDefaultAttributeCombo( categoryOptionCombo )
             .withPeriodTypeXs( periodTypes )
@@ -183,8 +175,8 @@ class DataValidationTaskTest
         Map<DimensionalItemObject, Object> vals = new HashMap<>();
         vals.put( deA, 12.4 );
 
-        mockExpressionService( leftExpression, vals, ctx, 8.4 );
-        mockExpressionService( rightExpression, vals, ctx, -10.0 );
+        mockExpressionService( leftExpression, vals, 8.4 );
+        mockExpressionService( rightExpression, vals, -10.0 );
 
         when( expressionService.getExpressionValue( ExpressionParams.builder()
             .expression( "8.4!=-10.0" ).parseType( SIMPLE_TEST ).build() ) )
@@ -214,7 +206,6 @@ class DataValidationTaskTest
 
         ValidationRunContext ctx = ValidationRunContext.newBuilder()
             .withOrgUnits( organisationUnits )
-            .withConstantMap( constantMap )
             .withDefaultAttributeCombo( categoryOptionCombo )
             .withPeriodTypeXs( periodTypes )
             .withMaxResults( 500 )
@@ -232,14 +223,12 @@ class DataValidationTaskTest
         assertThat( ctx.getValidationResults().size(), is( 0 ) );
     }
 
-    private void mockExpressionService( Expression expression, Map<DimensionalItemObject, Object> vals,
-        ValidationRunContext ctx, Double val )
+    private void mockExpressionService( Expression expression, Map<DimensionalItemObject, Object> vals, Double val )
     {
         ExpressionParams exParams = ExpressionParams.builder()
             .expression( expression.getExpression() )
             .parseType( VALIDATION_RULE_EXPRESSION )
             .valueMap( vals )
-            .constantMap( ctx.getConstantMap() )
             .missingValueStrategy( expression.getMissingValueStrategy() )
             .orgUnit( ouA )
             .build();

--- a/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
@@ -44,6 +44,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -39,18 +39,15 @@ import lombok.Setter;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.hisp.dhis.antlr.AntlrExpressionVisitor;
 import org.hisp.dhis.common.DimensionService;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.constant.Constant;
-import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.expression.ExpressionInfo;
 import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.ProgramIndicatorService;
 import org.hisp.dhis.program.ProgramStageService;
-import org.hisp.dhis.relationship.RelationshipTypeService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 
 /**
@@ -65,21 +62,15 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 public class CommonExpressionVisitor
     extends AntlrExpressionVisitor
 {
+    private IdentifiableObjectManager idObjectManager;
+
     private DimensionService dimensionService;
-
-    private OrganisationUnitService organisationUnitService;
-
-    private OrganisationUnitGroupService organisationUnitGroupService;
 
     private ProgramIndicatorService programIndicatorService;
 
     private ProgramStageService programStageService;
 
-    private DataElementService dataElementService;
-
     private TrackedEntityAttributeService attributeService;
-
-    private RelationshipTypeService relationshipTypeService;
 
     private StatementBuilder statementBuilder;
 

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -96,26 +96,26 @@ public class CommonExpressionVisitor
      * Parameters to evaluate the expression to a value.
      */
     @Builder.Default
-    private ExpressionParams exParams = ExpressionParams.builder().build();
+    private ExpressionParams params = ExpressionParams.builder().build();
 
     /**
      * Parameters to generate SQL from a program expression.
      */
     @Builder.Default
-    private ProgramExpressionParams progExParams = ProgramExpressionParams.builder().build();
+    private ProgramExpressionParams progParams = ProgramExpressionParams.builder().build();
 
     /**
      * State variables during an expression evaluation.
      */
     @Builder.Default
-    private ExpressionState exState = new ExpressionState();
+    private ExpressionState state = new ExpressionState();
 
     /**
      * Information found from parsing the raw expression (contains nothing that
      * is the result of data or metadata found in the database).
      */
     @Builder.Default
-    private ExpressionInfo exInfo = new ExpressionInfo();
+    private ExpressionInfo info = new ExpressionInfo();
 
     /**
      * Used to collect the string replacements to build a description. This may
@@ -161,13 +161,13 @@ public class CommonExpressionVisitor
      */
     public Object visitAllowingNulls( ParserRuleContext ctx )
     {
-        boolean savedReplaceNulls = exState.isReplaceNulls();
+        boolean savedReplaceNulls = state.isReplaceNulls();
 
-        exState.setReplaceNulls( false );
+        state.setReplaceNulls( false );
 
         Object result = visit( ctx );
 
-        exState.setReplaceNulls( savedReplaceNulls );
+        state.setReplaceNulls( savedReplaceNulls );
 
         return result;
     }
@@ -181,13 +181,13 @@ public class CommonExpressionVisitor
      */
     public Object visitWithQueryMods( ParserRuleContext ctx, QueryModifiers mods )
     {
-        QueryModifiers savedQueryMods = exState.getQueryMods();
+        QueryModifiers savedQueryMods = state.getQueryMods();
 
-        exState.setQueryMods( mods );
+        state.setQueryMods( mods );
 
         Object result = visit( ctx );
 
-        exState.setQueryMods( savedQueryMods );
+        state.setQueryMods( savedQueryMods );
 
         return result;
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -27,46 +27,30 @@
  */
 package org.hisp.dhis.parser.expression;
 
-import static org.hisp.dhis.common.QueryModifiers.QueryModifiersBuilder;
-import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
-import static org.hisp.dhis.parser.expression.ParserUtils.ITEM_REGENERATE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
-import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
 
 import org.antlr.v4.runtime.ParserRuleContext;
-import org.apache.commons.lang3.Validate;
 import org.hisp.dhis.antlr.AntlrExpressionVisitor;
-import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.common.DimensionService;
-import org.hisp.dhis.common.DimensionalItemId;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.common.QueryModifiers;
-import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
-import org.hisp.dhis.expression.MissingValueStrategy;
+import org.hisp.dhis.expression.ExpressionInfo;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramIndicatorService;
-import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.relationship.RelationshipTypeService;
-import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 
 /**
@@ -75,6 +59,9 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
  *
  * @author Jim Grace
  */
+@Getter
+@Setter
+@Builder
 public class CommonExpressionVisitor
     extends AntlrExpressionVisitor
 {
@@ -99,168 +86,55 @@ public class CommonExpressionVisitor
     private I18n i18n;
 
     /**
-     * Map of ExprItem instances to call for each expression item
+     * Map of constant values to use in evaluating the expression.
+     */
+    @Builder.Default
+    private Map<String, Constant> constantMap = new HashMap<>();
+
+    /**
+     * Map of ExprItem object instances to call for each expression item.
      */
     private Map<Integer, ExpressionItem> itemMap;
 
     /**
-     * Method to call within the ExprItem instance
+     * Method to call within the ExprItem object instance.
      */
     private ExpressionItemMethod itemMethod;
 
     /**
-     * By default, replace nulls with 0 or ''.
+     * Parameters to evaluate the expression to a value.
      */
-    private boolean replaceNulls = true;
+    @Builder.Default
+    private ExpressionParams exParams = ExpressionParams.builder().build();
 
     /**
-     * Item query modifiers, if any, in effect during parsing.
+     * Parameters to generate SQL from a program expression.
      */
-    private QueryModifiers queryMods = null;
-
-    private int stageOffset = Integer.MIN_VALUE;
+    @Builder.Default
+    private ProgramExpressionParams progExParams = ProgramExpressionParams.builder().build();
 
     /**
-     * Used to collect the string replacements to build a description.
+     * State variables during an expression evaluation.
      */
+    @Builder.Default
+    private ExpressionState exState = new ExpressionState();
+
+    /**
+     * Information found from parsing the raw expression (contains nothing that
+     * is the result of data or metadata found in the database).
+     */
+    @Builder.Default
+    private ExpressionInfo exInfo = new ExpressionInfo();
+
+    /**
+     * Used to collect the string replacements to build a description. This may
+     * contain names of metadata from the database.
+     */
+    @Builder.Default
     private Map<String, String> itemDescriptions = new HashMap<>();
 
-    /**
-     * Constants to use in evaluating an expression.
-     */
-    private Map<String, Constant> constantMap = new HashMap<>();
-
-    /**
-     * Used to collect the dimensional item ids in the expression.
-     */
-    private Set<DimensionalItemId> itemIds = new HashSet<>();
-
-    /**
-     * Used to collect the sampled dimensional item ids in the expression.
-     */
-    private Set<DimensionalItemId> sampleItemIds = new HashSet<>();
-
-    /**
-     * Used to collect the organisation unit group ids in the expression.
-     */
-    private Set<String> orgUnitGroupIds = new HashSet<>();
-
-    /**
-     * Organisation unit group counts to use in evaluating an expression.
-     */
-    Map<String, Integer> orgUnitCountMap = new HashMap<>();
-
-    /**
-     * Organisation unit groups to use in evaluating an expression.
-     */
-    Map<String, OrganisationUnitGroup> orgUnitGroupMap = new HashMap<>();
-
-    /**
-     * The current organisation unit.
-     */
-    OrganisationUnit organisationUnit;
-
-    /**
-     * Count of days in period to use in evaluating an expression.
-     */
-    private Double days = null;
-
-    /**
-     * The {@see DimensionalItemObject}s present in the expression.
-     */
-    private Map<DimensionalItemId, DimensionalItemObject> dimItemMap;
-
-    /**
-     * Values to use for dimensional items in evaluating an expression.
-     */
-    private Map<DimensionalItemObject, Object> itemValueMap;
-
-    /**
-     * Dimensional item values by period for aggregating in evaluating an
-     * expression.
-     */
-    private MapMap<Period, DimensionalItemObject, Object> periodItemValueMap;
-
-    /**
-     * Periods to sample over for predictor sample functions.
-     */
-    private List<Period> samplePeriods;
-
-    /**
-     * Flag to check if a null date was found.
-     */
-    private boolean unprotectedNullDateFound = false;
-
-    /**
-     * Count of dimension items found.
-     */
-    private int itemsFound = 0;
-
-    /**
-     * Count of dimension item values found.
-     */
-    private int itemValuesFound = 0;
-
-    /**
-     * Strategy for handling missing values.
-     */
-    private MissingValueStrategy missingValueStrategy = NEVER_SKIP;
-
-    /**
-     * Current program indicator.
-     */
-    private ProgramIndicator programIndicator;
-
-    /**
-     * Reporting start date.
-     */
-    private Date reportingStartDate;
-
-    /**
-     * Reporting end date.
-     */
-    private Date reportingEndDate;
-
-    /**
-     * Idenfitiers of DataElements and Attribuetes in expression.
-     */
-    private Set<String> dataElementAndAttributeIdentifiers;
-
-    /**
-     * Default value for data type double.
-     */
-    public static final double DEFAULT_DOUBLE_VALUE = 1d;
-
-    /**
-     * Default value for data type date.
-     */
-    public static final String DEFAULT_DATE_VALUE = "2017-07-08";
-
-    /**
-     * Default value for data type boolean.
-     */
-    public static final boolean DEFAULT_BOOLEAN_VALUE = false;
-
     // -------------------------------------------------------------------------
-    // Constructors
-    // -------------------------------------------------------------------------
-
-    protected CommonExpressionVisitor()
-    {
-    }
-
-    /**
-     * Creates a new Builder for CommonExpressionVisitor.
-     *
-     * @return a Builder for CommonExpressionVisitor.
-     */
-    public static Builder newBuilder()
-    {
-        return new CommonExpressionVisitor.Builder();
-    }
-
-    // -------------------------------------------------------------------------
-    // Visitor methods
+    // Visitor logic
     // -------------------------------------------------------------------------
 
     @Override
@@ -279,22 +153,13 @@ public class CommonExpressionVisitor
             return itemMethod.apply( item, ctx, this );
         }
 
-        if ( itemMethod == ITEM_REGENERATE )
-        {
-            return regenerateAllChildren( ctx );
-        }
-
-        if ( ctx.expr().size() > 0 ) // If there's an expr, visit the expr
+        if ( !ctx.expr().isEmpty() ) // If there's an expr, visit the expr
         {
             return visit( ctx.expr( 0 ) );
         }
 
         return visit( ctx.getChild( 0 ) ); // All others: visit first child.
     }
-
-    // -------------------------------------------------------------------------
-    // Logic for expression items
-    // -------------------------------------------------------------------------
 
     /**
      * Visits a context while allowing null values (not replacing them with 0 or
@@ -305,13 +170,13 @@ public class CommonExpressionVisitor
      */
     public Object visitAllowingNulls( ParserRuleContext ctx )
     {
-        boolean savedReplaceNulls = replaceNulls;
+        boolean savedReplaceNulls = exState.isReplaceNulls();
 
-        replaceNulls = false;
+        exState.setReplaceNulls( false );
 
         Object result = visit( ctx );
 
-        replaceNulls = savedReplaceNulls;
+        exState.setReplaceNulls( savedReplaceNulls );
 
         return result;
     }
@@ -325,516 +190,14 @@ public class CommonExpressionVisitor
      */
     public Object visitWithQueryMods( ParserRuleContext ctx, QueryModifiers mods )
     {
-        QueryModifiers savedQueryMods = queryMods;
+        QueryModifiers savedQueryMods = exState.getQueryMods();
 
-        queryMods = mods;
+        exState.setQueryMods( mods );
 
         Object result = visit( ctx );
 
-        queryMods = savedQueryMods;
+        exState.setQueryMods( savedQueryMods );
 
         return result;
-    }
-
-    /**
-     * Handles nulls and missing values.
-     * <p/>
-     * If we should replace nulls with the default value, then do so, and
-     * remember how many items found, and how many of them had values, for
-     * subsequent MissingValueStrategy analysis.
-     * <p/>
-     * If we should not replace nulls with the default value, then don't, as
-     * this is likely for some function that is testing for nulls, and a missing
-     * value should not count towards the MissingValueStrategy.
-     *
-     * @param value the (possibly null) value.
-     * @param valueType the type of value to substitute if null.
-     * @return the value we should return.
-     */
-    public Object handleNulls( Object value, ValueType valueType )
-    {
-        if ( replaceNulls )
-        {
-            itemsFound++;
-            if ( value == null && valueType.isDate() )
-            {
-                unprotectedNullDateFound = true;
-                return null;
-            }
-            else if ( value == null )
-            {
-                return ValidationUtils.getNullReplacementValue( valueType );
-            }
-            else
-            {
-                itemValuesFound++;
-            }
-        }
-
-        return value;
-    }
-
-    /**
-     * Validates a program stage id / data element id pair
-     *
-     * @param text expression text containing both program stage id and data
-     *        element id
-     * @param programStageId the program stage id
-     * @param dataElementId the data element id
-     * @return the ValueType of the data element
-     */
-    public ValueType validateStageDataElement( String text, String programStageId, String dataElementId )
-    {
-        ProgramStage programStage = programStageService.getProgramStage( programStageId );
-        DataElement dataElement = dataElementService.getDataElement( dataElementId );
-
-        if ( programStage == null )
-        {
-            throw new org.hisp.dhis.antlr.ParserExceptionWithoutContext(
-                "Program stage " + programStageId + " not found" );
-        }
-
-        if ( dataElement == null )
-        {
-            throw new ParserExceptionWithoutContext( "Data element " + dataElementId + " not found" );
-        }
-
-        String description = programStage.getDisplayName() + ProgramIndicator.SEPARATOR_ID
-            + dataElement.getDisplayName();
-
-        itemDescriptions.put( text, description );
-
-        return dataElement.getValueType();
-    }
-
-    /**
-     * Regenerates an expression by visiting all the children of the expression
-     * node (including any terminal nodes).
-     *
-     * @param ctx the expression context
-     * @return the regenerated expression (as a String)
-     */
-    public Object regenerateAllChildren( ExprContext ctx )
-    {
-        return ctx.children.stream().map( this::castStringVisit )
-            .collect( Collectors.joining() );
-    }
-
-    /**
-     * Returns a {@see QueryModifiersBuilder} that can be used to add modifiers
-     * to be be applied while parsing. If there are no query modifiers at
-     * present, returns a fresh builder. If there are query modifiers at
-     * present, returns a builder based on current modifiers.
-     *
-     * @return a {@see QueryModifiersBuilder}
-     */
-    public QueryModifiersBuilder getQueryModsBuilder()
-    {
-        return (queryMods == null)
-            ? QueryModifiers.builder()
-            : queryMods.toBuilder();
-    }
-
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    public DimensionService getDimensionService()
-    {
-        return dimensionService;
-    }
-
-    public OrganisationUnitService getOrganisationUnitService()
-    {
-        return organisationUnitService;
-    }
-
-    public OrganisationUnitGroupService getOrganisationUnitGroupService()
-    {
-        return organisationUnitGroupService;
-    }
-
-    public ProgramIndicatorService getProgramIndicatorService()
-    {
-        return programIndicatorService;
-    }
-
-    public ProgramStageService getProgramStageService()
-    {
-        return programStageService;
-    }
-
-    public DataElementService getDataElementService()
-    {
-        return dataElementService;
-    }
-
-    public TrackedEntityAttributeService getAttributeService()
-    {
-        return attributeService;
-    }
-
-    public RelationshipTypeService getRelationshipTypeService()
-    {
-        return relationshipTypeService;
-    }
-
-    public StatementBuilder getStatementBuilder()
-    {
-        return statementBuilder;
-    }
-
-    public I18n getI18n()
-    {
-        return i18n;
-    }
-
-    public ProgramIndicator getProgramIndicator()
-    {
-        return programIndicator;
-    }
-
-    public void setProgramIndicator(
-        ProgramIndicator programIndicator )
-    {
-        this.programIndicator = programIndicator;
-    }
-
-    public Date getReportingStartDate()
-    {
-        return reportingStartDate;
-    }
-
-    public void setReportingStartDate( Date reportingStartDate )
-    {
-        this.reportingStartDate = reportingStartDate;
-    }
-
-    public Date getReportingEndDate()
-    {
-        return reportingEndDate;
-    }
-
-    public void setReportingEndDate( Date reportingEndDate )
-    {
-        this.reportingEndDate = reportingEndDate;
-    }
-
-    public Set<String> getDataElementAndAttributeIdentifiers()
-    {
-        return dataElementAndAttributeIdentifiers;
-    }
-
-    public void setDataElementAndAttributeIdentifiers(
-        Set<String> dataElementAndAttributeIdentifiers )
-    {
-        this.dataElementAndAttributeIdentifiers = dataElementAndAttributeIdentifiers;
-    }
-
-    public Map<String, String> getItemDescriptions()
-    {
-        return itemDescriptions;
-    }
-
-    public Map<String, Constant> getConstantMap()
-    {
-        return constantMap;
-    }
-
-    public boolean getReplaceNulls()
-    {
-        return replaceNulls;
-    }
-
-    public void setReplaceNulls( boolean replaceNulls )
-    {
-        this.replaceNulls = replaceNulls;
-    }
-
-    public QueryModifiers getQueryMods()
-    {
-        return queryMods;
-    }
-
-    public int getStageOffset()
-    {
-        return stageOffset;
-    }
-
-    public void setStageOffset( int stageOffset )
-    {
-        this.stageOffset = stageOffset;
-    }
-
-    public Set<DimensionalItemId> getItemIds()
-    {
-        return itemIds;
-    }
-
-    public void setItemIds( Set<DimensionalItemId> itemIds )
-    {
-        this.itemIds = itemIds;
-    }
-
-    public Set<DimensionalItemId> getSampleItemIds()
-    {
-        return sampleItemIds;
-    }
-
-    public void setSampleItemIds( Set<DimensionalItemId> sampleItemIds )
-    {
-        this.sampleItemIds = sampleItemIds;
-    }
-
-    public Set<String> getOrgUnitGroupIds()
-    {
-        return orgUnitGroupIds;
-    }
-
-    public Map<String, Integer> getOrgUnitCountMap()
-    {
-        return orgUnitCountMap;
-    }
-
-    public void setOrgUnitCountMap( Map<String, Integer> orgUnitCountMap )
-    {
-        this.orgUnitCountMap = orgUnitCountMap;
-    }
-
-    public Map<DimensionalItemObject, Object> getItemValueMap()
-    {
-        return itemValueMap;
-    }
-
-    public Map<String, OrganisationUnitGroup> getOrgUnitGroupMap()
-    {
-        return orgUnitGroupMap;
-    }
-
-    public void setOrgUnitGroupMap( Map<String, OrganisationUnitGroup> orgUnitGroupMap )
-    {
-        this.orgUnitGroupMap = orgUnitGroupMap;
-    }
-
-    public OrganisationUnit getOrganizationUnit()
-    {
-        return organisationUnit;
-    }
-
-    public void setOrganisationUnit( OrganisationUnit organisationUnit )
-    {
-        this.organisationUnit = organisationUnit;
-    }
-
-    public void setDimItemMap( Map<DimensionalItemId, DimensionalItemObject> dimItemMap )
-    {
-        this.dimItemMap = dimItemMap;
-    }
-
-    public Map<DimensionalItemId, DimensionalItemObject> getDimItemMap()
-    {
-        return dimItemMap;
-    }
-
-    public void setItemValueMap( Map<DimensionalItemObject, Object> itemValueMap )
-    {
-        this.itemValueMap = itemValueMap;
-    }
-
-    public MapMap<Period, DimensionalItemObject, Object> getPeriodItemValueMap()
-    {
-        return periodItemValueMap;
-    }
-
-    public void setPeriodItemValueMap( MapMap<Period, DimensionalItemObject, Object> periodItemValueMap )
-    {
-        this.periodItemValueMap = periodItemValueMap;
-    }
-
-    public List<Period> getSamplePeriods()
-    {
-        return samplePeriods;
-    }
-
-    public Double getDays()
-    {
-        return days;
-    }
-
-    public void setDays( Double days )
-    {
-        this.days = days;
-    }
-
-    public int getItemsFound()
-    {
-        return itemsFound;
-    }
-
-    public void setItemsFound( int itemsFound )
-    {
-        this.itemsFound = itemsFound;
-    }
-
-    public int getItemValuesFound()
-    {
-        return itemValuesFound;
-    }
-
-    public void setItemValuesFound( int itemValuesFound )
-    {
-        this.itemValuesFound = itemValuesFound;
-    }
-
-    public boolean isUnprotectedNullDateFound()
-    {
-        return unprotectedNullDateFound;
-    }
-
-    public MissingValueStrategy getMissingValueStrategy()
-    {
-        return missingValueStrategy;
-    }
-
-    // -------------------------------------------------------------------------
-    // Builder
-    // -------------------------------------------------------------------------
-
-    /**
-     * Builder for {@link CommonExpressionVisitor} instances.
-     */
-    public static class Builder
-    {
-        private CommonExpressionVisitor visitor;
-
-        protected Builder()
-        {
-            this.visitor = new CommonExpressionVisitor();
-        }
-
-        public Builder withItemMap( Map<Integer, ExpressionItem> itemMap )
-        {
-            this.visitor.itemMap = itemMap;
-            return this;
-        }
-
-        public Builder withItemMethod( ExpressionItemMethod itemMethod )
-        {
-            this.visitor.itemMethod = itemMethod;
-            return this;
-        }
-
-        public Builder withDimensionService( DimensionService dimensionService )
-        {
-            this.visitor.dimensionService = dimensionService;
-            return this;
-        }
-
-        public Builder withOrganisationUnitService( OrganisationUnitService organisationUnitService )
-        {
-            this.visitor.organisationUnitService = organisationUnitService;
-            return this;
-        }
-
-        public Builder withOrganisationUnitGroupService( OrganisationUnitGroupService organisationUnitGroupService )
-        {
-            this.visitor.organisationUnitGroupService = organisationUnitGroupService;
-            return this;
-        }
-
-        public Builder withProgramIndicatorService( ProgramIndicatorService programIndicatorService )
-        {
-            this.visitor.programIndicatorService = programIndicatorService;
-            return this;
-        }
-
-        public Builder withProgramStageService( ProgramStageService programStageService )
-        {
-            this.visitor.programStageService = programStageService;
-            return this;
-        }
-
-        public Builder withDataElementService( DataElementService dataElementService )
-        {
-            this.visitor.dataElementService = dataElementService;
-            return this;
-        }
-
-        public Builder withAttributeService( TrackedEntityAttributeService attributeService )
-        {
-            this.visitor.attributeService = attributeService;
-            return this;
-        }
-
-        public Builder withRelationshipTypeService( RelationshipTypeService relationshipTypeService )
-        {
-            this.visitor.relationshipTypeService = relationshipTypeService;
-            return this;
-        }
-
-        public Builder withStatementBuilder( StatementBuilder statementBuilder )
-        {
-            this.visitor.statementBuilder = statementBuilder;
-            return this;
-        }
-
-        public Builder withI18n( I18n i18n )
-        {
-            this.visitor.i18n = i18n;
-            return this;
-        }
-
-        public Builder withConstantMap( Map<String, Constant> constantMap )
-        {
-            this.visitor.constantMap = constantMap;
-            return this;
-        }
-
-        public Builder withSamplePeriods( List<Period> samplePeriods )
-        {
-            this.visitor.samplePeriods = samplePeriods;
-            return this;
-        }
-
-        public Builder withMissingValueStrategy( MissingValueStrategy missingValueStrategy )
-        {
-            this.visitor.missingValueStrategy = missingValueStrategy;
-            return this;
-        }
-
-        public CommonExpressionVisitor buildForExpressions()
-        {
-            Validate.notNull( this.visitor.dimensionService, "Missing required property 'dimensionService'" );
-            Validate.notNull( this.visitor.organisationUnitGroupService,
-                "Missing required property 'organisationUnitGroupService'" );
-            Validate.notNull( this.visitor.missingValueStrategy, "Missing required property 'missingValueStrategy'" );
-
-            return validateCommonProperties();
-        }
-
-        public CommonExpressionVisitor buildForProgramIndicatorExpressions()
-        {
-            Validate.notNull( this.visitor.programIndicatorService,
-                "Missing required property 'programIndicatorService'" );
-            Validate.notNull( this.visitor.programStageService, "Missing required property 'programStageService'" );
-            Validate.notNull( this.visitor.dataElementService, "Missing required property 'dataElementService'" );
-            Validate.notNull( this.visitor.attributeService, "Missing required property 'attributeService'" );
-            Validate.notNull( this.visitor.relationshipTypeService,
-                "Missing required property 'relationshipTypeService'" );
-            Validate.notNull( this.visitor.statementBuilder, "Missing required property 'statementBuilder'" );
-            Validate.notNull( this.visitor.i18n, "Missing required property 'i18n'" );
-
-            return validateCommonProperties();
-        }
-
-        private CommonExpressionVisitor validateCommonProperties()
-        {
-            Validate.notNull( this.visitor.constantMap, "Missing required property 'constantMap'" );
-            Validate.notNull( this.visitor.itemMap, "Missing required property 'itemMap'" );
-            Validate.notNull( this.visitor.itemMethod, "Missing required property 'itemMethod'" );
-            Validate.notNull( this.visitor.samplePeriods, "Missing required property 'samplePeriods'" );
-
-            return visitor;
-        }
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ExpressionItem.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ExpressionItem.java
@@ -27,12 +27,11 @@
  */
 package org.hisp.dhis.parser.expression;
 
-import static org.hisp.dhis.parser.expression.CommonExpressionVisitor.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import org.hisp.dhis.antlr.AntlrExprItem;
 import org.hisp.dhis.antlr.AntlrExpressionVisitor;
-import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 
 /**
@@ -43,13 +42,21 @@ import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 public interface ExpressionItem
     extends AntlrExprItem
 {
+    ExpressionItemMethod ITEM_GET_DESCRIPTIONS = ExpressionItem::getDescription;
+
+    ExpressionItemMethod ITEM_GET_EXPRESSION_INFO = ExpressionItem::getExpressionInfo;
+
+    ExpressionItemMethod ITEM_EVALUATE = ExpressionItem::evaluate;
+
+    ExpressionItemMethod ITEM_GET_SQL = ExpressionItem::getSql;
+
     /**
      * Collects the description of an individual data item, to use later in
      * constructing a description of the expression as a whole.
-     * <p/>
+     * <p>
      * This method only needs to be overridden for items that have UIDs that
      * need to be translated into human-readable object names.
-     * <p/>
+     * <p>
      * For other items, evaluate all paths to be sure that we collect the
      * description of any items that may be within this expression.
      *
@@ -63,13 +70,13 @@ public interface ExpressionItem
     }
 
     /**
-     * Collects the item id of an individual data item, so it can later be
-     * looked up in the database (as with indicators, validation rules and
-     * predictors.)
-     * <p/>
+     * Collects the information we need from an expression such as the ids of
+     * metadata items for which we will need to find the metadata, and then (at
+     * least for some items) the corresponding data.
+     * <p>
      * This method only needs to be overridden for items that have UIDs that
      * need to be looked up in the database.
-     * <p/>
+     * <p>
      * For other items, evaluate all paths to be sure that we collect the UIDs
      * of any items that may be within this expression. But don't return null
      * from this function, to make sure that no part of the expression is
@@ -79,7 +86,7 @@ public interface ExpressionItem
      * @param visitor the tree visitor
      * @return a dummy value for the item
      */
-    default Object getItemId( ExprContext ctx, CommonExpressionVisitor visitor )
+    default Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         Object value = evaluateAllPaths( ctx, visitor );
 
@@ -87,40 +94,13 @@ public interface ExpressionItem
     }
 
     /**
-     * Collects the organisation unit group for which we will need counts.
-     * (applies to expression service items).
-     * <p/>
-     * This method only needs to be overridden for the organisation unit group
-     * count.
-     * <p/>
-     * For other items, evaluate all paths to be sure that we collect any
-     * organisation unit groups that may be within this expression. But if we
-     * hit a parser exception (like constant not found), continue.
-     *
-     * @param ctx the expression context
-     * @param visitor the tree visitor
-     * @return a dummy value for the item
-     */
-    default Object getOrgUnitGroup( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        try
-        {
-            return evaluateAllPaths( ctx, visitor );
-        }
-        catch ( ParserException e )
-        {
-            return DEFAULT_DOUBLE_VALUE;
-        }
-    }
-
-    /**
      * Returns the value of the expression item. Also used for syntax checking.
      * (For program indicator-only items, this may return a dummy value because
      * the real evaluation is done in SQL.)
-     * <p/>
+     * <p>
      * For the lower-level Antlr... items, this method calls the lower-level
      * evaluate routine.
-     * <p/>
+     * <p>
      * For all other items, this method must be overridden.
      *
      * @param ctx the expression context
@@ -135,9 +115,9 @@ public interface ExpressionItem
     /**
      * Provides a default implementation for the lower-level Antlr... evaluate
      * method.
-     * <p/>
+     * <p>
      * The lower-level Antlr... items must provide this method.
-     * <p/>
+     * <p>
      * If a higher-level item does not override the method evaluate(...
      * CommonExpressionVisitor ...) then this default implementation will be
      * called, resulting in an exception.
@@ -156,10 +136,10 @@ public interface ExpressionItem
      * Finds the value of an expression function, evaluating all the arguments
      * of logical functions that might not always evaluate all arguments based
      * on the truth value of some arguments (e.g. if, and, or, firstNonNull).
-     * <p/>
+     * <p>
      * For those few logical functions that may not normally evaluate all
      * arguments, this method must be overridden.
-     * <p/>
+     * <p>
      * For other items, this method does not need to be overridden.
      *
      * @param ctx the expression context
@@ -173,10 +153,10 @@ public interface ExpressionItem
 
     /**
      * Generates the SQL for a program indicator expression item.
-     * <p/>
+     * <p>
      * This method must be overridden for all items used in program indicator
      * expressions, otherwise an exception will be thrown.
-     * <p/>
+     * <p>
      * For other items, this method does not need to be overridden.
      *
      * @param ctx the expression context
@@ -186,30 +166,5 @@ public interface ExpressionItem
     default Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         throw new ParserExceptionWithoutContext( "getSql not implemented for " + ctx.getText() );
-    }
-
-    /**
-     * Regenerates the original item syntax from the parse tree, or in some
-     * cases substitutes a value if one is present. This method is used to
-     * regenerate the expression in the backend while substituting key
-     * backend-determined values, such as DHIS 2 constants and the number of org
-     * units in an org unit group. The expression, with these backend-determined
-     * values substituted, can then be passed to the front-end for evaluation
-     * that fills in the other data values.
-     * <p/>
-     * This method only needs to be overridden for items such as DHIS 2
-     * constants and org unit groups counts that provide back-end values before
-     * the front-end fills in the data values.
-     * <p/>
-     * For other items, this method just reconstructs the expression text from
-     * the current token and the token's children.
-     *
-     * @param ctx the expression context
-     * @param visitor the tree visitor
-     * @return the regenerated expression (as a String) for the item
-     */
-    default Object regenerate( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        return visitor.regenerateAllChildren( ctx );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ExpressionState.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ExpressionState.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import org.hisp.dhis.common.QueryModifiers;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.system.util.ValidationUtils;
+
+/**
+ * Current state of an expression during evaluation.
+ * <p>
+ * This class holds values that can change as an expression is evaluated. These
+ * values can affect how parsing is done in a subtree, or how final results are
+ * computed.
+ *
+ * @author Jim Grace
+ */
+@Getter
+@Setter
+public class ExpressionState
+{
+    /**
+     * By default, replace nulls with a default value.
+     */
+    private boolean replaceNulls = true;
+
+    /**
+     * Item query modifiers, if any, in effect during parsing.
+     */
+    private QueryModifiers queryMods = null;
+
+    /**
+     * Current program stage offset in effect.
+     */
+    private int stageOffset = Integer.MIN_VALUE;
+
+    /**
+     * Flag to check if a null date was found.
+     */
+    private boolean unprotectedNullDateFound = false;
+
+    /**
+     * Count of dimension items found.
+     */
+    private int itemsFound = 0;
+
+    /**
+     * Count of dimension item values found.
+     */
+    private int itemValuesFound = 0;
+
+    // -------------------------------------------------------------------------
+    // Logic
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a {@see QueryModifiersBuilder} that can be used to add modifiers
+     * to be be applied while parsing. If there are no query modifiers at
+     * present, returns a fresh builder. If there are query modifiers at
+     * present, returns a builder based on current modifiers.
+     *
+     * @return a {@see QueryModifiersBuilder}
+     */
+    public QueryModifiers.QueryModifiersBuilder getQueryModsBuilder()
+    {
+        return (queryMods == null)
+            ? QueryModifiers.builder()
+            : queryMods.toBuilder();
+    }
+
+    /**
+     * Handles nulls and missing values.
+     * <p>
+     * If we should replace nulls with the default value, then do so, and
+     * remember how many items found, and how many of them had values, for
+     * subsequent MissingValueStrategy analysis.
+     * <p>
+     * If we should not replace nulls with the default value, then don't, as
+     * this is likely for some function that is testing for nulls, and a missing
+     * value should not count towards the MissingValueStrategy.
+     *
+     * @param value the (possibly null) value.
+     * @param valueType the type of value to substitute if null.
+     * @return the value we should return.
+     */
+    public Object handleNulls( Object value, ValueType valueType )
+    {
+        if ( replaceNulls )
+        {
+            itemsFound++;
+            if ( value == null && valueType.isDate() )
+            {
+                unprotectedNullDateFound = true;
+                return null;
+            }
+            else if ( value == null )
+            {
+                return ValidationUtils.getNullReplacementValue( valueType );
+            }
+            else
+            {
+                itemValuesFound++;
+            }
+        }
+
+        return value;
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -59,7 +59,6 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.VERTICAL_BA
 import static org.hisp.dhis.util.DateUtils.parseDate;
 
 import java.util.Date;
-import java.util.List;
 
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.dataitem.ItemConstant;
@@ -87,10 +86,7 @@ import org.hisp.dhis.parser.expression.operator.OperatorMathModulus;
 import org.hisp.dhis.parser.expression.operator.OperatorMathMultiply;
 import org.hisp.dhis.parser.expression.operator.OperatorMathPlus;
 import org.hisp.dhis.parser.expression.operator.OperatorMathPower;
-import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodType;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -156,24 +152,20 @@ public class ParserUtils
 
         .build();
 
-    public static final ExpressionItemMethod ITEM_GET_DESCRIPTIONS = ExpressionItem::getDescription;
-
-    public static final ExpressionItemMethod ITEM_GET_IDS = ExpressionItem::getItemId;
-
-    public static final ExpressionItemMethod ITEM_GET_ORG_UNIT_GROUPS = ExpressionItem::getOrgUnitGroup;
-
-    public static final ExpressionItemMethod ITEM_EVALUATE = ExpressionItem::evaluate;
-
-    public static final ExpressionItemMethod ITEM_GET_SQL = ExpressionItem::getSql;
-
-    public static final ExpressionItemMethod ITEM_REGENERATE = ExpressionItem::regenerate;
+    /**
+     * Default value for data type double.
+     */
+    public static final double DEFAULT_DOUBLE_VALUE = 1d;
 
     /**
-     * Used for syntax checking when we don't have a list of actual periods for
-     * collecting samples.
+     * Default value for data type date.
      */
-    public static final List<Period> DEFAULT_SAMPLE_PERIODS = ImmutableList.of(
-        PeriodType.getPeriodFromIsoString( "20010101" ) );
+    public static final String DEFAULT_DATE_VALUE = "2017-07-08";
+
+    /**
+     * Default value for data type boolean.
+     */
+    public static final boolean DEFAULT_BOOLEAN_VALUE = false;
 
     /**
      * Parse a date. The input format is guaranteed by the expression parser to

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ProgramExpressionParams.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ProgramExpressionParams.java
@@ -36,7 +36,7 @@ import lombok.Getter;
 import org.hisp.dhis.program.ProgramIndicator;
 
 /**
- * Parameters to generate SQL from a program expression
+ * Parameters to generate SQL from a program indicator expression
  *
  * @author Jim Grace
  */
@@ -47,20 +47,20 @@ public class ProgramExpressionParams
     /**
      * Program indicator
      */
-    private ProgramIndicator programIndicator;
+    private final ProgramIndicator programIndicator;
 
     /**
      * Program reporting start date
      */
-    private Date reportingStartDate;
+    private final Date reportingStartDate;
 
     /**
      * Program reporting end date
      */
-    private Date reportingEndDate;
+    private final Date reportingEndDate;
 
     /**
      * UIDs of all the DataElements and Attributes in the expression
      */
-    Set<String> dataElementAndAttributeIdentifiers;
+    private final Set<String> dataElementAndAttributeIdentifiers;
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ProgramExpressionParams.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ProgramExpressionParams.java
@@ -25,32 +25,42 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.program.variable;
+package org.hisp.dhis.parser.expression;
 
-import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-import org.hisp.dhis.parser.expression.ProgramExpressionParams;
-import org.hisp.dhis.program.AnalyticsType;
+import java.util.Date;
+import java.util.Set;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import org.hisp.dhis.program.ProgramIndicator;
 
 /**
- * Program indicator variable: event date (also used for execution date)
+ * Parameters to generate SQL from a program expression
  *
  * @author Jim Grace
  */
-public class vEventDate
-    extends ProgramDateVariable
+@Getter
+@Builder
+public class ProgramExpressionParams
 {
-    @Override
-    public Object getSql( CommonExpressionVisitor visitor )
-    {
-        ProgramExpressionParams progExParams = visitor.getProgExParams();
+    /**
+     * Program indicator
+     */
+    private ProgramIndicator programIndicator;
 
-        if ( AnalyticsType.ENROLLMENT == progExParams.getProgramIndicator().getAnalyticsType() )
-        {
-            return visitor.getStatementBuilder().getProgramIndicatorEventColumnSql(
-                null, "executiondate", progExParams.getReportingStartDate(), progExParams.getReportingEndDate(),
-                progExParams.getProgramIndicator() );
-        }
+    /**
+     * Program reporting start date
+     */
+    private Date reportingStartDate;
 
-        return "executiondate";
-    }
+    /**
+     * Program reporting end date
+     */
+    private Date reportingEndDate;
+
+    /**
+     * UIDs of all the DataElements and Attributes in the expression
+     */
+    Set<String> dataElementAndAttributeIdentifiers;
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/dataitem/ItemConstant.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/dataitem/ItemConstant.java
@@ -83,17 +83,4 @@ public class ItemConstant
 
         return Double.valueOf( constant.getValue() ).toString();
     }
-
-    @Override
-    public Object regenerate( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        Constant constant = visitor.getConstantMap().get( ctx.uid0.getText() );
-
-        if ( constant == null )
-        {
-            return ctx.getText();
-        }
-
-        return Double.valueOf( constant.getValue() ).toString();
-    }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMaxDate.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMaxDate.java
@@ -49,7 +49,7 @@ public class FunctionMaxDate
     {
         Date maxDate = parseExpressionDate( ctx.maxDate.getText() );
 
-        QueryModifiers queryMods = visitor.getQueryModsBuilder().maxDate( maxDate ).build();
+        QueryModifiers queryMods = visitor.getExState().getQueryModsBuilder().maxDate( maxDate ).build();
 
         return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMaxDate.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMaxDate.java
@@ -49,7 +49,7 @@ public class FunctionMaxDate
     {
         Date maxDate = parseExpressionDate( ctx.maxDate.getText() );
 
-        QueryModifiers queryMods = visitor.getExState().getQueryModsBuilder().maxDate( maxDate ).build();
+        QueryModifiers queryMods = visitor.getState().getQueryModsBuilder().maxDate( maxDate ).build();
 
         return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMinDate.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMinDate.java
@@ -49,7 +49,7 @@ public class FunctionMinDate
     {
         Date minDate = parseExpressionDate( ctx.minDate.getText() );
 
-        QueryModifiers queryMods = visitor.getQueryModsBuilder().minDate( minDate ).build();
+        QueryModifiers queryMods = visitor.getExState().getQueryModsBuilder().minDate( minDate ).build();
 
         return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMinDate.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionMinDate.java
@@ -49,7 +49,7 @@ public class FunctionMinDate
     {
         Date minDate = parseExpressionDate( ctx.minDate.getText() );
 
-        QueryModifiers queryMods = visitor.getExState().getQueryModsBuilder().minDate( minDate ).build();
+        QueryModifiers queryMods = visitor.getState().getQueryModsBuilder().minDate( minDate ).build();
 
         return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/PeriodOffset.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/PeriodOffset.java
@@ -47,15 +47,15 @@ public class PeriodOffset
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        ExpressionState exState = visitor.getExState();
+        ExpressionState state = visitor.getState();
 
-        int existingPeriodOffset = (exState.getQueryMods() == null) ? 0 : exState.getQueryMods().getPeriodOffset();
+        int existingPeriodOffset = (state.getQueryMods() == null) ? 0 : state.getQueryMods().getPeriodOffset();
 
         int parsedPeriodOffset = (ctx.period == null) ? 0 : firstNonNull( parseInt( ctx.period.getText() ), 0 );
 
         int periodOffset = existingPeriodOffset + parsedPeriodOffset;
 
-        QueryModifiers queryMods = exState.getQueryModsBuilder().periodOffset( periodOffset ).build();
+        QueryModifiers queryMods = state.getQueryModsBuilder().periodOffset( periodOffset ).build();
 
         return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/PeriodOffset.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/PeriodOffset.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.system.util.MathUtils.parseInt;
 import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.ExpressionState;
 
 /**
  * Function periodOffset
@@ -46,13 +47,15 @@ public class PeriodOffset
     @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        int existingPeriodOffset = (visitor.getQueryMods() == null) ? 0 : visitor.getQueryMods().getPeriodOffset();
+        ExpressionState exState = visitor.getExState();
+
+        int existingPeriodOffset = (exState.getQueryMods() == null) ? 0 : exState.getQueryMods().getPeriodOffset();
 
         int parsedPeriodOffset = (ctx.period == null) ? 0 : firstNonNull( parseInt( ctx.period.getText() ), 0 );
 
         int periodOffset = existingPeriodOffset + parsedPeriodOffset;
 
-        QueryModifiers queryMods = visitor.getQueryModsBuilder().periodOffset( periodOffset ).build();
+        QueryModifiers queryMods = exState.getQueryModsBuilder().periodOffset( periodOffset ).build();
 
         return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/RepeatableProgramStageOffset.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/RepeatableProgramStageOffset.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.parser.expression.function;
 
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.ExpressionState;
 import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
 
 /**
@@ -51,13 +52,15 @@ public class RepeatableProgramStageOffset implements ExpressionItem
 
     private Object next( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        int oldStageOffset = visitor.getStageOffset();
+        ExpressionState exState = visitor.getExState();
 
-        visitor.setStageOffset( Integer.parseInt( ctx.stage.getText() ) );
+        int oldStageOffset = exState.getStageOffset();
+
+        exState.setStageOffset( Integer.parseInt( ctx.stage.getText() ) );
 
         Object ret = visitor.visit( ctx.expr( 0 ) );
 
-        visitor.setStageOffset( oldStageOffset );
+        exState.setStageOffset( oldStageOffset );
 
         return ret;
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/RepeatableProgramStageOffset.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/RepeatableProgramStageOffset.java
@@ -52,15 +52,15 @@ public class RepeatableProgramStageOffset implements ExpressionItem
 
     private Object next( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        ExpressionState exState = visitor.getExState();
+        ExpressionState state = visitor.getState();
 
-        int oldStageOffset = exState.getStageOffset();
+        int oldStageOffset = state.getStageOffset();
 
-        exState.setStageOffset( Integer.parseInt( ctx.stage.getText() ) );
+        state.setStageOffset( Integer.parseInt( ctx.stage.getText() ) );
 
         Object ret = visitor.visit( ctx.expr( 0 ) );
 
-        exState.setStageOffset( oldStageOffset );
+        state.setStageOffset( oldStageOffset );
 
         return ret;
     }


### PR DESCRIPTION
The main effect of this PR is to make `CommonExpressionVisitor` much smaller and better-organized so that it is easier to understand and maintain. It is reduced from 823 lines to 195 lines.

This PR also lays the foundation for implementing [DHIS2-12082](https://jira.dhis2.org/browse/DHIS2-12082) (OrgUnit dataSet and program expression functions) and [DHIS2-11522](https://jira.dhis2.org/browse/DHIS2-11522) (Indicator sub-expressions). I hope it can get a relatively quick review and approval (after fixing anything serious of course) so I can get these features into 2.38. I believe that the code can be further improved, but hopefully this can be done after the PR is merged rather than delaying its approval.

### CommonExpressionVisitor decomposition

In addition to service and I18n references, `CommonExpressionVisitor` used to have 26 fields, and it was not immediately obvious which were parameters, which were state variables, and which were output values. With the refactor it now has 4 fields plus references to the following four classes:

- `ExpressionParams exParams` was recently introduced to simplify and better structure calls to _ExpressionService.getExpressionValue_, but was also done with this refactor in mind. _exParams_ is now just referenced by _CommonExpressionVisitor_ rather than copying individual fields from _exParams_ into _CommonExpressionVisitor_.

- `ProgramExpressionParams progExParams` is likewise used inside _CommonExpressionVisitor_ for parameters provided by _ProgramIndicatorService_.

- `ExpressionState exState` contains state information that may change as nodes in a parsed expression tree are visited, like the current values of _periodOffset_ and _stageOffset_, whether nulls should be replaced by default values in this part of the parse tree, etc.

- `ExpressionInfo exInfo` contains information that is gathered and returned from the (raw, unevaluated) expression by the new `ExpressionItem::getExpressionInfo` method (see below).

Expression visiting code had been referencing all 26 fields directly from _CommonExpressionVisitor_. Now most of these fields must be referenced through these other classes. Examples:

> visitor.getValueMap() -> visitor.getExParams().getValueMap()
> visitor.getProgramIndicator() -> visitor.getProgExParams().getProgramIndicator()
> visitor.getStageOffset() -> visitor.getExState().getStageOffset()
> visitor.getItemIds() -> visitor.getExInfo().getItemIds()

### ExpressionItem visiting modes

The `ExpressionItem` interface has been refactored to reduce the number of main visiting modes from six to four:

`ExpressionItem::getExpressionInfo` (ITEM_GET_EXPRESSION_INFO) takes the place of both `getItemId` and `getOrgUnitGroup`. The `getItemId` method had collected _DimensionalItemIds_ (for _DataElements_, _ProgramAttributes_, etc.) and `getOrgUnitGroup` had collected _OrgUnitGroup_ ids. This followed the pattern of the pre-ANTLR code where a different regexp search was used to find different types of results. However, the upcoming [DHIS2-12082](https://jira.dhis2.org/browse/DHIS2-12082) will additionally require the collection of _DataSet_ and _Program_ ids from the new parse nodes. Rather than having one pass through the nodes for each different type of information to be collected, it makes sense to collect these in a single pass and put them into the `ExpressionInfo` object. In the future, calls to _ExpressionService_ may make better use of this single pass instead of multiple passes through the parse tree, by referring to a once-collected _ExpressionInfo_ object. The _ExpressionInfo_ object could even be cached. The same expression string will always produce the same _ExpressionInfo_ object.

Note that the `getExpressionInfo` method is still different from `getDescription`, since the latter fetches metadata object names from the database, which is only needed when the user is viewing the expression in the Maintenance app. Because of the database access, _getDescription_ takes substantially longer than _getExpressionInfo_.

Note also that the fromer `getOrgUnitGroup` had been kind of overloaded in that it collected the _orgUnitGroup_ ids from both the `OUG{uid}` org unit group count data item (used only in indicators) and also the `orgUnit.group` function (used only in validation rules and predictors). For clarity, these are now collected in two separate fields in _ExpressionInfo::orgUnitGroupCountIds_, and _ExpressionInfo::orgUnitGroupIds_.  They are retrieved by two different methods in _ExpressionService_.

`ExpressionItem::regenerate `(ITEM_REGENERATE) has been removed, along with the code that implemented it. (TLDR; This had been used to substitute constants and _orgUnitGroup_ counts into indicator expressions that are downloaded into the data entry form and evaluated in JavaScript to provide additional values for reference during data entry. Because ANTLR performed poorly at walking the parse tree so many times for data entry in some implementations, this feature was reverted back to regexp code, and can be found at `DefaultExpressionService::regenerateIndicatorExpression`.)

The remaining four visiting method definitions, used as _CommonExpressionVisitor_ arguments, have been moved from the _ParserUtils_ class to the _ExpressionItem_ interface where the methods they reference are defined. (Note that this code was written before lambda expressions were available. If there is a more elegant way to do this with lambda expressions, perhaps it can be done later. For the upcoming features these were the important changes to make.)

### constantMap

It was once the case that all users of `ExpressionService` had to fetch the constant map (all constants in the system) from `ConstantService` and pass this map to `ExpressionService.` However for getting expression information (_itemIds_, _orgUnitGroups_, and descriptions), the constant map was fetched by `DefaultExpressionService` on behalf of the caller. Profiling showed that this fetching was a substantial part of the time required for these operations, so a cache had been added.

When `ExpressionParams` was recently implemented, this behaviour was not changed, and _constantMap_ was added to _ExpressionParams_. For this PR, however, a simple refactor would have added _constantMap_ to _ProgramExpressionParams_ also. This would have resulted in the _constantMap_ being supplied by two different params classes.

Instead, _constantMap_ has now been removed from _ExpressionParams_ so it is no longer the burden of the _ExpressionService_ caller (indicators, validation rules, and predictors) to fetch. _DefaultExpressionService_ now always fetches the _constantMap_, using the cache, and provides the map to _CommonExpressionVisitor_. It also shares access to this cache for use by `DefaultProgramIndicatorService`, providing a consistent and fast way of supplying the _constantMap_ to all expression parsing.

### IdObjectManager

The `IdentifiableObjectManager` is now being used where possible to look up objects. This allows several class-specific services to be removed from _CommonExpressionVisitor_ (and from several classes that create it).