### PR TITLE
fix: Update nodejs version to support newer computers

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-apps/pom.xml
@@ -39,7 +39,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
-                            <nodeVersion>v8.11.1</nodeVersion>
+                            <nodeVersion>v16.13.2</nodeVersion>
                         </configuration>
                     </execution>
 


### PR DESCRIPTION
The old version (8.11.1) does not have an alternative for the arm64 cpu. As a result, building the dhis-web-apps module on newer laptops with these cpus, will result in a 404 error and fail.

The new version, 16.13.2, have been tested by @varl , and supports the arm64 cpus

