### PR TITLE
fix: approvalService.isApproved w/o writing

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -68,6 +68,7 @@ import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodStore;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -103,6 +104,8 @@ public class HibernateDataApprovalStore
 
     private final PeriodService periodService;
 
+    private final PeriodStore periodStore;
+
     private CurrentUserService currentUserService;
 
     private final CategoryService categoryService;
@@ -113,7 +116,7 @@ public class HibernateDataApprovalStore
 
     public HibernateDataApprovalStore( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
         ApplicationEventPublisher publisher, CacheProvider cacheProvider, PeriodService periodService,
-        CurrentUserService currentUserService, CategoryService categoryService,
+        PeriodStore periodStore, CurrentUserService currentUserService, CategoryService categoryService,
         SystemSettingManager systemSettingManager,
         StatementBuilder statementBuilder )
     {
@@ -121,12 +124,14 @@ public class HibernateDataApprovalStore
 
         checkNotNull( cacheProvider );
         checkNotNull( periodService );
+        checkNotNull( periodStore );
         checkNotNull( currentUserService );
         checkNotNull( categoryService );
         checkNotNull( systemSettingManager );
         checkNotNull( statementBuilder );
 
         this.periodService = periodService;
+        this.periodStore = periodStore;
         this.currentUserService = currentUserService;
         this.categoryService = categoryService;
         this.systemSettingManager = systemSettingManager;
@@ -235,7 +240,12 @@ public class HibernateDataApprovalStore
 
     private boolean dataApprovalExistsInternal( DataApproval dataApproval )
     {
-        Period storedPeriod = periodService.reloadPeriod( dataApproval.getPeriod() );
+        Period storedPeriod = periodStore.reloadPeriod( dataApproval.getPeriod() );
+
+        if ( storedPeriod == null )
+        {
+            return false;
+        }
 
         String sql = "select dataapprovalid " +
             "from dataapproval " +

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceTest.java
@@ -72,7 +72,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class DataApprovalServiceTest extends IntegrationTestBase
 {
-
     private static final String AUTH_APPR_LEVEL = "F_SYSTEM_SETTING";
 
     private final static boolean ACCEPTED = true;
@@ -731,6 +730,46 @@ class DataApprovalServiceTest extends IntegrationTestBase
         assertEquals( DataApprovalState.UNAPPROVED_READY, status.getState() );
         level = status.getApprovedLevel();
         assertNull( level );
+    }
+
+    @Test
+    void testIsApprovedTrue()
+    {
+        switchToApprovalUser( organisationUnitA, DataApproval.AUTH_APPROVE, DataApproval.AUTH_APPROVE_LOWER_LEVELS );
+
+        DataApproval dataApprovalB = new DataApproval( level2, workflow12, periodA, organisationUnitB,
+            defaultOptionCombo, NOT_ACCEPTED, new Date(), userB );
+        dataApprovalService.approveData( newArrayList( dataApprovalB ) );
+
+        // Get a period without periodId
+        Period testPeriodA = createPeriod( periodA.getIsoDate() );
+
+        assertTrue( dataApprovalService.isApproved( workflow12, testPeriodA, organisationUnitB,
+            defaultOptionCombo ) );
+    }
+
+    @Test
+    void testIsApprovedFalse()
+    {
+        switchToApprovalUser( organisationUnitA, DataApproval.AUTH_APPROVE, DataApproval.AUTH_APPROVE_LOWER_LEVELS );
+
+        // Get a period without periodId
+        Period testPeriodA = createPeriod( periodA.getIsoDate() );
+
+        assertFalse( dataApprovalService.isApproved( workflow12, testPeriodA, organisationUnitB,
+            defaultOptionCombo ) );
+    }
+
+    @Test
+    void testIsApprovedPeriodDoesNotExist()
+    {
+        switchToApprovalUser( organisationUnitA, DataApproval.AUTH_APPROVE, DataApproval.AUTH_APPROVE_LOWER_LEVELS );
+
+        // Get a period without periodId (and that isn't in the database)
+        Period testPeriodX = createPeriod( "201010" );
+
+        assertFalse( dataApprovalService.isApproved( workflow12, testPeriodX, organisationUnitB,
+            defaultOptionCombo ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodStore;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
@@ -90,6 +91,9 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
 
     @Autowired
     private PeriodService periodService;
+
+    @Autowired
+    private PeriodStore periodStore;
 
     @Autowired
     private CategoryService categoryService;
@@ -173,7 +177,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
         throws Exception
     {
         dataApprovalStore = new HibernateDataApprovalStore( sessionFactory, jdbcTemplate,
-            publisher, cacheProvider, periodService, currentUserService, categoryService,
+            publisher, cacheProvider, periodService, periodStore, currentUserService, categoryService,
             systemSettingManager, new PostgreSQLStatementBuilder() );
 
         // ---------------------------------------------------------------------


### PR DESCRIPTION
`DefaultDataApprovalService.isApproved` (with a read-only transaction) was calling down to `HibernateDataApprovalStore.dataApprovalExistsInternal`, which further called to `HibernatePeriodStore.reloadForceAddPeriod` -> `HibernatePeriodStore.addPeriod`. This failed if the approval status was requested for a non-existent period.

`HibernateDataApprovalStore.dataApprovalExistsInternal` has now been refactored to call `HibernatePeriodStore.reloadPeriod` instead of `DefaultPeriodService.reloadPeriod` (which did a "force" restore that tried to create the period if it didn't exist.)

A test has been added to `DataApprovalServiceTest` that fails without the fix and succeeds with it.