### PR TITLE
fix: system settings JSON as default [DHIS2-12516]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -266,7 +266,7 @@ public class SystemSettingController
         return Optional.empty();
     }
 
-    @GetMapping( produces = { APPLICATION_JSON_VALUE, ContextUtils.CONTENT_TYPE_HTML } )
+    @GetMapping( produces = APPLICATION_JSON_VALUE )
     public ResponseEntity<Map<String, Serializable>> getSystemSettingsJson(
         @RequestParam( value = "key", required = false ) Set<String> keys )
     {
@@ -275,14 +275,14 @@ public class SystemSettingController
             .body( systemSettingManager.getSystemSettings( getSettingKeysToFetch( keys ) ) );
     }
 
-    @GetMapping( produces = "application/javascript" )
+    @GetMapping( produces = "application/javascript", params = "callback" )
     public void getSystemSettingsJsonP( @RequestParam( value = "key", required = false ) Set<String> keys,
         @RequestParam( defaultValue = "callback" ) String callback, HttpServletResponse response )
         throws IOException
     {
         Set<SettingKey> settingKeys = getSettingKeysToFetch( keys );
 
-        response.setContentType( APPLICATION_JSON_VALUE );
+        response.setContentType( "application/javascript" );
         response.setHeader( ContextUtils.HEADER_CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue() );
         renderService.toJsonP( response.getOutputStream(), systemSettingManager.getSystemSettings( settingKeys ),
             callback );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemSettingController.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -273,19 +272,6 @@ public class SystemSettingController
         return ResponseEntity.ok()
             .cacheControl( CacheControl.noCache().cachePrivate() )
             .body( systemSettingManager.getSystemSettings( getSettingKeysToFetch( keys ) ) );
-    }
-
-    @GetMapping( produces = "application/javascript", params = "callback" )
-    public void getSystemSettingsJsonP( @RequestParam( value = "key", required = false ) Set<String> keys,
-        @RequestParam( defaultValue = "callback" ) String callback, HttpServletResponse response )
-        throws IOException
-    {
-        Set<SettingKey> settingKeys = getSettingKeysToFetch( keys );
-
-        response.setContentType( "application/javascript" );
-        response.setHeader( ContextUtils.HEADER_CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue() );
-        renderService.toJsonP( response.getOutputStream(), systemSettingManager.getSystemSettings( settingKeys ),
-            callback );
     }
 
     private Set<SettingKey> getSettingKeysToFetch( Set<String> keys )


### PR DESCRIPTION
### Summary
The problem here was that the endpoint path was mapped twice and depending on what a browser would send by default in its `Accept` header one or the other would win. I think the JSON returning one was given the `produces` with HTML for that reason so that it would win. But it  never actually return HTML - always JSON. 

After discussion in Slack we decided to remove the JSONP endpoint resolving the ambiguity.

### Automatic Testing
Does cover the method, did not need adjustment.

### Manual Testing
* `GET /api/systemSettings` without setting any headers in a browser should get you JSON
* `GET /api/systemSettings` without setting any `Accept` header at all in a REST tool should get you JSON

### Release Notes Update
https://github.com/dhis2/dhis2-releases/pull/72