### PR TITLE
feat: Support display names in different forms in events [TECH-996]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -90,7 +90,6 @@ public class JdbcEnrollmentAnalyticsManager
     extends AbstractJdbcEventAnalyticsManager
     implements EnrollmentAnalyticsManager
 {
-
     private final EnrollmentTimeFieldSqlRenderer timeFieldSqlRenderer;
 
     private static final String ANALYTICS_EVENT = "analytics_event_";
@@ -99,14 +98,8 @@ public class JdbcEnrollmentAnalyticsManager
 
     private static final String LIMIT_1 = "limit 1";
 
-    public static final String CREATED_BY_DISPLAY_NAME_COLUMN = "concat(createdbylastname, ', ', createdbyname, "
-        + "' (', createdbyusername, ')') as createdbydisplayname";
-
-    public static final String LAST_UPDATED_BY_DISPLAY_NAME_COLUMN = "concat(lastupdatedbylastname, ', '"
-        + ", lastupdatedbyname, ' (', lastupdatedbyusername, ')') as lastupdatedbydisplayaname";
-
     private List<String> COLUMNS = Lists.newArrayList( "pi", "tei", "enrollmentdate", "incidentdate",
-        "storedby", CREATED_BY_DISPLAY_NAME_COLUMN, LAST_UPDATED_BY_DISPLAY_NAME_COLUMN, "lastupdated",
+        "storedby", "createdbydisplayname", "lastupdatedbydisplayname", "lastupdated",
         "ST_AsGeoJSON(pigeometry)", "longitude", "latitude",
         "ouname", "oucode", "enrollmentstatus" );
 
@@ -133,7 +126,6 @@ public class JdbcEnrollmentAnalyticsManager
         {
             withExceptionHandling( () -> getEnrollments( params, grid, sql ) );
         }
-
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -31,8 +31,6 @@ import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.time.DateUtils.addYears;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LATITUDE;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LONGITUDE;
-import static org.hisp.dhis.analytics.event.data.JdbcEnrollmentAnalyticsManager.CREATED_BY_DISPLAY_NAME_COLUMN;
-import static org.hisp.dhis.analytics.event.data.JdbcEnrollmentAnalyticsManager.LAST_UPDATED_BY_DISPLAY_NAME_COLUMN;
 import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_GEOMETRY_COL_SUFFIX;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.DATE_PERIOD_STRUCT_ALIAS;
@@ -335,8 +333,8 @@ public class JdbcEventAnalyticsManager
     protected String getSelectClause( EventQueryParams params )
     {
         ImmutableList.Builder<String> cols = new ImmutableList.Builder<String>()
-            .add( "psi", "ps", "executiondate", "storedby", CREATED_BY_DISPLAY_NAME_COLUMN,
-                LAST_UPDATED_BY_DISPLAY_NAME_COLUMN, "lastupdated" );
+            .add( "psi", "ps", "executiondate", "storedby", "createdbydisplayname",
+                "lastupdatedbydisplayname", "lastupdated" );
 
         if ( params.containsScheduledDatePeriod() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -61,6 +61,24 @@ import org.springframework.jdbc.core.JdbcTemplate;
 public abstract class AbstractEventJdbcTableManager
     extends AbstractJdbcTableManager
 {
+    protected static final String STORED_BY_COL_NAME = "storedby";
+
+    protected static final String CREATED_BY_COL_USER_NAME = "createdbyusername";
+
+    protected static final String CREATED_BY_COL_NAME = "createdbyname";
+
+    protected static final String CREATED_BY_COL_LAST_NAME = "createdbylastname";
+
+    protected static final String CREATED_BY_COL_DISPLAY_LAST_NAME = "createdbydisplayname";
+
+    protected static final String LAST_UPDATED_BY_COL_USER_NAME = "lastupdatedbyusername";
+
+    protected static final String LAST_UPDATED_BY_COL_NAME = "lastupdatedbyname";
+
+    protected static final String LAST_UPDATED_BY_COL_LAST_NAME = "lastupdatedbylastname";
+
+    protected static final String LAST_UPDATED_BY_COL_DISPLAY_LAST_NAME = "lastupdatedbydisplayname";
+
     public AbstractEventJdbcTableManager( IdentifiableObjectManager idObjectManager,
         OrganisationUnitService organisationUnitService, CategoryService categoryService,
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
@@ -71,6 +89,86 @@ public abstract class AbstractEventJdbcTableManager
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
             databaseInfo, jdbcTemplate );
+    }
+
+    /**
+     * This method will extract/compose the display name, based on the tracker
+     * JSON objects living in the 'originColumn'. This method will return the
+     * display name respecting these rules:
+     *
+     * If (last name, firs tname and username) are populated => Last name, first
+     * name (username)
+     *
+     * If (only username is populated) => username
+     *
+     * If (only first name is populated) => first name
+     *
+     * If (only last name is populated) => last name
+     *
+     * If (only last name and first name are populated) => last name, first name
+     *
+     * If (only last name and username are populated) => last name (username)
+     *
+     * If (only first name and username are populated) => first name (username)
+     *
+     * @param originColumn the original column from where the JSON values are
+     *        extracted from
+     * @param tablePrefix the prefix of the tracker table
+     * @param columnAlias the alias of this column in the analytics database
+     * @return the trimmed display name
+     */
+    protected static String getDisplayName( final String originColumn, final String tablePrefix,
+        final String columnAlias )
+    {
+        return ("case"
+            // If all are empty, return null
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') = ''"
+            + " then null"
+
+            // If username only, return username
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') <> ''"
+            + " then trim({prefix}.{column} ->> 'username')"
+
+            // If firstName only, return firstName
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') <> ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') = ''"
+            + " then trim({prefix}.{column} ->> 'firstName')"
+
+            // If surname only, return surname
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') <> ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') = ''"
+            + " then trim({prefix}.{column} ->> 'surname')"
+
+            // If surname and firstName only, return surname + firstName
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') <> ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') <> ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') = ''"
+            + " then concat(trim({prefix}.{column} ->> 'surname'), ', ', trim({prefix}.{column} ->> 'firstName'))"
+
+            // If firstName and username only, return firstName + username
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') <> ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') <> ''"
+            + " then concat(trim({prefix}.{column} ->> 'firstName'), ' (', trim({prefix}.{column} ->> 'username'), ')')"
+
+            // If surname and username only, return surname + username
+            + " when coalesce(trim({prefix}.{column} ->> 'surname'), '') <> ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'firstName'), '') = ''"
+            + " and coalesce(trim({prefix}.{column} ->> 'username'), '') <> ''"
+            + " then concat(trim({prefix}.{column} ->> 'surname'), ' (', trim({prefix}.{column} ->> 'username'), ')')"
+
+            // If has all columns populated, return surname + firstName +
+            // username
+            + " else concat(trim({prefix}.{column} ->> 'surname'), ', ', trim({prefix}.{column} ->> 'firstName'), ' (', trim({prefix}.{column} ->> 'username'), ')') end"
+            + " as {alias}").replaceAll( "\\{column}", originColumn )
+                .replaceAll( "\\{prefix}", tablePrefix )
+                .replaceAll( "\\{alias}", columnAlias );
     }
 
     protected final String getNumericClause()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -86,20 +86,6 @@ public class JdbcEnrollmentAnalyticsTableManager
             databaseInfo, jdbcTemplate );
     }
 
