### PR TITLE
New syntax of repeatable stages in headers [2.38-DHIS2-12683]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RepeatableStageParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/RepeatableStageParams.java
@@ -51,6 +51,10 @@ public class RepeatableStageParams
     // related to execution date
     private Date endDate;
 
+    private boolean defaultObject = true;
+
+    private String dimension;
+
     /**
      * to string
      *

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -162,6 +162,7 @@ public abstract class AbstractAnalyticsService
             else
             {
                 final String uid = getItemUid( item );
+
                 final String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
 
                 grid.addHeader( new GridHeader( uid, column, item.getValueType(),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -147,12 +147,12 @@ public abstract class AbstractAnalyticsService
             }
             else if ( hasNonDefaultRepeatableProgramStageOffset( item ) )
             {
-                String name = item.getProgramStage().getUid() + "[" + item.getProgramStageOffset() + "]." +
-                    item.getItem().getUid();
 
                 String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
 
                 RepeatableStageParams repeatableStageParams = item.getRepeatableStageParams();
+
+                String name = repeatableStageParams.getDimension();
 
                 grid.addHeader( new GridHeader( name, column,
                     repeatableStageParams.simpleStageValueExpected() ? item.getValueType() : ValueType.REFERENCE,
@@ -539,6 +539,6 @@ public abstract class AbstractAnalyticsService
     private boolean hasNonDefaultRepeatableProgramStageOffset( QueryItem item )
     {
         return item != null && item.getProgramStage() != null && item.getRepeatableStageParams() != null
-            && (item.getRepeatableStageParams().getStartIndex() != 0 || item.getRepeatableStageParams().getCount() > 1);
+            && !item.getRepeatableStageParams().isDefaultObject();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultQueryItemLocator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultQueryItemLocator.java
@@ -231,8 +231,12 @@ public class DefaultQueryItemLocator
     {
         try
         {
-            return RepeatableStageParamsHelper.getRepeatableStageParams( dimension );
+            RepeatableStageParams repeatableStageParams = RepeatableStageParamsHelper
+                .getRepeatableStageParams( dimension );
 
+            repeatableStageParams.setDimension( dimension );
+
+            return repeatableStageParams;
         }
         catch ( InvalidRepeatableStageParamsException e )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/RepeatableStageParamsHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/RepeatableStageParamsHelper.java
@@ -44,7 +44,7 @@ import org.hisp.dhis.util.DateUtils;
 
 public class RepeatableStageParamsHelper
 {
-    private static final String SEPARATOR = "_";
+    private static final String SEPARATOR = "~";
 
     // [-1]
     private static final String PS_INDEX_REGEX = "\\[-?\\d+\\]";
@@ -62,7 +62,9 @@ public class RepeatableStageParamsHelper
         SEPARATOR + "\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])\\]";
 
     // [1,30, LAST_YEAR]
-    private static final String PS_INDEX_COUNT_RELATIVE_PERIOD_REGEX = "\\[-?\\d+,\\s*\\d+,\\s*\\w+\\]";
+    private static final String PS_INDEX_COUNT_RELATIVE_PERIOD_REGEX = "\\[-?\\d+" +
+        SEPARATOR + "\\s*\\d+" +
+        SEPARATOR + "\\s*\\w+\\]";
 
     // [2022-01-01, 2022-03-31]
     private static final String PS_START_DATE_END_DATE_REGEX = "\\[\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])"
@@ -275,6 +277,8 @@ public class RepeatableStageParamsHelper
 
         repeatableStageParams.setEndDate( endDate );
 
+        repeatableStageParams.setDefaultObject( false );
+
         return repeatableStageParams;
     }
 
@@ -313,6 +317,8 @@ public class RepeatableStageParamsHelper
         repeatableStageParams.setStartDate( startDate );
 
         repeatableStageParams.setEndDate( endDate );
+
+        repeatableStageParams.setDefaultObject( false );
 
         return repeatableStageParams;
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/RepeatableStageParamsHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/RepeatableStageParamsHelper.java
@@ -44,6 +44,8 @@ import org.hisp.dhis.util.DateUtils;
 
 public class RepeatableStageParamsHelper
 {
+    private static final String SEPARATOR = "_";
+
     // [-1]
     private static final String PS_INDEX_REGEX = "\\[-?\\d+\\]";
 
@@ -51,16 +53,21 @@ public class RepeatableStageParamsHelper
     private static final String PS_ASTERISK_REGEX = "\\[\\*\\]";
 
     // [1, 2]
-    private static final String PS_INDEX_COUNT_REGEX = "\\[-?\\d+,\\s*\\d+\\]";
+    private static final String PS_INDEX_COUNT_REGEX = "\\[-?\\d+" + SEPARATOR + "\\s*\\d+\\]";
 
     // [1, 2, 2022-01-01, 2022-03-31]
-    private static final String PS_INDEX_COUNT_START_DATE_END_DATE_REGEX = "\\[-?\\d+,\\s*\\d+,\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01]),\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])\\]";
+    private static final String PS_INDEX_COUNT_START_DATE_END_DATE_REGEX = "\\[-?\\d+" +
+        SEPARATOR + "\\s*\\d+" +
+        SEPARATOR + "\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])" +
+        SEPARATOR + "\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])\\]";
 
     // [1,30, LAST_YEAR]
     private static final String PS_INDEX_COUNT_RELATIVE_PERIOD_REGEX = "\\[-?\\d+,\\s*\\d+,\\s*\\w+\\]";
 
     // [2022-01-01, 2022-03-31]
-    private static final String PS_START_DATE_END_DATE_REGEX = "\\[\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01]),\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])\\]";
+    private static final String PS_START_DATE_END_DATE_REGEX = "\\[\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])"
+        +
+        SEPARATOR + "\\s*\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])\\]";
 
     // [LAST_3_MONTHS]
     private static final String PS_RELATIVE_PERIOD_REGEX = "\\[\\w+\\]";
@@ -222,6 +229,8 @@ public class RepeatableStageParamsHelper
 
         repeatableStageParams.setCount( count );
 
+        repeatableStageParams.setDefaultObject( false );
+
         return repeatableStageParams;
     }
 
@@ -327,7 +336,7 @@ public class RepeatableStageParamsHelper
                 .replace( "]", "" );
         }
 
-        String[] tokens = params.split( "," );
+        String[] tokens = params.split( SEPARATOR );
 
         if ( tokens.length != expectedTokenCount )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/queryItem/QueryItemLocatorTest.java
@@ -229,7 +229,7 @@ class QueryItemLocatorTest
         configureDimensionForQueryItem( dataElementA, programStageA );
 
         QueryItem queryItem = subject.getQueryItemFromDimension(
-            programStageUid + "[-1,1]" + PROGRAMSTAGE_SEP + dimension,
+            programStageUid + "[-1~1]" + PROGRAMSTAGE_SEP + dimension,
             programA, EventOutputType.ENROLLMENT );
 
         assertThat( queryItem, is( notNullValue() ) );
@@ -249,7 +249,7 @@ class QueryItemLocatorTest
         configureDimensionForQueryItem( dataElementA, programStageA );
 
         QueryItem queryItem = subject.getQueryItemFromDimension(
-            programStageUid + "[-1,1, 2022-01-01, 2022-01-31]" + PROGRAMSTAGE_SEP + dimension,
+            programStageUid + "[-1~1~ 2022-01-01~ 2022-01-31]" + PROGRAMSTAGE_SEP + dimension,
             programA, EventOutputType.ENROLLMENT );
 
         assertThat( queryItem, is( notNullValue() ) );
@@ -269,7 +269,7 @@ class QueryItemLocatorTest
         configureDimensionForQueryItem( dataElementA, programStageA );
 
         QueryItem queryItem = subject.getQueryItemFromDimension(
-            programStageUid + "[-1,1, LAST_3_MONTHS]" + PROGRAMSTAGE_SEP + dimension,
+            programStageUid + "[1~1~LAST_3_MONTHS]" + PROGRAMSTAGE_SEP + dimension,
             programA, EventOutputType.ENROLLMENT );
 
         assertThat( queryItem, is( notNullValue() ) );
@@ -278,7 +278,7 @@ class QueryItemLocatorTest
         assertThat( queryItem.getProgramStage(), is( programStageA ) );
 
         assertThrows( IllegalQueryException.class, () -> subject.getQueryItemFromDimension(
-            programStageUid + "[-1,1, LAST_A3_MONTHS]" + PROGRAMSTAGE_SEP + dimension,
+            programStageUid + "[-1~1~ LAST_A3_MONTHS]" + PROGRAMSTAGE_SEP + dimension,
             programA, EventOutputType.ENROLLMENT ) );
     }
 
@@ -293,7 +293,7 @@ class QueryItemLocatorTest
         configureDimensionForQueryItem( dataElementA, programStageA );
 
         QueryItem queryItem = subject.getQueryItemFromDimension(
-            programStageUid + "[2022-01-01, 2022-01-31]" + PROGRAMSTAGE_SEP + dimension,
+            programStageUid + "[2022-01-01~ 2022-01-31]" + PROGRAMSTAGE_SEP + dimension,
             programA, EventOutputType.ENROLLMENT );
 
         assertThat( queryItem, is( notNullValue() ) );


### PR DESCRIPTION
There is bug in headers, the separator had t be changed, now it is ~. Comma is not possible to use, cause we are using it for options, headers, etc separator.