### PR TITLE
fix: /generateAndReserve returns duplicate values when attribute pattern contains a constant [ DHIS2-12182 ] [ 2.37 ] 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/reservedvalue/hibernate/ReservedValue.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/reservedvalue/hibernate/ReservedValue.hbm.xml
@@ -37,7 +37,7 @@
         rs.ownerObject = :ownerObject
         and rs.ownerUid = :ownerUid
         and rs.key = :key
-        and rs.value in (:values)
+        and LOWER(rs.value) in (:values)
         ]]>
     </sql-query>
 </hibernate-mapping>

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/ReservedValueServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/reservedvalue/ReservedValueServiceIntegrationTest.java
@@ -70,6 +70,8 @@ public class ReservedValueServiceIntegrationTest extends TransactionalIntegratio
 
     private static TrackedEntityAttribute simpleRandomTextPattern;
 
+    private static TrackedEntityAttribute simpleRandomTextNumericPattern;
+
     private static TrackedEntityAttribute simpleStringPattern;
 
     @BeforeClass
@@ -87,6 +89,7 @@ public class ReservedValueServiceIntegrationTest extends TransactionalIntegratio
         simpleTextPattern = createTextPattern( tea, "\"FOOBAR\"" );
         simpleSequentialTextPattern = createTextPattern( tea, "\"TEST-\"+SEQUENTIAL(##)" );
         simpleRandomTextPattern = createTextPattern( tea, "\"TEST-\"+RANDOM(XXX)" );
+        simpleRandomTextNumericPattern = createTextPattern( tea, "\"EPI_\"+RANDOM(######)" );
         simpleStringPattern = createTextPattern( tea, "\"TEST-\"+ORG_UNIT_CODE(..)" );
     }
 
@@ -133,6 +136,34 @@ public class ReservedValueServiceIntegrationTest extends TransactionalIntegratio
             .filter( ( rv ) -> rv.getValue().indexOf( "TEST-" ) == 0 && rv.getValue().length() == 8 )
             .count() );
         assertEquals( 3, all.size() );
+    }
+
+    @Test
+    public void testReserveReserveRandomValuesWithExistingGenerationAndAlphaNumericPattern()
+        throws Exception
+    {
+        TrackedEntityAttribute tea = createTrackedEntityAttribute( 'A' );
+
+        simpleRandomTextNumericPattern = createTextPattern( tea, "\"EPI_\"+RANDOM(######)" );
+
+        ReservedValue reservedValue = new ReservedValue();
+        reservedValue.setTrackedEntityAttributeId( tea.getId() );
+        reservedValue.setCreated( new Date() );
+        reservedValue.setExpiryDate( new Date() );
+        reservedValue.setOwnerObject( simpleRandomTextNumericPattern.getTextPattern().getOwnerObject().toString() );
+        reservedValue.setOwnerUid( tea.getUid() );
+        reservedValue.setKey( "EPI_RANDOM(######)" );
+        reservedValue.setValue( "EPI_000000" );
+
+        reservedValueStore.save( reservedValue );
+
+        reservedValueService.reserve( simpleRandomTextNumericPattern, 3, new HashMap<>(), future );
+
+        List<ReservedValue> all = reservedValueStore.getAll();
+        assertEquals( 4, all.stream()
+            .filter( ( rv ) -> rv.getValue().indexOf( "EPI_" ) == 0 && rv.getValue().length() == 10 )
+            .count() );
+        assertEquals( 4, all.size() );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_44__Add_index_to_reserved_value.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.37/V2_37_44__Add_index_to_reserved_value.sql
@@ -1,0 +1,2 @@
+create unique index if not exists in_reservedvalue_value_generation on reservedvalue using btree (ownerobject, owneruid, key, lower (value));
+ALTER TABLE ONLY reservedvalue DROP CONSTRAINT IF EXISTS uk_2utuk3clxif3qi4icy859kdrb;


### PR DESCRIPTION
see https://github.com/dhis2/dhis2-core/pull/9983