### PR TITLE
chore: use newest version of json-tree (with builder)

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -68,7 +68,7 @@
         <!-- HISP Quick and Staxwax -->
         <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>
         <dhis-hisp-staxwax.version>2.0.0</dhis-hisp-staxwax.version>
-        <dhis-json-tree.version>0.1.0</dhis-json-tree.version>
+        <dhis-json-tree.version>0.2.0</dhis-json-tree.version>
 
         <!-- Security-->
         <spring-security.version>5.6.1</spring-security.version>


### PR DESCRIPTION
A while back I released version 0.2.0 of the JSON tree library. 
Mainly it rounds of some ends and introduces the JSON builder API in an accessible way. 
I just didn't switch core to the new version right away as I got distracted with other task while waiting for the artefact to become available in maven central. 