### PR TITLE
feat: Add .aggregationType() override DHIS2-4530

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -81,6 +81,20 @@ public class BaseDimensionalItemObject
     }
 
     // -------------------------------------------------------------------------
+    // Logic
+    // -------------------------------------------------------------------------
+
+    @Override
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public AggregationType getAggregationType()
+    {
+        return (queryMods != null && queryMods.getAggregationType() != null)
+            ? queryMods.getAggregationType()
+            : aggregationType;
+    }
+
+    // -------------------------------------------------------------------------
     // DimensionalItemObject
     // -------------------------------------------------------------------------
 
@@ -120,6 +134,11 @@ public class BaseDimensionalItemObject
     // Get and set methods
     // -------------------------------------------------------------------------
 
+    public void setAggregationType( AggregationType aggregationType )
+    {
+        this.aggregationType = aggregationType;
+    }
+
     @Override
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
@@ -153,19 +172,6 @@ public class BaseDimensionalItemObject
     public void setLegendSets( List<LegendSet> legendSets )
     {
         this.legendSets = legendSets;
-    }
-
-    @Override
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public AggregationType getAggregationType()
-    {
-        return aggregationType;
-    }
-
-    public void setAggregationType( AggregationType aggregationType )
-    {
-        this.aggregationType = aggregationType;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -45,6 +45,7 @@ import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIO
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_EXPRESSION_INFO;
 import static org.hisp.dhis.parser.expression.ParserUtils.COMMON_EXPRESSION_ITEMS;
 import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AGGREGATION_TYPE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AVG;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.A_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.COUNT;
@@ -119,6 +120,7 @@ import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.parser.expression.ExpressionItemMethod;
 import org.hisp.dhis.parser.expression.ExpressionState;
+import org.hisp.dhis.parser.expression.function.FunctionAggregationType;
 import org.hisp.dhis.parser.expression.function.FunctionMaxDate;
 import org.hisp.dhis.parser.expression.function.FunctionMinDate;
 import org.hisp.dhis.parser.expression.function.PeriodOffset;
@@ -210,6 +212,7 @@ public class DefaultExpressionService
     private static final ImmutableMap<Integer, ExpressionItem> INDICATOR_EXPRESSION_ITEMS = ImmutableMap
         .<Integer, ExpressionItem> builder()
         .putAll( BASE_EXPRESSION_ITEMS )
+        .put( AGGREGATION_TYPE, new FunctionAggregationType() )
         .put( N_BRACE, new DimItemIndicator() )
         .put( MAX_DATE, new FunctionMaxDate() )
         .put( MIN_DATE, new FunctionMinDate() )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.expression;
 
 import static java.util.Collections.singletonList;
+import static org.hisp.dhis.analytics.AggregationType.LAST;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.DataType.TEXT;
 import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
@@ -113,7 +114,6 @@ import com.google.common.collect.Lists;
  */
 class ExpressionServiceTest extends DhisSpringTest
 {
-
     @Autowired
     private ExpressionService expressionService;
 
@@ -1219,7 +1219,10 @@ class ExpressionServiceTest extends DhisSpringTest
         assertNull( error( "#{dataElemenF}" ) );
         assertNull( error( "#{dataElemenG}" ) );
         assertNull( error( "#{dataElemenH}" ) );
-        assertNull( error( "if(A, 1, 0)" ) );
+        assertNull( error( "#{dataElemenA}.aggregationType(NOT_AN_AGGREGATION_TYPE)" ) );
+        assertNull( error( "#{dataElemenA}.periodOffset('notANumber')" ) );
+        assertNull( error( "#{dataElemenA}.maxDate(2022-13-01)" ) );
+        assertNull( error( "#{dataElemenA}.minDate(notADate)" ) );
     }
 
     // -------------------------------------------------------------------------
@@ -1324,6 +1327,14 @@ class ExpressionServiceTest extends DhisSpringTest
     void testIndicatorFunctionParsing()
     {
         DimensionalItemId id;
+
+        id = new DimensionalItemId( DATA_ELEMENT, "dataElemenA",
+            (QueryModifiers) null );
+        assertEquals( id, parseItemId( "#{dataElemenA}" ) );
+
+        id = new DimensionalItemId( DATA_ELEMENT, "dataElemenA",
+            QueryModifiers.builder().aggregationType( LAST ).build() );
+        assertEquals( id, parseItemId( "#{dataElemenA}.aggregationType(LAST)" ) );
 
         id = new DimensionalItemId( DATA_ELEMENT, "dataElemenA",
             QueryModifiers.builder().periodOffset( 10 ).build() );

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -182,7 +182,16 @@ public class ParserUtils
             "-" + (dateParts[1].length() == 1 ? "0" : "") + dateParts[1] +
             "-" + (dateParts[2].length() == 1 ? "0" : "") + dateParts[2];
 
-        Date date = parseDate( fixedDateString );
+        Date date;
+
+        try
+        {
+            date = parseDate( fixedDateString );
+        }
+        catch ( Exception e )
+        {
+            throw new ParserExceptionWithoutContext( "Invalid date: " + dateString + " " + e.getMessage() );
+        }
 
         if ( date == null )
         {


### PR DESCRIPTION
See [DHIS2-4530](https://jira.dhis2.org/browse/DHIS2-4530). Add the function `.aggregationType()` to override the aggregation type of a `DataElement` or other `BaseDimensionalItemObject` when fetching values in an indicator expression.

While I was adding test cases, I added them also for recent functions `.minDate()` and `.maxDate()`, only to discover that Exceptions were not properly caught, so I fixed that too. (The code calls a method that calls `safeParseDateTime` which, as the name would not imply, does not catch Exceptions if the date format is invalid.)

In addition to the code passing the unit tests, it passes the "Testing Suggestions" from [DHIS2-4530](https://jira.dhis2.org/browse/DHIS2-4530).