### PR TITLE
fix: totalPages param does not work in event analytics [DHIS2-12529]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -112,4 +112,6 @@ public class EnrollmentAnalyticsQueryCriteria extends RequestTypeAware
     private String coordinateField;
 
     private SortOrder sortOrder;
+
+    private boolean totalPages;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -140,6 +140,8 @@ public class EventDataQueryRequest
 
     private boolean paging;
 
+    private boolean totalPages;
+
     /**
      * Copies all properties of this request onto the given request.
      *
@@ -186,6 +188,7 @@ public class EventDataQueryRequest
         queryRequest.page = this.page;
         queryRequest.pageSize = this.pageSize;
         queryRequest.paging = this.paging;
+        queryRequest.totalPages = this.totalPages;
         return request;
     }
 
@@ -240,7 +243,8 @@ public class EventDataQueryRequest
                 .outputIdScheme( criteria.getOutputIdScheme() )
                 .orgUnitField( criteria.getOrgUnitField() )
                 .coordinatesOnly( criteria.isCoordinatesOnly() )
-                .coordinateOuFallback( criteria.isCoordinateOuFallback() );
+                .coordinateOuFallback( criteria.isCoordinateOuFallback() )
+                .totalPages( criteria.isTotalPages() );
 
             if ( criteria.getDimension() == null )
             {
@@ -330,7 +334,8 @@ public class EventDataQueryRequest
                 .relativePeriodDate( criteria.getRelativePeriodDate() )
                 .userOrgUnit( criteria.getUserOrgUnit() )
                 .coordinateField( criteria.getCoordinateField() )
-                .sortOrder( criteria.getSortOrder() );
+                .sortOrder( criteria.getSortOrder() )
+                .totalPages( criteria.isTotalPages() );
 
             if ( criteria.getDimension() == null )
             {
@@ -445,6 +450,5 @@ public class EventDataQueryRequest
         {
             return dimension.startsWith( PERIOD_DIM_ID + DIMENSION_NAME_SEP );
         }
-
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventsAnalyticsQueryCriteria.java
@@ -30,8 +30,9 @@ package org.hisp.dhis.common;
 import java.util.Date;
 import java.util.Set;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.EventOutputType;
@@ -43,7 +44,8 @@ import org.hisp.dhis.program.ProgramStatus;
  * This class contains all the criteria that can be used to execute a DHIS2
  * Events analytics query using the EventAnalyticsController
  */
