### PR TITLE
fix: add assignedUserUsername and DisplayName to event DHIS2-12620

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -127,6 +127,12 @@ public class Event
     private String assignedUser;
 
     @JsonProperty
+    private String assignedUserUsername;
+
+    @JsonProperty
+    private String assignedUserDisplayName;
+
+    @JsonProperty
     private String createdBy;
 
     @JsonProperty


### PR DESCRIPTION
@stian-sandvold the fields where not exposed in `/tracker/events/a6f092d0d44` since we did not have them in our tracker domain models. This change exposes them. An open question I have is: should the fields be exposed on import as well? If yes, this change is ready. If not, I will need to make a few more changes 😄 