### PR TITLE
fix: Sms configuration update [ DHIS2-12590 ] 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsGatewayConfig.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsGatewayConfig.java
@@ -76,6 +76,9 @@ public abstract class SmsGatewayConfig
     @JsonView( SmsConfigurationViews.Public.class )
     private String urlTemplate;
 
+    @JsonView( SmsConfigurationViews.Public.class )
+    private String maxSmsLength;
+
     public String getUrlTemplate()
     {
         return urlTemplate;
@@ -144,6 +147,16 @@ public abstract class SmsGatewayConfig
     public void setSendUrlParameters( boolean sendUrlParameters )
     {
         this.sendUrlParameters = sendUrlParameters;
+    }
+
+    public String getMaxSmsLength()
+    {
+        return maxSmsLength;
+    }
+
+    public void setMaxSmsLength( String maxSmsLength )
+    {
+        this.maxSmsLength = maxSmsLength;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/outbound/GatewayResponse.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/outbound/GatewayResponse.java
@@ -47,6 +47,8 @@ public enum GatewayResponse
     NO_RECIPIENT( "no recipient", "No recipient found" ),
     SMS_DISABLED( "sms notifications are disabled", "sms notifications are disabled" ),
     SMPP_SESSION_FAILURE( "Smpp session initialization failure", "Smpp session initialization failure" ),
+    SMS_TEXT_MESSAGE_TOO_LONG( "Sms text message is too long",
+        "Sms text message is longer than the allowed max length for the default or gateway configuration" ),
 
     // -------------------------------------------------------------------------
     // BulkSms response codes

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsGateway.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsGateway.java
@@ -110,36 +110,28 @@ public abstract class SmsGateway
         {
             response = restTemplate.exchange( urlTemplate, httpMethod, request, klass );
 
-            if ( response != null )
-            {
-                statusCode = response.getStatusCode();
-            }
-            else
-            {
-                log.error( "Server response is null" );
-                statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
-            }
+            statusCode = response.getStatusCode();
         }
         catch ( HttpClientErrorException ex )
         {
-            log.error( "Client error", ex );
+            log.error( "Sms request Client error", ex );
 
             statusCode = ex.getStatusCode();
         }
         catch ( HttpServerErrorException ex )
         {
-            log.error( "Server error", ex );
+            log.error( "Sms request Server error", ex );
 
             statusCode = ex.getStatusCode();
         }
         catch ( Exception ex )
         {
-            log.error( "Error", ex );
+            log.error( "Sms request Error", ex );
 
             statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
         }
 
-        log.info( "Response status code: " + statusCode );
+        log.info( "Sms request status code: " + statusCode );
 
         return statusCode;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsGateway.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsGateway.java
@@ -114,19 +114,19 @@ public abstract class SmsGateway
         }
         catch ( HttpClientErrorException ex )
         {
-            log.error( "Sms request Client error", ex );
+            log.error( "Sms request client error", ex );
 
             statusCode = ex.getStatusCode();
         }
         catch ( HttpServerErrorException ex )
         {
-            log.error( "Sms request Server error", ex );
+            log.error( "Sms request server error", ex );
 
             statusCode = ex.getStatusCode();
         }
         catch ( Exception ex )
         {
-            log.error( "Sms request Error", ex );
+            log.error( "Sms request error", ex );
 
             statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsMessageSender.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsMessageSender.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.regex.Pattern;
@@ -48,6 +49,8 @@ import org.hisp.dhis.outboundmessage.OutboundMessageBatch;
 import org.hisp.dhis.outboundmessage.OutboundMessageBatchStatus;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponseSummary;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.sms.outbound.GatewayResponse;
 import org.hisp.dhis.sms.outbound.OutboundSms;
 import org.hisp.dhis.sms.outbound.OutboundSmsService;
@@ -76,6 +79,8 @@ import com.google.common.collect.Sets;
 public class SmsMessageSender
     implements MessageSender
 {
+    private static final String SMS_TEXT_MESSAGE_TOO_LONG = "Sms text message is too long";
+
     private static final String NO_CONFIG = "No default gateway configured";
 
     private static final String BATCH_ABORTED = "Aborted sending message batch";
@@ -89,16 +94,19 @@ public class SmsMessageSender
     // Dependencies
     // -------------------------------------------------------------------------
 
-    private GatewayAdministrationService gatewayAdminService;
+    private final GatewayAdministrationService gatewayAdminService;
 
-    private List<SmsGateway> smsGateways;
+    private final List<SmsGateway> smsGateways;
 
-    private UserSettingService userSettingService;
+    private final UserSettingService userSettingService;
 
-    private OutboundSmsService outboundSmsService;
+    private final OutboundSmsService outboundSmsService;
+
+    private final SystemSettingManager systemSettingManager;
 
     public SmsMessageSender( GatewayAdministrationService gatewayAdminService, List<SmsGateway> smsGateways,
-        UserSettingService userSettingService, OutboundSmsService outboundSmsService )
+        UserSettingService userSettingService, OutboundSmsService outboundSmsService,
+        SystemSettingManager systemSettingManager )
     {
 
         Preconditions.checkNotNull( gatewayAdminService );
@@ -111,6 +119,8 @@ public class SmsMessageSender
         this.smsGateways = smsGateways;
         this.userSettingService = userSettingService;
         this.outboundSmsService = outboundSmsService;
+        this.systemSettingManager = systemSettingManager;
+
     }
 
     // -------------------------------------------------------------------------
@@ -259,6 +269,16 @@ public class SmsMessageSender
         {
             if ( smsGateway.accept( gatewayConfig ) )
             {
+
+                if ( text.length() > Optional.ofNullable( gatewayConfig.getMaxSmsLength() )
+                    .map( Integer::parseInt )
+                    .orElseGet(
+                        () -> systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) ) )
+                {
+                    return new OutboundMessageResponse( SMS_TEXT_MESSAGE_TOO_LONG,
+                        GatewayResponse.SMS_TEXT_MESSAGE_TOO_LONG, false );
+                }
+
                 List<String> temp = new ArrayList<>( recipients );
 
                 List<List<String>> slices = Lists.partition( temp, MAX_RECIPIENTS_ALLOWED );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsMessageSender.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/config/SmsMessageSender.java
@@ -79,8 +79,6 @@ import com.google.common.collect.Sets;
 public class SmsMessageSender
     implements MessageSender
 {
-    private static final String SMS_TEXT_MESSAGE_TOO_LONG = "Sms text message is too long";
-
     private static final String NO_CONFIG = "No default gateway configured";
 
     private static final String BATCH_ABORTED = "Aborted sending message batch";
@@ -114,6 +112,7 @@ public class SmsMessageSender
         Preconditions.checkNotNull( outboundSmsService );
         Preconditions.checkNotNull( userSettingService );
         Preconditions.checkState( !smsGateways.isEmpty() );
+        Preconditions.checkNotNull( systemSettingManager );
 
         this.gatewayAdminService = gatewayAdminService;
         this.smsGateways = smsGateways;
@@ -275,7 +274,7 @@ public class SmsMessageSender
                     .orElseGet(
                         () -> systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) ) )
                 {
-                    return new OutboundMessageResponse( SMS_TEXT_MESSAGE_TOO_LONG,
+                    return new OutboundMessageResponse( GatewayResponse.SMS_TEXT_MESSAGE_TOO_LONG.getResponseMessage(),
                         GatewayResponse.SMS_TEXT_MESSAGE_TOO_LONG, false );
                 }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/sms/SmsMessageSenderTest.java
@@ -75,8 +75,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import com.google.common.collect.Sets;
 
@@ -84,7 +82,6 @@ import com.google.common.collect.Sets;
  * @author Zubair Asghar.
  */
 @ExtendWith( MockitoExtension.class )
-@MockitoSettings( strictness = Strictness.LENIENT )
 class SmsMessageSenderTest
 {
     private static final Integer MAX_ALLOWED_RECIPIENTS = 200;
@@ -146,9 +143,6 @@ class SmsMessageSenderTest
 
         smsGateways.add( bulkSmsGateway );
 
-        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
-            .thenReturn( maxSmsLength );
-
         smsMessageSender = new SmsMessageSender( gatewayAdministrationService, smsGateways, userSettingService,
             outboundSmsService, systemSettingManager );
 
@@ -169,6 +163,10 @@ class SmsMessageSenderTest
     @Test
     void testSendMessageWithGatewayConfig()
     {
+
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
@@ -222,6 +220,9 @@ class SmsMessageSenderTest
     @Test
     void testSendMessageWithListOfUsers()
     {
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         when( userSettingService.getUserSetting( any(), any() ) ).thenReturn( Boolean.TRUE );
         when( bulkSmsGateway.send( anyString(), anyString(), anySet(), isA( BulkSmsGatewayConfig.class ) ) )
@@ -261,6 +262,9 @@ class SmsMessageSenderTest
     @Test
     void testSendMessageWithSingleRecipient()
     {
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         when( bulkSmsGateway.accept( any() ) ).thenReturn( true );
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         when( bulkSmsGateway.send( anyString(), anyString(), anySet(), isA( BulkSmsGatewayConfig.class ) ) )
@@ -275,6 +279,10 @@ class SmsMessageSenderTest
     @Test
     void testSendMessageFailed()
     {
+
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
@@ -293,6 +301,10 @@ class SmsMessageSenderTest
     @Test
     void testNumberNormalization()
     {
+
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         // stub for GateAdministrationService
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
@@ -321,6 +333,9 @@ class SmsMessageSenderTest
     @Test
     void testSendMessageWithMaxRecipients()
     {
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
         List<Set<String>> recipientList = new ArrayList<>();
@@ -345,6 +360,10 @@ class SmsMessageSenderTest
     @Test
     void testSendMessageWithSmsLengthGreaterThanDefaultMaxSmsLength()
     {
+
+        when( systemSettingManager.getSystemSetting( SettingKey.SMS_MAX_LENGTH, Integer.class ) )
+            .thenReturn( maxSmsLength );
+
         when( gatewayAdministrationService.getDefaultGateway() ).thenReturn( smsGatewayConfig );
         mockGateway();
 

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -85,6 +85,11 @@ public enum SettingKey
     MIN_PASSWORD_LENGTH( "minPasswordLength", 8, Integer.class ),
     MAX_PASSWORD_LENGTH( "maxPasswordLength", 40, Integer.class ),
     SMS_CONFIG( "keySmsSetting", new SmsConfiguration(), SmsConfiguration.class ),
+    /**
+     * Max SMS text message length, default 7 * 153 ( 7 parts , 153 is message
+     * length for multi parts )
+     **/
+    SMS_MAX_LENGTH( "keySmsMaxLength", 1071, Integer.class ),
     CACHE_STRATEGY( "keyCacheStrategy", CacheStrategy.CACHE_1_MINUTE, CacheStrategy.class ),
     CACHEABILITY( "keyCacheability", Cacheability.PUBLIC, Cacheability.class ),
     ANALYTICS_FINANCIAL_YEAR_START( "analyticsFinancialYearStart",

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_38__Updates_Sms_Config.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_38__Updates_Sms_Config.sql
@@ -1,0 +1,3 @@
+-- Move message column from varchar to text to store larger messages outcome
+ALTER TABLE outbound_sms ALTER COLUMN message TYPE text;
+


### PR DESCRIPTION
[DHIS2-12590](https://jira.dhis2.org/browse/DHIS2-12590)

Default SMS length added as system key. Also added a maxSmsLength property for the gateway that can be set, otherwise default system one is used.
Message column in outbound_sms table it now text