### PR TITLE
fix: Master table population for partial update [DHIS2-12677]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -234,7 +234,8 @@ public abstract class AbstractJdbcTableManager
     public void swapTable( AnalyticsTableUpdateParams params, AnalyticsTable table )
     {
         boolean tableExists = partitionManager.tableExists( table.getTableName() );
-        boolean skipMasterTable = params.isPartialUpdate() && tableExists;
+        boolean skipMasterTable = params.isPartialUpdate() && tableExists
+            && table.getTableType().hasLatestPartition();
 
         log.info( String.format( "Swapping table, master table exists: %b, skip master table: %b", tableExists,
             skipMasterTable ) );


### PR DESCRIPTION
This is a tricky bug that happens during the analytics partial export.

When the update is partial the code will target the respective partition and will skip the master table. This is the current behaviour.

The problem arises when the table has no partitions (ie. `enrollments`). In such cases, the table export does not update any table (will also skip the master).

So, to fix it, I'm adding an extra condition (`&& table.getTableType().hasLatestPartition()`).
This condition will tell if the current table actually has partitions. If it does not have partitions we need to update the master table, so the data in the analytics enrollment tables get updated.

The client reported that when running analytics export setting `Number of last years of data to include` to `1`, he could see the new events rows, but not the new enrollments rows.
More details can be found in the issue: https://jira.dhis2.org/browse/DHIS2-12677
That's the reason why this bug is being fixed.
