### PR TITLE
fix: prevent category combination deletion when predictor is linked [DHIS2-10687]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import lombok.AllArgsConstructor;
 
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.expression.Expression;
@@ -60,6 +61,7 @@ public class PredictorDeletionHandler extends DeletionHandler
         whenDeleting( PredictorGroup.class, this::deletePredictorGroup );
         whenVetoing( DataElement.class, this::allowDeleteDataElement );
         whenVetoing( CategoryOptionCombo.class, this::allowDeleteCategoryOptionCombo );
+        whenVetoing( CategoryCombo.class, this::allowDeleteCategoryCombo );
     }
 
     private void deleteExpression( Expression expression )
@@ -109,6 +111,15 @@ public class PredictorDeletionHandler extends DeletionHandler
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
         return vetoIfExists( "SELECT COUNT(*) FROM predictor where generatoroutputcombo=" + optionCombo.getId() );
+    }
+
+    private DeletionVeto allowDeleteCategoryCombo( CategoryCombo categoryCombo )
+    {
+        return vetoIfExists( "SELECT COUNT(*) FROM predictor p where exists ("
+            + "select 1 from categorycombos_optioncombos co"
+            + " where co.categorycomboid=" + categoryCombo.getId()
+            + " and co.categoryoptioncomboid=p.generatoroutputcombo"
+            + ")" );
     }
 
     private DeletionVeto vetoIfExists( String sql )


### PR DESCRIPTION
### Summary
Also prevent CC deletion when there is a linked COC linked to a predictor.

### Manual Testing
1. create a new CC
2. create a new DE linked to the CC
3. create a new predictor linked to the new DE and also select a _output category option combo_ after selecting the _output data element_
4. try to delete the CC => should point out it is linked to a predictor
5. delete the predictor
6. try to delete the CC => now should be possible to delete

Rerun the above test but without selecting anything in the predictors _output category option combo_ field - the attempt to delete the CC in step 4 should now succeed directly.