### PR TITLE
fix: bump rule-engine version [DHIS2-12537]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -31,6 +31,7 @@ import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.hisp.dhis.system.util.MathUtils.parseDouble;
 
 import java.awt.geom.Point2D;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
@@ -657,6 +658,10 @@ public class ValidationUtils
         else if ( valueType.isBoolean() )
         {
             return false;
+        }
+        else if ( valueType.isDate() )
+        {
+            return new Date();
         }
         else
         {

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -56,7 +56,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine-->
-    <dhis2-rule-engine.version>2.0.27</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.0.37</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>
@@ -229,7 +229,7 @@
     <extra-enforcer-rules.version>1.3</extra-enforcer-rules.version>
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.6</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.19</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.26</dhis-antlr-expression-parser.version>
     <ow2.asm.version>9.0</ow2.asm.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.8.2</gson.version>


### PR DESCRIPTION
I changed the version of rule engine to the latest one that fix a problem in the logs. Now we are logging the evaluation of the rules in debug mode as before it was causing a lot of noise in the logs