### PR TITLE
feat: Sort D.Elements across P.Stages [DHIS2-12662]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -163,8 +163,8 @@ public class EventDataQueryRequest
         queryRequest.sortOrder = this.sortOrder;
         queryRequest.limit = this.limit;
         queryRequest.outputType = this.outputType;
-        queryRequest.eventStatus = this.eventStatus;
-        queryRequest.programStatus = this.programStatus;
+        queryRequest.eventStatus = new LinkedHashSet<>( this.eventStatus );
+        queryRequest.programStatus = new LinkedHashSet<>( this.programStatus );
         queryRequest.collapseDataDimensions = this.collapseDataDimensions;
         queryRequest.aggregateData = this.aggregateData;
         queryRequest.includeMetadataDetails = this.includeMetadataDetails;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -151,12 +151,12 @@ public class EventQueryParams
     /**
      * Columns to sort ascending.
      */
-    private List<DimensionalItemObject> asc = new ArrayList<>();
+    private List<QueryItem> asc = new ArrayList<>();
 
     /**
      * Columns to sort descending.
      */
-    private List<DimensionalItemObject> desc = new ArrayList<>();
+    private List<QueryItem> desc = new ArrayList<>();
 
     /**
      * The organisation unit selection mode.
@@ -197,7 +197,7 @@ public class EventQueryParams
     /**
      * Indicates the event status.
      */
-    private Set<EventStatus> eventStatus = new HashSet<>();
+    private Set<EventStatus> eventStatus = new LinkedHashSet<>();
 
     /**
      * Indicates whether the data dimension items should be collapsed into a
@@ -256,7 +256,7 @@ public class EventQueryParams
     /**
      * Indicates the program status
      */
