### PR TITLE
fix: remove fallback geometry property for /api/geoFeatures

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/GeoFeatureController.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.webapi.webdomain.GeoFeature;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,7 +80,7 @@ public class GeoFeatureController
     // Resources
     // -------------------------------------------------------------------------
 
-    @GetMapping( produces = { ContextUtils.CONTENT_TYPE_JSON, ContextUtils.CONTENT_TYPE_HTML } )
+    @GetMapping
     @ResponseBody
     public ResponseEntity<List<GeoFeature>> getGeoFeaturesJson(
         @RequestParam( required = false ) String ou,
@@ -111,6 +112,7 @@ public class GeoFeatureController
 
         return ResponseEntity.ok()
             .header( HttpHeaders.CACHE_CONTROL, GEOFEATURE_CACHE.getHeaderValue() )
+            .contentType( MediaType.APPLICATION_JSON )
             .body( features );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
@@ -566,7 +566,12 @@ public class GeoFeatureService
      */
     private boolean validateDimensionalItemObject( Object object, Attribute geoJsonAttribute )
     {
-        return hasGeometryCoordinates( object ) || hasGeoJsonAttributeCoordinates( object, geoJsonAttribute );
+        if ( geoJsonAttribute != null )
+        {
+            return hasGeoJsonAttributeCoordinates( object, geoJsonAttribute );
+        }
+
+        return hasGeometryCoordinates( object );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/GeoFeatureServiceMockTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/service/GeoFeatureServiceMockTest.java
@@ -125,13 +125,12 @@ public class GeoFeatureServiceMockTest
      * OrganisationUnit has coordinates from geometry property but not GeoJson
      * Attribute.
      * <p>
-     * Expected: the returned GeoFeature should include coordinates from
-     * geometry property.
+     * Expected: only return GeoFeature which has the coordinateField value.
      *
      * @throws IOException
      */
     @Test
-    public void testGeoJsonAttributeFallback()
+    public void testGeoJsonAttributeWithNoValue()
         throws IOException
     {
         OrganisationUnit ouA = createOrgUnitWithCoordinates();
@@ -156,8 +155,7 @@ public class GeoFeatureServiceMockTest
             .organisationUnit( "ou:LEVEL-2;LEVEL-3" )
             .build() );
 
-        assertEquals( 1, features.size() );
-        assertEquals( "[51.17431641,15.53705282]", features.get( 0 ).getCo() );
+        assertEquals( 0, features.size() );
     }
 
     private OrganisationUnit createOrgUnitWithoutCoordinates()


### PR DESCRIPTION
- Add Content-type to the `ResponseEntity`
- Remove the logic of fallback to `geometry` property if GeoJSON Attribute value is null. ( feedback from Bjorn )
- Update unit test.