### PR TITLE
feat: Mark legacy eventVisualization as NEW after PUT [DHIS2-12647]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -209,6 +209,11 @@ public class EventVisualization extends BaseAnalyticalObject
 
     /**
      * Indicates whether this is a legacy row (EventChart or EventReport).
+     *
+     * - EventVisualizations created through the new App will never be legacy.
+     *
+     * - Legacy EventVisualizations updated through the new App will always
+     * become non-legacy.
      */
     private boolean legacy;
 
@@ -1052,6 +1057,8 @@ public class EventVisualization extends BaseAnalyticalObject
         this.showDimensionLabels = showDimensionLabels;
     }
 
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
     public boolean isLegacy()
     {
         return legacy;

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_33__Drop_Legacy_Constraints_EventReport_EventChart.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_33__Drop_Legacy_Constraints_EventReport_EventChart.sql
@@ -1,0 +1,60 @@
+-- This script relates to the issue https://jira.dhis2.org/browse/DHIS2-12647
+-- Removes all foreign keys/constraints from legacy (unused) tables related to "event chart" and "event report".
+-- This is causing collection issues (during updated) on the new set of tables for "event visualization".
+
+-- 1) Removing all FKs from all "eventchart*" tables
+DO
+$$
+    DECLARE
+        t      text;
+        tables text[] := array ['eventchart','eventchart_attributedimensions','eventchart_categorydimensions',
+            'eventchart_categoryoptiongroupsetdimensions','eventchart_columns','eventchart_dataelementdimensions',
+            'eventchart_filters','eventchart_itemorgunitgroups','eventchart_organisationunits',
+            'eventchart_orgunitgroupsetdimensions','eventchart_orgunitlevels','eventchart_periods',
+            'eventchart_programindicatordimensions','eventchart_rows'];
+        r      record;
+    BEGIN
+        FOREACH t IN ARRAY tables
+            LOOP
+                FOR r IN (
+                    SELECT constraint_name
+                    FROM information_schema.table_constraints
+                    WHERE table_name = t
+                      AND constraint_name LIKE 'fk%'
+                )
+                    LOOP
+                        RAISE INFO '%','dropping ' || r.constraint_name || 'FROM TABLE ' || t;
+                        EXECUTE CONCAT('ALTER TABLE IF EXISTS ' || t || ' DROP CONSTRAINT IF EXISTS ' || r.constraint_name);
+                    END LOOP;
+            END LOOP;
+    END;
+$$ LANGUAGE plpgsql;
+
+
+-- 2) Removing all FKs from all "eventreport*" tables
+DO
+$$
+    DECLARE
+        t      text;
+        tables text[] := array ['eventreport','eventreport_attributedimensions','eventreport_categorydimensions',
+            'eventreport_categoryoptiongroupsetdimensions','eventreport_columns','eventreport_dataelementdimensions',
+            'eventreport_filters','eventreport_itemorgunitgroups','eventreport_organisationunits',
+            'eventreport_orgunitgroupsetdimensions','eventreport_orgunitlevels','eventreport_periods',
+            'eventreport_programindicatordimensions','eventreport_rows'];
+        r      record;
+    BEGIN
+        FOREACH t IN ARRAY tables
+            LOOP
+                FOR r IN (
+                    SELECT constraint_name
+                    FROM information_schema.table_constraints
+                    WHERE table_name = t
+                      AND constraint_name LIKE 'fk%'
+                )
+                    LOOP
+                        RAISE INFO '%','dropping ' || r.constraint_name || 'FROM TABLE ' || t;
+                        EXECUTE CONCAT('ALTER TABLE IF EXISTS ' || t || ' DROP CONSTRAINT IF EXISTS ' || r.constraint_name);
+                    END LOOP;
+            END LOOP;
+    END;
+$$ LANGUAGE plpgsql;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
@@ -184,6 +184,21 @@ public class EventVisualizationController
         }
     }
 
+    @Override
+    protected void preUpdateEntity( final EventVisualization eventVisualization,
+        final EventVisualization newEventVisualization )
+    {
+        /**
+         * Once a legacy EventVisualization is updated through this new
+         * endpoint, it will automatically become a non-legacy
+         * EventVisualization.
+         */
+        if ( eventVisualization != null && eventVisualization.isLegacy() )
+        {
+            newEventVisualization.setLegacy( false );
+        }
+    }
+
     private void prepare( final EventVisualization eventVisualization )
     {
         dimensionService.mergeAnalyticalObject( eventVisualization );


### PR DESCRIPTION
When an event report created in the old EventReport app (on `/eventReports`) is opened, modified and saved in the new app (it means PUT request to /eventVisualizations) it should be marked as incompatible with the old app and no longer show up on `/eventReports`.

This is achieved by setting the `legacy` flag to false on every PUT operation that is triggered through the new endpoint `/eventVisualizations`.

I also added a migration to remove all old FKs from the legacy/unused tables so they do not conflict with the new set of tables of EventVisualization.