-@Data
+@Getter
+@Setter
 @NoArgsConstructor
 public class EventsAnalyticsQueryCriteria extends RequestTypeAware
 {
@@ -318,4 +320,10 @@ public class EventsAnalyticsQueryCriteria extends RequestTypeAware
      * default is true (always paginate).
      */
     private boolean paging = true;
+
+    /**
+     * The paging parameter. When set to false we should not count total pages.
+     * The default is true (always total pages flag activated).
+     */
+    private boolean totalPages = true;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Grid.java
@@ -536,4 +536,8 @@ public interface Grid
      * @param newColumnsIndexes
      */
     void repositionColumns( final Set<Integer> newColumnsIndexes );
+
+    boolean hasLastDataRow();
+
+    void setLastDataRow( boolean lastDataRow );
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
@@ -28,15 +28,23 @@
 package org.hisp.dhis.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class EventDataQueryRequestTest
 {
+
+    public static boolean[] totalPagesFlags()
+    {
+        return new boolean[] { false, true };
+    }
 
     @Test
     void testDimensionRefactoringOnlyWhenQuery()
@@ -108,5 +116,32 @@ public class EventDataQueryRequestTest
         assertEquals( eventDataQueryRequest.getDimension(),
             Set.of(
                 "pe:LAST_MONTH;LAST_YEAR:ENROLLMENT_DATE;202111:INCIDENT_DATE;2021:INCIDENT_DATE;TODAY:INCIDENT_DATE" ) );
+    }
+
+    @Test
+    void testTotalPagesShouldReturnFalseWhenCalled()
+    {
+        EnrollmentAnalyticsQueryCriteria criteria = new EnrollmentAnalyticsQueryCriteria();
+
+        criteria.setTotalPages( false );
+
+        EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
+            .fromCriteria( criteria )
+            .build();
+
+        assertFalse( eventDataQueryRequest.isTotalPages() );
+    }
+
+    @ParameterizedTest
+    @MethodSource( value = "totalPagesFlags" )
+    void totalPagesShouldBeSameInCriteriaAndRequestWhenCalled( boolean totalPages )
+    {
+        EnrollmentAnalyticsQueryCriteria criteria = new EnrollmentAnalyticsQueryCriteria();
+
+        criteria.setTotalPages( totalPages );
+
+        assertEquals( EventDataQueryRequest.builder()
+            .fromCriteria( criteria )
+            .build().isTotalPages(), totalPages );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/EventDataQueryRequestTest.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -116,20 +115,6 @@ public class EventDataQueryRequestTest
         assertEquals( eventDataQueryRequest.getDimension(),
             Set.of(
                 "pe:LAST_MONTH;LAST_YEAR:ENROLLMENT_DATE;202111:INCIDENT_DATE;2021:INCIDENT_DATE;TODAY:INCIDENT_DATE" ) );
-    }
-
-    @Test
-    void testTotalPagesShouldReturnFalseWhenCalled()
-    {
-        EnrollmentAnalyticsQueryCriteria criteria = new EnrollmentAnalyticsQueryCriteria();
-
-        criteria.setTotalPages( false );
-
-        EventDataQueryRequest eventDataQueryRequest = EventDataQueryRequest.builder()
-            .fromCriteria( criteria )
-            .build();
-
-        assertFalse( eventDataQueryRequest.isTotalPages() );
     }
 
     @ParameterizedTest

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -179,6 +179,11 @@ public class EventQueryParams
     private boolean paging;
 
     /**
+     * The total pages flag.
+     */
+    private boolean totalPages;
+
+    /**
      * The value sort order.
      */
     private SortOrder sortOrder;
@@ -321,6 +326,7 @@ public class EventQueryParams
         params.page = this.page;
         params.pageSize = this.pageSize;
         params.paging = this.paging;
+        params.totalPages = this.totalPages;
         params.sortOrder = this.sortOrder;
         params.limit = this.limit;
         params.outputType = this.outputType;
@@ -822,6 +828,11 @@ public class EventQueryParams
     public boolean isPaging()
     {
         return paging || page != null || pageSize != null;
+    }
+
+    public boolean isTotalPages()
+    {
+        return totalPages;
     }
 
     public int getPageWithDefault()
@@ -1329,6 +1340,12 @@ public class EventQueryParams
         public Builder withPaging( boolean paging )
         {
             this.params.paging = paging;
+            return this;
+        }
+
+        public Builder withTotalPages( boolean totalPages )
+        {
+            this.params.totalPages = totalPages;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -219,11 +219,6 @@ public abstract class AbstractAnalyticsService
         }
     }
 
