### PR TITLE
fix: Today's date enrollments are ignored [DHIS2-12677]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -203,6 +203,19 @@ public class DateUtils
     }
 
     /**
+     * adds 1 day to provided Date and returns it
+     *
+     * @param date
+     * @return day after provided date
+     */
+    public static Date plusOneDay( Date date )
+    {
+        return Date.from( date
+            .toInstant()
+            .plus( 1, ChronoUnit.DAYS ) );
+    }
+
+    /**
      * Formats a Date according to the HTTP specification standard date format.
      *
      * @param date the Date to format.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
+import static org.hisp.dhis.util.DateUtils.plusOneDay;
 
 import java.util.List;
 
@@ -214,7 +215,7 @@ public class JdbcEnrollmentAnalyticsManager
             {
                 sql += sqlHelper.whereAnd() + " enrollmentdate >= '" + getMediumDateString( params.getStartDate() )
                     + "' ";
-                sql += "and enrollmentdate <= '" + getMediumDateString( params.getEndDate() ) + "' ";
+                sql += "and enrollmentdate < '" + getMediumDateString( plusOneDay( params.getEndDate() ) ) + "' ";
             }
             else // Periods
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -120,7 +120,7 @@ public class EnrollmentAnalyticsManagerTest
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
             +
-            " as ax where enrollmentdate >= '2017-01-01' and enrollmentdate <= '2017-12-31' and (uidlevel0 = 'ouabcdefghA' ) limit 10001";
+            " as ax where enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01' and (uidlevel0 = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
 
@@ -243,7 +243,7 @@ public class EnrollmentAnalyticsManagerTest
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
             +
-            " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate <= '2017-04-08' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
+            " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -285,7 +285,7 @@ public class EnrollmentAnalyticsManagerTest
             "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi ))" + " as \"" + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
             +
-            " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate <= '2017-04-08' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
+            " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -357,7 +357,7 @@ public class EnrollmentAnalyticsManagerTest
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
             +
-            " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate <= '2017-04-08' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
+            " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel0 = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }


### PR DESCRIPTION
This fixes an issue where enrollments that have `enrollmentdate` equals "today" are being ignored.

This uses the same approach/fix in master.