### PR TITLE
fix: data value set export by data element group [DHIS2-12691]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
@@ -116,7 +116,7 @@ public class IdSchemes
 
     public IdScheme getDataElementGroupIdScheme()
     {
-        return getScheme( dataElementIdScheme );
+        return getScheme( dataElementGroupIdScheme );
     }
 
     public IdSchemes setDataElementGroupIdScheme( String idScheme )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
@@ -212,6 +212,7 @@ public class SpringDataValueSetStore
         String dataElements = getCommaDelimitedString( getIdentifiers( params.getAllDataElements() ) );
         String orgUnits = getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) );
         String orgUnitGroups = getCommaDelimitedString( getIdentifiers( params.getOrganisationUnitGroups() ) );
+        String deGroups = getCommaDelimitedString( getIdentifiers( params.getDataElementGroups() ) );
 
         // ----------------------------------------------------------------------
         // Identifier schemes
@@ -260,7 +261,18 @@ public class SpringDataValueSetStore
             sql += "left join orgunitgroupmembers ougm on (ou.organisationunitid=ougm.organisationunitid) ";
         }
 
-        sql += "where de.dataelementid in (" + dataElements + ") ";
+        sql += "where ";
+
+        if ( !params.hasDataElementGroups() )
+        {
+            sql += "de.dataelementid in (" + dataElements + ") ";
+        }
+        else
+        {
+            sql += "dv.dataelementid in ("
+                + "select distinct degm.dataelementid from dataelementgroupmembers degm "
+                + "where degm.dataelementgroupid in (" + deGroups + ")) ";
+        }
 
         if ( params.isIncludeDescendants() )
         {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataValueSetControllerTest.java
@@ -158,8 +158,12 @@ class DataValueSetControllerTest extends DhisControllerConvenienceTest
     {
         String ouId = assertStatus( HttpStatus.CREATED, POST( "/organisationUnits/",
             "{'name':'My Unit', 'shortName':'OU1', 'openingDate': '2020-01-01', 'code':'OU1'}" ) );
-        JsonWebMessage response = GET( "/dataValueSets/?inputOrgUnitIdScheme=code&idScheme=name&orgUnit={ou}", "OU1" )
-            .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
+        String dsId = assertStatus( HttpStatus.CREATED,
+            POST( "/dataSets/", "{'name':'My data set', 'periodType':'Monthly'}" ) );
+        JsonWebMessage response = GET(
+            "/dataValueSets/?inputOrgUnitIdScheme=code&idScheme=name&orgUnit={ou}&period=2022-01&dataSet={ds}", "OU1",
+            dsId )
+                .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
         assertEquals( String.format( "User is not allowed to view org unit: `%s`", ouId ), response.getMessage() );
     }
 }


### PR DESCRIPTION
### Summary
This was a fix for a forgotten filter feature on SQL level that turned into 3 bug-fixes.

1. The original missing filtering for data element groups. The API accepts the `dataElementGroup` parameter but it is never used in the SQL
2. When trying to use different input schema for the data element group I found the getter `getDataElementGroupIdScheme` on the schema object was using the wrong field so the property would always be `UID`
3. because of the way writing directly to the HTTP response works once you started that you cannot back out. This means the validation of the parameters needs to be done before that so we can back out and have a 409 _Conflict_ returned. This meant I needed to change the controller slightly just to give the operations the proper order

### Automatic Testing
Moving the validation to be executed earlier fixed the issue that validation errors did not result in a HTTP conflict response code. This did require to fix test setup for tests that were created while the response code was broken and therefore went unnoticed.

### Manual Testing
Tested with the demo database these two should give you results:

* http://localhost:8080/api/dataValueSets?format=json&dataElementGroup=ART&orgUnit=DiszpKrYNg8&period=2022-01&inputDataElementGroupIdScheme=name
* http://localhost:8080/api/dataValueSets?format=json&dataElementGroup=k1M0nuodfhN&orgUnit=DiszpKrYNg8&period=2022-01

Tests should also check that exporting based on a dataset works, that multiple data element groups could be used.
That means one should also export using the import/export app.