### PR TITLE
 fix: data value set export by data element group [DHIS2-12691] (2.36)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdSchemes.java
@@ -44,6 +44,8 @@ public class IdSchemes
 
     private IdScheme dataElementIdScheme;
 
+    private IdScheme dataElementGroupIdScheme;
+
     private IdScheme categoryOptionComboIdScheme;
 
     private IdScheme categoryOptionIdScheme;
@@ -107,6 +109,17 @@ public class IdSchemes
     public IdSchemes setDataElementIdScheme( String idScheme )
     {
         this.dataElementIdScheme = IdScheme.from( idScheme );
+        return this;
+    }
+
+    public IdScheme getDataElementGroupIdScheme()
+    {
+        return getScheme( dataElementGroupIdScheme );
+    }
+
+    public IdSchemes setDataElementGroupIdScheme( String idScheme )
+    {
+        this.dataElementGroupIdScheme = IdScheme.from( idScheme );
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SpringDataValueSetStore.java
@@ -243,6 +243,7 @@ public class SpringDataValueSetStore
         String dataElements = getCommaDelimitedString( getIdentifiers( params.getAllDataElements() ) );
         String orgUnits = getCommaDelimitedString( getIdentifiers( params.getOrganisationUnits() ) );
         String orgUnitGroups = getCommaDelimitedString( getIdentifiers( params.getOrganisationUnitGroups() ) );
+        String deGroups = getCommaDelimitedString( getIdentifiers( params.getDataElementGroups() ) );
 
         // ----------------------------------------------------------------------
         // Identifier schemes
@@ -291,7 +292,18 @@ public class SpringDataValueSetStore
             sql += "left join orgunitgroupmembers ougm on (ou.organisationunitid=ougm.organisationunitid) ";
         }
 
-        sql += "where de.dataelementid in (" + dataElements + ") ";
+        sql += "where ";
+
+        if ( !params.hasDataElementGroups() )
+        {
+            sql += "de.dataelementid in (" + dataElements + ") ";
+        }
+        else
+        {
+            sql += "dv.dataelementid in ("
+                + "select distinct degm.dataelementid from dataelementgroupmembers degm "
+                + "where degm.dataelementgroupid in (" + deGroups + ")) ";
+        }
 
         if ( params.isIncludeChildren() )
         {


### PR DESCRIPTION
Backport to 2.36 based on cherry-pick of #9932

Manual merge was needed as the `dataElementGroupIdScheme` field did not exist in 2.36.
Also the updated test did not exist in 2.36 so these modifications were ignored.

