### PR TITLE
fix: can't translate program

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/TranslationsCheck.java
@@ -72,7 +72,7 @@ public class TranslationsCheck implements ObjectValidationCheck
         }
     }
 
-    private <T extends IdentifiableObject> void run( IdentifiableObject object, Class<T> klass,
+    public <T extends IdentifiableObject> void run( IdentifiableObject object, Class<T> klass,
         Consumer<ObjectReport> addReports, Schema schema, int index )
     {
         Set<Translation> translations = object.getTranslations();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -41,6 +41,7 @@ import static org.springframework.http.MediaType.APPLICATION_XML_VALUE;
 import static org.springframework.http.MediaType.TEXT_XML_VALUE;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -63,7 +64,7 @@ import org.hisp.dhis.dxf2.metadata.MetadataImportService;
 import org.hisp.dhis.dxf2.metadata.collection.CollectionService;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReport;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.TranslationsCheck;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.ObjectReport;
@@ -154,6 +155,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     @Autowired
     protected BulkPatchManager bulkPatchManager;
 
+    @Autowired
+    private TranslationsCheck translationsCheck;
+
     @PutMapping( value = "/{uid}/translations" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
     @ResponseBody
@@ -182,23 +186,17 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         HashSet<Translation> translations = new HashSet<>( inputObject.getTranslations() );
 
         persistedObject.setTranslations( translations );
+        List<ObjectReport> objectReports = new ArrayList<>();
+        translationsCheck.run( persistedObject, getEntityClass(), objectReport -> objectReports.add( objectReport ),
+            getSchema(), 0 );
 
-        MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
-
-        params.setUser( currentUser )
-            .setImportStrategy( ImportStrategy.UPDATE )
-            .addObject( persistedObject )
-            .setImportMode( ObjectBundleMode.VALIDATE );
-
-        ImportReport importReport = importService.importMetadata( params );
-
-        if ( !importReport.hasErrorReports() )
+        if ( objectReports.size() == 0 )
         {
-            manager.save( persistedObject );
+            manager.update( persistedObject, currentUser );
             return null;
         }
 
-        return importReport( importReport );
+        return objectReport( objectReports.get( 0 ) );
     }
 
     // --------------------------------------------------------------------------


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12624

### Issue
- Currently the `{objectType}/translations` endpoint make use of the importService with `importMode=VALIDATE`. This approach is having issue because the importService modifies the given object although it's a validating process. As a result, we got an error like below when trying to update translations for a `Program`. The error has nothing to do with the translations being updated.
```
Caused by: org.hibernate.HibernateException: A collection with cascade="all-delete-orphan" was no longer referenced by the owning entity instance: org.hisp.dhis.program.Program.notificationTemplates
	at org.hibernate.engine.internal.Collections.processDereferencedCollection(Collections.java:100)
	at org.hibernate.engine.internal.Collections.processUnreachableCollection(Collections.java:51)
	at org.hibernate.event.internal.AbstractFlushingEventListener.lambda$flushCollections$1(AbstractFlushingEventListener.java:252)
	at org.hibernate.engine.internal.StatefulPersistenceContext.forEachCollectionEntry(StatefulPersistenceContext.java:1136)
	at org.hibernate.event.internal.AbstractFlushingEventListener.flushCollections(AbstractFlushingEventListener.java:249)
	
```

### Fix
- This PR make use of the `TranslationCheck` and call it directly in the `AbstractCrudController`, this approach not only faster but also help to avoid interactions with unrelated services in the importService.

### Test
- All translation related tests in `AbstractCrudControllerTest` are still applicable.