### PR TITLE
fix: job scheduler - distringuish between manual cancel and abort after failure [DHIS2-12704]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -534,6 +534,11 @@ public interface JobProgress
             this.cancelledTime = new Date();
             this.status = Status.CANCELLED;
         }
+
+        public void abort()
+        {
+            completeExceptionally( "aborted after failed stage or item", null );
+        }
     }
 
     @Getter


### PR DESCRIPTION
### Summary
The issue addressed here was clarity of what had happened when a job process failed.
A manual cancellation would end up in state `CANCELLED` but when an item would fail causing state `ERROR` for the item the stage would automatically also abort. The control flow here was as intended but the way this aborting worked is by forcing a cancel using a `CancellationException` causing the stage and the process to end up with state `CANCELLED` not `ERROR` even though an exception had triggered this. 

While this could be identified by the item level having last item in state `ERROR` this was confusing or misleading when looking at the higher levels which would indicate `CANCELLED` instead.

The now got addressed by cancel always meaning a manual cancel while "automatic" end of processing after an failed item (or stage) is an abort which is separately flagged internally. This flag can only be set if the process is not already cancelled. 
On a technical level ending the process early is uniformly done by checking the cancelled flag independent of being caused by a manual cancel or an automatic abort. 

### Manual Testing
**Testing behaviour of automatic abort:**

1. The way I tested this was adding a new YAML data integrity check that would always fail due to illegal SQL being used (remember that the name of the check needs to be added to `data-integrity-checks.yaml`)
  ```yaml
name: test
description: A data integrity check that fails
section: Test
summary_sql: >-
  select 'not a number';
details_sql: >-
  SELECT 1;
severity: WARNING
  ```
2. I created a `DATA_INTEGRITY` job with only this check using the API (UI does not yet allow to select checks):
3. Manually run the check and check http://localhost:8080/api/scheduling/completed/DATA_INTEGRITY  has status `ERROR` for both process and stage level

**Testing behaviour of manual cancellation:**

1. create a "Generate Analytics Tables" job and run it manually
2. cancel the job using `POST` to http://localhost:8080/api/scheduling/cancel/ANALYTICS_TABLE
3. check http://localhost:8080/api/scheduling/completed/ANALYTICS_TABLE and see its status being `CANCELLED`