### PR TITLE
feat: make api geoFeatures to support GeoJsonObject

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -243,6 +243,7 @@ public enum ErrorCode
     E6002( "Class name {0} is not supported." ),
     E6003( "Could not patch object with id {0}." ),
     E6004( "Attribute `{0}` has invalid GeoJson value." ),
+    E6005( "Attribute `{0}` has unsupported GeoJson value." ),
 
     /* File resource */
     E6100( "Filename not present" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/GeoJsonAttributesCheck.java
@@ -28,11 +28,14 @@
 package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
 
 import static java.util.Collections.emptyList;
-import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.hisp.dhis.dxf2.metadata.objectbundle.validation.ValidationUtils.createObjectReport;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -172,72 +175,71 @@ public class GeoJsonAttributesCheck
     private void validateGeoJsonObject( GeoJsonObject geoJsonObject, String attributeId,
         Consumer<ErrorReport> addError )
     {
-        if ( !geoJsonObject.accept( new ValidatingGeoJsonVisitor() ) )
-        {
-            addError.accept( new ErrorReport( Attribute.class, ErrorCode.E6004, attributeId )
-                .setMainId( attributeId )
-                .setErrorProperty( "value" ) );
-        }
+        geoJsonObject.accept( new ValidatingGeoJsonVisitor() )
+            .ifPresent( errorCode -> addError.accept(
+                new ErrorReport( Attribute.class, errorCode, attributeId )
+                    .setMainId( attributeId )
+                    .setErrorProperty( "value" ) ) );
     }
 
     /**
      * Contains validator for each GeoJson Object type.
      */
     class ValidatingGeoJsonVisitor
-        implements GeoJsonObjectVisitor<Boolean>
+        implements GeoJsonObjectVisitor<Optional<ErrorCode>>
     {
         @Override
-        public Boolean visit( GeometryCollection geometryCollection )
+        public Optional<ErrorCode> visit( GeometryCollection geometryCollection )
         {
-            return isNotEmpty( geometryCollection.getGeometries() );
+            return of( ErrorCode.E6005 );
         }
 
         @Override
-        public Boolean visit( FeatureCollection featureCollection )
+        public Optional<ErrorCode> visit( FeatureCollection featureCollection )
         {
-            return isNotEmpty( featureCollection.getFeatures() );
+            return of( ErrorCode.E6005 );
         }
 
         @Override
-        public Boolean visit( Point point )
+        public Optional<ErrorCode> visit( Point point )
         {
-            return point.getCoordinates() != null;
+            return point.getCoordinates() == null ? of( ErrorCode.E6004 ) : empty();
         }
 
         @Override
-        public Boolean visit( Feature feature )
+        public Optional<ErrorCode> visit( Feature feature )
         {
-            return feature.getGeometry() != null && feature.getGeometry().accept( new ValidatingGeoJsonVisitor() );
+            return of( ErrorCode.E6005 );
         }
 
         @Override
-        public Boolean visit( MultiLineString multiLineString )
+        public Optional<ErrorCode> visit( MultiLineString multiLineString )
         {
-            return isNotEmpty( multiLineString.getCoordinates() );
+            return isEmpty( multiLineString.getCoordinates() ) ? of( ErrorCode.E6004 ) : empty();
         }
 
         @Override
-        public Boolean visit( Polygon polygon )
+        public Optional<ErrorCode> visit( Polygon polygon )
         {
-            return isNotEmpty( polygon.getCoordinates() );
+            return isEmpty( polygon.getCoordinates() ) ? of( ErrorCode.E6004 ) : empty();
         }
 
         @Override
-        public Boolean visit( MultiPolygon multiPolygon )
+        public Optional<ErrorCode> visit( MultiPolygon multiPolygon )
         {
-            return isNotEmpty( multiPolygon.getCoordinates() );
+            return isEmpty( multiPolygon.getCoordinates() ) ? of( ErrorCode.E6004 ) : empty();
         }
 
         @Override
-        public Boolean visit( MultiPoint multiPoint )
+        public Optional<ErrorCode> visit( MultiPoint multiPoint )
         {
-            return isNotEmpty( multiPoint.getCoordinates() );
+            return isEmpty( multiPoint.getCoordinates() ) ? of( ErrorCode.E6004 ) : empty();
         }
 
         @Override
-        public Boolean visit( LineString lineString )
+        public Optional<ErrorCode> visit( LineString lineString )
         {
-            return isNotEmpty( lineString.getCoordinates() );
+            return isEmpty( lineString.getCoordinates() ) ? of( ErrorCode.E6004 ) : empty();
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/GeoJsonAttributesCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/GeoJsonAttributesCheckTest.java
@@ -208,7 +208,7 @@ public class GeoJsonAttributesCheckTest
     }
 
     @Test
-    public void testInvalidFeature()
+    public void testInvalidGeoJsonType()
     {
         String geoJson = "{\"type\": \"Feature\", \"geometry\": { \"type\": \"Point\"," +
             "\"coordinasstes\": [125.6, 10.1] }, \"properties\": { \"name\": \"Dinagat Islands\" } }";
@@ -222,6 +222,6 @@ public class GeoJsonAttributesCheckTest
                 .emptyList(), ImportStrategy.CREATE_AND_UPDATE,
                 validationContext, objectReport -> objectReportList.add( objectReport ) );
         assertFalse( CollectionUtils.isEmpty( objectReportList ) );
-        assertEquals( ErrorCode.E6004, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+        assertEquals( ErrorCode.E6005, objectReportList.get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GeoFeatureControllerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * @author viet@dhis2.org
+ */
+public class GeoFeatureControllerTest extends DhisControllerConvenienceTest
+{
+    @Test
+    public void testGetWithCoordinateField()
+    {
+        POST( "/metadata",
+            "{\"organisationUnits\": ["
+
+                + "{\"id\":\"rXnqqH2Pu6N\",\"name\": \"My Unit 1\",\"shortName\": \"OU1\",\"openingDate\": \"2020-01-01\","
+                + "\"attributeValues\": [{\"value\":  \"{\\\"type\\\": \\\"Polygon\\\","
+                + "\\\"coordinates\\\":  [[[100,0],[101,0],[101,1],[100,1],[100,0]]] }\","
+                + "\"attribute\": {\"id\": \"RRH9IFiZZYN\"}}]},"
+
+                + "{\"id\":\"NBfMnCrwlQc\",\"name\": \"My Unit 3\",\"shortName\": \"OU3\",\"openingDate\": \"2020-01-01\"}"
+
+                + "],"
+                + "\"attributes\":[{\"id\":\"RRH9IFiZZYN\",\"valueType\":\"GEOJSON\",\"organisationUnitAttribute\":true,\"name\":\"testgeojson\"}]}" )
+                    .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/geoFeatures?ou=ou:LEVEL-1&&coordinateField=RRH9IFiZZYN" )
+            .content( HttpStatus.OK );
+        assertEquals( 1, response.size() );
+        assertEquals( "[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]",
+            response.getObject( 0 ).get( "co" ).node().value().toString() );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
@@ -27,43 +27,20 @@
  */
 package org.hisp.dhis.webapi.controller.mapping;
 
-import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_GROUP_DIM_ID;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.hisp.dhis.analytics.AggregationType;
-import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.analytics.DataQueryService;
-import org.hisp.dhis.common.DataQueryRequest;
 import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.common.DimensionalItemObject;
-import org.hisp.dhis.common.DimensionalObject;
-import org.hisp.dhis.common.DimensionalObjectUtils;
 import org.hisp.dhis.common.DisplayProperty;
-import org.hisp.dhis.common.coordinate.CoordinateObject;
-import org.hisp.dhis.organisationunit.FeatureType;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
-import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.system.util.ValidationUtils;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.util.ObjectUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.service.GeoFeatureService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.hisp.dhis.webapi.webdomain.GeoFeature;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
@@ -75,8 +52,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Lars Helge Overland
@@ -90,26 +65,14 @@ public class GeoFeatureController
 
     private static final CacheControl GEOFEATURE_CACHE = CacheControl.maxAge( 2, TimeUnit.HOURS ).cachePrivate();
 
-    private static final Map<FeatureType, Integer> FEATURE_TYPE_MAP = ImmutableMap.<FeatureType, Integer> builder()
-        .put( FeatureType.POINT, GeoFeature.TYPE_POINT ).put( FeatureType.MULTI_POLYGON, GeoFeature.TYPE_POLYGON )
-        .put( FeatureType.POLYGON, GeoFeature.TYPE_POLYGON ).build();
-
-    private final DataQueryService dataQueryService;
-
-    private final OrganisationUnitGroupService organisationUnitGroupService;
-
-    private final CurrentUserService currentUserService;
-
     private final RenderService renderService;
 
-    public GeoFeatureController( DataQueryService dataQueryService,
-        OrganisationUnitGroupService organisationUnitGroupService, CurrentUserService currentUserService,
-        RenderService renderService )
+    private final GeoFeatureService geoFeatureService;
+
+    public GeoFeatureController( RenderService renderService, GeoFeatureService geoFeatureService )
     {
-        this.dataQueryService = dataQueryService;
-        this.organisationUnitGroupService = organisationUnitGroupService;
-        this.currentUserService = currentUserService;
         this.renderService = renderService;
+        this.geoFeatureService = geoFeatureService;
     }
 
     // -------------------------------------------------------------------------
@@ -124,6 +87,7 @@ public class GeoFeatureController
         @RequestParam( required = false ) DisplayProperty displayProperty,
         @RequestParam( required = false ) Date relativePeriodDate,
         @RequestParam( required = false ) String userOrgUnit,
+        @RequestParam( required = false ) String coordinateField,
         @RequestParam( defaultValue = "false", value = "includeGroupSets" ) boolean rpIncludeGroupSets,
         @RequestParam Map<String, String> parameters,
         DhisApiVersion apiVersion,
@@ -132,8 +96,18 @@ public class GeoFeatureController
         WebOptions options = new WebOptions( parameters );
         boolean includeGroupSets = "detailed".equals( options.getViewClass() ) || rpIncludeGroupSets;
 
-        List<GeoFeature> features = getGeoFeatures( ou, oug, displayProperty, relativePeriodDate, userOrgUnit, request,
-            response, includeGroupSets, apiVersion );
+        List<GeoFeature> features = geoFeatureService.getGeoFeatures( GeoFeatureService.Parameters.builder()
+            .apiVersion( apiVersion )
+            .displayProperty( displayProperty )
+            .includeGroupSets( includeGroupSets )
+            .request( request )
+            .response( response )
+            .organisationUnit( ou )
+            .userOrgUnit( userOrgUnit )
+            .organisationUnitGroupId( oug )
+            .relativePeriodDate( relativePeriodDate )
+            .coordinateField( coordinateField )
+            .build() );
 
         return ResponseEntity.ok()
             .header( HttpHeaders.CACHE_CONTROL, GEOFEATURE_CACHE.getHeaderValue() )
@@ -147,6 +121,7 @@ public class GeoFeatureController
         @RequestParam( required = false ) DisplayProperty displayProperty,
         @RequestParam( required = false ) Date relativePeriodDate,
         @RequestParam( required = false ) String userOrgUnit,
+        @RequestParam( required = false ) String coordinateField,
         @RequestParam( defaultValue = "callback" ) String callback,
         @RequestParam( defaultValue = "false", value = "includeGroupSets" ) boolean rpIncludeGroupSets,
         @RequestParam Map<String, String> parameters,
@@ -157,8 +132,17 @@ public class GeoFeatureController
         WebOptions options = new WebOptions( parameters );
         boolean includeGroupSets = "detailed".equals( options.getViewClass() ) || rpIncludeGroupSets;
 
-        List<GeoFeature> features = getGeoFeatures( ou, oug, displayProperty, relativePeriodDate, userOrgUnit, request,
-            response, includeGroupSets, apiVersion );
+        List<GeoFeature> features = geoFeatureService.getGeoFeatures( GeoFeatureService.Parameters.builder()
+            .apiVersion( apiVersion )
+            .displayProperty( displayProperty )
+            .includeGroupSets( includeGroupSets )
+            .request( request )
+            .response( response )
+            .userOrgUnit( userOrgUnit )
+            .organisationUnitGroupId( oug )
+            .relativePeriodDate( relativePeriodDate )
+            .coordinateField( coordinateField )
+            .build() );
 
         if ( features == null )
         {
@@ -168,143 +152,5 @@ public class GeoFeatureController
         ContextUtils.setCacheControl( response, GEOFEATURE_CACHE );
         response.setContentType( "application/javascript" );
         renderService.toJsonP( response.getOutputStream(), features, callback );
-    }
-
-    // -------------------------------------------------------------------------
-    // Supportive methods
-    // -------------------------------------------------------------------------
-
-    /**
-     * Returns a list of {@link GeoFeature}. Returns null if not modified based
-     * on the request.
-     *
-     * @param ou the organisation unit parameter
-     * @param oug the organisation unit group parameter
-     * @param displayProperty the display property.
-     * @param relativePeriodDate the date to use as basis for relative periods.
-     * @param userOrgUnit the user organisation unit parameter.
-     * @param request the HTTP request.
-     * @param response the HTTP response.
-     * @param includeGroupSets whether to include organisation unit group sets.
-     * @return a list of geo features or null.
-     */
-    private List<GeoFeature> getGeoFeatures( String ou, String oug, DisplayProperty displayProperty,
-        Date relativePeriodDate,
-        String userOrgUnit, HttpServletRequest request, HttpServletResponse response, boolean includeGroupSets,
-        DhisApiVersion apiVersion )
-    {
-        Set<String> dimensionParams = new HashSet<>();
-        dimensionParams.add( ou );
-        dimensionParams.add( oug );
-
-        DataQueryRequest dataQueryRequest = DataQueryRequest.newBuilder()
-            .dimension( dimensionParams )
-            .aggregationType( AggregationType.SUM )
-            .displayProperty( displayProperty )
-            .relativePeriodDate( relativePeriodDate )
-            .userOrgUnit( userOrgUnit )
-            .apiVersion( apiVersion ).build();
-
-        DataQueryParams params = dataQueryService.getFromRequest( dataQueryRequest );
-
-        boolean useOrgUnitGroup = ou == null;
-        DimensionalObject dimensionalObject = params
-            .getDimension( useOrgUnitGroup ? ORGUNIT_GROUP_DIM_ID : ORGUNIT_DIM_ID );
-
-        if ( dimensionalObject == null )
-        {
-            throw new IllegalArgumentException( "Dimension is present in query without any valid dimension options" );
-        }
-
-        List<DimensionalItemObject> dimensionalItemObjects = DimensionalObjectUtils
-            .asTypedList( dimensionalObject.getItems() );
-
-        dimensionalItemObjects = dimensionalItemObjects.stream().filter( object -> {
-            CoordinateObject coordinateObject = (CoordinateObject) object;
-            return coordinateObject != null &&
-                coordinateObject.getFeatureType() != null &&
-                coordinateObject.hasCoordinates() &&
-                (coordinateObject.getFeatureType() != FeatureType.POINT
-                    || ValidationUtils.coordinateIsValid( coordinateObject.getCoordinates() ));
-        } ).collect( Collectors.toList() );
-
-        boolean modified = !ContextUtils.clearIfNotModified( request, response, dimensionalItemObjects );
-
-        if ( !modified )
-        {
-            return null;
-        }
-
-        return getGeoFeatures( params, dimensionalItemObjects, includeGroupSets, useOrgUnitGroup );
-    }
-
-    /**
-     * Returns a list of {@link GeoFeature}.
-     *
-     * @param params the {@link DataQueryParams}.
-     * @param dimensionalItemObjects the list of {@link DimensionalItemObject}.
-     * @param includeGroupSets whether to include group sets.
-     * @param useOrgUnitGroup whether to use org unit group when retrieving
-     *        features.
-     * @return a list of {@link GeoFeature}.
-     */
-    private List<GeoFeature> getGeoFeatures( DataQueryParams params,
-        List<DimensionalItemObject> dimensionalItemObjects, boolean includeGroupSets, boolean useOrgUnitGroup )
-    {
-        List<GeoFeature> features = new ArrayList<>();
-
-        List<OrganisationUnitGroupSet> groupSets = includeGroupSets
-            ? organisationUnitGroupService.getAllOrganisationUnitGroupSets()
-            : new ArrayList<>();
-
-        Set<OrganisationUnit> roots = currentUserService.getCurrentUser().getDataViewOrganisationUnitsWithFallback();
-
-        for ( DimensionalItemObject unit : dimensionalItemObjects )
-        {
-            GeoFeature feature = new GeoFeature();
-
-            CoordinateObject coordinateObject = (CoordinateObject) unit;
-
-            Integer ty = coordinateObject.getFeatureType() != null
-                ? FEATURE_TYPE_MAP.get( coordinateObject.getFeatureType() )
-                : null;
-
-            feature.setId( unit.getUid() );
-            feature.setCode( unit.getCode() );
-            feature.setHcd( coordinateObject.hasDescendantsWithCoordinates() );
-
-            if ( !useOrgUnitGroup )
-            {
-                OrganisationUnit castUnit = (OrganisationUnit) unit;
-                feature.setHcu( castUnit.hasCoordinatesUp() );
-                feature.setLe( castUnit.getLevel() );
-                feature.setPg( castUnit.getParentGraph( roots ) );
-                feature.setPi( castUnit.getParent() != null ? castUnit.getParent().getUid() : null );
-                feature.setPn( castUnit.getParent() != null ? castUnit.getParent().getDisplayName() : null );
-
-                if ( includeGroupSets )
-                {
-                    for ( OrganisationUnitGroupSet groupSet : groupSets )
-                    {
-                        OrganisationUnitGroup group = castUnit.getGroupInGroupSet( groupSet );
-
-                        if ( group != null )
-                        {
-                            feature.getDimensions().put( groupSet.getUid(), group.getUid() );
-                        }
-                    }
-                }
-            }
-
-            feature.setTy( ObjectUtils.firstNonNull( ty, 0 ) );
-            feature.setCo( coordinateObject.getCoordinates() );
-            feature.setNa( unit.getDisplayProperty( params.getDisplayProperty() ) );
-
-            features.add( feature );
-        }
-
-        features.sort( Comparator.comparing( GeoFeature::getTy ) );
-
-        return features;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
@@ -1,0 +1,610 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.service;
+
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_GROUP_DIM_ID;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.geojson.Feature;
+import org.geojson.FeatureCollection;
+import org.geojson.GeoJsonObject;
+import org.geojson.GeoJsonObjectVisitor;
+import org.geojson.GeometryCollection;
+import org.geojson.LineString;
+import org.geojson.MultiLineString;
+import org.geojson.MultiPoint;
+import org.geojson.MultiPolygon;
+import org.geojson.Point;
+import org.geojson.Polygon;
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.DataQueryService;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeService;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DataQueryRequest;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.DimensionalObjectUtils;
+import org.hisp.dhis.common.DisplayProperty;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.common.coordinate.CoordinateObject;
+import org.hisp.dhis.commons.util.DebugUtils;
+import org.hisp.dhis.organisationunit.FeatureType;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupService;
+import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
+import org.hisp.dhis.system.util.ValidationUtils;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.util.ObjectUtils;
+import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.hisp.dhis.webapi.webdomain.GeoFeature;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+/**
+ * Take the request parameters from
+ * {@link org.hisp.dhis.webapi.controller.mapping.GeoFeatureController}, process
+ * it then return List of {@link GeoFeature}
+ *
+ * @author viet@dhis2.org
+ */
+@Slf4j
+@Service
+public class GeoFeatureService
+{
+    private final DataQueryService dataQueryService;
+
+    private final OrganisationUnitGroupService organisationUnitGroupService;
+
+    private final CurrentUserService currentUserService;
+
+    private final AttributeService attributeService;
+
+    /**
+     * The {@link GeoFeature#getTy} in the response is integer, so we need to
+     * map {@link FeatureType} to integer and return to client.
+     */
+    private static final Map<FeatureType, Integer> FEATURE_TYPE_MAP = ImmutableMap.<FeatureType, Integer> builder()
+        .put( FeatureType.POINT, GeoFeature.TYPE_POINT ).put( FeatureType.MULTI_POLYGON, GeoFeature.TYPE_POLYGON )
+        .put( FeatureType.POLYGON, GeoFeature.TYPE_POLYGON ).build();
+
+    public GeoFeatureService( DataQueryService dataQueryService,
+        OrganisationUnitGroupService organisationUnitGroupService,
+        CurrentUserService currentUserService, AttributeService attributeService )
+    {
+        this.dataQueryService = dataQueryService;
+        this.organisationUnitGroupService = organisationUnitGroupService;
+        this.currentUserService = currentUserService;
+        this.attributeService = attributeService;
+    }
+
+    /**
+     * Returns a list of {@link GeoFeature}. Returns null if not modified based
+     * on the request.
+     *
+     * @param parameters the {@link Parameters} passing from controller.
+     * @return a list of geo features or null.
+     */
+    public List<GeoFeature> getGeoFeatures( Parameters parameters )
+    {
+        Attribute geoJsonAttribute = validateCoordinateField( parameters.getCoordinateField() );
+
+        Set<String> dimensionParams = new HashSet<>();
+        dimensionParams.add( parameters.getOrganisationUnit() );
+        dimensionParams.add( parameters.getOrganisationUnitGroupId() );
+
+        DataQueryRequest dataQueryRequest = DataQueryRequest.newBuilder()
+            .dimension( dimensionParams )
+            .aggregationType( AggregationType.SUM )
+            .displayProperty( parameters.getDisplayProperty() )
+            .relativePeriodDate( parameters.getRelativePeriodDate() )
+            .userOrgUnit( parameters.getUserOrgUnit() )
+            .apiVersion( parameters.getApiVersion() ).build();
+
+        DataQueryParams params = dataQueryService.getFromRequest( dataQueryRequest );
+
+        boolean useOrgUnitGroup = parameters.getOrganisationUnit() == null;
+        DimensionalObject dimensionalObject = params
+            .getDimension( useOrgUnitGroup ? ORGUNIT_GROUP_DIM_ID : ORGUNIT_DIM_ID );
+
+        if ( dimensionalObject == null )
+        {
+            throw new IllegalArgumentException( "Dimension is present in query without any valid dimension options" );
+        }
+
+        List<DimensionalItemObject> dimensionalItemObjects = DimensionalObjectUtils
+            .asTypedList( dimensionalObject.getItems() );
+
+        dimensionalItemObjects = dimensionalItemObjects.stream()
+            .filter( object -> validateDimensionalItemObject( object, geoJsonAttribute ) )
+            .collect( Collectors.toList() );
+
+        boolean modified = !ContextUtils.clearIfNotModified( parameters.getRequest(), parameters.getResponse(),
+            dimensionalItemObjects );
+
+        if ( !modified )
+        {
+            return null;
+        }
+
+        return getGeoFeatures( params, dimensionalItemObjects, parameters.isIncludeGroupSets(), useOrgUnitGroup,
+            geoJsonAttribute );
+    }
+
+    /**
+     * Returns a list of {@link GeoFeature}.
+     *
+     * @param params the {@link DataQueryParams}.
+     * @param dimensionalItemObjects the list of {@link DimensionalItemObject}.
+     * @param includeGroupSets whether to include group sets.
+     * @param useOrgUnitGroup whether to use org unit group when retrieving
+     *        features.
+     * @param geoJsonAttribute OrganisationUnit attribute used for retrieving
+     *        {@link GeoJsonObject}
+     * @return a list of {@link GeoFeature}.
+     */
+    private List<GeoFeature> getGeoFeatures( DataQueryParams params,
+        List<DimensionalItemObject> dimensionalItemObjects, boolean includeGroupSets, boolean useOrgUnitGroup,
+        Attribute geoJsonAttribute )
+    {
+        List<GeoFeature> features = new ArrayList<>();
+
+        List<OrganisationUnitGroupSet> groupSets = includeGroupSets
+            ? organisationUnitGroupService.getAllOrganisationUnitGroupSets()
+            : new ArrayList<>();
+
+        Set<OrganisationUnit> roots = currentUserService.getCurrentUser().getDataViewOrganisationUnitsWithFallback();
+
+        for ( DimensionalItemObject unit : dimensionalItemObjects )
+        {
+            GeoFeature feature = new GeoFeature();
+
+            CoordinateObject coordinateObject = (CoordinateObject) unit;
+
+            feature.setId( unit.getUid() );
+            feature.setCode( unit.getCode() );
+            feature.setHcd( coordinateObject.hasDescendantsWithCoordinates() );
+
+            if ( !useOrgUnitGroup )
+            {
+                OrganisationUnit castUnit = (OrganisationUnit) unit;
+                feature.setHcu( castUnit.hasCoordinatesUp() );
+                feature.setLe( castUnit.getLevel() );
+                feature.setPg( castUnit.getParentGraph( roots ) );
+                feature.setPi( castUnit.getParent() != null ? castUnit.getParent().getUid() : null );
+                feature.setPn( castUnit.getParent() != null ? castUnit.getParent().getDisplayName() : null );
+
+                if ( includeGroupSets )
+                {
+                    for ( OrganisationUnitGroupSet groupSet : groupSets )
+                    {
+                        OrganisationUnitGroup group = castUnit.getGroupInGroupSet( groupSet );
+
+                        if ( group != null )
+                        {
+                            feature.getDimensions().put( groupSet.getUid(), group.getUid() );
+                        }
+                    }
+                }
+            }
+
+            getCoordinates( feature, unit, geoJsonAttribute );
+
+            feature.setNa( unit.getDisplayProperty( params.getDisplayProperty() ) );
+            features.add( feature );
+        }
+
+        features.sort( Comparator.comparing( GeoFeature::getTy ) );
+
+        return features;
+    }
+
+    /**
+     * Get the {@link GeoFeature} coordinate from {@link DimensionalItemObject}
+     *
+     * @param feature the {@link GeoFeature}
+     * @param unit the {@link DimensionalItemObject} contains the coordinate
+     *        values.
+     * @return the given {@link GeoFeature} with updated coordinate value and
+     *         coordinate type.
+     */
+    private void getCoordinates( GeoFeature feature, DimensionalItemObject unit )
+    {
+        if ( !CoordinateObject.class.isAssignableFrom( unit.getClass() ) )
+        {
+            return;
+        }
+
+        CoordinateObject coordinateObject = (CoordinateObject) unit;
+
+        Integer ty = coordinateObject.getFeatureType() != null
+            ? FEATURE_TYPE_MAP.get( coordinateObject.getFeatureType() )
+            : null;
+        feature.setCo( coordinateObject.getCoordinates() );
+        feature.setTy( ObjectUtils.firstNonNull( ty, 0 ) );
+    }
+
+    /**
+     * Get the {@link GeoFeature} coordinate from {@link DimensionalItemObject}
+     * <p>
+     * The coordinate value is retrieved from {@link DimensionalItemObject}'s
+     * geoJsonAttribute value.
+     *
+     * @param feature the {@link GeoFeature}
+     * @param unit the {@link DimensionalItemObject} contains the coordinate
+     *        values.
+     * @param geoJsonAttribute The {@link Attribute} which has
+     *        {@link ValueType#GEOJSON} and is assigned to
+     *        {@link OrganisationUnit}.
+     * @return the given {@link GeoFeature} with updated coordinate value and
+     *         coordinate type.
+     */
+    private void getCoordinates( GeoFeature feature, DimensionalItemObject unit, Attribute geoJsonAttribute )
+    {
+        if ( geoJsonAttribute == null )
+        {
+            getCoordinates( feature, unit );
+            return;
+        }
+
+        if ( !unit.getClass().isAssignableFrom( OrganisationUnit.class ) )
+        {
+            return;
+        }
+
+        OrganisationUnit organisationUnit = (OrganisationUnit) unit;
+        Optional<AttributeValue> geoJsonAttributeValue = organisationUnit
+            .getAttributeValues().stream()
+            .filter( attributeValue -> attributeValue.getAttribute().getUid().equals( geoJsonAttribute.getUid() ) )
+            .findFirst();
+
+        if ( !geoJsonAttributeValue.isPresent() || StringUtils.isBlank( geoJsonAttributeValue.get().getValue() ) )
+        {
+            getCoordinates( feature, unit );
+            return;
+        }
+
+        try
+        {
+            GeoJsonObject geoJsonObject = new ObjectMapper()
+                .readValue( geoJsonAttributeValue.get().getValue(), GeoJsonObject.class );
+            GeoFeature geoJsonFeature = geoJsonObject.accept( new GeoFeatureVisitor() );
+
+            if ( geoJsonFeature == null )
+            {
+                return;
+            }
+
+            feature.setTy( geoJsonFeature.getTy() );
+            feature.setCo( geoJsonFeature.getCo() );
+        }
+        catch ( JsonProcessingException e )
+        {
+            log.error( String.format( "Couldn't read GeoJson value from organisationUnit %s: ", organisationUnit ), e );
+            getCoordinates( feature, unit );
+        }
+    }
+
+    /**
+     * Check if the given coordinateField is a valid {@link Attribute} ID
+     * <p>
+     * Also check if that Attribute has {@link ValueType#GEOJSON} and is
+     * assigned to {@link OrganisationUnit}
+     *
+     * @param coordinateField the {@link Attribute} ID
+     * @return the {@link Attribute} if valid, otherwise return throws
+     *         {@link IllegalArgumentException}
+     */
+    private Attribute validateCoordinateField( String coordinateField )
+    {
+        if ( StringUtils.isBlank( coordinateField ) )
+        {
+            return null;
+        }
+
+        Attribute attribute = attributeService.getAttribute( coordinateField );
+        if ( attribute == null )
+        {
+            throw new IllegalArgumentException( "Invalid coordinateField: " + coordinateField );
+        }
+
+        if ( attribute.getValueType() != ValueType.GEOJSON )
+        {
+            throw new IllegalArgumentException(
+                "ValueType of coordinateField must be GeoJSON but found: " + attribute.getValueType() );
+        }
+
+        if ( !attribute.getSupportedClasses().contains( OrganisationUnit.class ) )
+        {
+            throw new IllegalArgumentException(
+                "coordinateField does not support OrganisationUnit: " + attribute.getName() );
+        }
+
+        return attribute;
+    }
+
+    /**
+     * Convert {@link GeoJsonObject} to {@link GeoFeature}
+     * <p>
+     * Return null if GeoJsonObject type is not supported
+     */
+    class GeoFeatureVisitor implements GeoJsonObjectVisitor<GeoFeature>
+    {
+        @Override
+        public GeoFeature visit( GeometryCollection geometryCollection )
+        {
+            // Not support type
+            return null;
+        }
+
+        @Override
+        public GeoFeature visit( FeatureCollection featureCollection )
+        {
+            // Not support type
+            return null;
+        }
+
+        @Override
+        public GeoFeature visit( Point point )
+        {
+            GeoFeature geoFeature = new GeoFeature();
+            geoFeature.setTy( GeoFeature.TYPE_POINT );
+            geoFeature.setCo( convertGeoJsonObjectCoordinates( Lists.newArrayList( point.getCoordinates() ) ) );
+            return geoFeature;
+        }
+
+        @Override
+        public GeoFeature visit( Feature feature )
+        {
+            // Not support type
+            return null;
+        }
+
+        @Override
+        public GeoFeature visit( MultiLineString multiLineString )
+        {
+            // Not support type
+            return null;
+        }
+
+        @Override
+        public GeoFeature visit( Polygon polygon )
+        {
+            GeoFeature geoFeature = new GeoFeature();
+            geoFeature.setTy( GeoFeature.TYPE_POLYGON );
+            geoFeature.setCo( convertGeoJsonObjectCoordinates( polygon.getCoordinates() ) );
+
+            return geoFeature;
+        }
+
+        @Override
+        public GeoFeature visit( MultiPolygon multiPolygon )
+        {
+            GeoFeature geoFeature = new GeoFeature();
+            geoFeature.setTy( GeoFeature.TYPE_POLYGON );
+            geoFeature.setCo( convertGeoJsonObjectCoordinates( multiPolygon.getCoordinates() ) );
+            return geoFeature;
+        }
+
+        @Override
+        public GeoFeature visit( MultiPoint multiPoint )
+        {
+            GeoFeature geoFeature = new GeoFeature();
+            geoFeature.setTy( GeoFeature.TYPE_POINT );
+            geoFeature.setCo( convertGeoJsonObjectCoordinates( multiPoint.getCoordinates() ) );
+            return geoFeature;
+        }
+
+        @Override
+        public GeoFeature visit( LineString lineString )
+        {
+            GeoFeature geoFeature = new GeoFeature();
+            geoFeature.setTy( GeoFeature.TYPE_POLYGON );
+            geoFeature.setCo( convertGeoJsonObjectCoordinates( lineString.getCoordinates() ) );
+            return geoFeature;
+        }
+    }
+
+    /**
+     * Convert coordinates of an {@link GeoJsonObject} to String
+     *
+     * @param coordinates the coordinate of a GeoJsonObject, usually is a list
+     *        of {@link org.geojson.LngLatAlt}
+     * @return a String contains given GeoJsonObject's coordinates. Return null
+     *         if failed to convert.
+     */
+    private String convertGeoJsonObjectCoordinates( Object coordinates )
+    {
+        try
+        {
+            return new ObjectMapper().writeValueAsString( coordinates );
+        }
+        catch ( JsonProcessingException e )
+        {
+            log.error( String.format( "Failed to write coordinate to String: %s", coordinates ),
+                DebugUtils.getStackTrace( e ) );
+        }
+
+        return null;
+    }
+
+    /**
+     * Contains all parameters from
+     * {@link org.hisp.dhis.webapi.controller.mapping.GeoFeatureController}
+     */
+    @Getter
+    @Builder
+    public static class Parameters
+    {
+        /**
+         * OrganisationUnit parameter, can include both organisationUnitLevel
+         * and OrganisationUnitID.
+         * <p>
+         * The format is: ou:LEVEL-{levelNumber};{OrganisationUnit ID}
+         * <p>
+         * Example: To retrieve geo features for organisation units at a level
+         * within the boundary of an organisation unit (e.g. at level 2)
+         * <p>
+         * ou:LEVEL-4;O6uvpzGd5pu
+         * <p>
+         * Example: to retrieve geo features for all organisation units at level
+         * 3 in the organisation unit hierarchy
+         * <p>
+         * ou:LEVEL-3
+         */
+        private String organisationUnit;
+
+        /**
+         * OrganisationUnit Group ID
+         */
+        private String organisationUnitGroupId;
+
+        /**
+         * Display property
+         */
+        private DisplayProperty displayProperty;
+
+        /**
+         * relativePeriodDate the date to use as basis for relative periods.
+         */
+        private Date relativePeriodDate;
+
+        /**
+         * the user organisation unit parameter.
+         */
+        private String userOrgUnit;
+
+        /**
+         * The {@link Attribute} ID which should must have
+         * {@link org.hisp.dhis.common.ValueType#GEOJSON}
+         * <p>
+         * If this parameter is provided, then the coordinates will be retrieved
+         * from
+         * <p>
+         * {@link OrganisationUnit}'s GeoJSON attribute value instead of the
+         * {@link OrganisationUnit}'s geometry field.
+         */
+        private String coordinateField;
+
+        /**
+         * the HTTP request.
+         */
+        private HttpServletRequest request;
+
+        /**
+         * the HTTP response.
+         */
+        private HttpServletResponse response;
+
+        /**
+         * whether to include organisation unit group sets.
+         */
+        private boolean includeGroupSets;
+
+        /**
+         * DHIS2 Api Version.
+         */
+        private DhisApiVersion apiVersion;
+    }
+
+    /**
+     * Check if the given DimensionalItemObject has coordinates.
+     *
+     * @param object {@link DimensionalItemObject}
+     * @return true if given object has coordinates, otherwise return false.
+     */
+    private boolean validateDimensionalItemObject( Object object, Attribute geoJsonAttribute )
+    {
+        return hasGeometryCoordinates( object ) || hasGeoJsonAttributeCoordinates( object, geoJsonAttribute );
+    }
+
+    /**
+     * Check if given object has {@link org.locationtech.jts.geom.Geometry}
+     * property and it has valid coordinates.
+     *
+     * @param object the object for validating
+     * @return true if given object has valid Geometry coordinates, false
+     *         otherwise.
+     */
+    private boolean hasGeometryCoordinates( Object object )
+    {
+        CoordinateObject coordinateObject = (CoordinateObject) object;
+        return coordinateObject != null &&
+            coordinateObject.getFeatureType() != null &&
+            coordinateObject.hasCoordinates() &&
+            (coordinateObject.getFeatureType() != FeatureType.POINT
+                || ValidationUtils.coordinateIsValid( coordinateObject.getCoordinates() ));
+    }
+
+    /**
+     * Check if given object has GeoJson Attribute and its value is not blank.
+     *
+     * @param object the {@link BaseIdentifiableObject} for validating.
+     * @param geoJsonAttribute the {@link Attribute} which has
+     *        {@link ValueType#GEOJSON}.
+     * @return true if given object has GeoJson coordinates, false otherwise.
+     */
+    private boolean hasGeoJsonAttributeCoordinates( Object object, Attribute geoJsonAttribute )
+    {
+        if ( geoJsonAttribute == null || !BaseIdentifiableObject.class.isAssignableFrom( object.getClass() ) )
+        {
+            return false;
+        }
+
+        BaseIdentifiableObject identifiableObject = (BaseIdentifiableObject) object;
+        AttributeValue geoJsonValue = identifiableObject.getAttributeValue( geoJsonAttribute );
+
+        return geoJsonValue != null && StringUtils.isNotBlank( geoJsonValue.getValue() );
+    }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/GeoFeatureServiceMockTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/GeoFeatureServiceMockTest.java
@@ -25,71 +25,71 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.mapping;
+package org.hisp.dhis.webapi.service;
 
-import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.geotools.geojson.geom.GeometryJSON;
 import org.hisp.dhis.analytics.DataQueryParams;
-import org.hisp.dhis.analytics.DataQueryService;
-import org.hisp.dhis.common.DataQueryRequest;
+import org.hisp.dhis.analytics.data.DefaultDataQueryService;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeService;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.organisationunit.DefaultOrganisationUnitGroupService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.DefaultCurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.junit.jupiter.api.BeforeEach;
+import org.hisp.dhis.webapi.webdomain.GeoFeature;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 /**
- * @author Luciano Fiandesio
+ * @author viet@dhis2.org
  */
+@MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-class GeoFeatureControllerTest
+public class GeoFeatureServiceMockTest
 {
-    private MockMvc mockMvc;
+    @InjectMocks
+    private GeoFeatureService geoFeatureService;
 
     @Mock
-    private DataQueryService dataQueryService;
+    private DefaultDataQueryService dataQueryService;
 
     @Mock
-    private CurrentUserService currentUserService;
+    private DefaultOrganisationUnitGroupService organisationUnitGroupService;
+
+    @Mock
+    private DefaultCurrentUserService currentUserService;
+
+    @Mock
+    private AttributeService attributeService;
 
     private final static String POINT = "{" +
         "\"type\": \"Point\"," +
         "\"coordinates\": [" +
-        "51.17431640625," +
-        "15.537052823106482" +
+        "51.17431641," +
+        "15.53705282" +
         "]" +
         "}";
 
-    @InjectMocks
-    private GeoFeatureController geoFeatureController;
-
-    private final static String ENDPOINT = "/geoFeatures";
-
     private final BeanRandomizer rnd = BeanRandomizer.create( OrganisationUnit.class, "parent", "geometry" );
-
-    @BeforeEach
-    public void setUp()
-    {
-        mockMvc = MockMvcBuilders.standaloneSetup( geoFeatureController ).build();
-    }
 
     @Test
     void verifyGeoFeaturesReturnsOuData()
@@ -105,14 +105,59 @@ class GeoFeatureControllerTest
         DataQueryParams params = DataQueryParams.newBuilder().withOrganisationUnits( getList( ouA, ouB, ouC, ouD ) )
             .build();
 
-        when( dataQueryService.getFromRequest( any( DataQueryRequest.class ) ) ).thenReturn( params );
+        when( dataQueryService.getFromRequest( any() ) ).thenReturn( params );
         when( currentUserService.getCurrentUser() ).thenReturn( user );
+        HttpServletRequest request = mock( HttpServletRequest.class );
+        HttpServletResponse response = mock( HttpServletResponse.class );
 
-        mockMvc.perform( get( ENDPOINT ).accept( ContextUtils.CONTENT_TYPE_JSON )
-            .param( "ou", "ou:LEVEL-2;LEVEL-3" ) )
-            .andExpect( status().isOk() )
-            .andExpect( content().contentType( ContextUtils.CONTENT_TYPE_JSON ) )
-            .andExpect( jsonPath( "$", hasSize( 3 ) ) );
+        List<GeoFeature> features = geoFeatureService.getGeoFeatures( GeoFeatureService.Parameters.builder()
+            .request( request )
+            .response( response )
+            .organisationUnit( "ou:LEVEL-2;LEVEL-3" )
+            .build() );
+
+        assertEquals( 3, features.size() );
+    }
+
+    /**
+     * GET Request has "coordinateField" parameter.
+     * <p>
+     * OrganisationUnit has coordinates from geometry property but not GeoJson
+     * Attribute.
+     * <p>
+     * Expected: the returned GeoFeature should include coordinates from
+     * geometry property.
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testGeoJsonAttributeFallback()
+        throws IOException
+    {
+        OrganisationUnit ouA = createOrgUnitWithCoordinates();
+        User user = rnd.nextObject( User.class );
+        DataQueryParams params = DataQueryParams.newBuilder().withOrganisationUnits( getList( ouA ) )
+            .build();
+
+        when( dataQueryService.getFromRequest( any() ) ).thenReturn( params );
+        when( currentUserService.getCurrentUser() ).thenReturn( user );
+        HttpServletRequest request = mock( HttpServletRequest.class );
+        HttpServletResponse response = mock( HttpServletResponse.class );
+
+        Attribute attribute = new Attribute();
+        attribute.setValueType( ValueType.GEOJSON );
+        attribute.setOrganisationUnitAttribute( true );
+        when( attributeService.getAttribute( "GeoJSON_Attribute_ID" ) ).thenReturn( attribute );
+
+        List<GeoFeature> features = geoFeatureService.getGeoFeatures( GeoFeatureService.Parameters.builder()
+            .request( request )
+            .response( response )
+            .coordinateField( "GeoJSON_Attribute_ID" )
+            .organisationUnit( "ou:LEVEL-2;LEVEL-3" )
+            .build() );
+
+        assertEquals( 1, features.size() );
+        assertEquals( "[51.17431641,15.53705282]", features.get( 0 ).getCo() );
     }
 
     private OrganisationUnit createOrgUnitWithoutCoordinates()


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12654

1. This PR add a new parameter `coordinateField` to the controller `GeoFeatureController`
- If the `coordinateField` is not provided, then coordinates will be retrieved from `geometry` property of the OrganisationUnits.
- If the `coordinateField` parameter is present, then coordinates will be retrieved from GeoJson Attribute value of the OrganisationUnits. If the attribute value is null, then it will fallback to the `geometry` property value.

2. I have moved the business logics code from `GeoFeatureController` to new service class `GeoFeatureService`
3. Also updated the validation for GeoJsonObject import, add new error code for the cases of unsupported GeoJson type.