### PR TITLE
feat: add orgUnitFieldName to mapView

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/mapping/MapView.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.hisp.dhis.analytics.EventOutputType;
+import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.BaseAnalyticalObject;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -218,6 +219,15 @@ public class MapView
     private transient List<OrganisationUnit> organisationUnitsAtLevel = new ArrayList<>();
 
     private transient List<OrganisationUnit> organisationUnitsInGroups = new ArrayList<>();
+
+    /**
+     * The displayName of the {@link Attribute} which has ID stored by property
+     * {@link MapView#orgUnitField}
+     * <p>
+     * The value of this transient property will be set in
+     * MapController#postProcessResponseEntity
+     */
+    private transient String orgUnitFieldDisplayName;
 
     public MapView()
     {
@@ -876,5 +886,17 @@ public class MapView
     public void setParentLevel( int parentLevel )
     {
         this.parentLevel = parentLevel;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getOrgUnitFieldDisplayName()
+    {
+        return orgUnitFieldDisplayName;
+    }
+
+    public void setOrgUnitFieldDisplayName( String orgUnitFieldDisplayName )
+    {
+        this.orgUnitFieldDisplayName = orgUnitFieldDisplayName;
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
@@ -28,7 +28,11 @@
 package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -55,4 +59,25 @@ class MapControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Not Found", 404, "ERROR", "Map does not exist: xyz",
             PUT( "/maps/xyz", "{'name':'My updated map'}" ).content( HttpStatus.NOT_FOUND ) );
     }
+
+    @Test
+    void testGetWithMapViewAndOrgUnitField()
+    {
+        String attrId = assertStatus( HttpStatus.CREATED, POST( "/attributes",
+            "{  'name':'GeoJsonAttribute', " + "'valueType':'GEOJSON', " + "'organisationUnit':true}" ) );
+
+        String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/",
+            "{\"name\":\"My map\", \"mapViews\":[ { \"orgUnitField\": \"" + attrId + "\", " +
+                "\"layer\": \"thematic1\",\"renderingStrategy\": \"SINGLE\" } ]}" ) );
+
+        JsonResponse map = GET( "/maps/{uid}", mapId ).content();
+        assertNotNull( map.getArray( "mapViews" ) );
+        assertEquals( 1, map.getArray( "mapViews" ).size() );
+
+        JsonObject mapView = map.getArray( "mapViews" ).get( 0 ).as( JsonObject.class );
+        assertEquals( attrId, mapView.getString( "orgUnitField" ).string() );
+        assertEquals( "GeoJsonAttribute", mapView.getString( "orgUnitFieldDisplayName" ).string() );
+
+    }
+
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -41,6 +41,9 @@ import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeService;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.cache.CacheStrategy;
@@ -122,6 +125,9 @@ public class MapController
 
     @Autowired
     private ContextUtils contextUtils;
+
+    @Autowired
+    private AttributeService attributeService;
 
     // --------------------------------------------------------------------------
     // CRUD
@@ -240,6 +246,15 @@ public class MapController
                 for ( Period period : view.getPeriods() )
                 {
                     period.setName( format.formatPeriod( period ) );
+                }
+            }
+
+            if ( !StringUtils.isEmpty( view.getOrgUnitField() ) )
+            {
+                Attribute attribute = attributeService.getAttribute( view.getOrgUnitField() );
+                if ( attribute != null )
+                {
+                    view.setOrgUnitFieldDisplayName( attribute.getDisplayName() );
                 }
             }
         }


### PR DESCRIPTION
In https://github.com/dhis2/dhis2-core/pull/9934 we added property `orgUnitField` to `MapView` in database level, which stores an ID of an `Attribute`
Now, client also needs the `Attribute`'s name and doesn't want to send an additional request to server.

This PR add a transient property `orgUnitFieldName` to `MapView`, its value will be set in `MapController#postProcessResponseEntity`

Note that the method `attributeService.getAttribute(id)` is already using a `Cache<Attribute> attributeCache`

```json
"orgUnitFieldName": "testgeojson",
"orgUnitField": "jhqTNk3hS2N",
```
