### PR TITLE
Data Integrity checks (2.37)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
@@ -82,7 +82,8 @@ public interface Cache<V>
     Stream<V> getAll();
 
     /**
-     * Should only be used with caution in cases where the set of keys is known to be a small set.
+     * Should only be used with caution in cases where the set of keys is known
+     * to be a small set.
      *
      * @return an unmodifiable set of all keys set
      */
@@ -115,10 +116,10 @@ public interface Cache<V>
     void put( String key, V value, long ttlInSeconds );
 
     /**
-     * Associates the {@code value} with the {@code key} in this cache if and only of the cache does not already contain
-     * a value for the key.
+     * Associates the {@code value} with the {@code key} in this cache if and
+     * only of the cache does not already contain a value for the key.
      *
-     * @param key   the key for the value
+     * @param key the key for the value
      * @param value value to be mapped to the key
      * @return true, if the value was put, false otherwise
      * @throws IllegalArgumentException if the specified value is null
@@ -126,8 +127,9 @@ public interface Cache<V>
     boolean putIfAbsent( String key, V value );
 
     /**
-     * Discards any cached value for the {@code key}. The behavior of this operation is undefined for an entry that is
-     * being loaded and is otherwise not present.
+     * Discards any cached value for the {@code key}. The behavior of this
+     * operation is undefined for an entry that is being loaded and is otherwise
+     * not present.
      *
      * @param key the key whose mapping is to be removed from the cache
      */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/Cache.java
@@ -82,6 +82,13 @@ public interface Cache<V>
     Stream<V> getAll();
 
     /**
+     * Should only be used with caution in cases where the set of keys is known to be a small set.
+     *
+     * @return an unmodifiable set of all keys set
+     */
+    Iterable<String> keys();
+
+    /**
      * Associates the {@code value} with the {@code key} in this cache. If the
      * cache previously contained a value associated with the {@code key}, the
      * old value is replaced by the new {@code value}. Prefer
@@ -108,17 +115,26 @@ public interface Cache<V>
     void put( String key, V value, long ttlInSeconds );
 
     /**
-     * Discards any cached value for the {@code key}. The behavior of this
-     * operation is undefined for an entry that is being loaded and is otherwise
-     * not present.
+     * Associates the {@code value} with the {@code key} in this cache if and only of the cache does not already contain
+     * a value for the key.
+     *
+     * @param key   the key for the value
+     * @param value value to be mapped to the key
+     * @return true, if the value was put, false otherwise
+     * @throws IllegalArgumentException if the specified value is null
+     */
+    boolean putIfAbsent( String key, V value );
+
+    /**
+     * Discards any cached value for the {@code key}. The behavior of this operation is undefined for an entry that is
+     * being loaded and is otherwise not present.
      *
      * @param key the key whose mapping is to be removed from the cache
      */
     void invalidate( String key );
 
     /**
-     * Discards all entries in this cache instance. If a shared cache is used,
-     * this method does not clear anything.
+     * Discards all entries in this cache instance.
      */
     void invalidateAll();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -27,24 +27,26 @@
  */
 package org.hisp.dhis.cache;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.springframework.util.Assert.hasText;
+import org.cache2k.Cache2kBuilder;
 
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.cache2k.Cache2kBuilder;
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.springframework.util.Assert.hasText;
 
 /**
- * Local cache implementation of {@link Cache}. This implementation is backed by
- * Caffeine library which uses an in memory Map implementation.
+ * Local cache implementation of {@link Cache}. This implementation is backed by Caffeine library which uses an in
+ * memory Map implementation.
  *
  * @author Ameen Mohamed
  */
 public class LocalCache<V> implements Cache<V>
 {
+    private static final String VALUE_CANNOT_BE_NULL = "Value cannot be null";
+
     private org.cache2k.Cache<String, V> cache2kInstance;
 
     private V defaultValue;
@@ -129,11 +131,17 @@ public class LocalCache<V> implements Cache<V>
     }
 
     @Override
+    public Iterable<String> keys()
+    {
+        return cache2kInstance.keys();
+    }
+
+    @Override
     public void put( String key, V value )
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         cache2kInstance.put( key, value );
     }
@@ -141,9 +149,19 @@ public class LocalCache<V> implements Cache<V>
     @Override
     public void put( String key, V value, long ttlInSeconds )
     {
-        hasText( key, "Value cannot be null" );
+        hasText( key, VALUE_CANNOT_BE_NULL );
         cache2kInstance.invoke( key,
             e -> e.setValue( value ).setExpiryTime( currentTimeMillis() + SECONDS.toMillis( ttlInSeconds ) ) );
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        if ( null == value )
+        {
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
+        }
+        return cache2kInstance.putIfAbsent( key, value );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/LocalCache.java
@@ -27,19 +27,19 @@
  */
 package org.hisp.dhis.cache;
 
-import org.cache2k.Cache2kBuilder;
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.springframework.util.Assert.hasText;
 
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.springframework.util.Assert.hasText;
+import org.cache2k.Cache2kBuilder;
 
 /**
- * Local cache implementation of {@link Cache}. This implementation is backed by Caffeine library which uses an in
- * memory Map implementation.
+ * Local cache implementation of {@link Cache}. This implementation is backed by
+ * Caffeine library which uses an in memory Map implementation.
  *
  * @author Ameen Mohamed
  */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
@@ -27,21 +27,23 @@
  */
 package org.hisp.dhis.cache;
 
-import static org.springframework.util.Assert.hasText;
-
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptySet;
+import static org.springframework.util.Assert.hasText;
+
 /**
- * A No operation implementation of {@link Cache}. The implementation will not
- * cache anything and can be used during system testing when caching has to be
- * disabled.
+ * A No operation implementation of {@link Cache}. The implementation will not cache anything and can be used during
+ * system testing when caching has to be disabled.
  *
  * @author Ameen Mohamed
  */
 public class NoOpCache<V> implements Cache<V>
 {
+    private static final String VALUE_CANNOT_BE_NULL = "Value cannot be null";
+
     private final V defaultValue;
 
     public NoOpCache( CacheBuilder<V> cacheBuilder )
@@ -88,11 +90,17 @@ public class NoOpCache<V> implements Cache<V>
     }
 
     @Override
+    public Iterable<String> keys()
+    {
+        return emptySet();
+    }
+
+    @Override
     public void put( String key, V value )
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
         // No operation
     }
@@ -100,8 +108,19 @@ public class NoOpCache<V> implements Cache<V>
     @Override
     public void put( String key, V value, long ttlInSeconds )
     {
-        hasText( key, "Value cannot be null" );
+        hasText( key, VALUE_CANNOT_BE_NULL );
         // No operation
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        if ( null == value )
+        {
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
+        }
+        // No operation
+        return false;
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/cache/NoOpCache.java
@@ -27,16 +27,17 @@
  */
 package org.hisp.dhis.cache;
 
+import static java.util.Collections.emptySet;
+import static org.springframework.util.Assert.hasText;
+
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptySet;
-import static org.springframework.util.Assert.hasText;
-
 /**
- * A No operation implementation of {@link Cache}. The implementation will not cache anything and can be used during
- * system testing when caching has to be disabled.
+ * A No operation implementation of {@link Cache}. The implementation will not
+ * cache anything and can be used during system testing when caching has to be
+ * disabled.
  *
  * @author Ameen Mohamed
  */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheck.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheck.java
@@ -27,41 +27,52 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.io.Serializable;
+import java.util.function.Function;
 
-import org.hisp.dhis.scheduling.JobProgress;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @author Fredrik Fjeld (old API)
- * @author Jan Bernitt (new API)
+ * In-memory representation of a data integrity check.
+ *
+ * Alongside its informative fields it has a {@link Function} that given the
+ * check produces the {@link DataIntegritySummary} and one that produces the
+ * {@link DataIntegrityDetails} of the check.
+ *
+ * If a check does not support one or the other of the two check types the
+ * {@link Function} returns {@code null}.
+ *
+ * @author Jan Bernitt
  */
-public interface DataIntegrityService
+@Getter
+@Builder
+@AllArgsConstructor( access = AccessLevel.PRIVATE )
+public final class DataIntegrityCheck implements Serializable
 {
-    /*
-     * Old API
-     */
+    @JsonProperty
+    private final String name;
 
-    /**
-     * @deprecated Replaced by {@link #getSummaries(Set, long)} and
-     *             {@link #getDetails(Set, long)}, kept for backwards
-     *             compatibility until new UI exists
-     */
-    @Deprecated( since = "2.38", forRemoval = true )
-    FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress );
+    @JsonProperty
+    private final String section;
 
-    /*
-     * New generic API
-     */
+    @JsonProperty
+    private final DataIntegritySeverity severity;
 
-    Collection<DataIntegrityCheck> getDataIntegrityChecks();
+    @JsonProperty
+    private final String description;
 
-    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout );
+    @JsonProperty
+    private final String introduction;
 
-    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout );
+    @JsonProperty
+    private final String recommendation;
 
-    void runSummaryChecks( Set<String> checks, JobProgress progress );
+    private final transient Function<DataIntegrityCheck, DataIntegritySummary> runSummaryCheck;
 
-    void runDetailsChecks( Set<String> checks, JobProgress progress );
+    private final transient Function<DataIntegrityCheck, DataIntegrityDetails> runDetailsCheck;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheckType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheckType.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataintegrity;
+
+/**
+ * The different types of data integrity checks one can run
+ *
+ * @author Jan Bernitt
+ */
+public enum DataIntegrityCheckType
+{
+    /*
+     * Please note that the integrity checks will be performed in the order
+     * given by the types.
+     */
+
+    // DataElements
+    DATA_ELEMENTS_WITHOUT_DATA_SETS,
+    DATA_ELEMENTS_WITHOUT_GROUPS,
+    DATA_ELEMENTS_ASSIGNED_TO_DATA_SETS_WITH_DIFFERENT_PERIOD_TYPES,
+    DATA_ELEMENTS_VIOLATING_EXCLUSIVE_GROUP_SETS,
+    DATA_ELEMENTS_IN_DATA_SET_NOT_IN_FORM,
+
+    // CategoryOptionCombos
+    CATEGORY_COMBOS_BEING_INVALID,
+
+    // DataSets
+    DATA_SETS_NOT_ASSIGNED_TO_ORG_UNITS,
+
+    // Indicators
+    INDICATORS_WITH_IDENTICAL_FORMULAS,
+    INDICATORS_WITHOUT_GROUPS,
+    INDICATORS_WITH_INVALID_NUMERATOR,
+    INDICATORS_WITH_INVALID_DENOMINATOR,
+    INDICATORS_VIOLATING_EXCLUSIVE_GROUP_SETS,
+
+    // Periods
+    PERIODS_DUPLICATES,
+
+    // OrganisationUnits
+    ORG_UNITS_WITH_CYCLIC_REFERENCES,
+    ORG_UNITS_BEING_ORPHANED,
+    ORG_UNITS_WITHOUT_GROUPS,
+    ORG_UNITS_VIOLATING_EXCLUSIVE_GROUP_SETS,
+    ORG_UNIT_GROUPS_WITHOUT_GROUP_SETS,
+
+    // ValidationRules
+    VALIDATION_RULES_WITHOUT_GROUPS,
+    VALIDATION_RULES_WITH_INVALID_LEFT_SIDE_EXPRESSION,
+    VALIDATION_RULES_WITH_INVALID_RIGHT_SIDE_EXPRESSION,
+
+    // ProgramIndicators
+    PROGRAM_INDICATORS_WITH_INVALID_EXPRESSIONS,
+    PROGRAM_INDICATORS_WITH_INVALID_FILTERS,
+    PROGRAM_INDICATORS_WITHOUT_EXPRESSION,
+
+    // ProgramRules
+    PROGRAM_RULES_WITHOUT_CONDITION,
+    PROGRAM_RULES_WITHOUT_PRIORITY,
+    PROGRAM_RULES_WITHOUT_ACTION,
+
+    // ProgramRuleVariables
+    PROGRAM_RULE_VARIABLES_WITHOUT_DATA_ELEMENT,
+    PROGRAM_RULE_VARIABLES_WITHOUT_ATTRIBUTE,
+
+    // ProgramRuleActions
+    PROGRAM_RULE_ACTIONS_WITHOUT_DATA_OBJECT,
+    PROGRAM_RULE_ACTIONS_WITHOUT_NOTIFICATION,
+    PROGRAM_RULE_ACTIONS_WITHOUT_SECTION,
+    PROGRAM_RULE_ACTIONS_WITHOUT_STAGE;
+
+    public String getName()
+    {
+        return name().toLowerCase();
+    }
+
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataintegrity;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.hisp.dhis.common.IdentifiableObject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+/**
+ * The result data of a {@link DataIntegrityCheck#getRunDetailsCheck()} run.
+ *
+ * @author Jan Bernitt
+ */
+@Getter
+@AllArgsConstructor
+public class DataIntegrityDetails implements Serializable
+{
+    @JsonUnwrapped
+    private final DataIntegrityCheck check;
+
+    @JsonProperty
+    private final Date finishedTime;
+
+    @JsonProperty
+    private final String error;
+
+    @JsonProperty
+    private final List<DataIntegrityIssue> issues;
+
+    @Getter
+    @AllArgsConstructor
+    public static final class DataIntegrityIssue implements Serializable
+    {
+        @JsonProperty
+        private final String id;
+
+        @JsonProperty
+        private final String name;
+
+        @JsonProperty
+        private final String comment;
+
+        @JsonProperty
+        private final List<String> refs;
+
+        public static DataIntegrityIssue toIssue( IdentifiableObject obj )
+        {
+            return toIssue( obj, null, null );
+        }
+
+        public static DataIntegrityIssue toIssue( IdentifiableObject obj, String comment )
+        {
+            return toIssue( obj, comment, null );
+        }
+
+        public static DataIntegrityIssue toIssue( IdentifiableObject obj,
+            Collection<? extends IdentifiableObject> refs )
+        {
+            return toIssue( obj, null, refs );
+        }
+
+        public static DataIntegrityIssue toIssue( IdentifiableObject obj, String comment,
+            Collection<? extends IdentifiableObject> refs )
+        {
+            return new DataIntegrityIssue( obj.getUid(), issueName( obj ), comment,
+                refs == null || refs.isEmpty() ? List.of() : toRefsList( refs.stream() ) );
+        }
+
+        public static List<String> toRefsList( Stream<? extends IdentifiableObject> refs )
+        {
+            return refs.map( DataIntegrityIssue::issueName )
+                .sorted()
+                .collect( toUnmodifiableList() );
+        }
+
+        public static String issueName( IdentifiableObject object )
+        {
+            String displayName = object.getDisplayName();
+            String uid = object.getUid();
+            return displayName == null
+                ? uid
+                : displayName + ":" + uid;
+        }
+    }
+
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
@@ -27,21 +27,20 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hisp.dhis.common.IdentifiableObject;
 
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-import org.hisp.dhis.common.IdentifiableObject;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import static java.util.Collections.emptyList;
 
 /**
  * The result data of a {@link DataIntegrityCheck#getRunDetailsCheck()} run.
@@ -100,14 +99,14 @@ public class DataIntegrityDetails implements Serializable
             Collection<? extends IdentifiableObject> refs )
         {
             return new DataIntegrityIssue( obj.getUid(), issueName( obj ), comment,
-                refs == null || refs.isEmpty() ? List.of() : toRefsList( refs.stream() ) );
+                refs == null || refs.isEmpty() ? emptyList() : toRefsList( refs.stream() ) );
         }
 
         public static List<String> toRefsList( Stream<? extends IdentifiableObject> refs )
         {
             return refs.map( DataIntegrityIssue::issueName )
                 .sorted()
-                .collect( toUnmodifiableList() );
+                .collect( Collectors.toList() );
         }
 
         public static String issueName( IdentifiableObject object )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
@@ -27,11 +27,7 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import org.hisp.dhis.common.IdentifiableObject;
+import static java.util.Collections.emptyList;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -40,7 +36,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptyList;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.hisp.dhis.common.IdentifiableObject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 /**
  * The result data of a {@link DataIntegrityCheck#getRunDetailsCheck()} run.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.dataintegrity;
 
+import org.hisp.dhis.scheduling.JobProgress;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-
-import org.hisp.dhis.scheduling.JobProgress;
 
 /**
  * @author Fredrik Fjeld (old API)
@@ -48,7 +48,6 @@ public interface DataIntegrityService
      *             {@link #getDetails(Set, long)}, kept for backwards
      *             compatibility until new UI exists
      */
-    @Deprecated( since = "2.38", forRemoval = true )
     FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress );
 
     /*

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import org.hisp.dhis.scheduling.JobProgress;
-
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+
+import org.hisp.dhis.scheduling.JobProgress;
 
 /**
  * @author Fredrik Fjeld (old API)

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySeverity.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySeverity.java
@@ -27,41 +27,31 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-
-import org.hisp.dhis.scheduling.JobProgress;
-
 /**
- * @author Fredrik Fjeld (old API)
- * @author Jan Bernitt (new API)
+ * The severity of issues found by a {@link DataIntegrityCheck}.
+ *
+ * @author Jan Bernitt
  */
-public interface DataIntegrityService
+public enum DataIntegritySeverity
 {
-    /*
-     * Old API
+    /**
+     * Indicates that this is for information only.
      */
+    INFO,
+    /**
+     * A warning indicates that this may be a problem, but not necessarily an
+     * error. It is however recommended triaging these issues.
+     */
+    WARNING,
+    /**
+     * An error which should be fixed, but which may not necessarily lead to the
+     * system not functioning.
+     */
+    SEVERE,
 
     /**
-     * @deprecated Replaced by {@link #getSummaries(Set, long)} and
-     *             {@link #getDetails(Set, long)}, kept for backwards
-     *             compatibility until new UI exists
+     * An error which must be fixed, and which may lead to end-user error or
+     * system crashes.
      */
-    @Deprecated( since = "2.38", forRemoval = true )
-    FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress );
-
-    /*
-     * New generic API
-     */
-
-    Collection<DataIntegrityCheck> getDataIntegrityChecks();
-
-    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout );
-
-    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout );
-
-    void runSummaryChecks( Set<String> checks, JobProgress progress );
-
-    void runDetailsChecks( Set<String> checks, JobProgress progress );
+    CRITICAL
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityStore.java
@@ -27,41 +27,30 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
-
-import org.hisp.dhis.scheduling.JobProgress;
-
 /**
- * @author Fredrik Fjeld (old API)
- * @author Jan Bernitt (new API)
+ * Database support for running data integrity checks.
+ * <p>
+ * Mainly this supports the YAML based checks that have SQL in the YAML.
+ *
+ * @author Jan Bernitt
  */
-public interface DataIntegrityService
+public interface DataIntegrityStore
 {
-    /*
-     * Old API
+    /**
+     * Runs a query for a {@link DataIntegritySummary}
+     *
+     * @param check the check the SQL belongs to
+     * @param sql the native SQL to run from a YAML declaration
+     * @return the mapped summary
      */
+    DataIntegritySummary querySummary( DataIntegrityCheck check, String sql );
 
     /**
-     * @deprecated Replaced by {@link #getSummaries(Set, long)} and
-     *             {@link #getDetails(Set, long)}, kept for backwards
-     *             compatibility until new UI exists
+     * Runs a query for a {@link DataIntegrityDetails}.
+     *
+     * @param check the check the SQL belongs to
+     * @param sql the native SQL to run from a YAML declaration
+     * @return the mapped details
      */
-    @Deprecated( since = "2.38", forRemoval = true )
-    FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress );
-
-    /*
-     * New generic API
-     */
-
-    Collection<DataIntegrityCheck> getDataIntegrityChecks();
-
-    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout );
-
-    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout );
-
-    void runSummaryChecks( Set<String> checks, JobProgress progress );
-
-    void runDetailsChecks( Set<String> checks, JobProgress progress );
+    DataIntegrityDetails queryDetails( DataIntegrityCheck check, String sql );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
@@ -27,41 +27,37 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
+import java.io.Serializable;
+import java.util.Date;
 
-import org.hisp.dhis.scheduling.JobProgress;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 /**
- * @author Fredrik Fjeld (old API)
- * @author Jan Bernitt (new API)
+ * The result data of a {@link DataIntegrityCheck#getRunSummaryCheck()} run.
+ *
+ * @author Jan Bernitt
  */
-public interface DataIntegrityService
+@Getter
+@AllArgsConstructor
+public class DataIntegritySummary implements Serializable
 {
-    /*
-     * Old API
-     */
+    @JsonUnwrapped
+    private final DataIntegrityCheck check;
 
-    /**
-     * @deprecated Replaced by {@link #getSummaries(Set, long)} and
-     *             {@link #getDetails(Set, long)}, kept for backwards
-     *             compatibility until new UI exists
-     */
-    @Deprecated( since = "2.38", forRemoval = true )
-    FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress );
+    @JsonProperty
+    private final Date finishedTime;
 
-    /*
-     * New generic API
-     */
+    @JsonProperty
+    private final String error;
 
-    Collection<DataIntegrityCheck> getDataIntegrityChecks();
+    @JsonProperty
+    private final int count;
 
-    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout );
+    @JsonProperty
+    private final Double percentage;
 
-    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout );
-
-    void runSummaryChecks( Set<String> checks, JobProgress progress );
-
-    void runDetailsChecks( Set<String> checks, JobProgress progress );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,17 +27,19 @@
  */
 package org.hisp.dhis.dataintegrity;
 
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableList;
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
+import org.hisp.dhis.webmessage.WebMessageResponse;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -48,268 +50,235 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
-public class FlattenedDataIntegrityReport
+public class FlattenedDataIntegrityReport implements WebMessageResponse
 {
     @JsonProperty
-    private List<String> dataElementsWithoutDataSet;
+    private final List<String> dataElementsWithoutDataSet;
 
     @JsonProperty
-    private List<String> dataElementsWithoutGroups;
+    private final List<String> dataElementsWithoutGroups;
 
     @JsonProperty
-    private Map<String, Collection<String>> dataElementsAssignedToDataSetsWithDifferentPeriodTypes;
+    private final Map<String, List<String>> dataElementsAssignedToDataSetsWithDifferentPeriodTypes;
 
     @JsonProperty
-    private SortedMap<String, Collection<String>> dataElementsViolatingExclusiveGroupSets;
+    private final Map<String, List<String>> dataElementsViolatingExclusiveGroupSets;
 
     @JsonProperty
-    private SortedMap<String, Collection<String>> dataElementsInDataSetNotInForm;
+    private final Map<String, List<String>> dataElementsInDataSetNotInForm;
 
     @JsonProperty
-    private List<String> invalidCategoryCombos;
+    private final List<String> invalidCategoryCombos;
 
     @JsonProperty
-    private List<String> dataSetsNotAssignedToOrganisationUnits;
+    private final List<String> dataSetsNotAssignedToOrganisationUnits;
 
     @JsonProperty
-    private Collection<Collection<String>> indicatorsWithIdenticalFormulas;
+    private final List<List<String>> indicatorsWithIdenticalFormulas;
 
     @JsonProperty
-    private List<String> indicatorsWithoutGroups;
+    private final List<String> indicatorsWithoutGroups;
 
     @JsonProperty
-    private Map<String, String> invalidIndicatorNumerators;
+    private final Map<String, String> invalidIndicatorNumerators;
 
     @JsonProperty
-    private Map<String, String> invalidIndicatorDenominators;
+    private final Map<String, String> invalidIndicatorDenominators;
 
     @JsonProperty
-    private SortedMap<String, Collection<String>> indicatorsViolatingExclusiveGroupSets;
+    private final Map<String, List<String>> indicatorsViolatingExclusiveGroupSets;
 
     @JsonProperty
-    private List<String> duplicatePeriods;
+    private final List<String> duplicatePeriods;
 
     @JsonProperty
-    private List<String> organisationUnitsWithCyclicReferences;
+    private final List<String> organisationUnitsWithCyclicReferences;
 
     @JsonProperty
-    private List<String> orphanedOrganisationUnits;
+    private final List<String> orphanedOrganisationUnits;
 
     @JsonProperty
-    private List<String> organisationUnitsWithoutGroups;
+    private final List<String> organisationUnitsWithoutGroups;
 
     @JsonProperty
-    private SortedMap<String, Collection<String>> organisationUnitsViolatingExclusiveGroupSets;
+    private final Map<String, List<String>> organisationUnitsViolatingExclusiveGroupSets;
 
     @JsonProperty
-    private List<String> organisationUnitGroupsWithoutGroupSets;
+    private final List<String> organisationUnitGroupsWithoutGroupSets;
 
     @JsonProperty
-    private List<String> validationRulesWithoutGroups;
+    private final List<String> validationRulesWithoutGroups;
 
     @JsonProperty
-    private Map<String, String> invalidValidationRuleLeftSideExpressions;
+    private final Map<String, String> invalidValidationRuleLeftSideExpressions;
 
     @JsonProperty
-    private Map<String, String> invalidValidationRuleRightSideExpressions;
+    private final Map<String, String> invalidValidationRuleRightSideExpressions;
 
     @JsonProperty
-    private Map<String, String> invalidProgramIndicatorExpressions;
+    private final Map<String, String> invalidProgramIndicatorExpressions;
 
     @JsonProperty
-    private List<String> programIndicatorsWithNoExpression;
+    private final List<String> programIndicatorsWithNoExpression;
 
     @JsonProperty
-    private Map<String, String> invalidProgramIndicatorFilters;
+    private final Map<String, String> invalidProgramIndicatorFilters;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRulesWithNoCondition;
+    private final Map<String, List<String>> programRulesWithNoCondition;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRulesWithNoPriority;
+    private final Map<String, List<String>> programRulesWithNoPriority;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRulesWithNoAction;
+    private final Map<String, List<String>> programRulesWithNoAction;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRuleVariablesWithNoDataElement;
+    private final Map<String, List<String>> programRuleVariablesWithNoDataElement;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRuleVariablesWithNoAttribute;
+    private final Map<String, List<String>> programRuleVariablesWithNoAttribute;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRuleActionsWithNoDataObject;
+    private final Map<String, List<String>> programRuleActionsWithNoDataObject;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRuleActionsWithNoNotification;
+    private final Map<String, List<String>> programRuleActionsWithNoNotification;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRuleActionsWithNoSectionId;
+    private final Map<String, List<String>> programRuleActionsWithNoSectionId;
 
     @JsonProperty
-    private Map<String, Collection<String>> programRuleActionsWithNoStageId;
+    private final Map<String, List<String>> programRuleActionsWithNoStageId;
 
-    public FlattenedDataIntegrityReport( org.hisp.dhis.dataintegrity.DataIntegrityReport report )
+    public FlattenedDataIntegrityReport( Map<String, DataIntegrityDetails> detailsByName )
     {
-        dataElementsWithoutDataSet = transformCollection( report.getDataElementsWithoutDataSet() );
+        // name/UID only
+        this.dataElementsWithoutDataSet = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.DATA_ELEMENTS_WITHOUT_DATA_SETS.getName() ) );
+        this.dataElementsWithoutGroups = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.DATA_ELEMENTS_WITHOUT_GROUPS.getName() ) );
+        this.invalidCategoryCombos = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.CATEGORY_COMBOS_BEING_INVALID.getName() ) );
+        this.dataSetsNotAssignedToOrganisationUnits = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.DATA_SETS_NOT_ASSIGNED_TO_ORG_UNITS.getName() ) );
+        this.indicatorsWithoutGroups = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.INDICATORS_WITHOUT_GROUPS.getName() ) );
+        this.duplicatePeriods = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PERIODS_DUPLICATES.getName() ) );
+        this.organisationUnitsWithCyclicReferences = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.ORG_UNITS_WITH_CYCLIC_REFERENCES.getName() ) );
+        this.orphanedOrganisationUnits = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.ORG_UNITS_BEING_ORPHANED.getName() ) );
+        this.organisationUnitsWithoutGroups = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.ORG_UNITS_WITHOUT_GROUPS.getName() ) );
+        this.organisationUnitGroupsWithoutGroupSets = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.ORG_UNIT_GROUPS_WITHOUT_GROUP_SETS.getName() ) );
+        this.validationRulesWithoutGroups = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.VALIDATION_RULES_WITHOUT_GROUPS.getName() ) );
+        this.programIndicatorsWithNoExpression = listOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_INDICATORS_WITHOUT_EXPRESSION.getName() ) );
 