-    public static final String STORED_BY_COL_NAME = "storedby";
-
-    private static final String CREATED_BY_COL_USER_NAME = "createdbyusername";
-
-    private static final String CREATED_BY_COL_NAME = "createdbyname";
-
-    private static final String CREATED_BY_COL_LAST_NAME = "createdbylastname";
-
-    private static final String LAST_UPDATED_BY_COL_USER_NAME = "lastupdatedbyusername";
-
-    private static final String LAST_UPDATED_BY_COL_NAME = "lastupdatedbyname";
-
-    private static final String LAST_UPDATED_BY_COL_LAST_NAME = "lastupdatedbylastname";
-
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(
         new AnalyticsTableColumn( quote( "pi" ), CHARACTER_11, NOT_NULL, "pi.uid" ),
         new AnalyticsTableColumn( quote( "enrollmentdate" ), TIMESTAMP, "pi.enrollmentdate" ),
@@ -114,12 +100,17 @@ public class JdbcEnrollmentAnalyticsTableManager
             "pi.createdbyuserinfo ->> 'firstName' as " + CREATED_BY_COL_NAME ),
         new AnalyticsTableColumn( quote( CREATED_BY_COL_LAST_NAME ), VARCHAR_255,
             "pi.createdbyuserinfo ->> 'surname' as " + CREATED_BY_COL_LAST_NAME ),
+        new AnalyticsTableColumn( quote( CREATED_BY_COL_DISPLAY_LAST_NAME ), VARCHAR_255,
+            getDisplayName( "createdbyuserinfo",
+                "pi", CREATED_BY_COL_DISPLAY_LAST_NAME ) ),
         new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_USER_NAME ), VARCHAR_255,
             "pi.lastupdatedbyuserinfo ->> 'username' as " + LAST_UPDATED_BY_COL_USER_NAME ),
         new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_NAME ), VARCHAR_255,
             "pi.lastupdatedbyuserinfo ->> 'firstName' as " + LAST_UPDATED_BY_COL_NAME ),
         new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_LAST_NAME ), VARCHAR_255,
             "pi.lastupdatedbyuserinfo ->> 'surname' as " + LAST_UPDATED_BY_COL_LAST_NAME ),
