### PR TITLE
fix: Support NEQ operator [TECH-1012]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.common.QueryOperator.LE;
 import static org.hisp.dhis.common.QueryOperator.LIKE;
 import static org.hisp.dhis.common.QueryOperator.LT;
 import static org.hisp.dhis.common.QueryOperator.NE;
+import static org.hisp.dhis.common.QueryOperator.NEQ;
 import static org.hisp.dhis.common.QueryOperator.NIEQ;
 import static org.hisp.dhis.common.QueryOperator.NILIKE;
 import static org.hisp.dhis.common.QueryOperator.NLIKE;
@@ -64,6 +65,7 @@ public class QueryFilter
         .<QueryOperator, Function<Boolean, String>> builder()
         .put( EQ, isValueNull -> isValueNull ? "is" : "=" )
         .put( NE, isValueNull -> isValueNull ? "is not" : "!=" )
+        .put( NEQ, isValueNull -> isValueNull ? "is not" : "!=" )
         .put( IEQ, isValueNull -> isValueNull ? "is" : "=" )
         .put( NIEQ, isValueNull -> isValueNull ? "is not" : "=" )
         .put( GT, unused -> ">" )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -51,7 +51,9 @@ public enum QueryOperator
     EW( "ew" ),
     // Analytics specifics
     IEQ( "==", true ),
+    @Deprecated // Prefer NEQ instead
     NE( "!=", true ),
+    NEQ( "!=", true ),
     NIEQ( "!==", true ),
     NLIKE( "not like" ),
     ILIKE( "ilike" ),


### PR DESCRIPTION
This fix deprecates `NE`, and adds `NEQ` so we can follow the same standard as others operators and allows the usage of `!EQ` by the client.