### PR TITLE
fix: attribute id is missing in api response (#9651)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -405,7 +405,7 @@ public class DefaultFieldFilterService implements FieldFilterService
         if ( fieldMap.containsKey( "attribute" ) && AttributeValue.class.isAssignableFrom( object.getClass() ) )
         {
             AttributeValue attributeValue = (AttributeValue) object;
-            attributeValue.setAttribute( attributeService.getAttribute( attributeValue.getAttribute().getId() ) );
+            attributeValue.setAttribute( attributeService.getAttribute( attributeValue.getAttribute().getUid() ) );
         }
 
         for ( String fieldKey : fieldMap.keySet() )


### PR DESCRIPTION
Revert the [PR#9078](https://github.com/dhis2/dhis2-core/pull/9078) because it causes a regression issue [DHIS2-12468](https://jira.dhis2.org/browse/DHIS2-12468) and [DHIS2-12636](https://jira.dhis2.org/browse/DHIS2-12636)
PR#9078 tried to fix [DHIS2-8868](https://jira.dhis2.org/browse/DHIS2-8868), but currently I can't reproduce this issue after revert the fix.
I think we should merge this first to fix DHIS2-12468 , then QA can check if DHIS2-8868 still happen then I can investigate and create another PR to fix that.