### PR TITLE
fix: Return dates in NTI report with Iso8601NoTz format [DHIS2-11947]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerReportUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerReportUtils.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 
 /**
@@ -75,7 +76,7 @@ class TrackerReportUtils
         }
         else if ( Instant.class.isAssignableFrom( argument.getClass() ) )
         {
-            return DateFormat.getInstance().format( Date.from( (Instant) argument ) );
+            return DateUtils.getIso8601NoTz( DateUtils.fromInstant( (Instant) argument ) );
         }
         else if ( Enrollment.class.isAssignableFrom( argument.getClass() ) )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerReportUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerReportUtilsTest.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -58,7 +59,7 @@ class TrackerReportUtilsTest
         final Instant now = Instant.now();
         List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList( now ) );
         assertThat( args.size(), is( 1 ) );
-        assertThat( args.get( 0 ), is( DateFormat.getInstance().format( Date.from( now ) ) ) );
+        assertThat( args.get( 0 ), is( DateUtils.getIso8601NoTz( DateUtils.fromInstant( now ) ) ) );
     }
 
     @Test


### PR DESCRIPTION
[DHIS2-11947](https://jira.dhis2.org/browse/DHIS2-11947) couldn't be reproduce as the date was always present but the format was not the same that it is used in the payload