-    private static boolean isLastPage( int page, int pageSize, long count )
-    {
-        return (long) page * pageSize >= count;
-    }
-
     /**
      * Based on the given item this method returns the correct uid based on
      * internal rules/requirements.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.RepeatableStageParams;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -201,7 +202,10 @@ public abstract class AbstractAnalyticsService
 
         if ( params.isPaging() )
         {
-            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            Pager pager = params.isTotalPages()
+                ? new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() )
+                : new SlimPager( params.getPageWithDefault(), params.getPageSizeWithDefault(),
+                    isLastPage( params.getPageWithDefault(), params.getPageSizeWithDefault(), count ) );
 
             grid.getMetaData().put( PAGER.getKey(), pager );
         }
@@ -209,6 +213,11 @@ public abstract class AbstractAnalyticsService
         maybeApplyHeaders( params, grid );
 
         return grid;
+    }
+
+    private static boolean isLastPage( int page, int pageSize, long count )
+    {
+        return (long) page * pageSize >= count;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -200,6 +200,15 @@ public abstract class AbstractAnalyticsService
         // Paging
         // ---------------------------------------------------------------------
 
+        applyPaging( params, count, grid );
+
+        maybeApplyHeaders( params, grid );
+
+        return grid;
+    }
+
+    private static void applyPaging( EventQueryParams params, long count, Grid grid )
+    {
         if ( params.isPaging() )
         {
             Pager pager = params.isTotalPages()
@@ -209,10 +218,6 @@ public abstract class AbstractAnalyticsService
 
             grid.getMetaData().put( PAGER.getKey(), pager );
         }
-
-        maybeApplyHeaders( params, grid );
-
-        return grid;
     }
 
     private static boolean isLastPage( int page, int pageSize, long count )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -213,8 +213,7 @@ public abstract class AbstractAnalyticsService
         {
             Pager pager = params.isTotalPages()
                 ? new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() )
-                : new SlimPager( params.getPageWithDefault(), params.getPageSizeWithDefault(),
-                    isLastPage( params.getPageWithDefault(), params.getPageSizeWithDefault(), count ) );
+                : new SlimPager( params.getPageWithDefault(), params.getPageSizeWithDefault(), grid.hasLastDataRow() );
 
             grid.getMetaData().put( PAGER.getKey(), pager );
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -200,14 +200,14 @@ public abstract class AbstractAnalyticsService
         // Paging
         // ---------------------------------------------------------------------
 
-        applyPaging( params, count, grid );
+        maybeApplyPaging( params, count, grid );
 
         maybeApplyHeaders( params, grid );
 
         return grid;
     }
 
-    private static void applyPaging( EventQueryParams params, long count, Grid grid )
+    private static void maybeApplyPaging( EventQueryParams params, long count, Grid grid )
     {
         if ( params.isPaging() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -142,7 +142,8 @@ public abstract class AbstractJdbcEventAnalyticsManager
 
         if ( params.isPaging() )
         {
-            sql += "limit " + params.getPageSizeWithDefault() + " offset " + params.getOffset();
+            int limit = params.isTotalPages() ? params.getPageSizeWithDefault() : params.getPageSizeWithDefault() + 1;
+            sql += "limit " + limit + " offset " + params.getOffset();
         }
         else if ( maxLimit > 0 )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -96,6 +96,8 @@ import com.google.common.collect.Lists;
 @Slf4j
 public abstract class AbstractJdbcEventAnalyticsManager
 {
+    private static final String LIMIT = "limit";
+
     protected static final String COL_COUNT = "count";
 
     protected static final String COL_EXTENT = "extent";
@@ -143,11 +145,11 @@ public abstract class AbstractJdbcEventAnalyticsManager
         if ( params.isPaging() )
         {
             int limit = params.isTotalPages() ? params.getPageSizeWithDefault() : params.getPageSizeWithDefault() + 1;
-            sql += "limit " + limit + " offset " + params.getOffset();
+            sql += LIMIT + " " + limit + " offset " + params.getOffset();
         }
         else if ( maxLimit > 0 )
         {
-            sql += "limit " + (maxLimit + 1);
+            sql += LIMIT + " " + (maxLimit + 1);
         }
 
         return sql;
@@ -370,11 +372,11 @@ public abstract class AbstractJdbcEventAnalyticsManager
 
         if ( params.hasLimit() )
         {
-            sql += "limit " + params.getLimit();
+            sql += LIMIT + " " + params.getLimit();
         }
         else if ( maxLimit > 0 )
         {
-            sql += "limit " + (maxLimit + 1);
+            sql += LIMIT + " " + (maxLimit + 1);
         }
 
         // ---------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -791,12 +791,12 @@ public class DefaultEventAnalyticsService
 
         if ( params.getPartitions().hasAny() || params.isSkipPartitioning() )
         {
-            if ( params.isPaging() )
-            {
-                count += eventAnalyticsManager.getEventCount( params );
-            }
-
             eventAnalyticsManager.getEvents( params, grid, queryValidator.getMaxLimit() );
+
+            if ( params.isPaging() && params.isTotalPages() )
+            {
+                count = eventAnalyticsManager.getEventCount( params );
+            }
 
             timer.getTime( "Got events " + grid.getHeight() );
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -227,6 +227,7 @@ public class DefaultEventDataQueryService
             .withPage( request.getPage() )
             .withPageSize( request.getPageSize() )
             .withPaging( request.isPaging() )
+            .withTotalPages( request.isTotalPages() )
             .withProgramStatuses( request.getProgramStatus() )
             .withApiVersion( request.getApiVersion() );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -149,7 +149,7 @@ public class JdbcEventAnalyticsManager
      * @param grid the {@link Grid}.
      * @param sql the SQL statement used to retrieve events.
      */
