### PR TITLE
fix: use superuser in e2e tests

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/resources/config.properties
+++ b/dhis-2/dhis-e2e-test/src/main/resources/config.properties
@@ -3,16 +3,12 @@
 instance.url=http://localhost:8080/api
 # properties for user set up on the instance.
 # user must be able to import metadata.
-user.default.username=admin
-user.default.password=district
-
-
+user.default.username=system
+user.default.password=System123
 # properties for super user set up on the instance.
 # default: user that has been set up when running tests
 user.super.username=tasuperadmin
 user.super.password=Test1212?
-
 user.admin.username=taadmin
 user.admin.password=Test1212?
-
 test.cleanup=true


### PR DESCRIPTION
System user needs to be used in order for e2e to work with SL demo database.