### PR TITLE
fix: Error during partitions generation and swapping [TECH-1028]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableManager.java
@@ -143,6 +143,13 @@ public interface AnalyticsTableManager
     void dropTempTable( AnalyticsTable table );
 
     /**
+     * Drops the given {@link AnalyticsTablePartition}.
+     *
+     * @param tablePartition the analytics table.
+     */
+    void dropTempTablePartition( AnalyticsTablePartition tablePartition );
+
+    /**
      * Drops the given table.
      *
      * @param tableName the table name.


### PR DESCRIPTION
When adding a new column to the analytics events table, temporary partition tables are not being attached to the master table.

This happens because the master table is not being recreated if they already exist. So, when we add a new column it will fail at attachment time because the master table does not contain the new column (as it was not recreated).

When this error happens, it also leaves all temporary partitions populated, unattached and named with the "temp" suffixes. They stay in the DB as `orphan` objects.

Whit this PR, the master table will always be updated to ensure it gets any new column being added. It also prevents some SQL commands to fail when they actually could proceed.

These changes aim to fix those bugs and inconsistencies.

**_Backport from master/2.39_**