### PR TITLE
feat: Prefix p.stage in metadata element [TECH-982]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_NAME_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.PAGER;
-import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
@@ -222,10 +221,11 @@ public abstract class AbstractAnalyticsService
     {
         String uid = item.getItem().getUid();
 
-        if ( item.getItem().getDimensionItemType() == DATA_ELEMENT && item.getProgramStage() != null )
+        if ( item.hasProgramStage() )
         {
             uid = joinWith( ".", item.getProgramStage().getUid(), uid );
         }
+
         return uid;
     }
 
@@ -457,17 +457,19 @@ public abstract class AbstractAnalyticsService
 
         for ( QueryItem item : params.getItems() )
         {
+            final String itemUid = getItemUid( item );
+
             if ( item.hasOptionSet() )
             {
-                dimensionItems.put( item.getItemId(), getDimensionItemUidList( params, item, itemOptions ) );
+                dimensionItems.put( itemUid, getDimensionItemUidList( params, item, itemOptions ) );
             }
             else if ( item.hasLegendSet() )
             {
-                dimensionItems.put( item.getItemId(), item.getLegendSetFilterItemsOrAll() );
+                dimensionItems.put( itemUid, item.getLegendSetFilterItemsOrAll() );
             }
             else
             {
-                dimensionItems.put( item.getItemId(), Lists.newArrayList() );
+                dimensionItems.put( itemUid, Lists.newArrayList() );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultQueryItemLocator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultQueryItemLocator.java
@@ -183,6 +183,13 @@ public class DefaultQueryItemLocator
             ValueType valueType = legendSet != null ? ValueType.TEXT : at.getValueType();
 
             qi = new QueryItem( at, program, legendSet, valueType, at.getAggregationType(), at.getOptionSet() );
+
+            ProgramStage programStage = getProgramStageOrFail( dimension );
+
+            if ( programStage != null )
+            {
+                qi.setProgramStage( programStage );
+            }
         }
 
         return Optional.ofNullable( qi );
@@ -201,6 +208,8 @@ public class DefaultQueryItemLocator
 
         if ( pi != null )
         {
+            ProgramStage programStage = getProgramStageOrFail( dimension );
+
             if ( relationshipType != null )
             {
                 qi = new QueryItem( pi, program, legendSet, ValueType.NUMBER, pi.getAggregationType(), null,
@@ -212,6 +221,11 @@ public class DefaultQueryItemLocator
                 {
                     qi = new QueryItem( pi, program, legendSet, ValueType.NUMBER, pi.getAggregationType(), null );
                 }
+            }
+
+            if ( qi != null && programStage != null )
+            {
+                qi.setProgramStage( programStage );
             }
         }
 


### PR DESCRIPTION
This PR will make the `headers` and `metaData.dimensions` attributes aligned regarding elements that contain a program stage associated.

For example, the request below will produce the following response:

```
http://localhost:8080/dhis/api/29/analytics/events/query/eBAyeGv0exc.json?dimension=pe:LAST_12_MONTHS
&dimension=ou:ImspTQPwCqd
&dimension=Zj7UnCAulEk.K6uUAvq500H
&stage=Zj7UnCAulEk
&displayProperty=NAME
&outputType=EVENT
&desc=eventdate
&pageSize=100
&page=1
```
Response
```
{
  "headers": [
    ...
    {
      "name": "Zj7UnCAulEk.K6uUAvq500H",
      "column": "Diagnosis (ICD-10)",
      "valueType": "TEXT",
      "type": "java.lang.String",
      "hidden": false,
      "meta": true,
      "optionSet": "eUZ79clX7y1"
    }
],
  "metaData": {
    ...
    "dimensions": {
      ...
      "Zj7UnCAulEk.K6uUAvq500H": [
        "pLrxOwjko48",
        "x3eYha2WVJW",
        "mazaKtotbGR"
      ]
      ...
    }
  }
}
```