-    private void getEvents( EventQueryParams params, Grid grid, String sql, int limit )
+    private void getEvents( EventQueryParams params, Grid grid, String sql )
     {
         log.debug( String.format( "Analytics event query SQL: %s", sql ) );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -135,7 +135,7 @@ public class JdbcEventAnalyticsManager
         }
         else
         {
-            withExceptionHandling( () -> getEvents( params, grid, sql, maxLimit ) );
+            withExceptionHandling( () -> getEvents( params, grid, sql ) );
         }
 
         return grid;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -135,7 +135,7 @@ public class JdbcEventAnalyticsManager
         }
         else
         {
-            withExceptionHandling( () -> getEvents( params, grid, sql ) );
+            withExceptionHandling( () -> getEvents( params, grid, sql, maxLimit ) );
         }
 
         return grid;
@@ -149,14 +149,25 @@ public class JdbcEventAnalyticsManager
      * @param grid the {@link Grid}.
      * @param sql the SQL statement used to retrieve events.
      */
-    private void getEvents( EventQueryParams params, Grid grid, String sql )
+    private void getEvents( EventQueryParams params, Grid grid, String sql, int limit )
     {
         log.debug( String.format( "Analytics event query SQL: %s", sql ) );
 
         SqlRowSet rowSet = queryForRows( sql );
 
+        int rowsRed = 0;
+
+        grid.setLastDataRow( true );
+
         while ( rowSet.next() )
         {
+            if ( ++rowsRed > params.getPageSize() && !params.isTotalPages() )
+            {
+                grid.setLastDataRow( false );
+
+                continue;
+            }
+
             grid.addRow();
 
             int index = 1;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -223,7 +223,7 @@ public class JdbcEventAnalyticsManager
     @Override
     public long getEventCount( EventQueryParams params )
     {
-        String sql = "select count(psi) ";
+        String sql = "select count(1) ";
 
         sql += getFromClause( params );
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/ListGrid.java
@@ -139,6 +139,8 @@ public class ListGrid
      */
     private Map<String, Integer> columnIndexMap = new HashMap<>();
 
+    private boolean lastDataRow;
+
     /**
      * Default constructor.
      */
@@ -1241,6 +1243,18 @@ public class ListGrid
             columns.clear();
             columns.addAll( orderedColumns );
         }
+    }
+
+    @Override
+    public boolean hasLastDataRow()
+    {
+        return lastDataRow;
+    }
+
+    @Override
+    public void setLastDataRow( boolean lastDataRow )
+    {
+        this.lastDataRow = lastDataRow;
     }
 
     /**


### PR DESCRIPTION
Calculating total number and page count is a potential performance problem in event analytics '/query' endpoints. Currently the totalPages param is not working and returns the total.

The details for what should be returned are specified in this bug report: https://jira.dhis2.org/browse/DHIS2-12530