### PR TITLE
fix: NPE because of wrong list checking [TECH-1019]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttribute.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.trackedentity;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import org.hisp.dhis.common.BaseDimensionalItemObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemType;
@@ -160,7 +162,7 @@ public class TrackedEntityAttribute
     @Override
     public boolean hasLegendSet()
     {
-        return legendSets != null;
+        return isNotEmpty( legendSets );
     }
 
     @JsonIgnore


### PR DESCRIPTION
Small fix to prevent a NPE. Another part of the code is invoking `hasLegendSet()` and it's returning true when the list is empty, and this causes an NPE when the invoker try to access `getLegendSet().getUid()`. Ie.: `MetadataItem.java:157`