### PR TITLE
fix: don't let presets overwrite explicit fields

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -238,7 +238,12 @@ public class FieldPathHelper
             }
         }
 
-        fieldPaths.forEach( fp -> fieldPathMap.put( fp.toFullPath(), fp ) );
+        fieldPaths.forEach( fp -> {
+            if ( !fieldPathMap.containsKey( fp.toFullPath() ) )
+            {
+                fieldPathMap.put( fp.toFullPath(), fp );
+            }
+        } );
     }
 
     private void applyExclusions( List<FieldPath> exclusions, Map<String, FieldPath> fieldPathMap )

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -238,12 +238,7 @@ public class FieldPathHelper
             }
         }
 
-        fieldPaths.forEach( fp -> {
-            if ( !fieldPathMap.containsKey( fp.toFullPath() ) )
-            {
-                fieldPathMap.put( fp.toFullPath(), fp );
-            }
-        } );
+        fieldPaths.forEach( fp -> fieldPathMap.putIfAbsent( fp.toFullPath(), fp ) );
     }
 
     private void applyExclusions( List<FieldPath> exclusions, Map<String, FieldPath> fieldPathMap )


### PR DESCRIPTION
Fixes a bug where preset expansion would overwrite field transformers.