### PR TITLE
feat: Make interpretations backward compat. [DHIS2-12645]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/Interpretation.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/interpretation/Interpretation.java
@@ -135,18 +135,24 @@ public class Interpretation
         this.text = text;
     }
 
-    public Interpretation( EventReport eventReport, OrganisationUnit organisationUnit, String text )
+    public Interpretation( EventVisualization eventVisualization, EventReport eventReport,
+        OrganisationUnit organisationUnit, String text )
     {
         this.eventReport = eventReport;
         eventReport.getInterpretations().add( this );
+        this.eventVisualization = eventVisualization;
+        eventVisualization.getInterpretations().add( this );
         this.organisationUnit = organisationUnit;
         this.text = text;
     }
 
-    public Interpretation( EventChart eventChart, OrganisationUnit organisationUnit, String text )
+    public Interpretation( EventVisualization eventVisualization, EventChart eventChart,
+        OrganisationUnit organisationUnit, String text )
     {
         this.eventChart = eventChart;
         eventChart.getInterpretations().add( this );
+        this.eventVisualization = eventVisualization;
+        eventVisualization.getInterpretations().add( this );
         this.organisationUnit = organisationUnit;
         this.text = text;
     }
@@ -179,6 +185,10 @@ public class Interpretation
         {
             return VISUALIZATION;
         }
+        else if ( eventVisualization != null )
+        {
+            return EVENT_VISUALIZATION;
+        }
         else if ( map != null )
         {
             return MAP;
@@ -190,10 +200,6 @@ public class Interpretation
         else if ( eventChart != null )
         {
             return EVENT_CHART;
-        }
-        else if ( eventVisualization != null )
-        {
-            return EVENT_VISUALIZATION;
         }
         else if ( dataSet != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventchart/EventChart.hbm.xml
@@ -157,7 +157,7 @@
         <property name="hideSubtitle"/>
 
         <set name="interpretations" inverse="true">
-            <key column="eventvisualizationid"/>
+            <key column="eventchartid"/>
             <one-to-many class="org.hisp.dhis.interpretation.Interpretation"/>
         </set>
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventreport/EventReport.hbm.xml
@@ -157,7 +157,7 @@
         <property name="hideSubtitle"/>
 
         <set name="interpretations" inverse="true">
-            <key column="eventvisualizationid"/>
+            <key column="eventreportid"/>
             <one-to-many class="org.hisp.dhis.interpretation.Interpretation"/>
         </set>
 


### PR DESCRIPTION
This is about making new Interpretations also available in deprecated entities (EventReport and EventChart)  when saved through the new EventVisualization endpoint.

The opposite should also be true. When an Interpretation is saved in EventChart or EventReport it should also be present in EventVisualization.

This is being requested to keep backward/forward compatibility between EventVisualiztion and the deprecated entities (EventReport and EventChart).