### PR TITLE
fix: Typo in NIEQ comparator [TECH-1018]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -67,7 +67,7 @@ public class QueryFilter
         .put( NE, isValueNull -> isValueNull ? "is not" : "!=" )
         .put( NEQ, isValueNull -> isValueNull ? "is not" : "!=" )
         .put( IEQ, isValueNull -> isValueNull ? "is" : "=" )
-        .put( NIEQ, isValueNull -> isValueNull ? "is not" : "=" )
+        .put( NIEQ, isValueNull -> isValueNull ? "is not" : "!=" )
         .put( GT, unused -> ">" )
         .put( GE, unused -> ">=" )
         .put( LT, unused -> "<" )
@@ -127,22 +127,6 @@ public class QueryFilter
         return OPERATOR_MAP.get( operator ).apply( StringUtils.trimToEmpty( filter ).contains( NV ) );
     }
 
-    // TODO: unused. Remove ?
-    public String getJavaOperator()
-    {
-        if ( operator == null || operator == LIKE || operator == IN )
-        {
-            return null;
-        }
-
-        if ( operator == EQ ) // TODO why special case?
-        {
-            return "==";
-        }
-
-        return safelyGetOperator();
-    }
-
     public String getSqlFilter( final String encodedFilter )
     {
         if ( operator == null || encodedFilter == null )
@@ -154,7 +138,7 @@ public class QueryFilter
         {
             return "'%" + encodedFilter + "%'";
         }
-        else if ( EQ == operator || NE == operator || IEQ == operator || NIEQ == operator )
+        else if ( EQ == operator || NE == operator || NEQ == operator || IEQ == operator || NIEQ == operator )
         {
             if ( encodedFilter.equals( NV ) )
             {
@@ -183,7 +167,7 @@ public class QueryFilter
     {
         final String sqlFilter = getSqlFilter( encodedFilter );
 
-        // Force lowercase so we can do "equal" comparison ignoring case.
+        // Force lowercase so we can compare ignoring case.
         if ( IEQ == operator || NIEQ == operator )
         {
             return valueType.isText() ? sqlFilter.toLowerCase() : sqlFilter;
@@ -194,7 +178,7 @@ public class QueryFilter
 
     public String getSqlFilterColumn( final String column, final ValueType valueType )
     {
-        // Force lowercase so we can do "equal" comparison ignoring case.
+        // Force lowercase so we can compare ignoring case.
         if ( IEQ == operator || NIEQ == operator )
         {
             return valueType.isText() ? wrapLower( column ) : column;


### PR DESCRIPTION
This operator was not working properly because of a missing `!` mark.

This is now fixed.

Example of GET URL:
```
http://localhost:8080/dhis/api/28/analytics/events/query/ur1Edk5Oe2n.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&dimension=ZkbAXlQUYJG.FO4sWYJ64LQ:!IEQ:oslo&stage=ZkbAXlQUYJG&displayProperty=NAME&outputType=EVENT&desc=eventdate&pageSize=100&page=1
```