-        dataElementsWithoutGroups = transformCollection( report.getDataElementsWithoutGroups() );
+        // grouped name/UID
+        this.indicatorsWithIdenticalFormulas = groupedListOfDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.INDICATORS_WITH_IDENTICAL_FORMULAS.getName() ) );
 
-        dataElementsAssignedToDataSetsWithDifferentPeriodTypes = transformMapOfCollections(
-            report.getDataElementsAssignedToDataSetsWithDifferentPeriodTypes() );
+        // comments ny name/UID
+        this.invalidIndicatorNumerators = mapOfCommentByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.INDICATORS_WITH_INVALID_NUMERATOR.getName() ) );
+        this.invalidIndicatorDenominators = mapOfCommentByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.INDICATORS_WITH_INVALID_DENOMINATOR.getName() ) );
+        this.invalidValidationRuleLeftSideExpressions = mapOfCommentByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.VALIDATION_RULES_WITH_INVALID_LEFT_SIDE_EXPRESSION.getName() ) );
+        this.invalidValidationRuleRightSideExpressions = mapOfCommentByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.VALIDATION_RULES_WITH_INVALID_RIGHT_SIDE_EXPRESSION.getName() ) );
+        this.invalidProgramIndicatorExpressions = mapOfCommentByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_INDICATORS_WITH_INVALID_EXPRESSIONS.getName() ) );
+        this.invalidProgramIndicatorFilters = mapOfCommentByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_INDICATORS_WITH_INVALID_FILTERS.getName() ) );
 
-        dataElementsViolatingExclusiveGroupSets = transformSortedMap(
-            report.getDataElementsViolatingExclusiveGroupSets() );
-
-        dataElementsInDataSetNotInForm = transformSortedMap( report.getDataElementsInDataSetNotInForm() );
-
-        invalidCategoryCombos = transformCollection( report.getInvalidCategoryCombos() );
-
-        dataSetsNotAssignedToOrganisationUnits = transformCollection(
-            report.getDataSetsNotAssignedToOrganisationUnits() );
-
-        indicatorsWithIdenticalFormulas = transformCollectionOfCollections(
-            report.getIndicatorsWithIdenticalFormulas() );
-
-        indicatorsWithoutGroups = transformCollection( report.getIndicatorsWithoutGroups() );
-
-        invalidIndicatorNumerators = transformMapOfStrings( report.getInvalidIndicatorNumerators() );
-
-        invalidIndicatorDenominators = transformMapOfStrings( report.getInvalidIndicatorDenominators() );
-
-        indicatorsViolatingExclusiveGroupSets = transformSortedMap( report.getIndicatorsViolatingExclusiveGroupSets() );
-
-        duplicatePeriods = transformCollection( report.getDuplicatePeriods() );
-
-        organisationUnitsWithCyclicReferences = transformCollection(
-            report.getOrganisationUnitsWithCyclicReferences() );
-
-        orphanedOrganisationUnits = transformCollection( report.getOrphanedOrganisationUnits() );
-
-        organisationUnitsWithoutGroups = transformCollection( report.getOrganisationUnitsWithoutGroups() );
-
-        organisationUnitsViolatingExclusiveGroupSets = transformSortedMap(
-            report.getOrganisationUnitsViolatingExclusiveGroupSets() );
-
-        organisationUnitGroupsWithoutGroupSets = transformCollection(
-            report.getOrganisationUnitGroupsWithoutGroupSets() );
-
-        validationRulesWithoutGroups = transformCollection( report.getValidationRulesWithoutGroups() );
-
-        invalidValidationRuleLeftSideExpressions = transformMapOfStrings(
-            report.getInvalidValidationRuleLeftSideExpressions() );
-
-        invalidValidationRuleRightSideExpressions = transformMapOfStrings(
-            report.getInvalidValidationRuleRightSideExpressions() );
-
-        programIndicatorsWithNoExpression = transformCollection( report.getProgramIndicatorsWithNoExpression() );
-
-        invalidProgramIndicatorExpressions = transformMapOfStrings( report.getInvalidProgramIndicatorExpressions() );
-
-        invalidProgramIndicatorFilters = transformMapOfStrings( report.getInvalidProgramIndicatorFilters() );
-
-        programRulesWithNoCondition = transformMapOfCollections( report.getProgramRulesWithoutCondition() );
-
-        programRulesWithNoPriority = transformMapOfCollections( report.getProgramRulesWithNoPriority() );
-
-        programRulesWithNoAction = transformMapOfCollections( report.getProgramRulesWithNoAction() );
-
-        programRuleVariablesWithNoDataElement = transformMapOfCollections(
-            report.getProgramRuleVariablesWithNoDataElement() );
-
-        programRuleVariablesWithNoAttribute = transformMapOfCollections(
-            report.getProgramRuleVariablesWithNoAttribute() );
-
-        programRuleActionsWithNoDataObject = transformMapOfCollections(
-            report.getProgramRuleActionsWithNoDataObject() );
-
-        programRuleActionsWithNoNotification = transformMapOfCollections(
-            report.getProgramRuleActionsWithNoNotification() );
-
-        programRuleActionsWithNoSectionId = transformMapOfCollections( report.getProgramRuleActionsWithNoSectionId() );
-
-        programRuleActionsWithNoStageId = transformMapOfCollections( report.getProgramRuleActionsWithNoStageId() );
+        // refs by name/UID
+        this.dataElementsAssignedToDataSetsWithDifferentPeriodTypes = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get(
+                DataIntegrityCheckType.DATA_ELEMENTS_ASSIGNED_TO_DATA_SETS_WITH_DIFFERENT_PERIOD_TYPES.getName() ) );
+        this.dataElementsViolatingExclusiveGroupSets = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.DATA_ELEMENTS_VIOLATING_EXCLUSIVE_GROUP_SETS.getName() ) );
+        this.dataElementsInDataSetNotInForm = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.DATA_ELEMENTS_IN_DATA_SET_NOT_IN_FORM.getName() ) );
+        this.indicatorsViolatingExclusiveGroupSets = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.INDICATORS_VIOLATING_EXCLUSIVE_GROUP_SETS.getName() ) );
+        this.organisationUnitsViolatingExclusiveGroupSets = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.ORG_UNITS_VIOLATING_EXCLUSIVE_GROUP_SETS.getName() ) );
+        this.programRulesWithNoCondition = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULES_WITHOUT_CONDITION.getName() ) );
+        this.programRulesWithNoPriority = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULES_WITHOUT_PRIORITY.getName() ) );
+        this.programRulesWithNoAction = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULES_WITHOUT_ACTION.getName() ) );
+        this.programRuleVariablesWithNoDataElement = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULE_VARIABLES_WITHOUT_DATA_ELEMENT.getName() ) );
+        this.programRuleVariablesWithNoAttribute = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULE_VARIABLES_WITHOUT_ATTRIBUTE.getName() ) );
+        this.programRuleActionsWithNoDataObject = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULE_ACTIONS_WITHOUT_DATA_OBJECT.getName() ) );
+        this.programRuleActionsWithNoNotification = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULE_ACTIONS_WITHOUT_NOTIFICATION.getName() ) );
+        this.programRuleActionsWithNoSectionId = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULE_ACTIONS_WITHOUT_SECTION.getName() ) );
+        this.programRuleActionsWithNoStageId = mapOfRefsByDisplayNameOrUid(
+            detailsByName.get( DataIntegrityCheckType.PROGRAM_RULE_ACTIONS_WITHOUT_STAGE.getName() ) );
     }
 
-    // -------------------------------------------------------------------------
-    // Supportive methods
-    // -------------------------------------------------------------------------
-
-    private Collection<Collection<String>> transformCollectionOfCollections(
-        Collection<? extends Collection<? extends IdentifiableObject>> collection )
+    private List<String> listOfDisplayNameOrUid( DataIntegrityDetails details )
     {
-        Collection<Collection<String>> newCollection = new HashSet<>();
-
-        for ( Collection<? extends IdentifiableObject> c : collection )
-        {
-            newCollection.add( transformCollection( c ) );
-        }
-
-        return newCollection;
+        return details == null
+            ? null
+            : details.getIssues().stream()
+                .map( DataIntegrityIssue::getName )
+                .collect( toUnmodifiableList() );
     }
 
-    private Map<String, String> transformMapOfStrings( Map<? extends IdentifiableObject, String> map )
+    private List<List<String>> groupedListOfDisplayNameOrUid( DataIntegrityDetails details )
     {
-        HashMap<String, String> newMap = new HashMap<>( map.size() );
-
-        for ( Map.Entry<? extends IdentifiableObject, String> entry : map.entrySet() )
-        {
-            newMap.put( defaultIfNull( entry.getKey() ), entry.getValue() );
-        }
-
-        return newMap;
+        return details == null
+            ? null
+            : details.getIssues().stream()
+                .map( DataIntegrityIssue::getRefs )
+                .collect( toUnmodifiableList() );
     }
 
-    private Map<String, Collection<String>> transformMapOfCollections(
-        Map<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> map )
+    private static Map<String, String> mapOfCommentByDisplayNameOrUid( DataIntegrityDetails details )
     {
-        HashMap<String, Collection<String>> newMap = new HashMap<>();
-
-        for ( Map.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map
-            .entrySet() )
-        {
-            Collection<String> value = new HashSet<>();
-            value.addAll( transformCollection( entry.getValue() ) );
-
-            newMap.put( defaultIfNull( entry.getKey() ), value );
-        }
-
-        return newMap;
+        return details == null
+            ? null
+            : details.getIssues().stream().collect( toUnmodifiableMap(
+                DataIntegrityIssue::getName,
+                DataIntegrityIssue::getComment ) );
     }
 
-    private List<String> transformCollection( Collection<? extends IdentifiableObject> collection )
+    private static SortedMap<String, List<String>> mapOfRefsByDisplayNameOrUid(
+        DataIntegrityDetails details )
     {
-        List<String> newCollection = new ArrayList<>( collection.size() );
-
-        for ( IdentifiableObject o : collection )
-        {
-            newCollection.add( StringUtils.defaultIfBlank( o.getDisplayName(), o.getUid() ) );
-        }
-
-        return newCollection;
+        return details == null
+            ? null
+            : details.getIssues().stream().collect( toMap(
+                DataIntegrityIssue::getName,
+                DataIntegrityIssue::getRefs,
+                FlattenedDataIntegrityReport::concatLists,
+                TreeMap::new ) );
     }
 
-    private SortedMap<String, Collection<String>> transformSortedMap(
-        SortedMap<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> map )
+    /**
+     * On a "collision" (key already exists/has a value) we do combine both
+     * lists. At this point we have to assume the passed {@link Collection}s are
+     * read-only.
+     */
+    private static List<String> concatLists( List<String> a, List<String> b )
     {
-        SortedMap<String, Collection<String>> newMap = new TreeMap<>();
-
-        for ( Map.Entry<? extends IdentifiableObject, ? extends Collection<? extends IdentifiableObject>> entry : map
-            .entrySet() )
-        {
-            newMap.put( defaultIfNull( entry.getKey() ), transformCollection( entry.getValue() ) );
-        }
-
-        return newMap;
+        List<String> both = new ArrayList<>();
+        both.addAll( a );
+        both.addAll( b );
+        return both;
     }
 