-    private Set<ProgramStatus> programStatus;
+    private Set<ProgramStatus> programStatus = new LinkedHashSet<>();
 
     /**
      * Indicates whether to include metadata details to response
@@ -307,7 +307,6 @@ public class EventQueryParams
         params.partitions = new Partitions( this.partitions );
         params.tableName = this.tableName;
         params.periodType = this.periodType;
-
         params.program = this.program;
         params.programStage = this.programStage;
         params.items = new ArrayList<>( this.items );
@@ -326,7 +325,7 @@ public class EventQueryParams
         params.limit = this.limit;
         params.outputType = this.outputType;
         params.outputIdScheme = this.outputIdScheme;
-        params.eventStatus = this.eventStatus;
+        params.eventStatus = new LinkedHashSet<>( this.eventStatus );
         params.collapseDataDimensions = this.collapseDataDimensions;
         params.coordinatesOnly = this.coordinatesOnly;
         params.coordinateOuFallback = this.coordinateOuFallback;
@@ -337,7 +336,7 @@ public class EventQueryParams
         params.fallbackCoordinateField = this.fallbackCoordinateField;
         params.bbox = this.bbox;
         params.includeClusterPoints = this.includeClusterPoints;
-        params.programStatus = this.programStatus;
+        params.programStatus = new LinkedHashSet<>( this.programStatus );
         params.includeMetadataDetails = this.includeMetadataDetails;
         params.dataIdScheme = this.dataIdScheme;
         params.periodType = this.periodType;
@@ -424,8 +423,8 @@ public class EventQueryParams
         headers.forEach( header -> key.add( "headers", "[" + header + "]" ) );
         itemProgramIndicators.forEach( e -> key.add( "itemProgramIndicator", e.getUid() ) );
         eventStatus.forEach( status -> key.add( "eventStatus", "[" + status + "]" ) );
-        asc.forEach( e -> e.getUid() );
-        desc.forEach( e -> e.getUid() );
+        asc.forEach( e -> e.getItem().getUid() );
+        desc.forEach( e -> e.getItem().getUid() );
 
         return key
             .addIgnoreNull( "value", value, () -> value.getUid() )
@@ -994,7 +993,7 @@ public class EventQueryParams
         return programIndicator;
     }
 
-    public List<DimensionalItemObject> getAsc()
+    public List<QueryItem> getAsc()
     {
         return asc;
     }
@@ -1005,7 +1004,7 @@ public class EventQueryParams
         return dimensions;
     }
 
-    public List<DimensionalItemObject> getDesc()
+    public List<QueryItem> getDesc()
     {
         return desc;
     }
@@ -1345,13 +1344,13 @@ public class EventQueryParams
             return this;
         }
 
-        public Builder addAscSortItem( DimensionalItemObject sortItem )
+        public Builder addAscSortItem( QueryItem sortItem )
         {
             this.params.asc.add( sortItem );
             return this;
         }
 
-        public Builder addDescSortItem( DimensionalItemObject sortItem )
+        public Builder addDescSortItem( QueryItem sortItem )
         {
             this.params.desc.add( sortItem );
             return this;
@@ -1395,7 +1394,11 @@ public class EventQueryParams
 
         public Builder withEventStatuses( Set<EventStatus> eventStatuses )
         {
-            this.params.eventStatus = eventStatuses;
+            if ( isNotEmpty( eventStatuses ) )
+            {
+                this.params.eventStatus.addAll( eventStatuses );
+            }
+
             return this;
         }
 
@@ -1455,7 +1458,11 @@ public class EventQueryParams
 
         public Builder withProgramStatuses( Set<ProgramStatus> programStatuses )
         {
-            this.params.programStatus = programStatuses;
+            if ( isNotEmpty( programStatuses ) )
+            {
+                this.params.programStatus.addAll( programStatuses );
+            }
+
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -155,10 +155,6 @@ public abstract class AbstractJdbcEventAnalyticsManager
      */
     private String getSortClause( EventQueryParams params )
     {
-
-        // item.getItem().getDimensionItemType() == DATA_ELEMENT &&
-        // item.getProgramStage() != null
-
         String sql = "";
 
         if ( params.isSorting() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
+import static org.hisp.dhis.analytics.SortOrder.ASC;
+import static org.hisp.dhis.analytics.SortOrder.DESC;
 import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_GEOMETRY_COL_SUFFIX;
 import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_NAME_COL_SUFFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
@@ -36,6 +38,8 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ORG_UNIT_STRUCT_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
+import static org.hisp.dhis.common.DimensionItemType.PROGRAM_INDICATOR;
 import static org.hisp.dhis.common.DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP;
 import static org.hisp.dhis.system.util.MathUtils.getRounded;
 
@@ -53,9 +57,7 @@ import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
-import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DimensionType;
-import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
@@ -153,11 +155,15 @@ public abstract class AbstractJdbcEventAnalyticsManager
      */
     private String getSortClause( EventQueryParams params )
     {
+
+        // item.getItem().getDimensionItemType() == DATA_ELEMENT &&
+        // item.getProgramStage() != null
+
         String sql = "";
 
         if ( params.isSorting() )
         {
-            sql += "order by " + getSortColumns( params, SortOrder.ASC ) + getSortColumns( params, SortOrder.DESC );
+            sql += "order by " + getSortColumns( params, ASC ) + getSortColumns( params, DESC );
 
             sql = TextUtils.removeLastComma( sql ) + " ";
         }
@@ -169,18 +175,29 @@ public abstract class AbstractJdbcEventAnalyticsManager
     {
         String sql = "";
 
-        for ( DimensionalItemObject item : order.equals( SortOrder.ASC ) ? params.getAsc() : params.getDesc() )
+        for ( QueryItem item : order == ASC ? params.getAsc() : params.getDesc() )
         {
-            if ( DimensionItemType.PROGRAM_INDICATOR.equals( item.getDimensionItemType() )
-                || DimensionItemType.DATA_ELEMENT.equals( item.getDimensionItemType() ) )
+            if ( item.getItem().getDimensionItemType() == PROGRAM_INDICATOR )
             {
-                sql += quote( item.getUid() );
+                sql += quote( item.getItem().getUid() );
+            }
+            else if ( item.getItem().getDimensionItemType() == DATA_ELEMENT )
+            {
+                if ( item.getProgramStage() != null )
+                {
+                    sql += quote( item.getProgramStage().getUid() + "." + item.getItem().getUid() );
+                }
+                else
+                {
+                    sql += quote( item.getItem().getUid() );
+                }
             }
             else
             {
-                sql += quoteAlias( item.getUid() );
+                sql += quoteAlias( item.getItem().getUid() );
             }
-            sql += order.equals( SortOrder.ASC ) ? " asc," : " desc,";
+
+            sql += order == ASC ? " asc," : " desc,";
         }
 
         return sql;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -471,7 +471,7 @@ public class DefaultEventDataQueryService
         return queryItem;
     }
 
-    private DimensionalItemObject getSortItem( String item, Program program, EventOutputType type )
+    private QueryItem getSortItem( String item, Program program, EventOutputType type )
     {
         QueryItem queryItem;
 
@@ -487,7 +487,7 @@ public class DefaultEventDataQueryService
             queryItem = getQueryItem( item, program, type );
         }
 
-        return queryItem.getItem();
+        return queryItem;
     }
 
     private DimensionalItemObject getValueDimension( String value )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -28,10 +28,12 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.encode;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 import static org.hisp.dhis.common.QueryOperator.IN;
@@ -441,7 +443,7 @@ public class JdbcEnrollmentAnalyticsManager
                 createOrderTypeAndOffset( item.getProgramStageOffset() ) + " " + LIMIT_1 + " )";
         }
 
-        return StringUtils.EMPTY;
+        return EMPTY;
     }
 
     /**
@@ -460,6 +462,7 @@ public class JdbcEnrollmentAnalyticsManager
     protected String getColumn( final QueryItem item, final String suffix )
     {
         String colName = item.getItemName();
+        String alias = EMPTY;
 
         if ( item.hasProgramStage() )
         {
@@ -495,7 +498,12 @@ public class JdbcEnrollmentAnalyticsManager
                     + " " + LIMIT_1 + " )";
             }
 
-            return "(select " + colName
+            if ( item.getItem().getDimensionItemType() == DATA_ELEMENT && item.getProgramStage() != null )
+            {
+                alias = " as " + quote( item.getProgramStage().getUid() + "." + item.getItem().getUid() );
+            }
+
+            return "(select " + colName + alias
                 + " from " + eventTableName
                 + " where " + eventTableName + ".pi = " + ANALYTICS_TBL_ALIAS + ".pi "
                 + "and " + colName + " is not null " + "and ps = '" + item.getProgramStage().getUid() + "' "

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventDataQueryServiceTest.java
@@ -268,7 +268,7 @@ class EventDataQueryServiceTest extends DhisSpringTest
         assertEquals( 1, params.getFilterPeriods().size() );
         assertEquals( deA, params.getValue() );
         assertEquals( 1, params.getDesc().size() );
-        assertEquals( "executiondate", params.getDesc().get( 0 ).getName() );
+        assertEquals( "executiondate", params.getDesc().get( 0 ).getItem().getName() );
         assertEquals( AnalyticsAggregationType.AVERAGE, params.getAggregationType() );
     }
 
@@ -292,7 +292,7 @@ class EventDataQueryServiceTest extends DhisSpringTest
         assertEquals( 1, params.getFilterPeriods().size() );
         assertEquals( deA, params.getValue() );
         assertEquals( 1, params.getDesc().size() );
-        assertEquals( "ouname", params.getDesc().get( 0 ).getName() );
+        assertEquals( "ouname", params.getDesc().get( 0 ).getItem().getName() );
         assertEquals( AnalyticsAggregationType.AVERAGE, params.getAggregationType() );
     }
 
@@ -316,7 +316,7 @@ class EventDataQueryServiceTest extends DhisSpringTest
         assertEquals( 1, params.getFilterPeriods().size() );
         assertEquals( deA, params.getValue() );
         assertEquals( 1, params.getDesc().size() );
-        assertEquals( deA.getUid(), params.getDesc().get( 0 ).getUid() );
+        assertEquals( deA.getUid(), params.getDesc().get( 0 ).getItem().getUid() );
         assertEquals( AnalyticsAggregationType.AVERAGE, params.getAggregationType() );
     }
 
@@ -340,7 +340,7 @@ class EventDataQueryServiceTest extends DhisSpringTest
         assertEquals( 1, params.getFilterPeriods().size() );
         assertEquals( deA, params.getValue() );
         assertEquals( 1, params.getDesc().size() );
-        assertEquals( atA.getUid(), params.getDesc().get( 0 ).getUid() );
+        assertEquals( atA.getUid(), params.getDesc().get( 0 ).getItem().getUid() );
         assertEquals( AnalyticsAggregationType.AVERAGE, params.getAggregationType() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -453,9 +453,9 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
 
         final EventQueryParams.Builder eventQueryParamsBuilder = new EventQueryParams.Builder( params )
             .withProgram( program )
-            .addAscSortItem( piA )
-            .addDescSortItem( piB )
-            .addAscSortItem( deA );
+            .addAscSortItem( new QueryItem( piA ) )
+            .addDescSortItem( new QueryItem( piB ) )
+            .addAscSortItem( new QueryItem( deA ) );
 
         final String sql = subject.getEventsOrEnrollmentsSql( eventQueryParamsBuilder.build(), 100 );
 


### PR DESCRIPTION
This is needed in order to enable sorting by `dataElement.programStage`.
For events and enrollments.

Request example:

```
http://localhost:8080/dhis/api/29/analytics/enrollments/query/IpHINAT79UW.json?dimension=pe:LAST_12_MONTHS
&dimension=ou:jUb8gELQApl;TEQlaapDQoK;eIQbndfxQMb;Vth0fbpFcsO;PMa2VCrupOd;O6uvpzGd5pu;bL4ooGhyHRQ;kJq2mPyFEHo;fdc6uOvgoji;at6UHUQatSo;lc3eMKXaEfw;qhqAxPSTUXp;jmIPBj66vD6&dimension=A03MvHHogjR.wQLfBvPrXqq
&dimension=A03MvHHogjR.bx6fsa0t90x
&stage=A03MvHHogjR
&displayProperty=NAME
&outputType=ENROLLMENT
&pageSize=100
&page=1
&desc=A03MvHHogjR.wQLfBvPrXqq
```

**NOTE**
_I also fixed other points of the code that could potentially cause NPE._