+        new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_DISPLAY_LAST_NAME ), VARCHAR_255,
+            getDisplayName( "lastupdatedbyuserinfo", "pi", LAST_UPDATED_BY_COL_DISPLAY_LAST_NAME ) ),
         new AnalyticsTableColumn( quote( "enrollmentstatus" ), VARCHAR_50, "pi.status" ),
         new AnalyticsTableColumn( quote( "longitude" ), DOUBLE,
             "CASE WHEN 'POINT' = GeometryType(pi.geometry) THEN ST_X(pi.geometry) ELSE null END" ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -109,20 +109,6 @@ public class JdbcEventAnalyticsTableManager
             databaseInfo, jdbcTemplate );
     }
 
-    private static final String STORED_BY_COL_NAME = "storedby";
-
-    private static final String CREATED_BY_COL_USER_NAME = "createdbyusername";
-
-    private static final String CREATED_BY_COL_NAME = "createdbyname";
-
-    private static final String CREATED_BY_COL_LAST_NAME = "createdbylastname";
-
-    private static final String LAST_UPDATED_BY_COL_USER_NAME = "lastupdatedbyusername";
-
-    private static final String LAST_UPDATED_BY_COL_NAME = "lastupdatedbyname";
-
-    private static final String LAST_UPDATED_BY_COL_LAST_NAME = "lastupdatedbylastname";
-
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(
         new AnalyticsTableColumn( quote( "psi" ), CHARACTER_11, NOT_NULL, "psi.uid" ),
         new AnalyticsTableColumn( quote( "pi" ), CHARACTER_11, NOT_NULL, "pi.uid" ),
@@ -142,12 +128,16 @@ public class JdbcEventAnalyticsTableManager
             "psi.createdbyuserinfo ->> 'firstName' as " + CREATED_BY_COL_NAME ),
         new AnalyticsTableColumn( quote( CREATED_BY_COL_LAST_NAME ), VARCHAR_255,
             "psi.createdbyuserinfo ->> 'surname' as " + CREATED_BY_COL_LAST_NAME ),
+        new AnalyticsTableColumn( quote( CREATED_BY_COL_DISPLAY_LAST_NAME ), VARCHAR_255,
+            getDisplayName( "createdbyuserinfo", "psi", CREATED_BY_COL_DISPLAY_LAST_NAME ) ),
         new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_USER_NAME ), VARCHAR_255,
             "psi.lastupdatedbyuserinfo ->> 'username' as " + LAST_UPDATED_BY_COL_USER_NAME ),
         new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_NAME ), VARCHAR_255,
             "psi.lastupdatedbyuserinfo ->> 'firstName' as " + LAST_UPDATED_BY_COL_NAME ),
         new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_LAST_NAME ), VARCHAR_255,
             "psi.lastupdatedbyuserinfo ->> 'surname' as " + LAST_UPDATED_BY_COL_LAST_NAME ),
+        new AnalyticsTableColumn( quote( LAST_UPDATED_BY_COL_DISPLAY_LAST_NAME ), VARCHAR_255,
+            getDisplayName( "lastupdatedbyuserinfo", "psi", LAST_UPDATED_BY_COL_DISPLAY_LAST_NAME ) ),
         new AnalyticsTableColumn( quote( "pistatus" ), VARCHAR_50, "pi.status" ),
         new AnalyticsTableColumn( quote( "psistatus" ), VARCHAR_50, "psi.status" ),
         new AnalyticsTableColumn( quote( "psigeometry" ), GEOMETRY, "psi.geometry" )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -36,8 +36,6 @@ import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
 import static org.hisp.dhis.DhisConvenienceTest.getDate;
 import static org.hisp.dhis.analytics.QueryKey.NV;
-import static org.hisp.dhis.analytics.event.data.JdbcEnrollmentAnalyticsManager.CREATED_BY_DISPLAY_NAME_COLUMN;
-import static org.hisp.dhis.analytics.event.data.JdbcEnrollmentAnalyticsManager.LAST_UPDATED_BY_DISPLAY_NAME_COLUMN;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.common.DimensionalObject.OPTION_SEP;
@@ -115,7 +113,7 @@ class EnrollmentAnalyticsManagerTest extends
     private ArgumentCaptor<String> sql;
 
     private String DEFAULT_COLUMNS = "pi,tei,enrollmentdate,incidentdate,storedby,"
-        + CREATED_BY_DISPLAY_NAME_COLUMN + "," + LAST_UPDATED_BY_DISPLAY_NAME_COLUMN
+        + "createdbydisplayname" + "," + "lastupdatedbydisplayname"
         + ",lastupdated,ST_AsGeoJSON(pigeometry),longitude,latitude,ouname,oucode,enrollmentstatus";
 
     private final String TABLE_NAME = "analytics_enrollment";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventsAnalyticsManagerTest.java
@@ -37,8 +37,6 @@ import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
 import static org.hisp.dhis.analytics.QueryKey.NV;
-import static org.hisp.dhis.analytics.event.data.JdbcEnrollmentAnalyticsManager.CREATED_BY_DISPLAY_NAME_COLUMN;
-import static org.hisp.dhis.analytics.event.data.JdbcEnrollmentAnalyticsManager.LAST_UPDATED_BY_DISPLAY_NAME_COLUMN;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.OPTION_SEP;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
@@ -118,7 +116,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
     private final static String TABLE_NAME = "analytics_event";
 
     private final static String DEFAULT_COLUMNS_WITH_REGISTRATION = "psi,ps,executiondate,storedby,"
-        + CREATED_BY_DISPLAY_NAME_COLUMN + "," + LAST_UPDATED_BY_DISPLAY_NAME_COLUMN
+        + "createdbydisplayname" + "," + "lastupdatedbydisplayname"
         + ",lastupdated,enrollmentdate,incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,"
         + "oucode,pistatus,psistatus";
 
@@ -149,7 +147,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "select psi,ps,executiondate,storedby,"
-            + CREATED_BY_DISPLAY_NAME_COLUMN + "," + LAST_UPDATED_BY_DISPLAY_NAME_COLUMN
+            + "createdbydisplayname" + "," + "lastupdatedbydisplayname"
             + ",lastupdated,ST_AsGeoJSON(psigeometry, 6) as geometry,"
             + "longitude,latitude,ouname,oucode,pistatus,psistatus,ax.\"monthly\",ax.\"ou\"  from "
             + getTable( programA.getUid() )
@@ -172,7 +170,7 @@ class EventsAnalyticsManagerTest extends EventAnalyticsTest
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "select psi,ps,executiondate,storedby,"
-            + CREATED_BY_DISPLAY_NAME_COLUMN + "," + LAST_UPDATED_BY_DISPLAY_NAME_COLUMN
+            + "createdbydisplayname" + "," + "lastupdatedbydisplayname"
             + ",lastupdated,enrollmentdate,"
             + "incidentdate,tei,pi,ST_AsGeoJSON(psigeometry, 6) as geometry,longitude,latitude,ouname,oucode,pistatus,"
             + "psistatus,ax.\"monthly\",ax.\"ou\",\"" + dataElement.getUid() + "_name"

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -257,7 +257,7 @@ class JdbcEventAnalyticsTableManagerTest
         new AnalyticsTableAsserter.Builder( tables.get( 0 ) )
             .withTableType( AnalyticsTableType.EVENT )
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() )
-            .withColumnSize( 50 )
+            .withColumnSize( 52 )
             .withDefaultColumns( subject.getFixedColumns() )
             .addColumns( periodColumns )
             .addColumn( categoryA.getUid(), CHARACTER_11, "acs.", categoryA.getCreated() )
@@ -318,7 +318,7 @@ class JdbcEventAnalyticsTableManagerTest
         new AnalyticsTableAsserter.Builder( tables.get( 0 ) )
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() )
             .withTableType( AnalyticsTableType.EVENT )
-            .withColumnSize( 57 )
+            .withColumnSize( 59 )
             .addColumns( periodColumns )
             .addColumn( d1.getUid(), TEXT, toAlias( aliasD1, d1.getUid() ) ) // ValueType.TEXT
             .addColumn( d2.getUid(), DOUBLE, toAlias( aliasD2, d2.getUid() ) ) // ValueType.PERCENTAGE
@@ -374,7 +374,7 @@ class JdbcEventAnalyticsTableManagerTest
         new AnalyticsTableAsserter.Builder( tables.get( 0 ) )
             .withTableName( TABLE_PREFIX + program.getUid().toLowerCase() )
             .withTableType( AnalyticsTableType.EVENT )
-            .withColumnSize( 52 ).addColumns( periodColumns )
+            .withColumnSize( 54 ).addColumns( periodColumns )
             .addColumn( d1.getUid(), TEXT, toAlias( aliasD1, d1.getUid() ) ) // ValueType.TEXT
             .addColumn( tea1.getUid(), TEXT, String.format( aliasTea1, "ou.uid", tea1.getId(), tea1.getUid() ) )
             // Second Geometry column created from the OU column above


### PR DESCRIPTION
This is a request from the UI team to have different representations of the display name, depending on the values that are present in the tracker tables.

For the set of rules see TECH-996.

This will basically concatenate the `name`, `last name`, and `username` during the analytics table export. It will allow the sorting of those columns by their content/value, otherwise, it would not be possible.

The endpoints covered are: `/analytics/events/query` and `/analytics/enrollments/query`

**NOTE**
_With this solution, the user will not be able to know if he/she is seeing the name, last name or username in certain cases. Even knowing this limitation, the decision was to keep this logic/implementation._