-    private String defaultIfNull( IdentifiableObject object )
-    {
-        if ( object.getDisplayName() == null )
-        {
-            return object.getUid();
-        }
-
-        return object.getDisplayName() + ":" + object.getUid();
-    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
@@ -27,9 +27,8 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toUnmodifiableList;
-import static java.util.stream.Collectors.toUnmodifiableMap;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,19 +37,16 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
-import org.hisp.dhis.webmessage.WebMessageResponse;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 /**
- * Flattened, easily serializable object derivable from the more complex
- * DataIntegrityReport. Use an instance of this object to serialize and deliver
- * a DataIntegrityReport.
+ * Flattened, easily serializable object derivable from the more complex DataIntegrityReport. Use an instance of this
+ * object to serialize and deliver a DataIntegrityReport.
  *
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
-public class FlattenedDataIntegrityReport implements WebMessageResponse
+public class FlattenedDataIntegrityReport
 {
     @JsonProperty
     private final List<String> dataElementsWithoutDataSet;
@@ -234,8 +230,8 @@ public class FlattenedDataIntegrityReport implements WebMessageResponse
         return details == null
             ? null
             : details.getIssues().stream()
-                .map( DataIntegrityIssue::getName )
-                .collect( toUnmodifiableList() );
+            .map( DataIntegrityIssue::getName )
+            .collect( toList() );
     }
 
     private List<List<String>> groupedListOfDisplayNameOrUid( DataIntegrityDetails details )
@@ -243,17 +239,17 @@ public class FlattenedDataIntegrityReport implements WebMessageResponse
         return details == null
             ? null
             : details.getIssues().stream()
-                .map( DataIntegrityIssue::getRefs )
-                .collect( toUnmodifiableList() );
+            .map( DataIntegrityIssue::getRefs )
+            .collect( toList() );
     }
 
     private static Map<String, String> mapOfCommentByDisplayNameOrUid( DataIntegrityDetails details )
     {
         return details == null
             ? null
-            : details.getIssues().stream().collect( toUnmodifiableMap(
-                DataIntegrityIssue::getName,
-                DataIntegrityIssue::getComment ) );
+            : details.getIssues().stream().collect( toMap(
+            DataIntegrityIssue::getName,
+            DataIntegrityIssue::getComment ) );
     }
 
     private static SortedMap<String, List<String>> mapOfRefsByDisplayNameOrUid(

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/FlattenedDataIntegrityReport.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,12 +37,14 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Flattened, easily serializable object derivable from the more complex DataIntegrityReport. Use an instance of this
- * object to serialize and deliver a DataIntegrityReport.
+ * Flattened, easily serializable object derivable from the more complex
+ * DataIntegrityReport. Use an instance of this object to serialize and deliver
+ * a DataIntegrityReport.
  *
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
@@ -230,8 +232,8 @@ public class FlattenedDataIntegrityReport
         return details == null
             ? null
             : details.getIssues().stream()
-            .map( DataIntegrityIssue::getName )
-            .collect( toList() );
+                .map( DataIntegrityIssue::getName )
+                .collect( toList() );
     }
 
     private List<List<String>> groupedListOfDisplayNameOrUid( DataIntegrityDetails details )
@@ -239,8 +241,8 @@ public class FlattenedDataIntegrityReport
         return details == null
             ? null
             : details.getIssues().stream()
-            .map( DataIntegrityIssue::getRefs )
-            .collect( toList() );
+                .map( DataIntegrityIssue::getRefs )
+                .collect( toList() );
     }
 
     private static Map<String, String> mapOfCommentByDisplayNameOrUid( DataIntegrityDetails details )
@@ -248,8 +250,8 @@ public class FlattenedDataIntegrityReport
         return details == null
             ? null
             : details.getIssues().stream().collect( toMap(
-            DataIntegrityIssue::getName,
-            DataIntegrityIssue::getComment ) );
+                DataIntegrityIssue::getName,
+                DataIntegrityIssue::getComment ) );
     }
 
     private static SortedMap<String, List<String>> mapOfRefsByDisplayNameOrUid(

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/Job.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/Job.java
@@ -30,22 +30,23 @@ package org.hisp.dhis.scheduling;
 import org.hisp.dhis.feedback.ErrorReport;
 
 /**
- * This interface is used for jobs in the system which are scheduled or executed
- * by the Spring scheduler. The actual job will contain an execute method which
- * performs the appropriate actions.
+ * This interface is used for jobs in the system which are scheduled or executed by the Spring scheduler. The actual job
+ * will contain an execute method which performs the appropriate actions.
  * <p>
  * See {@link SchedulingManager} for more information about the scheduling.
  *
  * @author Henning Håkonsen
+ * @see <a href= "https://github.com/dhis2/wow-backend/blob/master/docs/job_scheduling.md">Docs</a>
  */
 public interface Job
 {
     JobType getJobType();
 
-    void execute( JobConfiguration jobConfiguration );
-
     default ErrorReport validate()
     {
         return null;
     }
+
+    void execute( JobConfiguration jobConfiguration, JobProgress progress );
+
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/Job.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/Job.java
@@ -30,13 +30,15 @@ package org.hisp.dhis.scheduling;
 import org.hisp.dhis.feedback.ErrorReport;
 
 /**
- * This interface is used for jobs in the system which are scheduled or executed by the Spring scheduler. The actual job
- * will contain an execute method which performs the appropriate actions.
+ * This interface is used for jobs in the system which are scheduled or executed
+ * by the Spring scheduler. The actual job will contain an execute method which
+ * performs the appropriate actions.
  * <p>
  * See {@link SchedulingManager} for more information about the scheduling.
  *
  * @author Henning Håkonsen
- * @see <a href= "https://github.com/dhis2/wow-backend/blob/master/docs/job_scheduling.md">Docs</a>
+ * @see <a href=
+ *      "https://github.com/dhis2/wow-backend/blob/master/docs/job_scheduling.md">Docs</a>
  */
 public interface Job
 {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ForkJoinPool;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * <h3>Tracking</h3>
+ *
+ * The {@link JobProgress} API is mainly contains methods to track the progress
+ * of long-running jobs on three levels:
+ * <ol>
+ * <li>Process: Outermost bracket around the entire work done by a job</li>
+ * <li>Stage: A logical step within the entire process of the job. A process is
+ * a strict sequence of stages. Stages do not run in parallel.</li>
+ * <li>(Work) Item: Performing an "non-interruptable" unit of work within a
+ * stage. Items can be processed in parallel or strictly sequential. Usually
+ * this is the function called in some form of a loop.</li>
+ * </ol>
+ *
+ * For each of the three levels a new node is announced up front by calling the
+ * corresponding {@link #startingProcess(String)},
+ * {@link #startingStage(String)} or {@link #startingWorkItem(String)} method.
+ *
+ * The process will now expect a corresponding completion, for example
+ * {@link #completedWorkItem(String)} in case of success or
+ * {@link #failedWorkItem(String)} in case of an error. The different
+ * {@link #runStage(Stream, Function, Consumer)} or
+ * {@link #runStageInParallel(int, Collection, Function, Consumer)} helpers can
+ * be used to do the error handling correctly and make sure the work items are
+ * completed in both success and failure scenarios.
+ *
+ * For stages that do not have work items {@link #runStage(Runnable)} and
+ * {@link #runStage(Object, Callable)} can be used to make sure completion is
+ * handled correctly.
+ *
+ * For stages with work items the number of items should be announced using
+ * {@link #startingStage(String, int)}. This is a best-effort estimation of the
+ * actual items to allow observers a better understanding how much progress has
+ * been made and how much work is left to do. For stages where this is not known
+ * up-front the estimation is given as -1.
+ *
+ * <h3>Flow-Control</h3>
+ *
+ * The second part of the {@link JobProgress} is control flow. This is all based
+ * on a single method {@link #isCancellationRequested()}. The coordination is
+ * cooperative. This means cancellation of the running process might be
+ * requested externally at any point or as a consequence of a failing work item.
+ * This would flip the state returned by {@link #isCancellationRequested()}
+ * which is/should be checked before starting a new stage or work item.
+ *
+ * A process should only continue starting new work as long as cancellation is
+ * not requested. When cancellation is requested ongoing work items are finished
+ * and the process exists cooperatively by not starting any further work.
+ *
+ * When a stage is cancelled the run-methods usually return false to give caller
+ * a chance to react if needed. The next call to {@link #startingStage(String)}
+ * will then throw a {@link CancellationException} and thereby short-circuit the
+ * rest of the process.
+ *
+ * @author Jan Bernitt
+ */
+public interface JobProgress
+{
+    /*
+     * Flow Control API:
+     */
+
+    /**
+     * @return true, if the job got cancelled and requests the processing thread
+     *         to terminate, else false to continue processing the job
+     */
+    boolean isCancellationRequested();
+
+    /*
+     * Tracking API:
+     */
+
+    void startingProcess( String description );
+
+    default void startingProcess()
+    {
+        startingProcess( null );
+    }
+
+    void completedProcess( String summary );
+
+    void failedProcess( String error );
+
+    default void failedProcess( Exception cause )
+    {
+        String message = cause.getMessage();
+        failedProcess( "Process failed: " + (isNotEmpty( message ) ? message : cause.getClass().getSimpleName()) );
+    }
+
+    /**
+     * Announce start of a new stage.
+     *
+     * @param description describes the work done
+     * @param workItems number of work items in the stage, -1 if unknown
+     * @throws CancellationException in case cancellation has been requested
+     *         before this stage had started
+     */
+    void startingStage( String description, int workItems )
+        throws CancellationException;
+
+    default void startingStage( String description )
+    {
+        startingStage( description, 0 );
+    }
+
+    void completedStage( String summary );
+
+    void failedStage( String error );
+
+    default void failedStage( Exception cause )
+    {
+        failedStage( cause.getMessage() );
+    }
+
+    void startingWorkItem( String description );
+
+    default void startingWorkItem( int i )
+    {
+        startingWorkItem( "#" + (i + 1) );
+    }
+
+    void completedWorkItem( String summary );
+
+    void failedWorkItem( String error );
+
+    default void failedWorkItem( Exception cause )
+    {
+        failedWorkItem( cause.getMessage() );
+    }
+
+    /*
+     * Running work items within a stage
+     */
+
+    /**
+     * Runs {@link Runnable} work items as sequence.
+     *
+     * @param items the work items to run in the sequence to run them
+     * @return true if all items were processed successful, otherwise false
+     *
+     * @see #runStage(Collection, Function, Consumer)
+     */
+    default boolean runStage( Collection<Runnable> items )
+    {
+        return runStage( items, item -> null, Runnable::run );
+    }
+
+    /**
+     * Runs {@link Runnable} work items as sequence.
+     *
+     * @param items the work items to run in the sequence to run them with the
+     *        keys used as item description. Items are processed in map
+     *        iteration order.
+     * @return true if all items were processed successful, otherwise false
+     *
+     * @see #runStage(Collection, Function, Consumer)
+     */
+    default boolean runStage( Map<String, Runnable> items )
+    {
+        return runStage( items.entrySet(), Entry::getKey, entry -> entry.getValue().run() );
+    }
+
+    /**
+     * Run work items as sequence using a {@link Collection} of work item inputs
+     * and an execution work {@link Consumer} function.
+     *
+     * @param items the work item inputs to run in the sequence to run them
+     * @param description function to extract a description for a work item, may
+     *        return {@code null}
+     * @param work function to execute the work of a single work item input
+     * @param <T> type of work item input
+     * @return true if all items were processed successful, otherwise false
+     *
+     * @see #runStage(Collection, Function, Consumer)
+     */
+    default <T> boolean runStage( Collection<T> items, Function<T, String> description, Consumer<T> work )
+    {
+        return runStage( items.stream(), description, work );
+    }
+
+    /**
+     * Run work items as sequence using a {@link Stream} of work item inputs and
+     * an execution work {@link Consumer} function.
+     *
+     * @see #runStage(Stream, Function, Consumer,BiFunction)
+     */
+    default <T> boolean runStage( Stream<T> items, Function<T, String> description, Consumer<T> work )
+    {
+        return runStage( items, description, work, ( success, failed ) -> null );
+    }
+
+    /**
+     * Run work items as sequence using a {@link Stream} of work item inputs and
+     * an execution work {@link Consumer} function.
+     * <p>
+     * The entire stage only is considered failed in case a failing work item
+     * caused a change of the cancellation requested status.
+     *
+     * @param items stream of inputs to execute a work item
+     * @param description function to extract a description for a work item, may
+     *        return {@code null}
+     * @param work function to execute the work of a single work item input
+     * @param summary accepts number of successful and failed items to compute a
+     *        summary, may return {@code null}
+     * @param <T> type of work item input
+     * @return true if all items were processed successful, otherwise false
+     */
+    default <T> boolean runStage( Stream<T> items, Function<T, String> description, Consumer<T> work,
+        BiFunction<Integer, Integer, String> summary )
+    {
+        int i = 0;
+        int failed = 0;
+        for ( Iterator<T> it = items.iterator(); it.hasNext(); )
+        {
+            T item = it.next();
+            if ( isCancellationRequested() )
+            {
+                failedStage( new CancellationException(
+                    format( "cancelled after %d successful and %d failed items", i - failed, failed ) ) );
+                return false; // ends the stage immediately
+            }
+            String desc = description.apply( item );
+            if ( desc == null )
+            {
+                startingWorkItem( i );
+            }
+            else
+            {
+                startingWorkItem( desc );
+            }
+            i++;
+            try
+            {
+                work.accept( item );
+                completedWorkItem( null );
+            }
+            catch ( RuntimeException ex )
+            {
+                failed++;
+                boolean cancellationRequestedBefore = isCancellationRequested();
+                failedWorkItem( ex );
+                if ( !cancellationRequestedBefore && isCancellationRequested() )
+                {
+                    failedStage(
+                        new CancellationException( "cancelled as failing item caused request for cancellation" ) );
+                    return false;
+                }
+            }
+        }
+        completedStage( summary.apply( i - failed, failed ) );
+        return true;
+    }
+
+    /**
+     * Run a stage with no individual work items but a single work
+     * {@link Runnable} with proper completion wrapping.
+     * <p>
+     * If the work task throws an {@link Exception} the stage is considered
+     * failed otherwise it is considered complete when done.
+     *
+     * @param work work for the entire stage
+     * @return true, if completed successful, false if completed exceptionally
+     */
+    default boolean runStage( Runnable work )
+    {
+        return runStage( false, () -> {
+            work.run();
+            return true;
+        } );
+    }
+
+    /**
+     * Run a stage with no individual work items but a single work
+     * {@link Runnable} with proper completion wrapping.
+     * <p>
+     * If the work task throws an {@link Exception} the stage is considered
+     * failed otherwise it is considered complete when done.
+     *
+     * @param errorValue the value returned in case the work throws an
+     *        {@link Exception}
+     * @param work work for the entire stage
+     * @return the value returned by work task when successful or the errorValue
+     *         in case the task threw an {@link Exception}
+     */
+    default <T> T runStage( T errorValue, Callable<T> work )
+    {
+        try
+        {
+            T res = work.call();
+            completedStage( null );
+            return res;
+        }
+        catch ( Exception ex )
+        {
+            failedStage( ex );
+            return errorValue;
+        }
+    }
+
+    /**
+     * Runs the work items of a stage with the given parallelism. At most a
+     * parallelism equal to the number of available processor cores is used.
+     * <p>
+     * If the parallelism is smaller or equal to 1 the items are processed
+     * sequentially using {@link #runStage(Collection, Function, Consumer)}.
+     * <p>
+     * While the items are processed in parallel this method is synchronous for
+     * the caller and will first return when all work is done.
+     * <p>
+     * If cancellation is requested work items might be skipped entirely.
+     *
+     * @param parallelism number of items that at maximum should be processed in
+     *        parallel
+     * @param items work item inputs to be processed in parallel
+     * @param description function to extract a description for a work item, may
+     *        return {@code null}
+     * @param work function to execute the work of a single work item input
+     * @param <T> type of work item input
+     * @return true if all items were processed successful, otherwise false
+     */
+    default <T> boolean runStageInParallel( int parallelism, Collection<T> items, Function<T, String> description,
+        Consumer<T> work )
+    {
+        if ( parallelism <= 1 )
+        {
+            return runStage( items, description, work );
+        }
+        int cores = Runtime.getRuntime().availableProcessors();
+        boolean useCustomPool = parallelism >= cores;
+
+        Callable<Boolean> task = () -> items.parallelStream().map( item -> {
+            if ( isCancellationRequested() )
+            {
+                return false;
+            }
+            startingWorkItem( description.apply( item ) );
+            try
+            {
+                work.accept( item );
+                completedWorkItem( null );
+                return true;
+            }
+            catch ( Exception ex )
+            {
+                failedWorkItem( ex );
+                return false;
+            }
+        } ).reduce( Boolean::logicalAnd ).orElse( false );
+
+        ForkJoinPool pool = useCustomPool ? new ForkJoinPool( parallelism ) : null;
+        try
+        {
+            // this might not be obvious but running a parallel stream
+            // as task in a FJP makes the stream use the pool
+            boolean allSuccessful = pool == null
+                ? task.call()
+                : pool.submit( task ).get();
+            if ( allSuccessful )
+            {
+                completedStage( null );
+            }
+            else if ( isCancellationRequested() )
+            {
+                failedStage( new CancellationException( "cancelled parallel processing" ) );
+            }
+            else
+            {
+                failedStage( (String) null );
+            }
+            return allSuccessful;
+        }
+        catch ( InterruptedException ex )
+        {
+            failedStage( ex );
+            Thread.currentThread().interrupt();
+        }
+        catch ( Exception ex )
+        {
+            failedStage( ex );
+        }
+        finally
+        {
+            if ( pool != null )
+            {
+                pool.shutdown();
+            }
+        }
+        return false;
+    }
+
+    /*
+     * Model (for representing progress as data)
+     */
+
+    enum Status
+    {
+        RUNNING,
+        SUCCESS,
+        ERROR,
+        CANCELLED
+    }
+
+    @Getter
+    abstract class Node implements Serializable
+    {
+        @JsonProperty
+        private String error;
+
+        @JsonProperty
+        private String summary;
+
+        private Exception cause;
+
+        @JsonProperty
+        protected Status status = Status.RUNNING;
+
+        @JsonProperty
+        private Date completedTime;
+
+        @JsonProperty
+        public abstract Date getStartedTime();
+
+        @JsonProperty
+        public long getDuration()
+        {
+            return completedTime == null
+                ? System.currentTimeMillis() - getStartedTime().getTime()
+                : completedTime.getTime() - getStartedTime().getTime();
+        }
+
+        @JsonProperty
+        public boolean isComplete()
+        {
+            return status != Status.RUNNING;
+        }
+
+        public void complete( String summary )
+        {
+            this.summary = summary;
+            this.status = Status.SUCCESS;
+            this.completedTime = new Date();
+        }
+
+        public void completeExceptionally( String error, Exception cause )
+        {
+            this.error = error;
+            this.cause = cause;
+            this.status = cause instanceof CancellationException ? Status.CANCELLED : Status.ERROR;
+            this.completedTime = new Date();
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    final class Process extends Node
+    {
+        public static Date startedTime( Collection<Process> job, Date defaultValue )
+        {
+            return job.isEmpty() ? defaultValue : job.iterator().next().getStartedTime();
+        }
+
+        private final Date startedTime = new Date();
+
+        @JsonProperty
+        private final String description;
+
+        @JsonProperty
+        private final Deque<Stage> stages = new ConcurrentLinkedDeque<>();
+
+        @Setter
+        @JsonProperty
+        private String jobId;
+
+        @JsonProperty
+        private Date cancelledTime;
+
+        public void cancel()
+        {
+            this.cancelledTime = new Date();
+            this.status = Status.CANCELLED;
+        }
+
+        public void abort()
+        {
+            completeExceptionally( "aborted after failed stage or item", null );
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    final class Stage extends Node
+    {
+        private final Date startedTime = new Date();
+
+        @JsonProperty
+        private final String description;
+
+        /**
+         * This is the number of expected items, negative when unknown, zero
+         * when the stage has no items granularity
+         */
+        @JsonProperty
+        private final int totalItems;
+
+        @JsonProperty
+        private final Deque<Item> items = new ConcurrentLinkedDeque<>();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    final class Item extends Node
+    {
+        private final Date startedTime = new Date();
+
+        @JsonProperty
+        private final String description;
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.scheduling;
 
-import com.google.common.collect.ImmutableMap;
+import static java.util.Collections.singletonMap;
+
+import java.util.Map;
+
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
@@ -42,9 +45,7 @@ import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 
-import java.util.Map;
-
-import static java.util.Collections.singletonMap;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Enum describing the different jobs in the system. Each job has a key, class,
@@ -66,7 +67,7 @@ public enum JobType
         "skipTableTypes", "/api/analytics/tableTypes", "skipPrograms", "/api/programs" ) ),
     CONTINUOUS_ANALYTICS_TABLE( true, SchedulingType.FIXED_DELAY,
         ContinuousAnalyticsJobParameters.class, ImmutableMap.of(
-        "skipTableTypes", "/api/analytics/tableTypes" ) ),
+            "skipTableTypes", "/api/analytics/tableTypes" ) ),
     DATA_SYNC( true, SchedulingType.CRON, DataSynchronizationJobParameters.class, null ),
     TRACKER_PROGRAMS_DATA_SYNC( true, SchedulingType.CRON,
         TrackerProgramsDataSynchronizationJobParameters.class, null ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.scheduling;
 
-import java.util.Map;
-
+import com.google.common.collect.ImmutableMap;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
+import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
@@ -42,7 +42,9 @@ import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
 
 /**
  * Enum describing the different jobs in the system. Each job has a key, class,
@@ -57,13 +59,14 @@ import com.google.common.collect.ImmutableMap;
 public enum JobType
 {
     DATA_STATISTICS( false ),
-    DATA_INTEGRITY( true ),
+    DATA_INTEGRITY( true, SchedulingType.CRON, DataIntegrityJobParameters.class,
+        singletonMap( "checks", "/api/dataIntegrity" ) ),
     RESOURCE_TABLE( true ),
     ANALYTICS_TABLE( true, SchedulingType.CRON, AnalyticsJobParameters.class, ImmutableMap.of(
         "skipTableTypes", "/api/analytics/tableTypes", "skipPrograms", "/api/programs" ) ),
     CONTINUOUS_ANALYTICS_TABLE( true, SchedulingType.FIXED_DELAY,
         ContinuousAnalyticsJobParameters.class, ImmutableMap.of(
-            "skipTableTypes", "/api/analytics/tableTypes" ) ),
+        "skipTableTypes", "/api/analytics/tableTypes" ) ),
     DATA_SYNC( true, SchedulingType.CRON, DataSynchronizationJobParameters.class, null ),
     TRACKER_PROGRAMS_DATA_SYNC( true, SchedulingType.CRON,
         TrackerProgramsDataSynchronizationJobParameters.class, null ),
@@ -137,6 +140,11 @@ public enum JobType
         this.schedulingType = schedulingType;
         this.jobParameters = jobParameters;
         this.relativeApiElements = relativeApiElements;
+    }
+
+    public boolean isUsingNotifications()
+    {
+        return this == RESOURCE_TABLE || this == ANALYTICS_TABLE || this == CONTINUOUS_ANALYTICS_TABLE;
     }
 
     public boolean isCronSchedulingType()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.scheduling;
 
+import org.hisp.dhis.scheduling.JobProgress.Process;
+
+import java.util.Collection;
 import java.util.Date;
 
 /**
@@ -57,11 +60,14 @@ import java.util.Date;
  * a specific point in time.</dd>
  * </dl>
  *
- * @author Henning Håkonsen
+ * @see <a href=
+ *      "https://github.com/dhis2/wow-backend/blob/master/docs/job_scheduling.md">Docs</a>
+ *
+ * @author Henning Håkonsen (initial)
+ * @author Jan Bernitt (overhaul and extension)
  */
 public interface SchedulingManager
 {
-
     /**
      * Schedules a job with the given job configuration.
      *
@@ -104,4 +110,33 @@ public interface SchedulingManager
      */
     boolean executeNow( JobConfiguration configuration );
 
+    /**
+     * Request cancellation for job of given type potentially running currently
+     *
+     * @param type job type to cancel
+     */
+    void cancel( JobType type );
+
+    /**
+     * @return a set of job types for which a job is running currently
+     */
+    Collection<JobType> getRunningTypes();
+
+    /**
+     * @return a set of job types for which a job has finished running. Each type will contain the most recent completed
+     * run. Newer runs replace older ones.
+     */
+    Collection<JobType> getCompletedTypes();
+
+    /**
+     * @param type job type for which to return the current running progress
+     * @return the progress of the running job
+     */
+    Collection<Process> getRunningProgress( JobType type );
+
+    /**
+     * @param type job type for which to return completed progress
+     * @return the progress of the completed job
+     */
+    Collection<Process> getCompletedProgress( JobType type );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.scheduling;
 
-import org.hisp.dhis.scheduling.JobProgress.Process;
-
 import java.util.Collection;
 import java.util.Date;
+
+import org.hisp.dhis.scheduling.JobProgress.Process;
 
 /**
  * {@link Job}s are tasks that are supposed to run asynchronously.
@@ -123,8 +123,9 @@ public interface SchedulingManager
     Collection<JobType> getRunningTypes();
 
     /**
-     * @return a set of job types for which a job has finished running. Each type will contain the most recent completed
-     * run. Newer runs replace older ones.
+     * @return a set of job types for which a job has finished running. Each
+     *         type will contain the most recent completed run. Newer runs
+     *         replace older ones.
      */
     Collection<JobType> getCompletedTypes();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DataIntegrityJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/DataIntegrityJobParameters.java
@@ -25,43 +25,51 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dataintegrity;
+package org.hisp.dhis.scheduling.parameters;
 
-import java.util.Collection;
-import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
-import org.hisp.dhis.scheduling.JobProgress;
+import lombok.Getter;
+import lombok.Setter;
+
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.scheduling.JobParameters;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
- * @author Fredrik Fjeld (old API)
- * @author Jan Bernitt (new API)
+ * @author Jan Bernitt
  */
-public interface DataIntegrityService
+@Getter
+@Setter
+@JacksonXmlRootElement( localName = "jobParameters", namespace = DxfNamespaces.DXF_2_0 )
+public class DataIntegrityJobParameters implements JobParameters
 {
-    /*
-     * Old API
-     */
+    public enum DataIntegrityReportType
+    {
+        REPORT,
+        SUMMARY,
+        DETAILS
+    }
 
-    /**
-     * @deprecated Replaced by {@link #getSummaries(Set, long)} and
-     *             {@link #getDetails(Set, long)}, kept for backwards
-     *             compatibility until new UI exists
-     */
-    @Deprecated( since = "2.38", forRemoval = true )
-    FlattenedDataIntegrityReport getReport( Set<String> checks, JobProgress progress );
+    private static final long serialVersionUID = 1073997854310838296L;
 
-    /*
-     * New generic API
-     */
+    @JsonProperty( required = false )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    private Set<String> checks;
 
-    Collection<DataIntegrityCheck> getDataIntegrityChecks();
+    @JsonProperty( required = false )
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    private DataIntegrityReportType type;
 
-    Map<String, DataIntegritySummary> getSummaries( Set<String> checks, long timeout );
+    @Override
+    public Optional<ErrorReport> validate()
+    {
+        return Optional.empty();
+    }
 
-    Map<String, DataIntegrityDetails> getDetails( Set<String> checks, long timeout );
-
-    void runSummaryChecks( Set<String> checks, JobProgress progress );
-
-    void runDetailsChecks( Set<String> checks, JobProgress progress );
 }

--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -2,21 +2,21 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.hisp.dhis</groupId>
     <artifactId>dhis-services</artifactId>
     <version>2.37.4-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>dhis-service-administration</artifactId>
   <packaging>jar</packaging>
   <name>DHIS Administration Service</name>
-  
+
   <dependencies>
-    
+
     <!-- DHIS -->
-    
+
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-api</artifactId>
@@ -33,9 +33,13 @@
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-service-program-rule</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
     <!-- Test -->
-    
+
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
@@ -75,9 +79,9 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <!-- Other -->
-    
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
@@ -87,7 +91,7 @@
       <artifactId>lombok</artifactId>
       <scope>compile</scope>
     </dependency>
-    
+
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataintegrity;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.core.io.ClassPathResource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+/**
+ * Reads {@link DataIntegrityCheck}s from YAML files.
+ *
+ * @author Jan Bernitt
+ */
+@Slf4j
+class DataIntegrityYamlReader
+{
+    private DataIntegrityYamlReader()
+    {
+        throw new UnsupportedOperationException( "util" );
+    }
+
+    static class ListYamlFile
+    {
+        @JsonProperty
+        List<String> checks;
+    }
+
+    @JsonIgnoreProperties( ignoreUnknown = true )
+    static class CheckYamlFile
+    {
+        @JsonProperty
+        String name;
+
+        @JsonProperty
+        String description;
+
+        @JsonProperty
+        String section;
+
+        @JsonProperty( "summary_sql" )
+        String summarySql;
+
+        @JsonProperty( "details_sql" )
+        String detailsSql;
+
+        @JsonProperty
+        String introduction;
+
+        @JsonProperty
+        String recommendation;
+
+        @JsonProperty
+        DataIntegritySeverity severity;
+    }
+
+    public static void readDataIntegrityYaml( String listFile, Consumer<DataIntegrityCheck> adder,
+        Function<String, Function<DataIntegrityCheck, DataIntegritySummary>> sqlToSummary,
+        Function<String, Function<DataIntegrityCheck, DataIntegrityDetails>> sqlToDetails )
+    {
+
+        ObjectMapper yaml = new ObjectMapper( new YAMLFactory() );
+        ListYamlFile file;
+        try
+        {
+            file = yaml.readValue( new ClassPathResource( listFile ).getInputStream(), ListYamlFile.class );
+        }
+        catch ( Exception ex )
+        {
+            log.warn( "Failed to load data integrity checks from YAML", ex );
+            return;
+        }
+        for ( String checkFile : file.checks )
+        {
+            try
+            {
+                String path = Path.of( listFile ).resolve( ".." )
+                    .resolve( "data-integrity-checks" ).resolve( checkFile ).toString();
+                CheckYamlFile e = yaml.readValue( new ClassPathResource( path ).getInputStream(),
+                    CheckYamlFile.class );
+
+                adder.accept( DataIntegrityCheck.builder()
+                    .name( trim( e.name ) )
+                    .description( trim( e.description ) )
+                    .introduction( trim( e.introduction ) )
+                    .recommendation( trim( e.recommendation ) )
+                    .section( trim( e.section ) )
+                    .severity( e.severity )
+                    .runSummaryCheck( sqlToSummary.apply( sanitiseSQL( e.summarySql ) ) )
+                    .runDetailsCheck( sqlToDetails.apply( sanitiseSQL( e.detailsSql ) ) )
+                    .build() );
+            }
+            catch ( Exception ex )
+            {
+                log.error( "Failed to load data integrity check " + checkFile, ex );
+            }
+        }
+    }
+
+    private static String trim( String str )
+    {
+        return str == null ? null : str.trim();
+    }
+
+    /**
+     * The purpose of this method is to strip some details from the SQL queries
+     * that are present for their 2nd use case scenario but are not needed here
+     * and might confuse the database (even if this is just in unit tests).
+     */
+    private static String sanitiseSQL( String sql )
+    {
+        return trim( sql
+            .replaceAll( "select '[^']+' as [^,]+,", "select " )
+            .replaceAll( "'[^']+' as description", "" )
+            .replace( "::varchar", "" )
+            .replace( "|| '%'", "" ) );
+    }
+
+}

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
@@ -27,17 +27,19 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ClassPathResource;
-
 import java.io.File;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.core.io.ClassPathResource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 /**
  * Reads {@link DataIntegrityCheck}s from YAML files.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
@@ -27,19 +27,17 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.core.io.ClassPathResource;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.File;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Reads {@link DataIntegrityCheck}s from YAML files.
@@ -108,7 +106,7 @@ class DataIntegrityYamlReader
         {
             try
             {
-                String path = Path.of( listFile ).resolve( ".." )
+                String path = new File( listFile ).toPath().resolve( ".." )
                     .resolve( "data-integrity-checks" ).resolve( checkFile ).toString();
                 CheckYamlFile e = yaml.readValue( new ClassPathResource( path ).getInputStream(),
                     CheckYamlFile.class );

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -27,8 +27,45 @@
  */
 package org.hisp.dhis.dataintegrity;
 
+import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.hisp.dhis.commons.collection.ListUtils.getDuplicates;
+import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toIssue;
+import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toRefsList;
+import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
+import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
+import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.annotation.PostConstruct;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -69,41 +106,6 @@ import org.hisp.dhis.validation.ValidationRule;
 import org.hisp.dhis.validation.ValidationRuleService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import static java.lang.System.currentTimeMillis;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableCollection;
-import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
-import static org.hisp.dhis.commons.collection.ListUtils.getDuplicates;
-import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toIssue;
-import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toRefsList;
-import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
-import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
-import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
 
 /**
  * @author Lars Helge Overland

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -27,45 +27,8 @@
  */
 package org.hisp.dhis.dataintegrity;
 
-import static java.lang.System.currentTimeMillis;
-import static java.util.Collections.unmodifiableCollection;
-import static java.util.Collections.unmodifiableSet;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toUnmodifiableList;
-import static java.util.stream.Collectors.toUnmodifiableSet;
-import static org.hisp.dhis.commons.collection.ListUtils.getDuplicates;
-import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toIssue;
-import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toRefsList;
-import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
-import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
-import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
-import javax.annotation.PostConstruct;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -106,6 +69,41 @@ import org.hisp.dhis.validation.ValidationRule;
 import org.hisp.dhis.validation.ValidationRuleService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableSet;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.hisp.dhis.commons.collection.ListUtils.getDuplicates;
+import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toIssue;
+import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.toRefsList;
+import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
+import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
+import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
 
 /**
  * @author Lars Helge Overland
@@ -173,7 +171,7 @@ public class DefaultDataIntegrityService
     {
         return items.map( DataIntegrityIssue::toIssue )
             .sorted( DefaultDataIntegrityService::alphabeticalOrder )
-            .collect( toUnmodifiableList() );
+            .collect( toList() );
     }
 
     private static <T extends IdentifiableObject> List<DataIntegrityIssue> toIssueList( Stream<T> items,
@@ -181,7 +179,7 @@ public class DefaultDataIntegrityService
     {
         return items.map( e -> DataIntegrityIssue.toIssue( e, toRefs.apply( e ) ) )
             .sorted( DefaultDataIntegrityService::alphabeticalOrder )
-            .collect( toUnmodifiableList() );
+            .collect( toList() );
     }
 
     // -------------------------------------------------------------------------
@@ -431,7 +429,7 @@ public class DefaultDataIntegrityService
             {
                 issues.add( new DataIntegrityIssue( null, group.getKey(), null,
                     group.getValue().stream().map( p -> p.toString() + ":" + p.getUid() )
-                        .collect( toUnmodifiableList() ) ) );
+                        .collect( toList() ) ) );
             }
         }
         return issues;
@@ -623,7 +621,7 @@ public class DefaultDataIntegrityService
             // report only needs these
             checks = Arrays.stream( DataIntegrityCheckType.values() )
                 .map( DataIntegrityCheckType::getName )
-                .collect( toUnmodifiableSet() );
+                .collect( toSet() );
         }
         runDetailsChecks( checks, progress );
         return new FlattenedDataIntegrityReport( getDetails( checks, -1L ) );
@@ -792,7 +790,7 @@ public class DefaultDataIntegrityService
         return values.stream().collect( groupingBy( property ) )
             .entrySet().stream()
             .map( e -> DataIntegrityIssue.toIssue( e.getKey(), e.getValue() ) )
-            .collect( toUnmodifiableList() );
+            .collect( toList() );
     }
 
     /*
@@ -839,7 +837,7 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity details checks", expandChecks( checks ), progress, detailsCache,
             check -> check.getRunDetailsCheck().apply( check ),
-            ( check, ex ) -> new DataIntegrityDetails( check, new Date(), ex.getMessage(), List.of() ) );
+            ( check, ex ) -> new DataIntegrityDetails( check, new Date(), ex.getMessage(), emptyList() ) );
     }
 
     private <T> Map<String, T> getCached( Set<String> checks, long timeout, Cache<T> cache )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataintegrity.hibernate;
+
+import static java.util.stream.Collectors.toUnmodifiableList;
+
+import java.util.Date;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue;
+import org.hisp.dhis.dataintegrity.DataIntegrityStore;
+import org.hisp.dhis.dataintegrity.DataIntegritySummary;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * As we want each check to be its own transaction the @{@link Transactional}
+ * annotation is used on the store and not the service level in this case.
+ *
+ * @author Jan Bernitt
+ */
+@Repository
+@AllArgsConstructor
+public class HibernateDataIntegrityStore implements DataIntegrityStore
+{
+    private final SessionFactory sessionFactory;
+
+    @Override
+    @Transactional( readOnly = true )
+    public DataIntegritySummary querySummary( DataIntegrityCheck check, String sql )
+    {
+        Object summary = sessionFactory.getCurrentSession()
+            .createNativeQuery( sql ).getSingleResult();
+        return new DataIntegritySummary( check, new Date(), null, parseCount( summary ),
+            parsePercentage( summary ) );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public DataIntegrityDetails queryDetails( DataIntegrityCheck check, String sql )
+    {
+        @SuppressWarnings( "unchecked" )
+        List<Object[]> rows = sessionFactory.getCurrentSession().createNativeQuery( sql )
+            .getResultList();
+        return new DataIntegrityDetails( check, new Date(), null, rows.stream()
+            .map( row -> new DataIntegrityIssue(
+                getIndex( row, 0 ), getIndex( row, 1 ), getIndex( row, 2 ), getRefs( row, 3 ) ) )
+            .collect( toUnmodifiableList() ) );
+    }
+
+    private static String getIndex( Object[] row, int index )
+    {
+        return row.length <= index ? null : (String) row[index];
+    }
+
+    private static List<String> getRefs( Object[] row, int index )
+    {
+        return row.length <= index ? null : List.of( (String[]) row[index] );
+    }
+
+    private static Double parsePercentage( Object value )
+    {
+        if ( !(value instanceof Object[]) )
+        {
+            return null;
+        }
+        Object[] row = (Object[]) value;
+        if ( row.length < 2 || row[1] == null )
+        {
+            return null;
+        }
+        value = row[1];
+        if ( value instanceof String )
+        {
+            return Double.parseDouble( value.toString().replace( "%", "" ) );
+        }
+        return ((Number) value).doubleValue();
+    }
+
+    private static int parseCount( Object value )
+    {
+        if ( value instanceof Object[] )
+        {
+            Object[] row = (Object[]) value;
+            return row.length == 0 ? -1 : parseCount( row[0] );
+        }
+        if ( value == null )
+        {
+            return 0;
+        }
+        if ( value instanceof String )
+        {
+            return Integer.parseInt( (String) value );
+        }
+        return ((Number) value).intValue();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -27,13 +27,7 @@
  */
 package org.hisp.dhis.dataintegrity.hibernate;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
-
-import java.util.Date;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
-
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
 import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
@@ -42,6 +36,11 @@ import org.hisp.dhis.dataintegrity.DataIntegrityStore;
 import org.hisp.dhis.dataintegrity.DataIntegritySummary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * As we want each check to be its own transaction the @{@link Transactional}
@@ -75,7 +74,7 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
         return new DataIntegrityDetails( check, new Date(), null, rows.stream()
             .map( row -> new DataIntegrityIssue(
                 getIndex( row, 0 ), getIndex( row, 1 ), getIndex( row, 2 ), getRefs( row, 3 ) ) )
-            .collect( toUnmodifiableList() ) );
+            .collect( Collectors.toList() ) );
     }
 
     private static String getIndex( Object[] row, int index )
@@ -85,7 +84,7 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
 
     private static List<String> getRefs( Object[] row, int index )
     {
-        return row.length <= index ? null : List.of( (String[]) row[index] );
+        return row.length <= index ? null : Arrays.asList( (String[]) row[index] );
     }
 
     private static Double parsePercentage( Object value )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -27,7 +27,13 @@
  */
 package org.hisp.dhis.dataintegrity.hibernate;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.AllArgsConstructor;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
 import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
@@ -36,11 +42,6 @@ import org.hisp.dhis.dataintegrity.DataIntegrityStore;
 import org.hisp.dhis.dataintegrity.DataIntegritySummary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * As we want each check to be its own transaction the @{@link Transactional}

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
@@ -27,10 +27,7 @@
  */
 package org.hisp.dhis.dataintegrity.jobs;
 
-import java.util.Set;
-
 import lombok.AllArgsConstructor;
-
 import org.hisp.dhis.commons.timer.SystemTimer;
 import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.dataintegrity.DataIntegrityService;
@@ -44,6 +41,9 @@ import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters.DataIntegr
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
@@ -67,7 +67,7 @@ public class DataIntegrityJob implements Job
     {
         DataIntegrityJobParameters parameters = (DataIntegrityJobParameters) config.getJobParameters();
         Set<String> checks = parameters == null
-            ? Set.of()
+            ? Collections.emptySet()
             : parameters.getChecks();
 
         DataIntegrityReportType type = parameters == null ? null : parameters.getType();

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/jobs/DataIntegrityJob.java
@@ -27,7 +27,11 @@
  */
 package org.hisp.dhis.dataintegrity.jobs;
 
+import java.util.Collections;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.commons.timer.SystemTimer;
 import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.dataintegrity.DataIntegrityService;
@@ -41,9 +45,6 @@ import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters.DataIntegr
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
-
-import java.util.Collections;
-import java.util.Set;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderElectionJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderElectionJob.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.leader.election;
 
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
 
@@ -57,8 +58,7 @@ public class LeaderElectionJob implements Job
         return JobType.LEADER_ELECTION;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         leaderManager.electLeader();
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderElectionJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderElectionJob.java
@@ -58,7 +58,8 @@ public class LeaderElectionJob implements Job
         return JobType.LEADER_ELECTION;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         leaderManager.electLeader();
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
@@ -58,7 +58,8 @@ public class LeaderRenewalJob implements Job
         return JobType.LEADER_RENEWAL;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         leaderManager.renewLeader();
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/leader/election/LeaderRenewalJob.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.leader.election;
 
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
 
@@ -57,8 +58,7 @@ public class LeaderRenewalJob implements Job
         return JobType.LEADER_RENEWAL;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         leaderManager.renewLeader();
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
@@ -27,6 +27,12 @@
  */
 package org.hisp.dhis.sms.scheduling;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
+
+import java.util.Date;
+import java.util.List;
+
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
@@ -41,12 +47,6 @@ import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
-import java.util.List;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
 
 @Component( "sendScheduledMessageJob" )
 public class SendScheduledMessageJob implements Job
@@ -79,7 +79,8 @@ public class SendScheduledMessageJob implements Job
         return JobType.SEND_SCHEDULED_MESSAGE;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
@@ -27,17 +27,12 @@
  */
 package org.hisp.dhis.sms.scheduling;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
-
-import java.util.Date;
-import java.util.List;
-
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.sms.outbound.OutboundSms;
 import org.hisp.dhis.sms.outbound.OutboundSmsService;
@@ -46,6 +41,12 @@ import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
 
 @Component( "sendScheduledMessageJob" )
 public class SendScheduledMessageJob implements Job
@@ -78,8 +79,7 @@ public class SendScheduledMessageJob implements Job
         return JobType.SEND_SCHEDULED_MESSAGE;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks.yaml
@@ -1,0 +1,7 @@
+checks:
+  - categories/categories_no_options.yaml
+  - categories/categories_one_default_category.yaml
+  - categories/categories_one_default_category_option.yaml
+  - categories/categories_one_default_category_combo.yaml
+  - categories/categories_one_default_category_option_combo.yaml
+  - categories/categories_unique_category_combo.yaml

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_no_options.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_no_options.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) 2021, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: categories_no_options
+description: Categories with no category options
+section: Categories
+summary_sql: >-
+    select
+    COUNT(*) as value,
+    (100 * COUNT(*) / (SELECT COUNT(*) FROM dataelementcategory)) as percent
+    from dataelementcategory where categoryid
+    not in (select distinct categoryid from categories_categoryoptions);
+details_sql: >-
+    SELECT uid,name from dataelementcategory
+    where categoryid
+    not in (select distinct categoryid from categories_categoryoptions)
+    ORDER BY name;
+severity: WARNING
+introduction: >
+    Categories should always have at least a single category options.
+recommendation: >
+    Any categories without category options should either be removed from the
+    system if they are not in use. Otherwise, appropriate category options
+    should be added to the category.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: categories_one_default_category
+description: Only one "default" category should exist
+section: Categories
+summary_sql: >-
+  SELECT count(*) AS count FROM dataelementcategory
+  WHERE name = 'default' AND uid != 'GLevLNI9wkl';
+details_sql: >-
+  SELECT uid, name FROM dataelementcategory
+  WHERE name = 'default' AND uid != 'GLevLNI9wkl'
+  ORDER BY categoryid;
+severity: SEVERE
+introduction: >
+  There should only exist one category with name and code "default".
+recommendation: >
+  Only the category with UID "GLevLNI9wkl" should be named "default" and have code "default".
+  Either rename the conflicting category or move all references to category "GLevLNI9wkl"
+  and then remove the unused conflicting category.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_combo.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_combo.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: categories_one_default_category_combo
+description: Only one "default" category combo should exist
+section: Categories
+summary_sql: >-
+  SELECT count(*) AS count FROM categorycombo
+  WHERE name = 'default' AND uid != 'bjDvmb4bfuf';
+details_sql: >-
+  SELECT uid, name FROM categorycombo
+  WHERE name = 'default' AND uid != 'bjDvmb4bfuf'
+  ORDER BY categorycomboid;
+severity: SEVERE
+introduction: >
+  There should only exist one category combo with name and code "default".
+recommendation: >
+  Only the category combo with UID "bjDvmb4bfuf" should be named "default" and have code "default".
+  Either rename the conflicting category combo or move all references to category combo "bjDvmb4bfuf"
+  and then remove the unused conflicting category combo.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: categories_one_default_category_option
+description: Only one "default" category option should exist
+section: Categories
+summary_sql: >-
+  SELECT count(*) AS count FROM dataelementcategoryoption
+  WHERE name = 'default' AND uid != 'xYerKDKCefk';
+details_sql: >-
+  SELECT uid, name FROM dataelementcategoryoption
+  WHERE name = 'default' AND uid != 'xYerKDKCefk'
+  ORDER BY categoryoptionid;
+severity: SEVERE
+introduction: >
+  There should only exist one category option with name and code "default".
+recommendation: >
+  Only the category option with UID "xYerKDKCefk" should be named "default" and have code "default".
+  Either rename the conflicting category option or move all references to category option "xYerKDKCefk"
+  and then remove the unused conflicting category option.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option_combo.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option_combo.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+---
+name: categories_one_default_category_option_combo
+description: Only one "default" category option combo should exist
+section: Categories
+summary_sql: >-
+  SELECT count(*) AS count FROM categoryoptioncombo
+  WHERE name = 'default' AND uid != 'HllvX50cXC0';
+details_sql: >-
+  SELECT uid, name FROM categoryoptioncombo
+  WHERE name = 'default' AND uid != 'HllvX50cXC0'
+  ORDER BY categoryoptioncomboid;
+severity: SEVERE
+introduction: >
+  There should only exist one category option with name and code "default".
+recommendation: >
+  Only the category option combo with UID "HllvX50cXC0" should be named "default" and have code "default".
+  Either rename the conflicting category option combo or move all references to category option combo "HllvX50cXC0"
+  and then remove the unused conflicting category option combo.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_unique_category_combo.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_unique_category_combo.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2022, University of Oslo
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+# Neither the name of the HISP project nor the names of its contributors may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+# SQL comments:
+#
+#     b.cats @> a.cats and a.cats @> b.cats
+#
+#   checks if a and b are the same set by checking that a is included in b and vice-versa
+---
+name: categories_unique_category_combo
+description: Lists category combos that share a combination of categories with at least one other category combo
+section: Categories
+summary_sql: >-
+  with combo_sets as (
+    select categorycomboid as id, array_agg(categoryid) as cats from categorycombos_categories
+    group by categorycomboid
+    order by cats
+  )
+  select count(*) as value,
+  (100 * COUNT(*) / (SELECT COUNT(*) FROM categorycombo)) as percent
+  from combo_sets a
+  where exists (select 1 from combo_sets c where c.id != a.id and c.cats @> a.cats and a.cats @> c.cats)
+details_sql: >-
+  with combo_sets as (
+    select categorycomboid as id, array_agg(categoryid) as cats from categorycombos_categories
+    group by categorycomboid
+    order by cats
+  )
+  select cca.uid, cca.name, null as comment, (
+    select array_agg(ccb.uid || ':' || ccb.name)
+    from combo_sets b
+    left join categorycombo ccb on b.id = ccb.categorycomboid
+    where b.id != a.id and b.cats @> a.cats and a.cats @> b.cats
+  )
+  from combo_sets a
+  left join categorycombo cca on a.id = cca.categorycomboid
+  where exists (select 1 from combo_sets c where c.id != a.id and c.cats @> a.cats and a.cats @> c.cats)
+severity: SEVERE
+introduction: >
+  A category combo should be a unique combination of categories
+recommendation: >
+  One category combo is kept, all references are updated to use this combo and other combos are removed.

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -27,6 +27,41 @@
  */
 package org.hisp.dhis.dataintegrity;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
+import static org.hisp.dhis.DhisConvenienceTest.createDataElementGroup;
+import static org.hisp.dhis.DhisConvenienceTest.createDataSet;
+import static org.hisp.dhis.DhisConvenienceTest.createIndicator;
+import static org.hisp.dhis.DhisConvenienceTest.createIndicatorGroup;
+import static org.hisp.dhis.DhisConvenienceTest.createIndicatorType;
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
+import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnitGroup;
+import static org.hisp.dhis.DhisConvenienceTest.createProgram;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramRule;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramRuleAction;
+import static org.hisp.dhis.DhisConvenienceTest.createProgramRuleVariable;
+import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.issueName;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryService;
@@ -68,41 +103,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static com.google.common.collect.Lists.newArrayList;
-import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
-import static org.hisp.dhis.DhisConvenienceTest.createDataElementGroup;
-import static org.hisp.dhis.DhisConvenienceTest.createDataSet;
-import static org.hisp.dhis.DhisConvenienceTest.createIndicator;
-import static org.hisp.dhis.DhisConvenienceTest.createIndicatorGroup;
-import static org.hisp.dhis.DhisConvenienceTest.createIndicatorType;
-import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnit;
-import static org.hisp.dhis.DhisConvenienceTest.createOrganisationUnitGroup;
-import static org.hisp.dhis.DhisConvenienceTest.createProgram;
-import static org.hisp.dhis.DhisConvenienceTest.createProgramRule;
-import static org.hisp.dhis.DhisConvenienceTest.createProgramRuleAction;
-import static org.hisp.dhis.DhisConvenienceTest.createProgramRuleVariable;
-import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssue.issueName;
-import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Lars Helge Overland

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -165,7 +165,7 @@ public class DataIntegrityServiceTest
 
     private DefaultDataIntegrityService subject;
 
-    private BeanRandomizer rnd;
+    private BeanRandomizer rnd = new BeanRandomizer();
 
     private DataElementGroup elementGroupA;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/AnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/AnalyticsTableJob.java
@@ -27,17 +27,18 @@
  */
 package org.hisp.dhis.analytics.table.scheduling;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Date;
-
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -64,8 +65,7 @@ public class AnalyticsTableJob implements Job
         return JobType.ANALYTICS_TABLE;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         AnalyticsJobParameters parameters = (AnalyticsJobParameters) jobConfiguration.getJobParameters();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/AnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/AnalyticsTableJob.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.analytics.table.scheduling;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Date;
+
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.scheduling.Job;
@@ -35,10 +39,6 @@ import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -65,7 +65,8 @@ public class AnalyticsTableJob implements Job
         return JobType.ANALYTICS_TABLE;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         AnalyticsJobParameters parameters = (AnalyticsJobParameters) jobConfiguration.getJobParameters();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
@@ -27,17 +27,14 @@
  */
 package org.hisp.dhis.analytics.table.scheduling;
 
-import static org.hisp.dhis.util.DateUtils.getLongDateString;
-
-import java.util.Date;
-
+import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
 import org.hisp.dhis.setting.SettingKey;
@@ -45,7 +42,9 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.Preconditions;
+import java.util.Date;
+
+import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 /**
  * Job for continuous update of analytics tables. Performs analytics table
@@ -85,8 +84,7 @@ public class ContinuousAnalyticsTableJob implements Job
         return JobType.CONTINUOUS_ANALYTICS_TABLE;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         ContinuousAnalyticsJobParameters parameters = (ContinuousAnalyticsJobParameters) jobConfiguration
             .getJobParameters();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ContinuousAnalyticsTableJob.java
@@ -27,8 +27,12 @@
  */
 package org.hisp.dhis.analytics.table.scheduling;
 
-import com.google.common.base.Preconditions;
+import static org.hisp.dhis.util.DateUtils.getLongDateString;
+
+import java.util.Date;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
@@ -42,9 +46,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
-
-import static org.hisp.dhis.util.DateUtils.getLongDateString;
+import com.google.common.base.Preconditions;
 
 /**
  * Job for continuous update of analytics tables. Performs analytics table
@@ -84,7 +86,8 @@ public class ContinuousAnalyticsTableJob implements Job
         return JobType.CONTINUOUS_ANALYTICS_TABLE;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         ContinuousAnalyticsJobParameters parameters = (ContinuousAnalyticsJobParameters) jobConfiguration
             .getJobParameters();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ResourceTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ResourceTableJob.java
@@ -27,14 +27,14 @@
  */
 package org.hisp.dhis.analytics.table.scheduling;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -61,7 +61,8 @@ public class ResourceTableJob implements Job
         return JobType.RESOURCE_TABLE;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         analyticsTableGenerator.generateResourceTables( jobConfiguration );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ResourceTableJob.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/scheduling/ResourceTableJob.java
@@ -27,13 +27,14 @@
  */
 package org.hisp.dhis.analytics.table.scheduling;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.hisp.dhis.analytics.AnalyticsTableGenerator;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -60,8 +61,7 @@ public class ResourceTableJob implements Job
         return JobType.RESOURCE_TABLE;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         analyticsTableGenerator.generateResourceTables( jobConfiguration );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationJob.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.dataset.notifications;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.scheduling.JobType.DATA_SET_NOTIFICATION;
+
+import java.util.Date;
+
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -36,11 +41,6 @@ import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.scheduling.JobType.DATA_SET_NOTIFICATION;
 
 /**
  * Created by zubair@dhis2.org on 21.07.17.
@@ -76,7 +76,8 @@ public class DataSetNotificationJob implements Job
         return DATA_SET_NOTIFICATION;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         final Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DataSetNotificationJob.java
@@ -27,19 +27,20 @@
  */
 package org.hisp.dhis.dataset.notifications;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.scheduling.JobType.DATA_SET_NOTIFICATION;
-
-import java.util.Date;
-
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.scheduling.JobType.DATA_SET_NOTIFICATION;
 
 /**
  * Created by zubair@dhis2.org on 21.07.17.
@@ -75,8 +76,7 @@ public class DataSetNotificationJob implements Job
         return DATA_SET_NOTIFICATION;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         final Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -27,21 +27,21 @@
  */
 package org.hisp.dhis.fileresource;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Deletes any orphaned FileResources. Queries for non-assigned or failed-upload
@@ -70,8 +70,7 @@ public class FileResourceCleanUpJob implements Job
         return JobType.FILE_RESOURCE_CLEANUP;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         FileResourceRetentionStrategy retentionStrategy = (FileResourceRetentionStrategy) systemSettingManager
             .getSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -27,8 +27,12 @@
  */
 package org.hisp.dhis.fileresource;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.DeleteNotAllowedException;
@@ -39,9 +43,6 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Deletes any orphaned FileResources. Queries for non-assigned or failed-upload
@@ -70,7 +71,8 @@ public class FileResourceCleanUpJob implements Job
         return JobType.FILE_RESOURCE_CLEANUP;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         FileResourceRetentionStrategy retentionStrategy = (FileResourceRetentionStrategy) systemSettingManager
             .getSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
@@ -27,6 +27,14 @@
  */
 package org.hisp.dhis.fileresource;
 
+import lombok.extern.slf4j.Slf4j;
+import org.hisp.dhis.commons.util.DebugUtils;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.scheduling.JobType;
+import org.springframework.stereotype.Component;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -34,14 +42,6 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.scheduling.Job;
-import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.JobType;
-import org.springframework.stereotype.Component;
 
 /**
  * Job will fetch all the image FileResources with flag hasMultiple set to
@@ -75,8 +75,7 @@ public class ImageResizingJob implements Job
         return JobType.IMAGE_PROCESSING;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         List<FileResource> fileResources = fileResourceService.getAllUnProcessedImagesFiles();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
@@ -27,14 +27,6 @@
  */
 package org.hisp.dhis.fileresource;
 
-import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.scheduling.Job;
-import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.JobProgress;
-import org.hisp.dhis.scheduling.JobType;
-import org.springframework.stereotype.Component;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -42,6 +34,15 @@ import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.commons.util.DebugUtils;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.scheduling.JobType;
+import org.springframework.stereotype.Component;
 
 /**
  * Job will fetch all the image FileResources with flag hasMultiple set to
@@ -75,7 +76,8 @@ public class ImageResizingJob implements Job
         return JobType.IMAGE_PROCESSING;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         List<FileResource> fileResources = fileResourceService.getAllUnProcessedImagesFiles();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationJob.java
@@ -27,18 +27,19 @@
  */
 package org.hisp.dhis.program.notification;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Calendar;
-
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.stereotype.Component;
+
+import java.util.Calendar;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Halvdan Hoem Grelland
@@ -75,8 +76,7 @@ public class ProgramNotificationJob implements Job
         return JobType.PROGRAM_NOTIFICATIONS;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         final Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/ProgramNotificationJob.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.program.notification;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Calendar;
+
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -36,10 +40,6 @@ import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.stereotype.Component;
-
-import java.util.Calendar;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Halvdan Hoem Grelland
@@ -76,7 +76,8 @@ public class ProgramNotificationJob implements Job
         return JobType.PROGRAM_NOTIFICATIONS;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         final Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveUsedOrExpiredReservedValuesJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveUsedOrExpiredReservedValuesJob.java
@@ -28,9 +28,9 @@
 package org.hisp.dhis.reservedvalue;
 
 import lombok.RequiredArgsConstructor;
-
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
 
@@ -49,8 +49,7 @@ public class RemoveUsedOrExpiredReservedValuesJob implements Job
         return JobType.REMOVE_USED_OR_EXPIRED_RESERVED_VALUES;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         reservedValueService.removeUsedOrExpiredReservations();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveUsedOrExpiredReservedValuesJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveUsedOrExpiredReservedValuesJob.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.reservedvalue;
 
 import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
@@ -49,7 +50,8 @@ public class RemoveUsedOrExpiredReservedValuesJob implements Job
         return JobType.REMOVE_USED_OR_EXPIRED_RESERVED_VALUES;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         reservedValueService.removeUsedOrExpiredReservations();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -27,19 +27,13 @@
  */
 package org.hisp.dhis.scheduling;
 
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.hisp.dhis.cache.Cache;
-import org.hisp.dhis.cache.CacheProvider;
-import org.hisp.dhis.commons.util.DebugUtils;
-import org.hisp.dhis.leader.election.LeaderManager;
-import org.hisp.dhis.message.MessageService;
-import org.hisp.dhis.scheduling.JobProgress.Process;
-import org.hisp.dhis.system.notification.Notifier;
-import org.hisp.dhis.system.util.Clock;
-import org.slf4j.MDC;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableSet;
+import static org.hisp.dhis.scheduling.JobStatus.COMPLETED;
+import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
+import static org.hisp.dhis.scheduling.JobStatus.RUNNING;
 
-import javax.annotation.PostConstruct;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -51,12 +45,20 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.unmodifiableCollection;
-import static java.util.Collections.unmodifiableSet;
-import static org.hisp.dhis.scheduling.JobStatus.COMPLETED;
-import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
-import static org.hisp.dhis.scheduling.JobStatus.RUNNING;
+import javax.annotation.PostConstruct;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.commons.util.DebugUtils;
+import org.hisp.dhis.leader.election.LeaderManager;
+import org.hisp.dhis.message.MessageService;
+import org.hisp.dhis.scheduling.JobProgress.Process;
+import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.system.util.Clock;
+import org.slf4j.MDC;
 
 /**
  * Base for synchronous or asynchronous {@link SchedulingManager} implementation
@@ -204,8 +206,8 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         Date now = new Date();
         return localInfo.isEmpty()
             || Process.startedTime( remoteInfo.get(), now ).after( Process.startedTime( localInfo, now ) )
-            ? unmodifiableCollection( remoteInfo.get() )
-            : localInfo;
+                ? unmodifiableCollection( remoteInfo.get() )
+                : localInfo;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,12 +27,21 @@
  */
 package org.hisp.dhis.scheduling;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableCollection;
+import static java.util.Collections.unmodifiableSet;
 import static org.hisp.dhis.scheduling.JobStatus.COMPLETED;
 import static org.hisp.dhis.scheduling.JobStatus.DISABLED;
 import static org.hisp.dhis.scheduling.JobStatus.RUNNING;
 
+import java.util.Collection;
 import java.util.Date;
+import java.util.Deque;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.PostConstruct;
@@ -40,10 +49,15 @@ import javax.annotation.PostConstruct;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.cache.Cache;
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.message.MessageService;
+import org.hisp.dhis.scheduling.JobProgress.Process;
+import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
+import org.slf4j.MDC;
 
 /**
  * Base for synchronous or asynchronous {@link SchedulingManager} implementation
@@ -64,18 +78,72 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
 
     private final LeaderManager leaderManager;
 
-    @PostConstruct
-    public void init()
-    {
-        leaderManager.setSchedulingManager( this );
-    }
+    private final Notifier notifier;
 
     /**
      * Set of currently running jobs. We use a map to use CAS operation
      * {@link Map#putIfAbsent(Object, Object)} to "atomically" start or abort
      * execution.
      */
-    private final Map<JobType, Boolean> runningJobTypes = new ConcurrentHashMap<>();
+    private final Map<JobType, ControlledJobProgress> runningLocally = new ConcurrentHashMap<>();
+
+    private final Map<JobType, ControlledJobProgress> completedLocally = new ConcurrentHashMap<>();
+
+    private final Cache<Deque<Process>> runningRemotely;
+
+    private final Cache<Deque<Process>> completedRemotely;
+
+    private final Cache<Boolean> cancelledRemotely;
+
+    protected AbstractSchedulingManager( JobService jobService, JobConfigurationService jobConfigurationService,
+        MessageService messageService, LeaderManager leaderManager, Notifier notifier, CacheProvider cacheProvider )
+    {
+        this.jobService = jobService;
+        this.jobConfigurationService = jobConfigurationService;
+        this.messageService = messageService;
+        this.leaderManager = leaderManager;
+        this.notifier = notifier;
+
+        this.runningRemotely = cacheProvider.createRunningJobsInfoCache();
+        this.completedRemotely = cacheProvider.createCompletedJobsInfoCache();
+        this.cancelledRemotely = cacheProvider.createJobCancelRequestedCache();
+    }
+
+    @PostConstruct
+    public void init()
+    {
+        leaderManager.setSchedulingManager( this );
+    }
+
+    protected final void clusterHeartbeat()
+    {
+        for ( Entry<JobType, ControlledJobProgress> info : runningLocally.entrySet() )
+        {
+            String key = info.getKey().name();
+            if ( cancelledRemotely.getIfPresent( key ).isPresent() )
+            {
+                cancel( info.getKey() );
+                cancelledRemotely.invalidate( key );
+            }
+            else
+            {
+                // heart beat update so the entry does not expire
+                runningRemotely.put( key, info.getValue().getProcesses() );
+            }
+        }
+        // always use most recent local in the cache
+        for ( Entry<JobType, ControlledJobProgress> localInfo : completedLocally.entrySet() )
+        {
+            String key = localInfo.getKey().name();
+            Optional<Deque<Process>> remoteInfo = completedRemotely.getIfPresent( key );
+            Date now = new Date();
+            if ( remoteInfo.isEmpty() || Process.startedTime( remoteInfo.get(), now )
+                .before( Process.startedTime( localInfo.getValue().getProcesses(), now ) ) )
+            {
+                completedRemotely.put( key, localInfo.getValue().getProcesses() );
+            }
+        }
+    }
 
     /**
      * Check if this job configuration is currently running
@@ -83,9 +151,77 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
      * @param type type of job to check
      * @return true/false
      */
-    boolean isRunning( JobType type )
+    final boolean isRunning( JobType type )
     {
-        return runningJobTypes.containsKey( type );
+        return isRunningLocally( type ) || isRunningRemotely( type );
+    }
+
+    final boolean isRunningLocally( JobType type )
+    {
+        return runningLocally.containsKey( type );
+    }
+
+    final boolean isRunningRemotely( JobType type )
+    {
+        return runningRemotely.getIfPresent( type.name() ).isPresent();
+    }
+
+    @Override
+    public final Collection<JobType> getRunningTypes()
+    {
+        return unmodifiableUnionOf( runningRemotely, runningLocally );
+    }
+
+    @Override
+    public final Collection<JobType> getCompletedTypes()
+    {
+        return unmodifiableUnionOf( completedRemotely, completedLocally );
+    }
+
+    @Override
+    public final Collection<Process> getRunningProgress( JobType type )
+    {
+        ControlledJobProgress local = runningLocally.get( type );
+        if ( local != null )
+        {
+            return unmodifiableCollection( local.getProcesses() );
+        }
+        var remoteInfo = runningRemotely.getIfPresent( type.name() );
+        return remoteInfo.isEmpty() ? emptyList() : unmodifiableCollection( remoteInfo.get() );
+    }
+
+    @Override
+    public final Collection<Process> getCompletedProgress( JobType type )
+    {
+        ControlledJobProgress local = completedLocally.get( type );
+        Collection<Process> localInfo = local == null
+            ? emptyList()
+            : unmodifiableCollection( local.getProcesses() );
+        var remoteInfo = completedRemotely.getIfPresent( type.name() );
+        if ( remoteInfo.isEmpty() )
+        {
+            return localInfo;
+        }
+        Date now = new Date();
+        return localInfo.isEmpty()
+            || Process.startedTime( remoteInfo.get(), now ).after( Process.startedTime( localInfo, now ) )
+                ? unmodifiableCollection( remoteInfo.get() )
+                : localInfo;
+    }
+
+    @Override
+    public final void cancel( JobType type )
+    {
+        ControlledJobProgress local = runningLocally.get( type );
+        if ( local != null )
+        {
+            local.requestCancellation();
+        }
+        else
+        {
+            // no matter which node received the cancel this is shared
+            cancelledRemotely.put( type.name(), true );
+        }
     }
 
     protected final void execute( String jobId )
@@ -105,8 +241,18 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             whenLeaderOnlyOnNonLeader( configuration );
             return;
         }
-        if ( runningJobTypes.putIfAbsent( type, true ) != null )
+        ControlledJobProgress progress = createJobProgress( configuration );
+        // OBS: we cannot use computeIfAbsent since we have no way of
+        // atomically create and find out if there was a value before
+        // so we need to pay the price of creating the progress up front
+        if ( runningLocally.putIfAbsent( type, progress ) != null )
         {
+            whenAlreadyRunning( configuration );
+            return;
+        }
+        if ( !runningRemotely.putIfAbsent( type.name(), progress.getProcesses() ) )
+        {
+            runningLocally.remove( type );
             whenAlreadyRunning( configuration );
             return;
         }
@@ -123,8 +269,12 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             // in memory effect only: mark running (dirty)
             configuration.setLastExecutedStatus( JobStatus.RUNNING );
 
+            String identifier = configuration.getUid() != null
+                ? "UID:" + configuration.getUid()
+                : "TYPE:" + configuration.getJobType().name();
+            MDC.put( "sessionId", identifier );
             // run the actual job
-            jobService.getJob( type ).execute( configuration );
+            jobService.getJob( type ).execute( configuration, progress );
 
             if ( configuration.getLastExecutedStatus() == RUNNING )
             {
@@ -137,10 +287,19 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         }
         finally
         {
-            runningJobTypes.remove( configuration.getJobType() );
-
+            completedLocally.put( type, runningLocally.remove( type ) );
+            runningRemotely.invalidate( type.name() );
             whenRunIsDone( configuration, clock );
+            MDC.remove( "sessionId" );
         }
+    }
+
+    private ControlledJobProgress createJobProgress( JobConfiguration configuration )
+    {
+        JobProgress tracker = configuration.getJobType().isUsingNotifications()
+            ? new NotifierJobProgress( notifier, configuration )
+            : NoopJobProgress.INSTANCE;
+        return new ControlledJobProgress( configuration, tracker, true );
     }
 
     private void whenRunIsDone( JobConfiguration configuration, Clock clock )
@@ -207,5 +366,14 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         {
             messageService.sendSystemErrorNotification( message, new RuntimeException( message ) );
         }
+    }
+
+    private static Set<JobType> unmodifiableUnionOf( Cache<Deque<Process>> cluster,
+        Map<JobType, ControlledJobProgress> local )
+    {
+        EnumSet<JobType> all = EnumSet.noneOf( JobType.class );
+        cluster.keys().forEach( key -> all.add( JobType.valueOf( key ) ) );
+        all.addAll( local.keySet() );
+        return unmodifiableSet( all );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling;
+
+import java.util.Deque;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * The {@link ControlledJobProgress} take care of the flow control aspect of
+ * {@link JobProgress} API. Additional tracking can be done by wrapping another
+ * {@link JobProgress} as {@link #tracker}.
+ *
+ * The implementation does allow for parallel items but would merge parallel
+ * stages or processes. Stages and processes should always be sequential in a
+ * main thread.
+ *
+ * @author Jan Bernitt
+ */
+@RequiredArgsConstructor
+public class ControlledJobProgress implements JobProgress
+{
+    private final JobConfiguration configuration;
+
+    private final JobProgress tracker;
+
+    private final boolean abortOnFailure;
+
+    private final AtomicBoolean cancellationRequested = new AtomicBoolean();
+
+    private final AtomicBoolean abortAfterFailure = new AtomicBoolean();
+
+    private final Deque<Process> processes = new ConcurrentLinkedDeque<>();
+
+    private final AtomicReference<Process> incompleteProcess = new AtomicReference<>();
+
+    private final AtomicReference<Stage> incompleteStage = new AtomicReference<>();
+
+    private final ThreadLocal<Item> incompleteItem = new ThreadLocal<>();
+
+    public void requestCancellation()
+    {
+        if ( cancellationRequested.compareAndSet( false, true ) )
+        {
+            processes.forEach( Process::cancel );
+        }
+    }
+
+    public Deque<Process> getProcesses()
+    {
+        return processes;
+    }
+
+    @Override
+    public boolean isCancellationRequested()
+    {
+        return cancellationRequested.get();
+    }
+
+    @Override
+    public void startingProcess( String description )
+    {
+        if ( isCancellationRequested() )
+        {
+            throw new CancellationException();
+        }
+        tracker.startingProcess( description );
+        incompleteProcess.set( null );
+        incompleteStage.set( null );
+        incompleteItem.remove();
+        addProcessRecord( description );
+    }
+
+    @Override
+    public void completedProcess( String summary )
+    {
+        tracker.completedProcess( summary );
+        getOrAddLastIncompleteProcess().complete( summary );
+    }
+
+    @Override
+    public void failedProcess( String error )
+    {
+        tracker.failedProcess( error );
+        if ( processes.getLast().getStatus() != Status.CANCELLED )
+        {
+            automaticAbort();
+            getOrAddLastIncompleteProcess().completeExceptionally( error, null );
+        }
+    }
+
+    @Override
+    public void failedProcess( Exception cause )
+    {
+        cause = cancellationAsAbort( cause );
+        tracker.failedProcess( cause );
+        if ( processes.getLast().getStatus() != Status.CANCELLED )
+        {
+            automaticAbort();
+            getOrAddLastIncompleteProcess().completeExceptionally( cause.getMessage(), cause );
+        }
+    }
+
+    @Override
+    public void startingStage( String description, int workItems )
+    {
+        if ( isCancellationRequested() )
+        {
+            throw new CancellationException();
+        }
+        tracker.startingStage( description, workItems );
+        addStageRecord( getOrAddLastIncompleteProcess(), description, workItems );
+    }
+
+    @Override
+    public void completedStage( String summary )
+    {
+        tracker.completedStage( summary );
+        getOrAddLastIncompleteStage().complete( summary );
+    }
+
+    @Override
+    public void failedStage( String error )
+    {
+        tracker.failedStage( error );
+        automaticAbort();
+        getOrAddLastIncompleteStage().completeExceptionally( error, null );
+    }
+
+    @Override
+    public void failedStage( Exception cause )
+    {
+        cause = cancellationAsAbort( cause );
+        tracker.failedStage( cause );
+        automaticAbort();
+        getOrAddLastIncompleteStage().completeExceptionally( cause.getMessage(), cause );
+    }
+
+    @Override
+    public void startingWorkItem( String description )
+    {
+        tracker.startingWorkItem( description );
+        addItemRecord( getOrAddLastIncompleteStage(), description );
+    }
+
+    @Override
+    public void completedWorkItem( String summary )
+    {
+        tracker.completedWorkItem( summary );
+        getOrAddLastIncompleteItem().complete( summary );
+    }
+
+    @Override
+    public void failedWorkItem( String error )
+    {
+        tracker.failedWorkItem( error );
+        automaticAbort();
+        getOrAddLastIncompleteItem().completeExceptionally( error, null );
+    }
+
+    @Override
+    public void failedWorkItem( Exception cause )
+    {
+        tracker.failedProcess( cause );
+        automaticAbort();
+        getOrAddLastIncompleteItem().completeExceptionally( cause.getMessage(), cause );
+    }
+
+    private void automaticAbort()
+    {
+        if ( abortOnFailure
+            // OBS! we only mark abort if we could mark cancellation
+            // if we already cancelled manually we do not abort but cancel
+            && cancellationRequested.compareAndSet( false, true )
+            && abortAfterFailure.compareAndSet( false, true ) )
+        {
+            processes.forEach( Process::abort );
+        }
+    }
+
+    private Process getOrAddLastIncompleteProcess()
+    {
+        Process process = incompleteProcess.get();
+        return process != null && !process.isComplete()
+            ? process
+            : addProcessRecord( null );
+    }
+
+    private Process addProcessRecord( String description )
+    {
+        Process process = new Process( description );
+        if ( configuration != null )
+        {
+            process.setJobId( configuration.getUid() );
+        }
+        incompleteProcess.set( process );
+        processes.add( process );
+        return process;
+    }
+
+    private Stage getOrAddLastIncompleteStage()
+    {
+        Stage stage = incompleteStage.get();
+        return stage != null && !stage.isComplete()
+            ? stage
+            : addStageRecord( getOrAddLastIncompleteProcess(), null, -1 );
+    }
+
+    private Stage addStageRecord( Process process, String description, int totalItems )
+    {
+        Deque<Stage> stages = process.getStages();
+        Stage stage = new Stage( description, totalItems );
+        stages.addLast( stage );
+        incompleteStage.set( stage );
+        return stage;
+    }
+
+    private Item getOrAddLastIncompleteItem()
+    {
+        Item item = incompleteItem.get();
+        return item != null && !item.isComplete()
+            ? item
+            : addItemRecord( getOrAddLastIncompleteStage(), null );
+    }
+
+    private Item addItemRecord( Stage stage, String description )
+    {
+        Deque<Item> items = stage.getItems();
+        Item item = new Item( description );
+        items.addLast( item );
+        incompleteItem.set( item );
+        return item;
+    }
+
+    private Exception cancellationAsAbort( Exception cause )
+    {
+        return cause instanceof CancellationException && abortAfterFailure.get()
+            ? new RuntimeException( "processing aborted: " + cause.getMessage() )
+            : cause;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobConfigurationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -216,55 +217,72 @@ public class DefaultJobConfigurationService
     {
         List<Property> jobParameters = new ArrayList<>();
 
-        Class<?> clazz = jobType.getJobParameters();
+        Class<?> paramsType = jobType.getJobParameters();
 
-        if ( clazz == null )
+        if ( paramsType == null )
         {
             return jobParameters;
         }
 
-        final Set<String> propertyNames = Stream.of( PropertyUtils.getPropertyDescriptors( clazz ) )
-            .filter( pd -> pd.getReadMethod() != null && pd.getWriteMethod() != null
-                && pd.getReadMethod().getAnnotation( JsonProperty.class ) != null )
-            .map( PropertyDescriptor::getName )
+        final Set<PropertyDescriptor> properties = Stream.of( PropertyUtils.getPropertyDescriptors( paramsType ) )
+            .filter( pd -> pd.getReadMethod() != null && pd.getWriteMethod() != null )
             .collect( Collectors.toSet() );
 
-        for ( Field field : Stream.of( clazz.getDeclaredFields() ).filter( f -> propertyNames.contains( f.getName() ) )
-            .collect( Collectors.toList() ) )
+        for ( Field field : paramsType.getDeclaredFields() )
         {
-            Property property = new Property( Primitives.wrap( field.getType() ), null, null );
-            property.setName( field.getName() );
-            property.setFieldName( TextUtils.getPrettyPropertyName( field.getName() ) );
-
-            try
+            PropertyDescriptor descriptor = properties.stream().filter( pd -> pd.getName().equals( field.getName() ) )
+                .findFirst().orElse( null );
+            if ( isProperty( field, descriptor ) )
             {
-                field.setAccessible( true );
-                property.setDefaultValue( field.get( jobType.getJobParameters().newInstance() ) );
+                jobParameters.add( getProperty( jobType, paramsType, field ) );
             }
-            catch ( IllegalAccessException | InstantiationException e )
-            {
-                log.error(
-                    "Fetching default value for JobParameters properties failed for property: " + field.getName(), e );
-            }
-
-            String relativeApiElements = jobType.getRelativeApiElements() != null
-                ? jobType.getRelativeApiElements().get( field.getName() )
-                : "";
-
-            if ( relativeApiElements != null && !relativeApiElements.equals( "" ) )
-            {
-                property.setRelativeApiEndpoint( relativeApiElements );
-            }
-
-            if ( Collection.class.isAssignableFrom( field.getType() ) )
-            {
-                property = setPropertyIfCollection( property, field, clazz );
-            }
-
-            jobParameters.add( property );
         }
 
         return jobParameters;
+    }
+
+    private boolean isProperty( Field field, PropertyDescriptor descriptor )
+    {
+        return !(descriptor == null || (descriptor.getReadMethod().getAnnotation( JsonProperty.class ) == null
+            && field.getAnnotation( JsonProperty.class ) == null));
+    }
+
+    private static Property getProperty( JobType jobType, Class<?> paramsType, Field field )
+    {
+        Class<?> valueType = field.getType();
+        Property property = new Property( Primitives.wrap( valueType ), null, null );
+        property.setName( field.getName() );
+        property.setFieldName( TextUtils.getPrettyPropertyName( field.getName() ) );
+
+        try
+        {
+            field.setAccessible( true );
+            property.setDefaultValue( field.get( jobType.getJobParameters().newInstance() ) );
+        }
+        catch ( IllegalAccessException | InstantiationException e )
+        {
+            log.error(
+                "Fetching default value for JobParameters properties failed for property: " + field.getName(), e );
+        }
+
+        String relativeApiElements = jobType.getRelativeApiElements() != null
+            ? jobType.getRelativeApiElements().get( field.getName() )
+            : "";
+
+        if ( relativeApiElements != null && !relativeApiElements.equals( "" ) )
+        {
+            property.setRelativeApiEndpoint( relativeApiElements );
+        }
+
+        if ( Collection.class.isAssignableFrom( valueType ) )
+        {
+            return setPropertyIfCollection( property, field, paramsType );
+        }
+        if ( valueType.isEnum() )
+        {
+            property.setConstants( getConstants( valueType ) );
+        }
+        return property;
     }
 
     private static Property setPropertyIfCollection( Property property, Field field, Class<?> klass )
@@ -284,8 +302,18 @@ public class DefaultJobConfigurationService
             property.setNameableObject( NameableObject.class.isAssignableFrom( itemKlass ) );
             property.setEmbeddedObject( EmbeddedObject.class.isAssignableFrom( klass ) );
             property.setAnalyticalObject( AnalyticalObject.class.isAssignableFrom( klass ) );
+            if ( itemKlass.isEnum() )
+            {
+                property.setConstants( getConstants( itemKlass ) );
+            }
         }
-
         return property;
+    }
+
+    private static List<String> getConstants( Class<?> enumType )
+    {
+        return Arrays.stream( enumType.getEnumConstants() )
+            .map( e -> ((Enum<?>) e).name() )
+            .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/MockJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/MockJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -42,7 +42,7 @@ public class MockJob implements Job
     }
 
     @Override
-    public void execute( JobConfiguration jobConfiguration )
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         try
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -27,30 +27,80 @@
  */
 package org.hisp.dhis.scheduling;
 
-import java.util.EnumMap;
-import java.util.Map;
-
-import lombok.AllArgsConstructor;
-
-import org.springframework.context.ApplicationContext;
-import org.springframework.stereotype.Service;
-
 /**
+ * The {@link NoopJobProgress} can be used as a {@link JobProgress} instance
+ * when no actual flow control and tracking is wanted. For example in test
+ * context or in manual runs of operations that would generally support the
+ * tracking though the {@link JobProgress} abstraction.
+ *
  * @author Jan Bernitt
  */
-@Service
-@AllArgsConstructor
-public class DefaultJobService implements JobService
+public class NoopJobProgress implements JobProgress
 {
-    private final ApplicationContext applicationContext;
+    public static final JobProgress INSTANCE = new NoopJobProgress();
 
-    private final Map<JobType, Job> jobsByType = new EnumMap<>( JobType.class );
+    private NoopJobProgress()
+    {
+        // hide
+    }
 
     @Override
-    public Job getJob( JobType type )
+    public boolean isCancellationRequested()
     {
-        return jobsByType.computeIfAbsent( type,
-            key -> applicationContext.getBeansOfType( Job.class ).values().stream()
-                .filter( job -> job.getJobType() == type ).findFirst().orElse( null ) );
+        return false;
+    }
+
+    @Override
+    public void startingProcess( String description )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void completedProcess( String summary )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void failedProcess( String error )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void startingStage( String description, int workItems )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void completedStage( String summary )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void failedStage( String error )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void startingWorkItem( String description )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void completedWorkItem( String summary )
+    {
+        // as the name said we do nothing
+    }
+
+    @Override
+    public void failedWorkItem( String error )
+    {
+        // as the name said we do nothing
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling;
+
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.system.notification.NotificationLevel;
+import org.hisp.dhis.system.notification.Notifier;
+
+/**
+ * A {@link JobProgress} implementation that forwards the tracking to a
+ * {@link Notifier}. It has no flow control and should be wrapped in a
+ * {@link ControlledJobProgress} for that purpose.
+ *
+ * @see ControlledJobProgress
+ */
+@RequiredArgsConstructor
+public class NotifierJobProgress implements JobProgress
+{
+    private final Notifier notifier;
+
+    private final JobConfiguration jobId;
+
+    @Override
+    public boolean isCancellationRequested()
+    {
+        return false;
+    }
+
+    @Override
+    public void startingProcess( String description )
+    {
+        String message = isNotEmpty( description )
+            ? description
+            : jobId.getJobType() + " process started";
+        notifier.clear( jobId ).notify( jobId, message );
+    }
+
+    @Override
+    public void completedProcess( String summary )
+    {
+        notifier.notify( jobId, NotificationLevel.INFO, summary, true );
+    }
+
+    @Override
+    public void failedProcess( String error )
+    {
+        notifier.notify( jobId, NotificationLevel.ERROR, error, true );
+    }
+
+    @Override
+    public void startingStage( String description, int workItems )
+    {
+        if ( isNotEmpty( description ) )
+        {
+            notifier.notify( jobId, description );
+        }
+    }
+
+    @Override
+    public void completedStage( String summary )
+    {
+        if ( isNotEmpty( summary ) )
+        {
+            notifier.notify( jobId, NotificationLevel.INFO, summary, isCancellationRequested() );
+        }
+    }
+
+    @Override
+    public void failedStage( String error )
+    {
+        if ( isNotEmpty( error ) )
+        {
+            notifier.notify( jobId, NotificationLevel.ERROR, error, isCancellationRequested() );
+        }
+    }
+
+    @Override
+    public void startingWorkItem( String description )
+    {
+        if ( isNotEmpty( description ) )
+        {
+            notifier.notify( jobId, NotificationLevel.INFO, description );
+        }
+    }
+
+    @Override
+    public void completedWorkItem( String summary )
+    {
+        if ( isNotEmpty( summary ) )
+        {
+            notifier.notify( jobId, NotificationLevel.INFO, summary, false );
+        }
+    }
+
+    @Override
+    public void failedWorkItem( String error )
+    {
+        if ( isNotEmpty( error ) )
+        {
+            notifier.notify( jobId, NotificationLevel.ERROR, error, false );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/job/SendSmsJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/job/SendSmsJob.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.sms.job;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.HashSet;
+
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.scheduling.Job;
@@ -40,10 +44,6 @@ import org.hisp.dhis.sms.outbound.OutboundSmsStatus;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-
-import java.util.HashSet;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 @Component( "sendSmsJob" )
 public class SendSmsJob implements Job
@@ -76,7 +76,8 @@ public class SendSmsJob implements Job
         return JobType.SMS_SEND;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         SmsJobParameters parameters = (SmsJobParameters) jobConfiguration.getJobParameters();
         OutboundSms sms = new OutboundSms();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/job/SendSmsJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/job/SendSmsJob.java
@@ -27,14 +27,11 @@
  */
 package org.hisp.dhis.sms.job;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.HashSet;
-
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
 import org.hisp.dhis.sms.outbound.OutboundSms;
@@ -43,6 +40,10 @@ import org.hisp.dhis.sms.outbound.OutboundSmsStatus;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 @Component( "sendSmsJob" )
 public class SendSmsJob implements Job
@@ -75,8 +76,7 @@ public class SendSmsJob implements Job
         return JobType.SMS_SEND;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         SmsJobParameters parameters = (SmsJobParameters) jobConfiguration.getJobParameters();
         OutboundSms sms = new OutboundSms();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
@@ -27,8 +27,13 @@
  */
 package org.hisp.dhis.user.job;
 
+import static java.lang.String.format;
+
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
@@ -42,10 +47,6 @@ import org.hisp.dhis.user.UserAccountExpiryInfo;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-
-import static java.lang.String.format;
 
 /**
  * Sends an email alert to all users that are soon to expire due to an account
@@ -84,7 +85,8 @@ public class AccountExpiryAlertJob implements Job
         return null;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         if ( systemSettingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRY_ALERT, Boolean.class ) == Boolean.FALSE )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
@@ -27,18 +27,14 @@
  */
 package org.hisp.dhis.user.job;
 
-import static java.lang.String.format;
-
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -46,6 +42,10 @@ import org.hisp.dhis.user.UserAccountExpiryInfo;
 import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.lang.String.format;
 
 /**
  * Sends an email alert to all users that are soon to expire due to an account
@@ -84,8 +84,7 @@ public class AccountExpiryAlertJob implements Job
         return null;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         if ( systemSettingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRY_ALERT, Boolean.class ) == Boolean.FALSE )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -27,7 +27,15 @@
  */
 package org.hisp.dhis.user.job;
 
+import static java.time.ZoneId.systemDefault;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.email.EmailService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -37,13 +45,6 @@ import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.UserService;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.util.Date;
-import java.util.Set;
-
-import static java.time.ZoneId.systemDefault;
 
 /**
  * @author Jan Bernitt
@@ -64,7 +65,8 @@ public class DisableInactiveUsersJob implements Job
         return JobType.DISABLE_INACTIVE_USERS;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         DisableInactiveUsersJobParameters parameters = (DisableInactiveUsersJobParameters) jobConfiguration
             .getJobParameters();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -27,23 +27,23 @@
  */
 package org.hisp.dhis.user.job;
 
-import static java.time.ZoneId.systemDefault;
+import lombok.AllArgsConstructor;
+import org.hisp.dhis.email.EmailService;
+import org.hisp.dhis.scheduling.Job;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
+import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.user.UserService;
+import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Set;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.email.EmailService;
-import org.hisp.dhis.scheduling.Job;
-import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.JobType;
-import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
-import org.hisp.dhis.system.notification.Notifier;
-import org.hisp.dhis.user.UserService;
-import org.springframework.stereotype.Component;
+import static java.time.ZoneId.systemDefault;
 
 /**
  * @author Jan Bernitt
@@ -64,8 +64,7 @@ public class DisableInactiveUsersJob implements Job
         return JobType.DISABLE_INACTIVE_USERS;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         DisableInactiveUsersJobParameters parameters = (DisableInactiveUsersJobParameters) jobConfiguration
             .getJobParameters();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -27,15 +27,6 @@
  */
 package org.hisp.dhis.fileresource;
 
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
-
 import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.ValueType;
@@ -51,6 +42,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.User;
@@ -65,6 +57,15 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Kristian Wærstad
@@ -147,7 +148,7 @@ public class FileResourceCleanUpJobTest
 
         dataValueService.deleteDataValue( dataValueA );
 
-        cleanUpJob.execute( null );
+        cleanUpJob.execute( null, NoopJobProgress.INSTANCE );
 
         assertNull( fileResourceService.getFileResource( dataValueA.getValue() ) );
     }
@@ -178,7 +179,7 @@ public class FileResourceCleanUpJobTest
         audit.setCreated( getDate( 2000, 1, 1 ) );
         dataValueAuditStore.updateDataValueAudit( audit );
 
-        cleanUpJob.execute( null );
+        cleanUpJob.execute( null, NoopJobProgress.INSTANCE );
 
         assertNotNull( fileResourceService.getFileResource( dataValueA.getValue() ) );
         assertTrue( fileResourceService.getFileResource( dataValueA.getValue() ).isAssigned() );
@@ -212,7 +213,7 @@ public class FileResourceCleanUpJobTest
         assertNotNull( fileResourceService.getFileResource( uidA ) );
         assertNotNull( fileResourceService.getFileResource( uidB ) );
 
-        cleanUpJob.execute( null );
+        cleanUpJob.execute( null, NoopJobProgress.INSTANCE );
 
         assertNull( fileResourceService.getFileResource( uidA ) );
         assertNotNull( fileResourceService.getFileResource( uidB ) );
@@ -239,7 +240,7 @@ public class FileResourceCleanUpJobTest
         ex.getFileResource().setAssigned( false );
         fileResourceService.updateFileResource( ex.getFileResource() );
 
-        cleanUpJob.execute( null );
+        cleanUpJob.execute( null, NoopJobProgress.INSTANCE );
 
         assertNotNull( externalFileResourceService.getExternalFileResourceByAccessToken( ex.getAccessToken() ) );
         assertNotNull( fileResourceService.getFileResource( uid ) );
@@ -260,7 +261,7 @@ public class FileResourceCleanUpJobTest
         ex.getFileResource().setStorageStatus( FileResourceStorageStatus.PENDING );
         fileResourceService.updateFileResource( ex.getFileResource() );
 
-        cleanUpJob.execute( null );
+        cleanUpJob.execute( null, NoopJobProgress.INSTANCE );
 
         assertNull( externalFileResourceService.getExternalFileResourceByAccessToken( ex.getAccessToken() ) );
         assertNull( fileResourceService.getFileResource( uid ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/FileResourceCleanUpJobTest.java
@@ -27,6 +27,15 @@
  */
 package org.hisp.dhis.fileresource;
 
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
 import org.hisp.dhis.IntegrationTestBase;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.common.ValueType;
@@ -57,15 +66,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.nio.charset.StandardCharsets;
-import java.util.Date;
-
-import static junit.framework.TestCase.assertNotNull;
-import static junit.framework.TestCase.assertNull;
-import static junit.framework.TestCase.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Kristian Wærstad

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/JobConfigurationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/JobConfigurationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,24 +27,24 @@
  */
 package org.hisp.dhis.scheduling;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.scheduling.parameters.MockJobParameters;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Henning Håkonsen
  */
-public class JobConfigurationServiceTest
-    extends DhisSpringTest
+class JobConfigurationServiceTest extends DhisSpringTest
 {
+
     private static final String CRON_EVERY_MIN = "0 * * ? * *";
 
     @Autowired
@@ -60,60 +60,50 @@ public class JobConfigurationServiceTest
     {
         jobA = new JobConfiguration( "jobA", JobType.MOCK, CRON_EVERY_MIN, new MockJobParameters( "test" ) );
         jobB = new JobConfiguration( "jobB", JobType.DATA_INTEGRITY, CRON_EVERY_MIN, null );
-
         jobConfigurationService.addJobConfiguration( jobA );
         jobConfigurationService.addJobConfiguration( jobB );
     }
 
     @Test
-    public void testGetJobTypeInfo()
+    void testGetJobTypeInfo()
     {
         List<JobTypeInfo> jobTypes = jobConfigurationService.getJobTypeInfo();
-
         assertNotNull( jobTypes );
         assertFalse( jobTypes.isEmpty() );
-
-        JobTypeInfo jobType = jobTypes.stream()
-            .filter( j -> j.getJobType() == JobType.CONTINUOUS_ANALYTICS_TABLE )
+        JobTypeInfo jobType = jobTypes.stream().filter( j -> j.getJobType() == JobType.CONTINUOUS_ANALYTICS_TABLE )
             .findFirst().get();
-
         assertNotNull( jobType );
         assertEquals( JobType.CONTINUOUS_ANALYTICS_TABLE.getSchedulingType(), jobType.getSchedulingType() );
     }
 
     @Test
-    public void testGetJob()
+    void testGetJob()
     {
         List<JobConfiguration> jobConfigurationList = jobConfigurationService.getAllJobConfigurations();
-        assertEquals( "The number of job configurations does not match", 2, jobConfigurationList.size() );
-
+        assertEquals( 2, jobConfigurationList.size(), "The number of job configurations does not match" );
         assertEquals( JobType.MOCK, jobConfigurationService.getJobConfigurationByUid( jobA.getUid() ).getJobType() );
         MockJobParameters jobParameters = (MockJobParameters) jobConfigurationService
             .getJobConfigurationByUid( jobA.getUid() ).getJobParameters();
-
         assertNotNull( jobParameters );
         assertEquals( "test", jobParameters.getMessage() );
-
         assertEquals( JobType.DATA_INTEGRITY,
             jobConfigurationService.getJobConfigurationByUid( jobB.getUid() ).getJobType() );
         assertNull( jobConfigurationService.getJobConfigurationByUid( jobB.getUid() ).getJobParameters() );
     }
 
     @Test
-    public void testUpdateJob()
+    void testUpdateJob()
     {
         JobConfiguration test = jobConfigurationService.getJobConfigurationByUid( jobA.getUid() );
         test.setName( "testUpdate" );
         jobConfigurationService.updateJobConfiguration( test );
-
         assertEquals( "testUpdate", jobConfigurationService.getJobConfigurationByUid( jobA.getUid() ).getName() );
     }
 
     @Test
-    public void testDeleteJob()
+    void testDeleteJob()
     {
         jobConfigurationService.deleteJobConfiguration( jobA );
-
         assertNull( jobConfigurationService.getJobConfigurationByUid( jobA.getUid() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/JobConfigurationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/JobConfigurationServiceTest.java
@@ -27,22 +27,22 @@
  */
 package org.hisp.dhis.scheduling;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.scheduling.parameters.MockJobParameters;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Henning Håkonsen
  */
-class JobConfigurationServiceTest extends DhisSpringTest
+public class JobConfigurationServiceTest extends DhisSpringTest
 {
 
     private static final String CRON_EVERY_MIN = "0 * * ? * *";
@@ -65,7 +65,7 @@ class JobConfigurationServiceTest extends DhisSpringTest
     }
 
     @Test
-    void testGetJobTypeInfo()
+    public void testGetJobTypeInfo()
     {
         List<JobTypeInfo> jobTypes = jobConfigurationService.getJobTypeInfo();
         assertNotNull( jobTypes );
@@ -77,10 +77,10 @@ class JobConfigurationServiceTest extends DhisSpringTest
     }
 
     @Test
-    void testGetJob()
+    public void testGetJob()
     {
         List<JobConfiguration> jobConfigurationList = jobConfigurationService.getAllJobConfigurations();
-        assertEquals( 2, jobConfigurationList.size(), "The number of job configurations does not match" );
+        assertEquals( "The number of job configurations does not match", 2, jobConfigurationList.size() );
         assertEquals( JobType.MOCK, jobConfigurationService.getJobConfigurationByUid( jobA.getUid() ).getJobType() );
         MockJobParameters jobParameters = (MockJobParameters) jobConfigurationService
             .getJobConfigurationByUid( jobA.getUid() ).getJobParameters();
@@ -92,7 +92,7 @@ class JobConfigurationServiceTest extends DhisSpringTest
     }
 
     @Test
-    void testUpdateJob()
+    public void testUpdateJob()
     {
         JobConfiguration test = jobConfigurationService.getJobConfigurationByUid( jobA.getUid() );
         test.setName( "testUpdate" );
@@ -101,7 +101,7 @@ class JobConfigurationServiceTest extends DhisSpringTest
     }
 
     @Test
-    void testDeleteJob()
+    public void testDeleteJob()
     {
         jobConfigurationService.deleteJobConfiguration( jobA );
         assertNull( jobConfigurationService.getJobConfigurationByUid( jobA.getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -60,8 +60,8 @@ import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.TaskScheduler;
@@ -75,13 +75,13 @@ import org.springframework.util.concurrent.SuccessCallback;
  * Since most test setups run with a mock {@link SchedulingManager}
  * implementation this test focuses on testing the
  * {@link DefaultSchedulingManager} implementation.
- *
+ * <p>
  * This does not run any actual {@link Job} but checks that the ceremony around
  * running them works.
  *
  * @author Jan Bernitt
  */
-class SchedulingManagerTest
+public class SchedulingManagerTest
 {
 
     private final TaskScheduler taskScheduler = mock( TaskScheduler.class );
@@ -94,8 +94,8 @@ class SchedulingManagerTest
 
     private DefaultSchedulingManager schedulingManager;
 
-    @BeforeEach
-    void setUp()
+    @Before
+    public void setUp()
     {
         when( applicationContext.getBeansOfType( any() ) ).thenReturn( Collections.singletonMap( "test", job ) );
 
@@ -110,7 +110,7 @@ class SchedulingManagerTest
     }
 
     @Test
-    void testScheduleRunCronJob()
+    public void testScheduleRunCronJob()
     {
         JobConfiguration configuration = createCronJonConfiguration();
         when( job.getJobType() ).thenReturn( configuration.getJobType() );
@@ -122,7 +122,7 @@ class SchedulingManagerTest
     }
 
     @Test
-    void testScheduleRunFixedDelayJob()
+    public void testScheduleRunFixedDelayJob()
     {
         JobConfiguration configuration = createFixedDelayJobConfiguration();
         when( job.getJobType() ).thenReturn( configuration.getJobType() );
@@ -136,7 +136,7 @@ class SchedulingManagerTest
     }
 
     @Test
-    void testScheduleRunWithStartTimeJob()
+    public void testScheduleRunWithStartTimeJob()
     {
         JobConfiguration configuration = createStartTimeJobConfiguration();
         when( job.getJobType() ).thenReturn( configuration.getJobType() );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,10 @@ package org.hisp.dhis.scheduling;
 
 import static org.hisp.dhis.common.CodeGenerator.generateUid;
 import static org.hisp.dhis.commons.util.CronUtils.getDailyCronExpression;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -52,13 +52,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.hisp.dhis.cache.CacheProvider;
+import org.hisp.dhis.cache.TestCache;
 import org.hisp.dhis.common.AsyncTaskExecutor;
 import org.hisp.dhis.leader.election.LeaderManager;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
-import org.junit.Before;
-import org.junit.Test;
+import org.hisp.dhis.system.notification.Notifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.TaskScheduler;
@@ -78,7 +81,7 @@ import org.springframework.util.concurrent.SuccessCallback;
  *
  * @author Jan Bernitt
  */
-public class SchedulingManagerTest
+class SchedulingManagerTest
 {
 
     private final TaskScheduler taskScheduler = mock( TaskScheduler.class );
@@ -91,60 +94,56 @@ public class SchedulingManagerTest
 
     private DefaultSchedulingManager schedulingManager;
 
-    @Before
-    public void setUp()
+    @BeforeEach
+    void setUp()
     {
         when( applicationContext.getBeansOfType( any() ) ).thenReturn( Collections.singletonMap( "test", job ) );
 
+        CacheProvider cacheProvider = mock( CacheProvider.class );
+        when( cacheProvider.createJobCancelRequestedCache() ).thenReturn( new TestCache<>() );
+        when( cacheProvider.createRunningJobsInfoCache() ).thenReturn( new TestCache<>() );
+        when( cacheProvider.createCompletedJobsInfoCache() ).thenReturn( new TestCache<>() );
+
         schedulingManager = new DefaultSchedulingManager( new DefaultJobService( applicationContext ),
-            jobConfigurationService, mock( MessageService.class ),
-            mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ) );
+            jobConfigurationService, mock( MessageService.class ), mock( Notifier.class ),
+            mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ), cacheProvider );
     }
 
     @Test
-    public void testScheduleRunCronJob()
+    void testScheduleRunCronJob()
     {
         JobConfiguration configuration = createCronJonConfiguration();
         when( job.getJobType() ).thenReturn( configuration.getJobType() );
         when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
-
         ArgumentCaptor<Runnable> cronTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.schedule( cronTask.capture(), any( Trigger.class ) ) ).thenReturn( new MockFuture<>() );
-
         schedulingManager.schedule( configuration );
-
         assertScheduledJob( configuration, SchedulingManagerTest::createCronJonConfiguration, cronTask.getValue() );
     }
 
     @Test
-    public void testScheduleRunFixedDelayJob()
+    void testScheduleRunFixedDelayJob()
     {
         JobConfiguration configuration = createFixedDelayJobConfiguration();
         when( job.getJobType() ).thenReturn( configuration.getJobType() );
         when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
-
         ArgumentCaptor<Runnable> delayTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.scheduleWithFixedDelay( delayTask.capture(), any( Instant.class ), any( Duration.class ) ) )
             .thenReturn( new MockFuture<>() );
-
         schedulingManager.schedule( configuration );
-
         assertScheduledJob( configuration, SchedulingManagerTest::createFixedDelayJobConfiguration,
             delayTask.getValue() );
     }
 
     @Test
-    public void testScheduleRunWithStartTimeJob()
+    void testScheduleRunWithStartTimeJob()
     {
         JobConfiguration configuration = createStartTimeJobConfiguration();
         when( job.getJobType() ).thenReturn( configuration.getJobType() );
         when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
-
         ArgumentCaptor<Runnable> startTimeTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.schedule( startTimeTask.capture(), any( Date.class ) ) ).thenReturn( new MockFuture<>() );
-
         schedulingManager.scheduleWithStartTime( configuration, new Date() );
-
         assertScheduledJob( configuration, SchedulingManagerTest::createStartTimeJobConfiguration,
             startTimeTask.getValue() );
     }
@@ -175,7 +174,7 @@ public class SchedulingManagerTest
 
     private void assertScheduledJob( JobConfiguration configuration, Supplier<JobConfiguration> copy, Runnable task )
     {
-        assertNotNull( "job was not scheduled", task );
+        assertNotNull( task, "job was not scheduled" );
         assertScheduledJobCompletes( configuration, task );
         assertScheduledJobDoesNotStartWhenAlreadyRunning( configuration, task );
         assertScheduledJobStops( configuration, task );
@@ -187,17 +186,16 @@ public class SchedulingManagerTest
     private void assertScheduledJobCompletes( JobConfiguration configuration, Runnable task )
     {
         setUpJobExecute( this::assertIsRunning );
-
-        task.run(); // synchronously
-
+        // synchronously
+        task.run();
         verify( applicationContext, atLeastOnce() ).getBeansOfType( any() );
         if ( !configuration.isInMemoryJob() )
         {
             assertEquals( JobStatus.COMPLETED, configuration.getLastExecutedStatus() );
-            assertNotNull( "job did not complete", configuration.getLastExecuted() );
+            assertNotNull( configuration.getLastExecuted(), "job did not complete" );
         }
-        assertFalse( "job is still considered running when it is actually finished",
-            schedulingManager.isRunning( configuration.getJobType() ) );
+        assertFalse( schedulingManager.isRunning( configuration.getJobType() ),
+            "job is still considered running when it is actually finished" );
     }
 
     private void assertIsRunning( JobConfiguration configuration )
@@ -209,9 +207,8 @@ public class SchedulingManagerTest
     private void assertScheduledJobDoesNotStartWhenAlreadyRunning( JobConfiguration configuration, Runnable task )
     {
         setUpJobExecute( jobConfiguration -> assertFalse( schedulingManager.executeNow( configuration ) ) );
-
-        task.run(); // synchronously
-
+        // synchronously
+        task.run();
         assertTrue( schedulingManager.executeNow( configuration ) );
     }
 
@@ -219,9 +216,8 @@ public class SchedulingManagerTest
     {
         // once running the job stops itself
         setUpJobExecute( jobConfiguration -> schedulingManager.stop( jobConfiguration ) );
-
-        task.run(); // synchronously
-
+        // synchronously
+        task.run();
         assertEquals( JobStatus.STOPPED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
     }
@@ -229,9 +225,8 @@ public class SchedulingManagerTest
     private void assertScheduledJobStopWhenInterrupted( JobConfiguration configuration, Runnable task )
     {
         setUpJobExecute( jobConfiguration -> Thread.currentThread().interrupt() );
-
-        task.run(); // synchronously
-
+        // synchronously
+        task.run();
         assertEquals( JobStatus.STOPPED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
     }
@@ -241,9 +236,8 @@ public class SchedulingManagerTest
         setUpJobExecute( jobConfiguration -> {
             throw new IllegalStateException( "Something goes wrong while doing the work..." );
         } );
-
-        task.run(); // synchronously
-
+        // synchronously
+        task.run();
         assertEquals( JobStatus.FAILED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
     }
@@ -259,9 +253,8 @@ public class SchedulingManagerTest
                 persistent.setJobStatus( JobStatus.DISABLED );
                 when( jobConfigurationService.getJobConfigurationByUid( anyString() ) ).thenReturn( persistent );
             } );
-
-            task.run(); // synchronously
-
+            // synchronously
+            task.run();
             assertEquals( JobStatus.DISABLED, configuration.getJobStatus() );
             assertFalse( configuration.isEnabled() );
         }
@@ -272,7 +265,7 @@ public class SchedulingManagerTest
         doAnswer( invocation -> {
             execute.accept( invocation.getArgument( 0, JobConfiguration.class ) );
             return null;
-        } ).when( job ).execute( any( JobConfiguration.class ) );
+        } ).when( job ).execute( any( JobConfiguration.class ), any( JobProgress.class ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
@@ -27,6 +27,17 @@
  */
 package org.hisp.dhis.user.job;
 
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Date;
+
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
@@ -39,17 +50,6 @@ import org.hisp.dhis.user.UserService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-
-import java.sql.Date;
-
-import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@link AccountExpiryAlertJob} using mocks to only test the logic of

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/job/AccountExpiryAlertJobTest.java
@@ -27,6 +27,21 @@
  */
 package org.hisp.dhis.user.job;
 
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.NoopJobProgress;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.UserAccountExpiryInfo;
+import org.hisp.dhis.user.UserService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.sql.Date;
+
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -35,20 +50,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.sql.Date;
-
-import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.message.MessageSender;
-import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.setting.SettingKey;
-import org.hisp.dhis.setting.SystemSettingManager;
-import org.hisp.dhis.user.UserAccountExpiryInfo;
-import org.hisp.dhis.user.UserService;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 /**
  * Tests the {@link AccountExpiryAlertJob} using mocks to only test the logic of
@@ -80,7 +81,7 @@ public class AccountExpiryAlertJobTest
     {
         when( settingManager.getSystemSetting( SettingKey.ACCOUNT_EXPIRY_ALERT, Boolean.class ) ).thenReturn( false );
 
-        job.execute( new JobConfiguration() );
+        job.execute( new JobConfiguration(), NoopJobProgress.INSTANCE );
 
         verify( userService, never() ).getExpiringUserAccounts( anyInt() );
     }
@@ -92,7 +93,7 @@ public class AccountExpiryAlertJobTest
             .thenReturn( singletonList( new UserAccountExpiryInfo( "username", "email@example.com",
                 Date.valueOf( "2021-08-23" ) ) ) );
 
-        job.execute( new JobConfiguration() );
+        job.execute( new JobConfiguration(), NoopJobProgress.INSTANCE );
 
         ArgumentCaptor<String> subject = ArgumentCaptor.forClass( String.class );
         ArgumentCaptor<String> text = ArgumentCaptor.forClass( String.class );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -27,7 +27,14 @@
  */
 package org.hisp.dhis.dxf2.metadata.jobs;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncParams;
 import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPostProcessor;
@@ -48,12 +55,6 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * This is the runnable that takes care of the Metadata Synchronization.
@@ -133,7 +134,8 @@ public class MetadataSyncJob extends SynchronizationJob
         return JobType.META_DATA_SYNC;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         log.info( "Metadata Sync cron Job started" );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/jobs/MetadataSyncJob.java
@@ -27,16 +27,13 @@
  */
 package org.hisp.dhis.dxf2.metadata.jobs;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
-import org.hisp.dhis.dxf2.metadata.sync.*;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncParams;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPostProcessor;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncPreProcessor;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncService;
+import org.hisp.dhis.dxf2.metadata.sync.MetadataSyncSummary;
 import org.hisp.dhis.dxf2.metadata.sync.exception.DhisVersionMismatchException;
 import org.hisp.dhis.dxf2.metadata.sync.exception.MetadataSyncServiceException;
 import org.hisp.dhis.dxf2.sync.SynchronizationJob;
@@ -44,12 +41,19 @@ import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.MetadataSyncJobParameters;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * This is the runnable that takes care of the Metadata Synchronization.
@@ -129,8 +133,7 @@ public class MetadataSyncJob extends SynchronizationJob
         return JobType.META_DATA_SYNC;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         log.info( "Metadata Sync cron Job started" );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventProgramsDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventProgramsDataSynchronizationJob.java
@@ -27,7 +27,12 @@
  */
 package org.hisp.dhis.dxf2.sync;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageService;
@@ -37,10 +42,6 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author David Katuscak <katuscak.d@gmail.com>
@@ -76,7 +77,8 @@ public class EventProgramsDataSynchronizationJob extends SynchronizationJob
         return JobType.EVENT_PROGRAMS_DATA_SYNC;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         try
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventProgramsDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventProgramsDataSynchronizationJob.java
@@ -27,20 +27,20 @@
  */
 package org.hisp.dhis.dxf2.sync;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Optional;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.EventProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author David Katuscak <katuscak.d@gmail.com>
@@ -76,8 +76,7 @@ public class EventProgramsDataSynchronizationJob extends SynchronizationJob
         return JobType.EVENT_PROGRAMS_DATA_SYNC;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         try
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerProgramsDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerProgramsDataSynchronizationJob.java
@@ -27,20 +27,20 @@
  */
 package org.hisp.dhis.dxf2.sync;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Optional;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author David Katuscak <katuscak.d@gmail.com>
@@ -76,8 +76,7 @@ public class TrackerProgramsDataSynchronizationJob extends SynchronizationJob
         return JobType.TRACKER_PROGRAMS_DATA_SYNC;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         try
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerProgramsDataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerProgramsDataSynchronizationJob.java
@@ -27,7 +27,12 @@
  */
 package org.hisp.dhis.dxf2.sync;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.dxf2.synch.SynchronizationManager;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageService;
@@ -37,10 +42,6 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author David Katuscak <katuscak.d@gmail.com>
@@ -76,7 +77,8 @@ public class TrackerProgramsDataSynchronizationJob extends SynchronizationJob
         return JobType.TRACKER_PROGRAMS_DATA_SYNC;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         try
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.dxf2.synch;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
+
 import org.hisp.dhis.dxf2.sync.CompleteDataSetRegistrationSynchronization;
 import org.hisp.dhis.dxf2.sync.DataValueSynchronization;
 import org.hisp.dhis.dxf2.sync.SynchronizationJob;
@@ -37,10 +41,6 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -82,7 +82,8 @@ public class DataSynchronizationJob extends SynchronizationJob
         return JobType.DATA_SYNC;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         DataSynchronizationJobParameters jobParameters = (DataSynchronizationJobParameters) jobConfiguration
             .getJobParameters();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/synch/DataSynchronizationJob.java
@@ -27,19 +27,20 @@
  */
 package org.hisp.dhis.dxf2.synch;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Optional;
-
 import org.hisp.dhis.dxf2.sync.CompleteDataSetRegistrationSynchronization;
 import org.hisp.dhis.dxf2.sync.DataValueSynchronization;
 import org.hisp.dhis.dxf2.sync.SynchronizationJob;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Lars Helge Overland
@@ -81,8 +82,7 @@ public class DataSynchronizationJob extends SynchronizationJob
         return JobType.DATA_SYNC;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         DataSynchronizationJobParameters jobParameters = (DataSynchronizationJobParameters) jobConfiguration
             .getJobParameters();

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
@@ -27,7 +27,15 @@
  */
 package org.hisp.dhis.credentials;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
@@ -43,13 +51,6 @@ import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Created by zubair on 29.03.17.
@@ -96,7 +97,8 @@ public class CredentialsExpiryAlertJob implements Job
         return JobType.CREDENTIALS_EXPIRY_ALERT;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         boolean isExpiryAlertEnabled = (Boolean) systemSettingManager
             .getSystemSetting( SettingKey.CREDENTIALS_EXPIRY_ALERT );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
@@ -27,20 +27,13 @@
  */
 package org.hisp.dhis.credentials;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -50,6 +43,13 @@ import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Created by zubair on 29.03.17.
@@ -96,8 +96,7 @@ public class CredentialsExpiryAlertJob implements Job
         return JobType.CREDENTIALS_EXPIRY_ALERT;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         boolean isExpiryAlertEnabled = (Boolean) systemSettingManager
             .getSystemSetting( SettingKey.CREDENTIALS_EXPIRY_ALERT );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsJob.java
@@ -27,14 +27,15 @@
  */
 package org.hisp.dhis.datastatistics;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Yrjan A. F. Fraschetti
@@ -62,7 +63,8 @@ public class DataStatisticsJob implements Job
         return JobType.DATA_STATISTICS;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         long id = dataStatisticsService.saveDataStatisticsSnapshot();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsJob.java
@@ -27,14 +27,14 @@
  */
 package org.hisp.dhis.datastatistics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.springframework.stereotype.Component;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Yrjan A. F. Fraschetti
@@ -62,8 +62,7 @@ public class DataStatisticsJob implements Job
         return JobType.DATA_STATISTICS;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         long id = dataStatisticsService.saveDataStatisticsSnapshot();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictorJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictorJob.java
@@ -27,13 +27,14 @@
  */
 package org.hisp.dhis.predictor;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.springframework.stereotype.Component;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Henning Håkonsen
@@ -56,8 +57,7 @@ public class PredictorJob implements Job
         return JobType.PREDICTOR;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         PredictorJobParameters predictorJobParameters = (PredictorJobParameters) jobConfiguration.getJobParameters();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictorJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictorJob.java
@@ -27,14 +27,14 @@
  */
 package org.hisp.dhis.predictor;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Henning Håkonsen
@@ -57,7 +57,8 @@ public class PredictorJob implements Job
         return JobType.PREDICTOR;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         PredictorJobParameters predictorJobParameters = (PredictorJobParameters) jobConfiguration.getJobParameters();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/PushAnalysisJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/PushAnalysisJob.java
@@ -27,14 +27,15 @@
  */
 package org.hisp.dhis.pushanalysis.scheduling;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.hisp.dhis.pushanalysis.PushAnalysisService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.springframework.stereotype.Component;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Stian Sandvold
@@ -60,8 +61,7 @@ public class PushAnalysisJob implements Job
         return JobType.PUSH_ANALYSIS;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         PushAnalysisJobParameters parameters = (PushAnalysisJobParameters) jobConfiguration.getJobParameters();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/PushAnalysisJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/PushAnalysisJob.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.pushanalysis.scheduling;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.hisp.dhis.pushanalysis.PushAnalysisService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -34,8 +36,6 @@ import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.springframework.stereotype.Component;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Stian Sandvold
@@ -61,7 +61,8 @@ public class PushAnalysisJob implements Job
         return JobType.PUSH_ANALYSIS;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         PushAnalysisJobParameters parameters = (PushAnalysisJobParameters) jobConfiguration.getJobParameters();
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
@@ -27,8 +27,16 @@
  */
 package org.hisp.dhis.validation.scheduling;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.hisp.dhis.message.MessageService;
@@ -49,15 +57,8 @@ import org.hisp.dhis.validation.ValidationService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
-import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 /**
  * @author Lars Helge Overland

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
@@ -27,16 +27,8 @@
  */
 package org.hisp.dhis.validation.scheduling;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
-import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
-
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.hisp.dhis.message.MessageService;
@@ -44,6 +36,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
@@ -56,8 +49,15 @@ import org.hisp.dhis.validation.ValidationService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
+import static org.hisp.dhis.system.notification.NotificationLevel.INFO;
 
 /**
  * @author Lars Helge Overland
@@ -104,7 +104,7 @@ public class MonitoringJob implements Job
 
     @Override
     @Transactional
-    public void execute( JobConfiguration jobConfiguration )
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         notifier.clear( jobConfiguration ).notify( jobConfiguration, "Monitoring data" );
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/ValidationResultNotificationJob.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/ValidationResultNotificationJob.java
@@ -27,17 +27,18 @@
  */
 package org.hisp.dhis.validation.notification;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Stian Sandvold
@@ -73,8 +74,7 @@ public class ValidationResultNotificationJob implements Job
         return JobType.VALIDATION_RESULTS_NOTIFICATION;
     }
 
-    @Override
-    public void execute( JobConfiguration jobConfiguration )
+    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         final Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/ValidationResultNotificationJob.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/ValidationResultNotificationJob.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.validation.notification;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -37,8 +39,6 @@ import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.Clock;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Stian Sandvold
@@ -74,7 +74,8 @@ public class ValidationResultNotificationJob implements Job
         return JobType.VALIDATION_RESULTS_NOTIFICATION;
     }
 
-    @Override public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
         final Clock clock = new Clock().startClock();
 

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/ListUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/ListUtils.java
@@ -27,9 +27,16 @@
  */
 package org.hisp.dhis.commons.collection;
 
-import java.util.*;
-
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Utility methods for list operations.
@@ -163,11 +170,11 @@ public class ListUtils
     /**
      * Returns the duplicates in the given list.
      *
-     * @param <T> type.
+     * @param <T>  type.
      * @param list the list.
      * @return a set of duplicates from the given list.
      */
-    public static <T> Set<T> getDuplicates( List<T> list )
+    public static <T> Set<T> getDuplicates( Collection<T> list )
     {
         Set<T> duplicates = new HashSet<>();
         UniqueArrayList<T> uniqueElements = new UniqueArrayList<>();

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/ListUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/ListUtils.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.commons.collection;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,6 +35,8 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utility methods for list operations.
@@ -170,7 +170,7 @@ public class ListUtils
     /**
      * Returns the duplicates in the given list.
      *
-     * @param <T>  type.
+     * @param <T> type.
      * @param list the list.
      * @return a set of duplicates from the given list.
      */

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
@@ -48,6 +48,7 @@ public class DhisPostgresDialect
         super();
         registerColumnType( Types.JAVA_OBJECT, "jsonb" );
         registerHibernateType( Types.OTHER, "pg-uuid" );
+        registerHibernateType( Types.ARRAY, StringArrayType.class.getName() );
         registerFunction( JsonbFunctions.EXTRACT_PATH,
             new StandardSQLFunction( JsonbFunctions.EXTRACT_PATH, StandardBasicTypes.STRING ) );
         registerFunction( JsonbFunctions.EXTRACT_PATH_TEXT,

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -114,6 +114,12 @@ public interface CacheProvider
 
     <V> Cache<V> createApiKeyCache();
 
+    <V> Cache<V> createRunningJobsInfoCache();
+
+    <V> Cache<V> createCompletedJobsInfoCache();
+
+    <V> Cache<V> createJobCancelRequestedCache();
+
     <V> Cache<V> createDataIntegritySummaryCache();
 
     <V> Cache<V> createDataIntegrityDetailsCache();

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.cache;
 
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
-
 import java.time.Duration;
+
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 
 /**
  * The {@link CacheProvider} has a factory method for each {@link Cache} use

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CacheProvider.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.cache;
 
-import java.time.Duration;
-
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+
+import java.time.Duration;
 
 /**
  * The {@link CacheProvider} has a factory method for each {@link Cache} use
@@ -113,4 +113,8 @@ public interface CacheProvider
     <V> Cache<V> createCatOptOrgUnitAssociationCache();
 
     <V> Cache<V> createApiKeyCache();
+
+    <V> Cache<V> createDataIntegritySummaryCache();
+
+    <V> Cache<V> createDataIntegrityDetailsCache();
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/CappedLocalCache.java
@@ -27,15 +27,10 @@
  */
 package org.hisp.dhis.cache;
 
-import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Hibernate;
-import org.hisp.dhis.cache.CacheInfo.CacheBurdenInfo;
-import org.hisp.dhis.cache.CacheInfo.CacheCapInfo;
-import org.hisp.dhis.cache.CacheInfo.CacheGroupInfo;
-import org.hisp.dhis.external.conf.ConfigurationKey;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import static java.lang.Integer.parseInt;
+import static java.lang.Math.max;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.unmodifiableSet;
 
 import java.util.ArrayList;
 import java.util.Deque;
@@ -53,10 +48,16 @@ import java.util.function.LongConsumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
-import static java.lang.Integer.parseInt;
-import static java.lang.Math.max;
-import static java.lang.System.currentTimeMillis;
-import static java.util.Collections.unmodifiableSet;
+import lombok.extern.slf4j.Slf4j;
+
+import org.hibernate.Hibernate;
+import org.hisp.dhis.cache.CacheInfo.CacheBurdenInfo;
+import org.hisp.dhis.cache.CacheInfo.CacheCapInfo;
+import org.hisp.dhis.cache.CacheInfo.CacheGroupInfo;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 /**
  * The {@link CappedLocalCache} is a multi-region cache that tries to estimate

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -27,21 +27,22 @@
  */
 package org.hisp.dhis.cache;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
-
-import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
 
 /**
  * The {@link DefaultCacheProvider} has the specific configuration for each of
@@ -118,7 +119,9 @@ public class DefaultCacheProvider
         programStageWebHookNotificationTemplateCache,
         pgmOrgUnitAssocCache,
         catOptOrgUnitAssocCache,
-        apiTokensCache
+        apiTokensCache,
+        dataIntegritySummaryCache,
+        dataIntegrityDetailsCache
     }
 
     private final Map<String, Cache<?>> allCaches = new ConcurrentHashMap<>();
@@ -504,11 +507,27 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createApiKeyCache()
     {
-        return registerCache( this.<V> newBuilder()
+        return registerCache( this.<V>newBuilder()
             .forRegion( Region.apiTokensCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) ) );
+    }
+
+    @Override
+    public <V> Cache<V> createDataIntegritySummaryCache()
+    {
+        return registerCache( this.<V>newBuilder()
+            .forRegion( Region.dataIntegritySummaryCache.name() )
+            .expireAfterWrite( 1, HOURS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createDataIntegrityDetailsCache()
+    {
+        return registerCache( this.<V>newBuilder()
+            .forRegion( Region.dataIntegrityDetailsCache.name() )
+            .expireAfterWrite( 1, HOURS ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -27,23 +27,23 @@
  */
 package org.hisp.dhis.cache;
 
-import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
-import org.hisp.dhis.external.conf.ConfigurationKey;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.springframework.context.event.EventListener;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
 
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import static java.util.concurrent.TimeUnit.HOURS;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
+import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
 
 /**
  * The {@link DefaultCacheProvider} has the specific configuration for each of
@@ -511,7 +511,7 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createApiKeyCache()
     {
-        return registerCache( this.<V>newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.apiTokensCache.name() )
             .expireAfterWrite( 1, TimeUnit.HOURS )
             .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
@@ -522,7 +522,7 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createRunningJobsInfoCache()
     {
-        return registerCache( this.<V>newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.runningJobsInfo.name() )
             .expireAfterWrite( 60, SECONDS ) );
     }
@@ -530,7 +530,7 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createCompletedJobsInfoCache()
     {
-        return registerCache( this.<V>newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.completedJobsInfo.name() )
             .expireAfterWrite( 60, SECONDS ) );
     }
@@ -538,7 +538,7 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createJobCancelRequestedCache()
     {
-        return registerCache( this.<V>newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.jobCancelRequested.name() )
             .expireAfterWrite( 60, SECONDS ) );
     }
@@ -546,7 +546,7 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createDataIntegritySummaryCache()
     {
-        return registerCache( this.<V>newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.dataIntegritySummaryCache.name() )
             .expireAfterWrite( 1, HOURS ) );
     }
@@ -554,7 +554,7 @@ public class DefaultCacheProvider
     @Override
     public <V> Cache<V> createDataIntegrityDetailsCache()
     {
-        return registerCache( this.<V>newBuilder()
+        return registerCache( this.<V> newBuilder()
             .forRegion( Region.dataIntegrityDetailsCache.name() )
             .expireAfterWrite( 1, HOURS ) );
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/DefaultCacheProvider.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hisp.dhis.commons.util.SystemUtils.isTestRun;
 
 /**
@@ -120,6 +121,9 @@ public class DefaultCacheProvider
         pgmOrgUnitAssocCache,
         catOptOrgUnitAssocCache,
         apiTokensCache,
+        runningJobsInfo,
+        completedJobsInfo,
+        jobCancelRequested,
         dataIntegritySummaryCache,
         dataIntegrityDetailsCache
     }
@@ -513,6 +517,30 @@ public class DefaultCacheProvider
             .withInitialCapacity( (int) getActualSize( SIZE_1K ) )
             .forceInMemory()
             .withMaximumSize( orZeroInTestRun( getActualSize( SIZE_10K ) ) ) );
+    }
+
+    @Override
+    public <V> Cache<V> createRunningJobsInfoCache()
+    {
+        return registerCache( this.<V>newBuilder()
+            .forRegion( Region.runningJobsInfo.name() )
+            .expireAfterWrite( 60, SECONDS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createCompletedJobsInfoCache()
+    {
+        return registerCache( this.<V>newBuilder()
+            .forRegion( Region.completedJobsInfo.name() )
+            .expireAfterWrite( 60, SECONDS ) );
+    }
+
+    @Override
+    public <V> Cache<V> createJobCancelRequestedCache()
+    {
+        return registerCache( this.<V>newBuilder()
+            .forRegion( Region.jobCancelRequested.name() )
+            .expireAfterWrite( 60, SECONDS ) );
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
@@ -27,8 +27,10 @@
  */
 package org.hisp.dhis.cache;
 
-import org.springframework.data.redis.core.BoundValueOperations;
-import org.springframework.data.redis.core.RedisTemplate;
+import static java.util.Collections.emptySet;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toSet;
+import static org.springframework.util.Assert.hasText;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,14 +38,12 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static java.util.Collections.emptySet;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toSet;
-import static org.springframework.util.Assert.hasText;
+import org.springframework.data.redis.core.BoundValueOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 
 /**
- * A redis backed implementation of {@link Cache}. This implementation uses a shared redis cache server for any number
- * of instances.
+ * A redis backed implementation of {@link Cache}. This implementation uses a
+ * shared redis cache server for any number of instances.
  *
  * @author Ameen Mohamed
  */

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/cache/RedisCache.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.cache;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.springframework.util.Assert.hasText;
+import org.springframework.data.redis.core.BoundValueOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 
 import java.util.List;
 import java.util.Optional;
@@ -36,16 +36,21 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import org.springframework.data.redis.core.RedisTemplate;
+import static java.util.Collections.emptySet;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toSet;
+import static org.springframework.util.Assert.hasText;
 
 /**
- * A redis backed implementation of {@link Cache}. This implementation uses a
- * shared redis cache server for any number of instances.
+ * A redis backed implementation of {@link Cache}. This implementation uses a shared redis cache server for any number
+ * of instances.
  *
  * @author Ameen Mohamed
  */
 public class RedisCache<V> implements Cache<V>
 {
+    private static final String VALUE_CANNOT_BE_NULL = "Value cannot be null";
+
     private RedisTemplate<String, V> redisTemplate;
 
     private boolean refreshExpriryOnAccess;
@@ -137,9 +142,22 @@ public class RedisCache<V> implements Cache<V>
     @Override
     public Stream<V> getAll()
     {
-        Set<String> keySet = redisTemplate.keys( cacheRegion + "*" );
+        Set<String> keySet = redisTemplate.keys( getAllKeysInRegionPattern() );
+        if ( keySet == null )
+        {
+            return Stream.empty();
+        }
         List<V> values = redisTemplate.opsForValue().multiGet( keySet );
         return values == null ? Stream.empty() : values.stream();
+    }
+
+    @Override
+    public Set<String> keys()
+    {
+        Set<String> keys = redisTemplate.keys( getAllKeysInRegionPattern() );
+        return keys == null
+            ? emptySet()
+            : keys.stream().map( key -> key.substring( key.indexOf( ':' ) + 1 ) ).collect( toSet() );
     }
 
     @Override
@@ -147,11 +165,10 @@ public class RedisCache<V> implements Cache<V>
     {
         if ( null == value )
         {
-            throw new IllegalArgumentException( "Value cannot be null" );
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
         }
 
         String redisKey = generateKey( key );
-
         if ( expiryEnabled )
         {
             redisTemplate.boundValueOps( redisKey ).set( value, expiryInSeconds, SECONDS );
@@ -165,11 +182,31 @@ public class RedisCache<V> implements Cache<V>
     @Override
     public void put( String key, V value, long ttlInSeconds )
     {
-        hasText( key, "Value cannot be null" );
+        hasText( key, VALUE_CANNOT_BE_NULL );
 
-        final String redisKey = generateKey( key );
+        String redisKey = generateKey( key );
 
         redisTemplate.boundValueOps( redisKey ).set( value, ttlInSeconds, SECONDS );
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        if ( null == value )
+        {
+            throw new IllegalArgumentException( VALUE_CANNOT_BE_NULL );
+        }
+        String redisKey = generateKey( key );
+
+        BoundValueOperations<String, V> ops = redisTemplate.boundValueOps( redisKey );
+        if ( expiryEnabled )
+        {
+            return ops.setIfAbsent( value, expiryInSeconds, SECONDS ) == Boolean.TRUE;
+        }
+        else
+        {
+            return ops.setIfAbsent( value ) == Boolean.TRUE;
+        }
     }
 
     @Override
@@ -183,10 +220,15 @@ public class RedisCache<V> implements Cache<V>
         return cacheRegion.concat( ":" ).concat( key );
     }
 
+    private String getAllKeysInRegionPattern()
+    {
+        return generateKey( "*" );
+    }
+
     @Override
     public void invalidateAll()
     {
-        Set<String> keysToDelete = redisTemplate.keys( cacheRegion.concat( ":*" ) );
+        Set<String> keysToDelete = redisTemplate.keys( getAllKeysInRegionPattern() );
         redisTemplate.delete( keysToDelete );
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
@@ -33,6 +33,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static java.util.Collections.unmodifiableSet;
+
 /**
  * @author Luciano Fiandesio
  */
@@ -72,6 +74,12 @@ public class TestCache<V> implements Cache<V>
     }
 
     @Override
+    public Iterable<String> keys()
+    {
+        return unmodifiableSet( mapCache.keySet() );
+    }
+
+    @Override
     public void put( String key, V value )
     {
         mapCache.put( key, value );
@@ -82,6 +90,12 @@ public class TestCache<V> implements Cache<V>
     {
         // Ignoring ttl for this testing cache
         mapCache.put( key, value );
+    }
+
+    @Override
+    public boolean putIfAbsent( String key, V value )
+    {
+        return mapCache.putIfAbsent( key, value ) != value;
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/cache/TestCache.java
@@ -27,13 +27,13 @@
  */
 package org.hisp.dhis.cache;
 
+import static java.util.Collections.unmodifiableSet;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import static java.util.Collections.unmodifiableSet;
 
 /**
  * @author Luciano Fiandesio

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityCheck.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityCheck.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import org.hisp.dhis.dataintegrity.DataIntegritySeverity;
+import org.hisp.dhis.webapi.json.Expected;
+import org.hisp.dhis.webapi.json.JsonObject;
+
+/**
+ * JSON API equivalent of the
+ * {@link org.hisp.dhis.dataintegrity.DataIntegrityCheck}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonDataIntegrityCheck extends JsonObject
+{
+    @Expected
+    default String getName()
+    {
+        return getString( "name" ).string();
+    }
+
+    default String getSection()
+    {
+        return getString( "section" ).string();
+    }
+
+    default DataIntegritySeverity getSeverity()
+    {
+        return getString( "severity" ).parsed( DataIntegritySeverity::valueOf );
+    }
+
+    default String getDescription()
+    {
+        return getString( "description" ).string();
+    }
+
+    default String getIntroduction()
+    {
+        return getString( "introduction" ).string();
+    }
+
+    default String getRecommendation()
+    {
+        return getString( "recommendation" ).string();
+    }
+
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.time.LocalDateTime;
+
+import org.hisp.dhis.webapi.json.Expected;
+import org.hisp.dhis.webapi.json.JsonDate;
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.hisp.dhis.webapi.json.JsonString;
+
+/**
+ * JSON API equivalent of the
+ * {@link org.hisp.dhis.dataintegrity.DataIntegrityDetails}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonDataIntegrityDetails extends JsonDataIntegrityCheck
+{
+    @Expected
+    default LocalDateTime getFinishedTime()
+    {
+        return get( "finishedTime", JsonDate.class ).date();
+    }
+
+    default String getError()
+    {
+        return getString( "error" ).string( null );
+    }
+
+    @Expected
+    default JsonList<JsonDataIntegrityIssue> getIssues()
+    {
+        return getList( "issues", JsonDataIntegrityIssue.class );
+    }
+
+    interface JsonDataIntegrityIssue extends JsonObject
+    {
+        @Expected
+        default String getId()
+        {
+            return getString( "id" ).string();
+        }
+
+        @Expected
+        default String getName()
+        {
+            return getString( "name" ).string();
+        }
+
+        default JsonString getComment()
+        {
+            return getString( "comment" );
+        }
+
+        default JsonList<JsonString> getRefs()
+        {
+            return getList( "refs", JsonString.class );
+        }
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.json.domain;
+
+import java.time.LocalDateTime;
+
+import org.hisp.dhis.webapi.json.Expected;
+import org.hisp.dhis.webapi.json.JsonDate;
+
+/**
+ * JSON API equivalent of
+ * {@link org.hisp.dhis.dataintegrity.DataIntegritySummary}.
+ *
+ * @author Jan Bernitt
+ */
+public interface JsonDataIntegritySummary extends JsonDataIntegrityCheck
+{
+    @Expected
+    default LocalDateTime getFinishedTime()
+    {
+        return get( "finishedTime", JsonDate.class ).date();
+    }
+
+    default String getError()
+    {
+        return getString( "error" ).string( null );
+    }
+
+    default int getCount()
+    {
+        return getNumber( "count" ).intValue();
+    }
+
+    default Number getPercentage()
+    {
+        return getNumber( "percentage" ).number();
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -27,8 +27,15 @@
  */
 package org.hisp.dhis.webapi;
 
-import com.google.common.collect.ImmutableMap;
+import java.beans.PropertyVetoException;
+import java.sql.SQLException;
+import java.util.Date;
+
+import javax.sql.DataSource;
+import javax.transaction.Transactional;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.commons.util.DebugUtils;
@@ -80,11 +87,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource;
-import javax.transaction.Transactional;
-import java.beans.PropertyVetoException;
-import java.sql.SQLException;
-import java.util.Date;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -27,15 +27,9 @@
  */
 package org.hisp.dhis.webapi;
 
-import java.beans.PropertyVetoException;
-import java.sql.SQLException;
-import java.util.Date;
-
-import javax.sql.DataSource;
-import javax.transaction.Transactional;
-
+import com.google.common.collect.ImmutableMap;
 import lombok.extern.slf4j.Slf4j;
-
+import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.config.DataSourceConfig;
@@ -64,6 +58,7 @@ import org.hisp.dhis.scheduling.JobService;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.hisp.dhis.startup.DefaultAdminUserPopulator;
+import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.webapi.mvc.ContentNegotiationConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -85,7 +80,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 
-import com.google.common.collect.ImmutableMap;
+import javax.sql.DataSource;
+import javax.transaction.Transactional;
+import java.beans.PropertyVetoException;
+import java.sql.SQLException;
+import java.util.Date;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com
@@ -225,9 +224,10 @@ public class WebTestConfiguration
     @Primary
     public SchedulingManager synchronousSchedulingManager( JobService jobService,
         JobConfigurationService jobConfigurationService,
-        MessageService messageService, LeaderManager leaderManager )
+        MessageService messageService, Notifier notifier, LeaderManager leaderManager, CacheProvider cacheProvider )
     {
-        return new TestSchedulingManager( jobService, jobConfigurationService, messageService, leaderManager );
+        return new TestSchedulingManager( jobService, jobConfigurationService, messageService, notifier,
+            leaderManager, cacheProvider );
     }
 
     public static class TestSchedulingManager extends AbstractSchedulingManager
@@ -235,9 +235,9 @@ public class WebTestConfiguration
         private boolean enabled = true;
 
         public TestSchedulingManager( JobService jobService, JobConfigurationService jobConfigurationService,
-            MessageService messageService, LeaderManager leaderManager )
+            MessageService messageService, Notifier notifier, LeaderManager leaderManager, CacheProvider cacheProvider )
         {
-            super( jobService, jobConfigurationService, messageService, leaderManager );
+            super( jobService, jobConfigurationService, messageService, leaderManager, notifier, cacheProvider );
         }
 
         @Override

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataIntegrityControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataIntegrityControllerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.JsonObject;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
+import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
+
+/**
+ * Base class for all test classes for the {@link DataIntegrityController}.
+ *
+ * @author Jan Bernitt
+ */
+abstract class AbstractDataIntegrityControllerTest extends DhisControllerConvenienceTest
+{
+    protected final JsonDataIntegrityDetails getDetails( String check )
+    {
+        JsonObject content = GET( "/dataIntegrity/details?checks={check}&timeout=1000", check ).content();
+        JsonDataIntegrityDetails details = content.get( check.replace( '-', '_' ), JsonDataIntegrityDetails.class );
+        assertTrue( "check " + check + " did not complete in time or threw an exception", details.exists() );
+        assertTrue( details.isObject() );
+        return details;
+    }
+
+    /**
+     * Triggers the single check provided
+     *
+     * @param check name of the check to perform
+     */
+    protected final void postDetails( String check )
+    {
+        HttpResponse trigger = POST( "/dataIntegrity/details?checks=" + check );
+        assertEquals( "http://localhost/dataIntegrity/details?checks=" + check, trigger.location() );
+        assertTrue( trigger.content().isA( JsonWebMessage.class ) );
+    }
+
+    protected final JsonDataIntegritySummary getSummary( String check )
+    {
+        JsonObject content = GET( "/dataIntegrity/summary?checks={check}&timeout=1000", check ).content();
+        JsonDataIntegritySummary summary = content.get( check.replace( '-', '_' ), JsonDataIntegritySummary.class );
+        assertTrue( summary.exists() );
+        assertTrue( summary.isObject() );
+        return summary;
+    }
+
+    protected final void postSummary( String check )
+    {
+        HttpResponse trigger = POST( "/dataIntegrity/summary?checks=" + check );
+        assertEquals( "http://localhost/dataIntegrity/summary?checks=" + check, trigger.location() );
+        assertTrue( trigger.content().isA( JsonWebMessage.class ) );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityCategoriesControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityCategoriesControllerTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryComboStore;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryOptionComboStore;
+import org.hisp.dhis.category.CategoryOptionStore;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.category.CategoryStore;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Tests the {@link DataIntegrityController} API with focus on checks for
+ * {@link Category}s and its related objects.
+ * <p>
+ * This includes both the
+ * {@link org.hisp.dhis.dataintegrity.DataIntegritySummary} and the
+ * {@link org.hisp.dhis.dataintegrity.DataIntegrityDetails} results.
+ *
+ * @author Jan Bernitt
+ */
+public class DataIntegrityCategoriesControllerTest extends AbstractDataIntegrityControllerTest
+{
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private CategoryStore categoryStore;
+
+    @Autowired
+    private CategoryOptionStore categoryOptionStore;
+
+    @Autowired
+    private CategoryComboStore categoryComboStore;
+
+    @Autowired
+    private CategoryOptionComboStore categoryOptionComboStore;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @Test
+    public void testSummaryCategories_no_options()
+    {
+        assertStatus( HttpStatus.CREATED,
+            POST( "/categories", "{'name': 'CatDog', 'shortName': 'CD', 'dataDimensionType': 'ATTRIBUTE'}" ) );
+
+        postSummary( "categories-no-options" );
+        JsonDataIntegritySummary summary = getSummary( "categories-no-options" );
+        assertEquals( 1, summary.getCount() );
+        assertEquals( 50, summary.getPercentage().intValue() );
+    }
+
+    @Test
+    public void testDetailsCategories_no_options()
+    {
+        String uid = assertStatus( HttpStatus.CREATED,
+            POST( "/categories", "{'name': 'CatDog', 'shortName': 'CD', 'dataDimensionType': 'ATTRIBUTE'}" ) );
+
+        postDetails( "categories-no-options" );
+        JsonDataIntegrityDetails details = getDetails( "categories-no-options" );
+
+        assertEquals( 1, details.getIssues().size() );
+        assertEquals( uid, details.getIssues().get( 0 ).getId() );
+        assertEquals( "CatDog", details.getIssues().get( 0 ).getName() );
+    }
+
+    /**
+     * Ideally we would have created a second category named default, but we
+     * have made this impossible by unique constraint. So the best we can do is
+     * changing the UID of the existing default to some other UID.
+     */
+    @Test
+    public void testSummaryCategories_one_default_category()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryToUid( uid ) );
+
+        postSummary( "categories_one_default_category" );
+        JsonDataIntegritySummary summary = getSummary( "categories_one_default_category" );
+
+        assertEquals( 1, summary.getCount() );
+        assertNull( summary.getPercentage() );
+    }
+
+    /**
+     * Ideally we would have created a second category named default, but we
+     * have made this impossible by unique constraint. So the best we can do is
+     * changing the UID of the existing default to some other UID.
+     */
+    @Test
+    public void testDetailsCategories_one_default_category()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryToUid( uid ) );
+
+        postDetails( "categories_one_default_category" );
+        JsonDataIntegrityDetails details = getDetails( "categories_one_default_category" );
+
+        assertEquals( 1, details.getIssues().size() );
+        assertEquals( uid, details.getIssues().get( 0 ).getId() );
+        assertEquals( "default", details.getIssues().get( 0 ).getName() );
+    }
+
+    /**
+     * Ideally we would have created a second category option named default, but
+     * we have made this impossible by unique constraint. So the best we can do
+     * is changing the UID of the existing default to some other UID.
+     */
+    @Test
+    public void testSummaryCategories_one_default_category_option()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryOptionToUid( uid ) );
+
+        postSummary( "categories_one_default_category_option" );
+        JsonDataIntegritySummary summary = getSummary( "categories_one_default_category_option" );
+
+        assertEquals( 1, summary.getCount() );
+        assertNull( summary.getPercentage() );
+    }
+
+    /**
+     * Ideally we would have created a second category option named default, but
+     * we have made this impossible by unique constraint. So the best we can do
+     * is changing the UID of the existing default to some other UID.
+     */
+    @Test
+    public void testDetailsCategories_one_default_category_option()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryOptionToUid( uid ) );
+
+        postDetails( "categories_one_default_category_option" );
+        JsonDataIntegrityDetails details = getDetails( "categories_one_default_category_option" );
+
+        assertEquals( 1, details.getIssues().size() );
+        assertEquals( uid, details.getIssues().get( 0 ).getId() );
+        assertEquals( "default", details.getIssues().get( 0 ).getName() );
+    }
+
+    /**
+     * Ideally we would have created a second category combo named default, but
+     * we have made this impossible by unique constraint. So the best we can do
+     * is changing the UID of the existing default to some other UID.
+     */
+    @Test
+    public void testSummaryCategories_one_default_category_combo()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryComboToUid( uid ) );
+
+        postSummary( "categories_one_default_category_combo" );
+        JsonDataIntegritySummary summary = getSummary( "categories_one_default_category_combo" );
+
+        assertEquals( 1, summary.getCount() );
+        assertNull( summary.getPercentage() );
+    }
+
+    /**
+     * Ideally we would have created a second category combo named default, but
+     * we have made this impossible by unique constraint. So the best we can do
+     * is changing the UID of the existing default to some other UID.
+     */
+    @Test
+    public void testDetailsCategories_one_default_category_combo()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryComboToUid( uid ) );
+
+        postDetails( "categories_one_default_category_combo" );
+        JsonDataIntegrityDetails details = getDetails( "categories_one_default_category_combo" );
+
+        assertEquals( 1, details.getIssues().size() );
+        assertEquals( uid, details.getIssues().get( 0 ).getId() );
+        assertEquals( "default", details.getIssues().get( 0 ).getName() );
+    }
+
+    /**
+     * Ideally we would have created a second category option combo named
+     * default, but we have made this impossible by unique constraint. So the
+     * best we can do is changing the UID of the existing default to some other
+     * UID.
+     */
+    @Ignore( "problem is updating the default in the setup" )
+    @Test
+    public void testSummaryCategories_one_default_category_option_combo()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryOptionComboToUid( uid ) );
+
+        postSummary( "categories_one_default_category_option_combo" );
+        JsonDataIntegritySummary summary = getSummary( "categories_one_default_category_option_combo" );
+
+        assertEquals( 1, summary.getCount() );
+        assertNull( summary.getPercentage() );
+    }
+
+    /**
+     * Ideally we would have created a second category option combo named
+     * default, but we have made this impossible by unique constraint. So the
+     * best we can do is changing the UID of the existing default to some other
+     * UID.
+     */
+    @Ignore( "problem is updating the default in the setup" )
+    @Test
+    public void testDetailsCategories_one_default_category_option_combo()
+    {
+        String uid = CodeGenerator.generateUid();
+        assertEquals( uid, updateDefaultCategoryOptionComboToUid( uid ) );
+
+        postDetails( "categories_one_default_category_option_combo" );
+        JsonDataIntegrityDetails details = getDetails( "categories_one_default_category_option_combo" );
+
+        assertEquals( 1, details.getIssues().size() );
+        assertEquals( uid, details.getIssues().get( 0 ).getId() );
+        assertEquals( "default", details.getIssues().get( 0 ).getName() );
+    }
+
+    private String updateDefaultCategoryToUid( String uid )
+    {
+        transactionTemplate.execute( status -> {
+            Category category = categoryService.getDefaultCategory();
+            category.setUid( uid );
+            categoryStore.save( category );
+            return null;
+        } );
+        // OBS! we need to read this to force the TX to be applied
+        return categoryService.getDefaultCategory().getUid();
+    }
+
+    private String updateDefaultCategoryOptionToUid( String uid )
+    {
+        transactionTemplate.execute( status -> {
+            CategoryOption option = categoryService.getDefaultCategoryOption();
+            option.setUid( uid );
+            categoryOptionStore.save( option );
+            return null;
+        } );
+        // OBS! we need to read this to force the TX to be applied
+        return categoryService.getDefaultCategoryOption().getUid();
+    }
+
+    private String updateDefaultCategoryComboToUid( String uid )
+    {
+        transactionTemplate.execute( status -> {
+            CategoryCombo combo = categoryService.getDefaultCategoryCombo();
+            combo.setUid( uid );
+            categoryComboStore.save( combo );
+            return null;
+        } );
+        // OBS! we need to read this to force the TX to be applied
+        return categoryService.getDefaultCategoryCombo().getUid();
+    }
+
+    private String updateDefaultCategoryOptionComboToUid( String uid )
+    {
+        transactionTemplate.execute( status -> {
+            CategoryOptionCombo combo = categoryService.getDefaultCategoryOptionCombo();
+            combo.setUid( uid );
+            categoryOptionComboStore.save( combo );
+            return null;
+        } );
+        // OBS! we need to read this to force the TX to be applied
+        return categoryService.getDefaultCategoryOptionCombo().getUid();
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityChecksControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityChecksControllerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityCheck;
+import org.junit.Test;
+
+/**
+ * Tests the {@link DataIntegrityController} API with focus API returning
+ * {@link org.hisp.dhis.dataintegrity.DataIntegrityCheck} information.
+ *
+ * @author Jan Bernitt
+ */
+public class DataIntegrityChecksControllerTest extends AbstractDataIntegrityControllerTest
+{
+    @Test
+    public void testGetAvailableChecks()
+    {
+        JsonList<JsonDataIntegrityCheck> checks = GET( "/dataIntegrity" ).content()
+            .asList( JsonDataIntegrityCheck.class );
+        assertFalse( checks.isEmpty() );
+        assertCheckExists( "categories_no_options", checks );
+        assertCheckExists( "categories_one_default_category", checks );
+        assertCheckExists( "categories_one_default_category_option", checks );
+        assertCheckExists( "categories_one_default_category_combo", checks );
+        assertCheckExists( "categories_one_default_category_option_combo", checks );
+        assertCheckExists( "categories_unique_category_combo", checks );
+        for ( DataIntegrityCheckType type : DataIntegrityCheckType.values() )
+        {
+            assertCheckExists( type.getName(), checks );
+        }
+    }
+
+    private void assertCheckExists( String name, JsonList<JsonDataIntegrityCheck> checks )
+    {
+        assertTrue( checks.stream().anyMatch( check -> check.getName().equals( name ) ) );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
+import org.hisp.dhis.webapi.json.JsonList;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegrityDetails.JsonDataIntegrityIssue;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the {@link DataIntegrityController} API with focus API returning
+ * {@link org.hisp.dhis.dataintegrity.DataIntegrityDetails}.
+ *
+ * @author Jan Bernitt
+ */
+public class DataIntegrityDetailsControllerTest extends AbstractDataIntegrityControllerTest
+{
+    @Test
+    public void testLegacyChecksOnly()
+    {
+        for ( DataIntegrityCheckType type : DataIntegrityCheckType.values() )
+        {
+            String check = type.getName();
+            postDetails( check );
+            JsonDataIntegrityDetails details = getDetails( check );
+            assertTrue( details.getIssues().isEmpty() );
+        }
+    }
+
+    @Test
+    public void testSingleCheckByPath()
+    {
+        String uid = assertStatus( HttpStatus.CREATED,
+            POST( "/categories", "{'name': 'CatDog', 'shortName': 'CD', 'dataDimensionType': 'ATTRIBUTE'}" ) );
+
+        postDetails( "categories-no-options" );
+        JsonDataIntegrityDetails details = GET( "/dataIntegrity/categories-no-options/details?timeout=1000" )
+            .content().as( JsonDataIntegrityDetails.class );
+
+        assertTrue( details.exists() );
+        assertTrue( details.isObject() );
+        JsonList<JsonDataIntegrityIssue> issues = details.getIssues();
+        assertTrue( issues.exists() );
+        assertEquals( 1, issues.size() );
+        assertEquals( uid, issues.get( 0 ).getId() );
+        assertEquals( "CatDog", issues.get( 0 ).getName() );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
+import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
+import org.junit.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the {@link DataIntegrityController} API with focus API returning
+ * {@link org.hisp.dhis.dataintegrity.DataIntegritySummary}.
+ *
+ * @author Jan Bernitt
+ */
+public class DataIntegritySummaryControllerTest extends AbstractDataIntegrityControllerTest
+{
+    @Test
+    public void testLegacyChecksHaveSummary()
+    {
+        for ( DataIntegrityCheckType type : DataIntegrityCheckType.values() )
+        {
+            String check = type.getName();
+            postSummary( check );
+            JsonDataIntegritySummary summary = getSummary( check );
+            assertTrue( "summary threw an exception", summary.getCount() >= 0 );
+        }
+    }
+
+    @Test
+    public void testSingleCheckByPath()
+    {
+        assertStatus( HttpStatus.CREATED,
+            POST( "/categories", "{'name': 'CatDog', 'shortName': 'CD', 'dataDimensionType': 'ATTRIBUTE'}" ) );
+
+        postSummary( "categories-no-options" );
+        JsonDataIntegritySummary summary = GET( "/dataIntegrity/categories-no-options/summary" ).content()
+            .as( JsonDataIntegritySummary.class );
+        assertTrue( summary.exists() );
+        assertTrue( summary.isObject() );
+        assertEquals( 1, summary.getCount() );
+        assertEquals( 50, summary.getPercentage().intValue() );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -90,7 +90,7 @@ public class JobConfigurationControllerTest extends DhisControllerConvenienceTes
             "{'name':'test','jobType':'DATA_INTEGRITY','cronExpression':'0 0 12 ? * MON-FRI'}" ) );
 
         JsonObject parameters = assertJobConfigurationExists( jobId, "DATA_INTEGRITY" );
-        assertFalse( parameters.exists() );
+        assertTrue( parameters.exists() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,54 +27,165 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
+import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
+import org.hisp.dhis.dataintegrity.DataIntegrityService;
+import org.hisp.dhis.dataintegrity.DataIntegritySummary;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.SchedulingManager;
-import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
+import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters.DataIntegrityReportType;
+import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
  */
 @Controller
-@RequestMapping
+@RequestMapping( "/dataIntegrity" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+@AllArgsConstructor
 public class DataIntegrityController
 {
-    @Autowired
-    private CurrentUserService currentUserService;
+    private final SchedulingManager schedulingManager;
 
-    @Autowired
-    private SchedulingManager schedulingManager;
-
-    public static final String RESOURCE_PATH = "/dataIntegrity";
-
-    // --------------------------------------------------------------------------
-    // Start asynchronous data integrity task
-    // --------------------------------------------------------------------------
+    private final DataIntegrityService dataIntegrityService;
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
-    @PostMapping( DataIntegrityController.RESOURCE_PATH )
+    @PostMapping
     @ResponseBody
-    public WebMessage runAsyncDataIntegrity()
+    public WebMessage runDataIntegrity(
+        @RequestParam( required = false ) List<String> checks,
+        @CurrentUser User currentUser )
     {
-        JobConfiguration jobConfiguration = new JobConfiguration( "runAsyncDataIntegrity", JobType.DATA_INTEGRITY, null,
-            true );
-        jobConfiguration.setUserUid( currentUserService.getCurrentUser().getUid() );
-        jobConfiguration.setAutoFields();
+        return runDataIntegrityAsync( checks, currentUser, "runDataIntegrity", DataIntegrityReportType.REPORT )
+            .setLocation( "/dataIntegrity/details?checks=" + toChecksList( checks ) );
+    }
 
-        schedulingManager.executeNow( jobConfiguration );
+    private WebMessage runDataIntegrityAsync( Collection<String> checks,
+        User currentUser,
+        String description,
+        DataIntegrityReportType type )
+    {
+        DataIntegrityJobParameters params = new DataIntegrityJobParameters();
+        params.setChecks( toUniformCheckNames( checks ) );
+        params.setType( type );
+        JobConfiguration config = new JobConfiguration( description, JobType.DATA_INTEGRITY, null,
+            params, true, true );
+        config.setUserUid( currentUser.getUid() );
+        config.setAutoFields();
 
-        return jobConfigurationReport( jobConfiguration );
+        if ( !schedulingManager.executeNow( config ) )
+        {
+            return conflict( "Data integrity check is already running" );
+        }
+        return jobConfigurationReport( config );
+    }
+
+    @GetMapping
+    @ResponseBody
+    public Collection<DataIntegrityCheck> getAvailableChecks()
+    {
+        return dataIntegrityService.getDataIntegrityChecks();
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @GetMapping( "/summary" )
+    @ResponseBody
+    public Map<String, DataIntegritySummary> getSummaries(
+        @RequestParam( required = false ) Set<String> checks,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
+    {
+        return dataIntegrityService.getSummaries( toUniformCheckNames( checks ), timeout );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @PostMapping( "/summary" )
+    @ResponseBody
+    public WebMessage runSummariesCheck(
+        @RequestParam( required = false ) Set<String> checks,
+        @CurrentUser User currentUser )
+    {
+        return runDataIntegrityAsync( checks, currentUser, "runSummariesCheck", DataIntegrityReportType.SUMMARY )
+            .setLocation( "/dataIntegrity/summary?checks=" + toChecksList( checks ) );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @GetMapping( "/details" )
+    @ResponseBody
+    public Map<String, DataIntegrityDetails> getDetails(
+        @RequestParam( required = false ) Set<String> checks,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
+    {
+        return dataIntegrityService.getDetails( toUniformCheckNames( checks ), timeout );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @PostMapping( "/details" )
+    @ResponseBody
+    public WebMessage runDetailsCheck(
+        @RequestParam( required = false ) Set<String> checks,
+        @CurrentUser User currentUser )
+    {
+        return runDataIntegrityAsync( checks, currentUser, "runDetailsCheck", DataIntegrityReportType.DETAILS )
+            .setLocation( "/dataIntegrity/details?checks=" + toChecksList( checks ) );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @GetMapping( "/{check}/summary" )
+    @ResponseBody
+    public DataIntegritySummary getSummary( @PathVariable String check,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
+    {
+        Set<String> checks = toUniformCheckNames( Set.of( check ) );
+        return dataIntegrityService.getSummaries( checks, timeout ).get( checks.iterator().next() );
+    }
+
+    @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
+    @GetMapping( "/{check}/details" )
+    @ResponseBody
+    public DataIntegrityDetails getDetails( @PathVariable String check,
+        @RequestParam( required = false, defaultValue = "0" ) long timeout )
+    {
+        Set<String> checks = toUniformCheckNames( Set.of( check ) );
+        return dataIntegrityService.getDetails( checks, timeout ).get( checks.iterator().next() );
+    }
+
+    /**
+     * Allow both dash or underscore in the API
+     */
+    private static Set<String> toUniformCheckNames( Collection<String> checks )
+    {
+        return checks == null
+            ? Set.of()
+            : checks.stream().map( check -> check.replace( '-', '_' ) ).collect( toUnmodifiableSet() );
+    }
+
+    private String toChecksList( Collection<String> checks )
+    {
+        return checks == null || checks.isEmpty() ? "" : String.join( ",", checks );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -27,7 +27,19 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toSet;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
 import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
@@ -49,17 +61,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
-import static java.util.stream.Collectors.toSet;
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -27,17 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static java.util.stream.Collectors.toUnmodifiableSet;
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
-import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import lombok.AllArgsConstructor;
-
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dataintegrity.DataIntegrityCheck;
 import org.hisp.dhis.dataintegrity.DataIntegrityDetails;
@@ -49,7 +39,6 @@ import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters.DataIntegrityReportType;
-import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -60,6 +49,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toSet;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
 
 /**
  * @author Halvdan Hoem Grelland <halvdanhg@gmail.com>
@@ -79,7 +79,7 @@ public class DataIntegrityController
     @ResponseBody
     public WebMessage runDataIntegrity(
         @RequestParam( required = false ) List<String> checks,
-        @CurrentUser User currentUser )
+        User currentUser )
     {
         return runDataIntegrityAsync( checks, currentUser, "runDataIntegrity", DataIntegrityReportType.REPORT )
             .setLocation( "/dataIntegrity/details?checks=" + toChecksList( checks ) );
@@ -127,7 +127,7 @@ public class DataIntegrityController
     @ResponseBody
     public WebMessage runSummariesCheck(
         @RequestParam( required = false ) Set<String> checks,
-        @CurrentUser User currentUser )
+        User currentUser )
     {
         return runDataIntegrityAsync( checks, currentUser, "runSummariesCheck", DataIntegrityReportType.SUMMARY )
             .setLocation( "/dataIntegrity/summary?checks=" + toChecksList( checks ) );
@@ -148,7 +148,7 @@ public class DataIntegrityController
     @ResponseBody
     public WebMessage runDetailsCheck(
         @RequestParam( required = false ) Set<String> checks,
-        @CurrentUser User currentUser )
+        User currentUser )
     {
         return runDataIntegrityAsync( checks, currentUser, "runDetailsCheck", DataIntegrityReportType.DETAILS )
             .setLocation( "/dataIntegrity/details?checks=" + toChecksList( checks ) );
@@ -160,7 +160,7 @@ public class DataIntegrityController
     public DataIntegritySummary getSummary( @PathVariable String check,
         @RequestParam( required = false, defaultValue = "0" ) long timeout )
     {
-        Set<String> checks = toUniformCheckNames( Set.of( check ) );
+        Set<String> checks = toUniformCheckNames( singleton( check ) );
         return dataIntegrityService.getSummaries( checks, timeout ).get( checks.iterator().next() );
     }
 
@@ -170,7 +170,7 @@ public class DataIntegrityController
     public DataIntegrityDetails getDetails( @PathVariable String check,
         @RequestParam( required = false, defaultValue = "0" ) long timeout )
     {
-        Set<String> checks = toUniformCheckNames( Set.of( check ) );
+        Set<String> checks = toUniformCheckNames( singleton( check ) );
         return dataIntegrityService.getDetails( checks, timeout ).get( checks.iterator().next() );
     }
 
@@ -180,8 +180,8 @@ public class DataIntegrityController
     private static Set<String> toUniformCheckNames( Collection<String> checks )
     {
         return checks == null
-            ? Set.of()
-            : checks.stream().map( check -> check.replace( '-', '_' ) ).collect( toUnmodifiableSet() );
+            ? emptySet()
+            : checks.stream().map( check -> check.replace( '-', '_' ) ).collect( toSet() );
     }
 
     private String toChecksList( Collection<String> checks )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2021, University of Oslo
+ * Copyright (c) 2004-2022, University of Oslo
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -50,8 +50,8 @@ import org.hisp.dhis.webapi.webdomain.JobTypes;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -89,8 +89,7 @@ public class JobConfigurationController
         return new JobTypes( jobConfigurationService.getJobTypeInfo() );
     }
 
-    @RequestMapping( value = "{uid}/execute", method = { RequestMethod.GET, RequestMethod.POST }, produces = {
-        APPLICATION_JSON_VALUE, "application/javascript" } )
+    @PostMapping( value = "{uid}/execute", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public ObjectReport executeJobConfiguration( @PathVariable( "uid" ) String uid )
         throws WebMessageException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulingController.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.scheduling;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.hisp.dhis.scheduling.JobProgress.Process;
+import org.hisp.dhis.scheduling.JobProgress.Stage;
+import org.hisp.dhis.scheduling.JobProgress.Status;
+import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.SchedulingManager;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Controller for status information on the {@link SchedulingManager} and
+ * running {@link org.hisp.dhis.scheduling.Job}s.
+ *
+ * @author Jan Bernitt
+ */
+@RestController
+@RequestMapping( value = "/scheduling" )
+@AllArgsConstructor
+public class SchedulingController
+{
+    private final SchedulingManager schedulingManager;
+
+    @GetMapping( value = { "/running", "/running/" }, produces = APPLICATION_JSON_VALUE )
+    @ResponseBody
+    public Map<JobType, Collection<ProcessInfo>> getRunningProgressTypes()
+    {
+        return schedulingManager.getRunningTypes().stream()
+            .collect( toMap( Function.identity(),
+                type -> flatten( schedulingManager.getRunningProgress( type ) ) ) );
+    }
+
+    @GetMapping( value = { "/completed", "/completed/" }, produces = APPLICATION_JSON_VALUE )
+    @ResponseBody
+    public Map<JobType, Collection<ProcessInfo>> getCompletedProgressTypes()
+    {
+        return schedulingManager.getCompletedTypes().stream()
+            .collect( toMap( Function.identity(),
+                type -> flatten( schedulingManager.getCompletedProgress( type ) ) ) );
+    }
+
+    @GetMapping( value = "/running/{type}", produces = APPLICATION_JSON_VALUE )
+    @ResponseBody
+    public Collection<Process> getRunningProgress( @PathVariable( "type" ) String type )
+    {
+        return schedulingManager.getRunningProgress( JobType.valueOf( type.toUpperCase() ) );
+    }
+
+    @GetMapping( value = "/completed/{type}", produces = APPLICATION_JSON_VALUE )
+    @ResponseBody
+    public Collection<Process> getCompletedProgress( @PathVariable( "type" ) String type )
+    {
+        return schedulingManager.getCompletedProgress( JobType.valueOf( type.toUpperCase() ) );
+    }
+
+    @PostMapping( "/cancel/{type}" )
+    @ResponseStatus( HttpStatus.NO_CONTENT )
+    public void requestCancellation( @PathVariable( "type" ) String type )
+    {
+        schedulingManager.cancel( JobType.valueOf( type.toUpperCase() ) );
+    }
+
+    private static Collection<ProcessInfo> flatten( Collection<Process> processes )
+    {
+        return processes.stream().map( ProcessInfo::new ).collect( toList() );
+    }
+
+    @Getter
+    public static final class ProcessInfo
+    {
+        @JsonProperty
+        private final String jobId;
+
+        @JsonProperty
+        private final Status status;
+
+        @JsonProperty
+        private final String description;
+
+        @JsonProperty
+        private final Date startedTime;
+
+        @JsonProperty
+        private final Date completedTime;
+
+        @JsonProperty
+        private final Date cancelledTime;
+
+        @JsonProperty
+        private final String summary;
+
+        @JsonProperty
+        private final String error;
+
+        @JsonProperty
+        private final List<String> stages;
+
+        ProcessInfo( Process process )
+        {
+            this.jobId = process.getJobId();
+            this.status = process.getStatus();
+            this.startedTime = process.getStartedTime();
+            this.completedTime = process.getCompletedTime();
+            this.cancelledTime = process.getCancelledTime();
+            this.description = process.getDescription();
+            this.summary = process.getSummary();
+            this.error = process.getError();
+            this.stages = process.getStages().stream().map( ProcessInfo::getDescription ).collect( toList() );
+        }
+
+        private static String getDescription( Stage stage )
+        {
+            return stage.getTotalItems() > 1
+                ? stage.getDescription() + " [" + stage.getItems().size() + "/" + stage.getTotalItems() + "]"
+                : stage.getDescription();
+        }
+    }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1856,6 +1856,11 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-yaml</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jdk8</artifactId>
         <version>${jackson.version}</version>


### PR DESCRIPTION
### Summary
This is a backport of data integrity domain code to 2.37 from master "as is".
That means majority of files were copied using `git checkout master <file>`.

As data integrity builds upon newst scheduling I also had to backport the scheduling domain in a similar way.

Both data integrity and scheduling also required new caches so the cache domain needed selective updates.

All in all little manual adjustment was needed after the initial copying. 
Most of it due to 2 key differences:
* Java 11 vs Java 8 (`List.of` => `Arrays.asList` and `toUnmodifiableList()` => `toList()`)
* junit5 vs junit4

### Automatic Testing
Existing tests were migrated back to junit4.
2 test scenarios needed to be `@Ignore`d but the issue was transaction boundaries in test setup.

### Manual Testing
* create and run analytics table job manually
* create and run resource table job manually
* create and run data integrity job manually and check `/api/scheduling/running/DATA_INTEGRITY` and `/api/scheduling/completed/DATA_INTEGRITY`
* run `/dhis-web-data-administration/index.html#/analytics` and check steps are shown and finish
* run `/dhis-web-data-administration/index.html#/resourceTables` and check steps are shown and finish
* trigger check: `POST` `/api/dataIntegrity/summary?checks=categories_unique_category_combo` and check results `GET` `/api/dataIntegrity/summary?checks=categories_unique_category_combo`
* trigger check: `POST` `/api/dataIntegrity/details?checks=categories_unique_category_combo` and check results `GET` `/api/dataIntegrity/details?checks=categories_unique_category_combo`