### PR TITLE
fix: consistent and unsurprising query param behavior tracker/relationships DHIS2-12659

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
@@ -119,6 +119,42 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
+    void getRelationshipsBadRequestWithAllParams()
+    {
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void getRelationshipsBadRequestWithTeiAndEnrollment()
+    {
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void getRelationshipsBadRequestWithTeiAndEvent()
+    {
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
+    void getRelationshipsBadRequestWithEnrollmentAndEvent()
+    {
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            GET( "/tracker/relationships?enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
+                .error( HttpStatus.BAD_REQUEST )
+                .getMessage() );
+    }
+
+    @Test
     void getRelationshipsByEvent()
     {
         TrackedEntityInstance tei = trackedEntityInstance();
@@ -196,25 +232,6 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
         assertEquals( "No trackedEntity 'Hq3Kc6HK4OZ' found.",
             GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.NOT_FOUND )
-                .getMessage() );
-    }
-
-    @Test
-    void getRelationshipsByMultipleParams()
-    {
-        TrackedEntityInstance tei = trackedEntityInstance();
-        ProgramInstance programInstance = programInstance( tei );
-
-        RelationshipType rType = relationshipType( RelationshipEntity.PROGRAM_INSTANCE,
-            RelationshipEntity.TRACKED_ENTITY_INSTANCE );
-        Relationship r = relationship( rType, programInstance, tei );
-
-        // the query parameters are processed in order tei, enrollment, event
-        // the first query parameter (unless another param found relationships)
-        // to find no relationships causes response NOT_FOUND
-        assertEquals( "No trackedEntity 'Hq3Kc6HK4OZ' found.",
-            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=" + programInstance.getUid() )
                 .error( HttpStatus.NOT_FOUND )
                 .getMessage() );
     }
@@ -298,11 +315,6 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     private JsonObject assertFirstRelationship( JsonObject body, Relationship r )
     {
         return assertNthRelationship( body, r, 0 );
-    }
-
-    private JsonObject assertSecondRelationship( JsonObject body, Relationship r )
-    {
-        return assertNthRelationship( body, r, 1 );
     }
 
     private JsonObject assertNthRelationship( JsonObject body, Relationship r, int n )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
@@ -119,37 +119,10 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
-    void getRelationshipsBadRequestWithAllParams()
+    void getRelationshipsBadRequestWithMultipleParams()
     {
         assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.BAD_REQUEST )
-                .getMessage() );
-    }
-
-    @Test
-    void getRelationshipsBadRequestWithTeiAndEnrollment()
-    {
-        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.BAD_REQUEST )
-                .getMessage() );
-    }
-
-    @Test
-    void getRelationshipsBadRequestWithTeiAndEvent()
-    {
-        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
-                .error( HttpStatus.BAD_REQUEST )
-                .getMessage() );
-    }
-
-    @Test
-    void getRelationshipsBadRequestWithEnrollmentAndEvent()
-    {
-        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
-            GET( "/tracker/relationships?enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
+            GET( "/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
     }
@@ -248,7 +221,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     {
 
         assertEquals( "No trackedEntity 'Hq3Kc6HK4OZ' found.",
-            GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ" )
+            GET( "/tracker/relationships?trackedEntity=Hq3Kc6HK4OZ" )
                 .error( HttpStatus.NOT_FOUND )
                 .getMessage() );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
@@ -112,7 +112,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsMissingParam()
     {
-        assertEquals( "Missing required parameter 'tei', 'enrollment' or 'event'.",
+        assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
             GET( "/tracker/relationships" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
@@ -121,7 +121,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsBadRequestWithAllParams()
     {
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
@@ -130,7 +130,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsBadRequestWithTeiAndEnrollment()
     {
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&enrollment=Hq3Kc6HK4OZ" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
@@ -139,7 +139,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsBadRequestWithTeiAndEvent()
     {
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             GET( "/tracker/relationships?tei=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
@@ -148,7 +148,7 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     @Test
     void getRelationshipsBadRequestWithEnrollmentAndEvent()
     {
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             GET( "/tracker/relationships?enrollment=Hq3Kc6HK4OZ&event=Hq3Kc6HK4OZ" )
                 .error( HttpStatus.BAD_REQUEST )
                 .getMessage() );
@@ -211,6 +211,23 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
     @Test
     void getRelationshipsByTrackedEntity()
+    {
+        TrackedEntityInstance tei = trackedEntityInstance();
+        ProgramInstance programInstance = programInstance( tei );
+        RelationshipType rType = relationshipType( RelationshipEntity.PROGRAM_INSTANCE,
+            RelationshipEntity.TRACKED_ENTITY_INSTANCE );
+        Relationship r = relationship( rType, programInstance, tei );
+
+        JsonObject relationship = GET( "/tracker/relationships?trackedEntity=" + tei.getUid() )
+            .content( HttpStatus.OK );
+
+        JsonObject jsonRelationship = assertFirstRelationship( relationship, r );
+        assertEnrollment( jsonRelationship.getObject( "from" ), programInstance );
+        assertTrackedEntity( jsonRelationship.getObject( "to" ), tei );
+    }
+
+    @Test
+    void getRelationshipsByTei()
     {
         TrackedEntityInstance tei = trackedEntityInstance();
         ProgramInstance programInstance = programInstance( tei );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerRelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerRelationshipCriteria.java
@@ -50,8 +50,7 @@ import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteria
 public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
 {
 
-    @Setter
-    private String tei;
+    private String trackedEntity;
 
     @Setter
     private String enrollment;
@@ -65,6 +64,19 @@ public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
 
     private Class<?> identifierClass;
 
+    public void setTei( String tei )
+    {
+        // this setter is kept for backwards-compatibility
+        // query parameter 'tei' should still be allowed, but 'trackedEntity' is
+        // preferred.
+        this.trackedEntity = tei;
+    }
+
+    public void setTrackedEntity( String trackedEntity )
+    {
+        this.trackedEntity = trackedEntity;
+    }
+
     public String getIdentifierParam()
         throws WebMessageException
     {
@@ -74,9 +86,9 @@ public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
         }
 
         int count = 0;
-        if ( !StringUtils.isBlank( this.tei ) )
+        if ( !StringUtils.isBlank( this.trackedEntity ) )
         {
-            this.identifier = this.tei;
+            this.identifier = this.trackedEntity;
             this.identifierName = "trackedEntity";
             this.identifierClass = TrackedEntityInstance.class;
             count++;
@@ -98,12 +110,13 @@ public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
 
         if ( count == 0 )
         {
-            throw new WebMessageException( badRequest( "Missing required parameter 'tei', 'enrollment' or 'event'." ) );
+            throw new WebMessageException(
+                badRequest( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'." ) );
         }
         else if ( count > 1 )
         {
             throw new WebMessageException(
-                badRequest( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed." ) );
+                badRequest( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed." ) );
         }
         return this.identifier;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationships/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationships/TrackerRelationshipsExportController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export.relationships;
 
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
@@ -45,7 +44,6 @@ import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
@@ -120,56 +118,15 @@ public class TrackerRelationshipsExportController
         TrackerRelationshipCriteria criteria )
         throws WebMessageException
     {
-        int count = 0;
-        if ( !StringUtils.isBlank( criteria.getTei() ) )
-        {
-            count++;
-        }
-        if ( !StringUtils.isBlank( criteria.getEnrollment() ) )
-        {
-            count++;
-        }
-        if ( !StringUtils.isBlank( criteria.getEvent() ) )
-        {
-            count++;
-        }
-
-        if ( count == 0 )
-        {
-            throw new WebMessageException( badRequest( "Missing required parameter 'tei', 'enrollment' or 'event'." ) );
-        }
-        else if ( count > 1 )
-        {
-            throw new WebMessageException(
-                badRequest( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed." ) );
-        }
-
+        String identifier = criteria.getIdentifierParam();
+        String identifierName = criteria.getIdentifierName();
         List<org.hisp.dhis.webapi.controller.tracker.export.relationships.Relationship> relationships = tryGetRelationshipFrom(
-            criteria.getTei(),
-            TrackedEntityInstance.class,
-            () -> notFound( "No trackedEntity '" + criteria.getTei() + "' found." ),
+            identifier,
+            criteria.getIdentifierClass(),
+            () -> notFound( "No " + identifierName + " '" + identifier + "' found." ),
             criteria );
 
-        if ( relationships.isEmpty() )
-        {
-            relationships = tryGetRelationshipFrom(
-                criteria.getEnrollment(),
-                ProgramInstance.class,
-                () -> notFound( "No enrollment '" + criteria.getEnrollment() + "' found." ),
-                criteria );
-        }
-
-        if ( relationships.isEmpty() )
-        {
-            relationships = tryGetRelationshipFrom(
-                criteria.getEvent(),
-                ProgramStageInstance.class,
-                () -> notFound( "No event '" + criteria.getEvent() + "' found." ),
-                criteria );
-        }
-
         PagingWrapper<org.hisp.dhis.webapi.controller.tracker.export.relationships.Relationship> relationshipPagingWrapper = new PagingWrapper<>();
-
         if ( criteria.isPagingRequest() )
         {
             relationshipPagingWrapper = relationshipPagingWrapper.withPager(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationships/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/relationships/TrackerRelationshipsExportController.java
@@ -45,6 +45,7 @@ import javax.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.events.relationship.RelationshipService;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
@@ -119,6 +120,29 @@ public class TrackerRelationshipsExportController
         TrackerRelationshipCriteria criteria )
         throws WebMessageException
     {
+        int count = 0;
+        if ( !StringUtils.isBlank( criteria.getTei() ) )
+        {
+            count++;
+        }
+        if ( !StringUtils.isBlank( criteria.getEnrollment() ) )
+        {
+            count++;
+        }
+        if ( !StringUtils.isBlank( criteria.getEvent() ) )
+        {
+            count++;
+        }
+
+        if ( count == 0 )
+        {
+            throw new WebMessageException( badRequest( "Missing required parameter 'tei', 'enrollment' or 'event'." ) );
+        }
+        else if ( count > 1 )
+        {
+            throw new WebMessageException(
+                badRequest( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed." ) );
+        }
 
         List<org.hisp.dhis.webapi.controller.tracker.export.relationships.Relationship> relationships = tryGetRelationshipFrom(
             criteria.getTei(),
@@ -142,11 +166,6 @@ public class TrackerRelationshipsExportController
                 ProgramStageInstance.class,
                 () -> notFound( "No event '" + criteria.getEvent() + "' found." ),
                 criteria );
-        }
-
-        if ( relationships.isEmpty() )
-        {
-            throw new WebMessageException( badRequest( "Missing required parameter 'tei', 'enrollment' or 'event'." ) );
         }
 
         PagingWrapper<org.hisp.dhis.webapi.controller.tracker.export.relationships.Relationship> relationshipPagingWrapper = new PagingWrapper<>();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerRelationshipCriteriaTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerRelationshipCriteriaTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.event.webrequest.tracker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.junit.jupiter.api.Test;
+
+class TrackerRelationshipCriteriaTest
+{
+    @Test
+    void getIdentifierParamIfTeiIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+    }
+
+    @Test
+    void getIdentifierNameIfTeiIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "trackedEntity", criteria.getIdentifierName() );
+    }
+
+    @Test
+    void getIdentifierClassIfTeiIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+
+        assertEquals( TrackedEntityInstance.class, criteria.getIdentifierClass() );
+    }
+
+    @Test
+    void getIdentifierParamIfEnrollmentIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+    }
+
+    @Test
+    void getIdentifierNameIfEnrollmentIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "enrollment", criteria.getIdentifierName() );
+    }
+
+    @Test
+    void getIdentifierClassIfEnrollmentIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        assertEquals( ProgramInstance.class, criteria.getIdentifierClass() );
+    }
+
+    @Test
+    void getIdentifierParamIfEventIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+    }
+
+    @Test
+    void getIdentifierNameIfEventIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "event", criteria.getIdentifierName() );
+    }
+
+    @Test
+    void getIdentifierClassIfEventIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        assertEquals( ProgramStageInstance.class, criteria.getIdentifierClass() );
+    }
+
+    @Test
+    void getIdentifierParamThrowsIfNoParamsIsSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Missing required parameter 'tei', 'enrollment' or 'event'.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierNameThrowsIfNoParamsIsSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierName() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Missing required parameter 'tei', 'enrollment' or 'event'.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierParamThrowsIfAllParamsAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierNameThrowsIfAllParamsAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierName() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierClassThrowsIfAllParamsAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierClass() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierParamThrowsIfTeiAndEnrollmentAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierClassThrowsIfTeiAndEnrollmentAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTei( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierClass() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierParamThrowsIfEnrollmentAndEventAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+        criteria.setEvent( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerRelationshipCriteriaTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/tracker/TrackerRelationshipCriteriaTest.java
@@ -40,6 +40,18 @@ import org.junit.jupiter.api.Test;
 class TrackerRelationshipCriteriaTest
 {
     @Test
+    void getIdentifierParamIfTrackedEntityIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam() );
+        assertEquals( "Hq3Kc6HK4OZ", criteria.getIdentifierParam(), "should return cached identifier" );
+    }
+
+    @Test
     void getIdentifierParamIfTeiIsSet()
         throws WebMessageException
     {
@@ -51,6 +63,17 @@ class TrackerRelationshipCriteriaTest
     }
 
     @Test
+    void getIdentifierNameIfTrackedEntityIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+
+        assertEquals( "trackedEntity", criteria.getIdentifierName() );
+    }
+
+    @Test
     void getIdentifierNameIfTeiIsSet()
         throws WebMessageException
     {
@@ -59,6 +82,17 @@ class TrackerRelationshipCriteriaTest
         criteria.setTei( "Hq3Kc6HK4OZ" );
 
         assertEquals( "trackedEntity", criteria.getIdentifierName() );
+    }
+
+    @Test
+    void getIdentifierClassIfTrackedEntityIsSet()
+        throws WebMessageException
+    {
+
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+
+        assertEquals( TrackedEntityInstance.class, criteria.getIdentifierClass() );
     }
 
     @Test
@@ -143,10 +177,10 @@ class TrackerRelationshipCriteriaTest
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Missing required parameter 'tei', 'enrollment' or 'event'.",
+        assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -155,10 +189,10 @@ class TrackerRelationshipCriteriaTest
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierName() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierName );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Missing required parameter 'tei', 'enrollment' or 'event'.",
+        assertEquals( "Missing required parameter 'trackedEntity', 'enrollment' or 'event'.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -166,14 +200,15 @@ class TrackerRelationshipCriteriaTest
     void getIdentifierParamThrowsIfAllParamsAreSet()
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -181,14 +216,15 @@ class TrackerRelationshipCriteriaTest
     void getIdentifierNameThrowsIfAllParamsAreSet()
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierName() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierName );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -196,14 +232,29 @@ class TrackerRelationshipCriteriaTest
     void getIdentifierClassThrowsIfAllParamsAreSet()
     {
         TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierClass() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierClass );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierParamThrowsIfTrackedEntityAndEnrollmentAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -214,10 +265,24 @@ class TrackerRelationshipCriteriaTest
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
+            exception.getWebMessage().getMessage() );
+    }
+
+    @Test
+    void getIdentifierClassThrowsIfTrackedEntityAndEnrollmentAreSet()
+    {
+        TrackerRelationshipCriteria criteria = new TrackerRelationshipCriteria();
+        criteria.setTrackedEntity( "Hq3Kc6HK4OZ" );
+        criteria.setEnrollment( "Hq3Kc6HK4OZ" );
+
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierClass );
+
+        assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -228,10 +293,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setTei( "Hq3Kc6HK4OZ" );
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierClass() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierClass );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getWebMessage().getMessage() );
     }
 
@@ -242,10 +307,10 @@ class TrackerRelationshipCriteriaTest
         criteria.setEnrollment( "Hq3Kc6HK4OZ" );
         criteria.setEvent( "Hq3Kc6HK4OZ" );
 
-        WebMessageException exception = assertThrows( WebMessageException.class, () -> criteria.getIdentifierParam() );
+        WebMessageException exception = assertThrows( WebMessageException.class, criteria::getIdentifierParam );
 
         assertEquals( BAD_REQUEST.value(), exception.getWebMessage().getHttpStatusCode() );
-        assertEquals( "Only one of parameters 'tei', 'enrollment' or 'event' is allowed.",
+        assertEquals( "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed.",
             exception.getWebMessage().getMessage() );
     }
 }


### PR DESCRIPTION
# What

* add query parameter `trackedEntity` (keeping parameter `tei` for backwards compatibility) to adhere to the new tracker APIs consistent naming
* fail if more than one of the mutually exclusive parameters (`trackedEntity`, `tei`, `enrollment`, `event`) is given as described in the API docs

No parameters leads to response

```json
{
  "httpStatus": "Bad Request",
  "httpStatusCode": 400,
  "status": "ERROR",
  "message": "Missing required parameter 'trackedEntity', 'enrollment' or 'event'."
}
```

More than one parameter leads to response

```json
{
  "httpStatus": "Bad Request",
  "httpStatusCode": 400,
  "status": "ERROR",
  "message": "Only one of parameters 'trackedEntity', 'enrollment' or 'event' is allowed."
}
```

# How

Since we already have code dealing with `trackedEntity`, `enrollment`, `event` in a generic way, I wanted to provide a single getter for the identifier to be fetched from the DB. No matter from which query param it originated from. 

At first I tried to make sure an invalid (query param count != 1) TrackerRelationshipCriteria could not be created by
* throwing `WebMessageException` in setters when more than one of the mutually exclusive query parameters were set
* trying `javax.validation` annotation on  TrackerRelationshipCriteria with an `@Valid` annotation on the controller method parameter `TrackerRelationshipCriteria`

These approaches did not work since they lead to a HTTP status 500 with stacktraces in the message, instead of the desired response messages shown above.

Would like to get your opinion @jbee on whether implementing it this way makes sense to you or if you would have a different approach in mind 😋 