### PR TITLE
fix: /generateAndReserve returns duplicate values when attribute pattern contains a constant [ DHIS2-12182 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/reservedvalue/hibernate/ReservedValue.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/reservedvalue/hibernate/ReservedValue.hbm.xml
@@ -37,7 +37,7 @@
         rs.ownerObject = :ownerObject
         and rs.ownerUid = :ownerUid
         and rs.key = :key
-        and rs.value in (:values)
+        and LOWER(rs.value) in (:values)
         ]]>
     </sql-query>
 </hibernate-mapping>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_1__Add_index_to_reserved_value.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_1__Add_index_to_reserved_value.sql
@@ -1,0 +1,1 @@
+create unique index if not exists in_reservedvalue_value_generation on reservedvalue using btree (ownerobject, owneruid, key, lower (value));

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_1__Add_index_to_reserved_value.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_1__Add_index_to_reserved_value.sql
@@ -1,1 +1,2 @@
 create unique index if not exists in_reservedvalue_value_generation on reservedvalue using btree (ownerobject, owneruid, key, lower (value));
+ALTER TABLE ONLY reservedvalue DROP CONSTRAINT IF EXISTS uk_2utuk3clxif3qi4icy859kdrb;


### PR DESCRIPTION
adds lower case in query and index to reserved value table