### PR TITLE
fix: Analytics export crash with invalid dates [DHIS2-12581]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTable.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.resourcetable;
 
+import static java.time.LocalDate.now;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -37,6 +39,10 @@ import org.hisp.dhis.common.CodeGenerator;
  */
 public abstract class ResourceTable<T>
 {
+    public static final int OLDEST_YEAR_PERIOD_SUPPORTED = 1975;
+
+    public static final int NEWEST_YEAR_PERIOD_SUPPORTED = now().plusYears( 2 ).getYear();
+
     protected static final String TEMP_TABLE_SUFFIX = "_temp";
 
     protected List<T> objects;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
@@ -92,8 +92,8 @@ public class DatePeriodResourceTable
 
         // TODO Create a dynamic solution instead of having fixed dates
 
-        Date startDate = new Cal( 1975, 1, 1, true ).time();
-        Date endDate = new Cal( 2025, 1, 1, true ).time();
+        Date startDate = new Cal( OLDEST_YEAR_PERIOD_SUPPORTED, 1, 1, true ).time();
+        Date endDate = new Cal( NEWEST_YEAR_PERIOD_SUPPORTED + 1, 1, 1, true ).time();
 
         List<Period> dailyPeriods = new DailyPeriodType().generatePeriods( startDate, endDate );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -39,6 +39,8 @@ import static org.hisp.dhis.analytics.ColumnNotNullConstraint.NOT_NULL;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.getClosingParentheses;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.getColumnType;
+import static org.hisp.dhis.resourcetable.ResourceTable.NEWEST_YEAR_PERIOD_SUPPORTED;
+import static org.hisp.dhis.resourcetable.ResourceTable.OLDEST_YEAR_PERIOD_SUPPORTED;
 import static org.hisp.dhis.system.util.MathUtils.NUMERIC_LENIENT_REGEXP;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
@@ -362,6 +364,9 @@ public class JdbcEventAnalyticsTableManager
             "and pr.programid=" + program.getId() + " " +
             "and psi.organisationunitid is not null " +
             "and psi.executiondate is not null " +
+            "and dps.yearly is not null " +
+            "and dps.year >= " + OLDEST_YEAR_PERIOD_SUPPORTED + " " +
+            "and dps.year <= " + NEWEST_YEAR_PERIOD_SUPPORTED + " " +
             "and psi.deleted is false ";
 
         populateTableInternal( partition, getDimensionColumns( program ), fromClause );
@@ -585,7 +590,8 @@ public class JdbcEventAnalyticsTableManager
 
     private List<Integer> getDataYears( AnalyticsTableUpdateParams params, Program program )
     {
-        String sql = "select distinct(extract(year from psi.executiondate)) " +
+        String sql = "select temp.supportedyear from " +
+            "(select distinct extract(year from psi.executiondate) as supportedyear " +
             "from programstageinstance psi " +
             "inner join programinstance pi on psi.programinstanceid = pi.programinstanceid " +
             "where psi.lastupdated <= '" + getLongDateString( params.getStartTime() ) + "' " +
@@ -593,11 +599,13 @@ public class JdbcEventAnalyticsTableManager
             "and psi.executiondate is not null " +
             "and psi.executiondate > '1000-01-01' " +
             "and psi.deleted is false ";
-
         if ( params.getFromDate() != null )
         {
             sql += "and psi.executiondate >= '" + DateUtils.getMediumDateString( params.getFromDate() ) + "'";
         }
+
+        sql += ") as temp where temp.supportedyear >= " + OLDEST_YEAR_PERIOD_SUPPORTED +
+            " and temp.supportedyear <= " + NEWEST_YEAR_PERIOD_SUPPORTED;
 
         return jdbcTemplate.queryForList( sql, Integer.class );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -49,6 +49,7 @@ import static org.hisp.dhis.analytics.ColumnDataType.GEOMETRY_POINT;
 import static org.hisp.dhis.analytics.ColumnDataType.INTEGER;
 import static org.hisp.dhis.analytics.ColumnDataType.TEXT;
 import static org.hisp.dhis.analytics.ColumnDataType.TIMESTAMP;
+import static org.hisp.dhis.resourcetable.ResourceTable.NEWEST_YEAR_PERIOD_SUPPORTED;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -468,7 +469,11 @@ class JdbcEventAnalyticsTableManagerTest
         when( idObjectManager.getAllNoAcl( Program.class ) ).thenReturn( Collections.singletonList( programA ) );
         when( organisationUnitService.getFilledOrganisationUnitLevels() ).thenReturn( ouLevels );
         when( jdbcTemplate.queryForList(
-            "select distinct(extract(year from psi.executiondate)) from programstageinstance psi inner join programinstance pi on psi.programinstanceid = pi.programinstanceid where psi.lastupdated <= '2019-08-01T00:00:00' and pi.programid = 0 and psi.executiondate is not null and psi.executiondate > '1000-01-01' and psi.deleted is false ",
+            "select temp.supportedyear from (select distinct extract(year from psi.executiondate) as supportedyear "
+                + "from programstageinstance psi inner join programinstance pi on psi.programinstanceid = pi.programinstanceid "
+                + "where psi.lastupdated <= '2019-08-01T00:00:00' and pi.programid = 0 and psi.executiondate is not null "
+                + "and psi.executiondate > '1000-01-01' and psi.deleted is false ) "
+                + "as temp where temp.supportedyear >= 1975 and temp.supportedyear <= " + NEWEST_YEAR_PERIOD_SUPPORTED,
             Integer.class ) ).thenReturn( Lists.newArrayList( 2018, 2019 ) );
 
         AnalyticsTableUpdateParams params = AnalyticsTableUpdateParams.newBuilder().withStartTime( START_TIME ).build();
@@ -600,7 +605,11 @@ class JdbcEventAnalyticsTableManagerTest
         when( idObjectManager.getAllNoAcl( Program.class ) ).thenReturn( Lists.newArrayList( programA ) );
 
         when( jdbcTemplate.queryForList(
-            "select distinct(extract(year from psi.executiondate)) from programstageinstance psi inner join programinstance pi on psi.programinstanceid = pi.programinstanceid where psi.lastupdated <= '2019-08-01T00:00:00' and pi.programid = 0 and psi.executiondate is not null and psi.executiondate > '1000-01-01' and psi.deleted is false and psi.executiondate >= '2018-01-01'",
+            "select temp.supportedyear from (select distinct extract(year from psi.executiondate) as supportedyear "
+                + "from programstageinstance psi inner join programinstance pi on psi.programinstanceid = pi.programinstanceid "
+                + "where psi.lastupdated <= '2019-08-01T00:00:00' and pi.programid = 0 and psi.executiondate is not null "
+                + "and psi.executiondate > '1000-01-01' and psi.deleted is false and psi.executiondate >= '2018-01-01') "
+                + "as temp where temp.supportedyear >= 1975 and temp.supportedyear <= " + NEWEST_YEAR_PERIOD_SUPPORTED,
             Integer.class ) ).thenReturn( Lists.newArrayList( 2018, 2019 ) );
 
         AnalyticsTableUpdateParams params = AnalyticsTableUpdateParams.newBuilder().withLastYears( 2 )
@@ -631,15 +640,17 @@ class JdbcEventAnalyticsTableManagerTest
 
     private String getYearQueryForCurrentYear( Program program, boolean withExecutionDate )
     {
-        String sql = "select distinct(extract(year from psi.executiondate)) from programstageinstance psi inner join "
+        String sql = "select temp.supportedyear from (select distinct extract(year from psi.executiondate) as supportedyear "
+            + "from programstageinstance psi inner join "
             + "programinstance pi on psi.programinstanceid = pi.programinstanceid where psi.lastupdated <= '"
             + "2019-08-01T00:00:00' and pi.programid = " + program.getId()
             + " and psi.executiondate is not null and psi.executiondate > '1000-01-01' and psi.deleted is false ";
-
         if ( withExecutionDate )
         {
             sql += "and psi.executiondate >= '2018-01-01'";
         }
+
+        sql += ") as temp where temp.supportedyear >= 1975 and temp.supportedyear <= " + NEWEST_YEAR_PERIOD_SUPPORTED;
 
         return sql;
     }


### PR DESCRIPTION
These changes aim to fix an issue/crash during the analytics tables export.

Currently, we have a limit of years allowed by the analytics table when exporting events.
As you can see below (in the PR), we are limited to dates between 1975 and 2024.
(I'm keeping this behaviour to minimize risks. Ideally, at some point in the future, we need to remove this limitation and stop using the periods' table during the analytics export.)

This fix will basically ensure that we only read events and years that belong to that interval (inclusive).
It will guarantee that no partitions with invalid years (out of that interval) will be created, avoiding joins with the table `_dateperiodstructure` on top of years that do not exist in that same table.

When we try to join using years out of the interval 1975-2024 the partition tables will be populated with `null` values in the `year` column.
Later, when the process tries to attach the partition to the main table, we get something like:
```
org.postgresql.util.PSQLException:
ERROR: partition constraint of relation "analytics_event_ywhgjzui7r5_1900" is violated by some row
```
That happens because 1900 is out of the interval and the partition table will contain `null` values in the `year` column with causes the violation.

This was reported by the community and more details can be found at https://jira.dhis2.org/browse/DHIS2-12581
