### PR TITLE
fix: support locales with 4 letter variants

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/i18n/ui/resourcebundle/DefaultResourceBundleManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/i18n/ui/resourcebundle/DefaultResourceBundleManager.java
@@ -215,7 +215,7 @@ public class DefaultResourceBundleManager
     private Locale getLocaleFromName( String name )
     {
         Pattern pattern = Pattern.compile( "^" + GLOBAL_RESOURCE_BUNDLE_NAME
-            + "(?:_([a-z]{2,3})(?:_([A-Z]{2})(?:_(.+))?)?)?" + EXT_RESOURCE_BUNDLE + "$" );
+            + "(?:_([a-z]{2,3})(?:_([A-Za-z]{2,4})(?:_(.+))?)?)?" + EXT_RESOURCE_BUNDLE + "$" );
 
         Matcher matcher = pattern.matcher( name );
 


### PR DESCRIPTION
## Summary

* Adds support for locale files that has variants between 2 and 4 letters (including lower and uppercase)

[DHIS2-10427](https://jira.dhis2.org/browse/DHIS2-10427)