### PR TITLE
fix: Error during partitions generation and swapping [TECH-1028]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableManager.java
@@ -145,6 +145,13 @@ public interface AnalyticsTableManager
     void dropTempTable( AnalyticsTable table );
 
     /**
+     * Drops the given {@link AnalyticsTablePartition}.
+     *
+     * @param tablePartition the analytics table.
+     */
+    void dropTempTablePartition( AnalyticsTablePartition tablePartition );
+
+    /**
      * Drops the given table.
      *
      * @param tableName the table name.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -33,7 +33,10 @@ import static org.hisp.dhis.analytics.ColumnDataType.TEXT;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
@@ -41,7 +44,16 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.analytics.*;
+import org.hisp.dhis.analytics.AnalyticsIndex;
+import org.hisp.dhis.analytics.AnalyticsTable;
+import org.hisp.dhis.analytics.AnalyticsTableColumn;
+import org.hisp.dhis.analytics.AnalyticsTableHook;
+import org.hisp.dhis.analytics.AnalyticsTableHookService;
+import org.hisp.dhis.analytics.AnalyticsTableManager;
+import org.hisp.dhis.analytics.AnalyticsTablePartition;
+import org.hisp.dhis.analytics.AnalyticsTablePhase;
+import org.hisp.dhis.analytics.AnalyticsTableType;
+import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.analytics.partition.PartitionManager;
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.category.CategoryService;
@@ -227,18 +239,13 @@ public abstract class AbstractJdbcTableManager
     @Override
     public void swapTable( AnalyticsTableUpdateParams params, AnalyticsTable table )
     {
-        boolean tableExists = partitionManager.tableExists( table.getTableName() );
-        boolean skipMasterTable = params.isPartialUpdate() && tableExists;
+        log.info( "Swapping master table {}, and its partitions", table.getTableName() );
 
-        log.info( "Swapping table, master table exists: {}, skip master table: {}", tableExists, skipMasterTable );
+        swapTable( table );
 
         if ( getPartitionColumn() != null )
         {
             table.getTablePartitions().forEach( p -> swapTable( table, p ) );
-        }
-        else
-        {
-            swapTable( table );
         }
     }
 
@@ -246,6 +253,12 @@ public abstract class AbstractJdbcTableManager
     public void dropTempTable( AnalyticsTable table )
     {
         dropTableCascade( table.getTempTableName() );
+    }
+
+    @Override
+    public void dropTempTablePartition( AnalyticsTablePartition tablePartition )
+    {
+        dropTableCascade( tablePartition.getTempTableName() );
     }
 
     @Override
@@ -627,18 +640,18 @@ public abstract class AbstractJdbcTableManager
         String tempTableName = tablePartition.getTempTableName();
 
         final String[] sqlSteps = {
-            " alter table " + mainTableName + " detach partition " + realTableName,
-            " drop table " + realTableName + " cascade",
-            " alter table " + tempTableName + " rename to " + realTableName,
-            " alter table " + mainTableName + " attach partition " + realTableName
+            " alter table if exists " + mainTableName + " detach partition " + realTableName,
+            " drop table if exists " + realTableName + " cascade",
+            " alter table if exists " + tempTableName + " rename to " + realTableName,
+            " alter table if exists " + mainTableName + " attach partition " + realTableName
                 + " for values in (" + tablePartition.getYear() + ")"
         };
 
-        final String sql = String.join( ";", sqlSteps ) + ";";
-
-        log.debug( sql );
-
-        executeSilently( sql );
+        for ( int i = 0; i < sqlSteps.length; i++ )
+        {
+            log.debug( sqlSteps[i] );
+            executeSilently( sqlSteps[i] );
+        }
     }
 
     private void swapTable( AnalyticsTable mainTable )
@@ -648,7 +661,7 @@ public abstract class AbstractJdbcTableManager
 
         final String[] sqlSteps = {
             " drop table if exists " + mainTableName + " cascade",
-            " alter table " + tempTableName + " rename to " + mainTableName
+            " alter table if exists " + tempTableName + " rename to " + mainTableName
         };
 
         final String sql = String.join( ";", sqlSteps ) + ";";
@@ -680,7 +693,7 @@ public abstract class AbstractJdbcTableManager
     {
         createTableAsPartitionOf( table, partition );
 
-        String tableName = partition == null ? table.getTableName() : partition.getTempTableName();
+        String tableName = partition == null ? table.getTempTableName() : partition.getTempTableName();
         String sqlCreate = "create table if not exists " + tableName + " (";
         for ( AnalyticsTableColumn col : ListUtils.union( table.getDimensionColumns(), table.getValueColumns() ) )
         {
@@ -715,7 +728,7 @@ public abstract class AbstractJdbcTableManager
         if ( partition != null && getPartitionColumn() != null )
         {
             String createTableAsPartitionOfSql = "create table if not exists " + partition.getTableName()
-                + " partition of " + table.getTableName() + " for values in " + "(" + partition.getYear() + ")";
+                + " partition of " + table.getTempTableName() + " for values in " + "(" + partition.getYear() + ")";
 
             log.debug( "Creating table: '{}', columns: {}", partition.getTableName(),
                 table.getDimensionColumns().size() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -154,7 +154,7 @@ public class DefaultAnalyticsTableService
         clock.logTime( "Performed pre-create table work" );
         notifier.notify( jobId, "Dropping temp tables" );
 
-        dropTempTables( tables );
+        dropAllTempTables( tables );
 
         clock.logTime( "Dropped temp tables" );
         notifier.notify( jobId, "Creating analytics tables" );
@@ -233,13 +233,35 @@ public class DefaultAnalyticsTableService
     // -------------------------------------------------------------------------
 
     /**
+     * Drops all temporary tables, including the ones used as partitions.
+     *
+     * @param tables
+     */
+    private void dropAllTempTables( final List<AnalyticsTable> tables )
+    {
+        dropTempTablesPartitions( tables );
+        dropTempTables( tables );
+    }
+
+    /**
      * Drops the given temporary analytics tables.
      *
      * @param tables the list of {@link AnalyticsTable}.
      */
-    private void dropTempTables( List<AnalyticsTable> tables )
+    private void dropTempTables( final List<AnalyticsTable> tables )
     {
         tables.forEach( table -> tableManager.dropTempTable( table ) );
+    }
+
+    /**
+     * Drops the given temporary analytics tables.
+     */
+    private void dropTempTablesPartitions( final List<AnalyticsTable> tables )
+    {
+        for ( final AnalyticsTable table : tables )
+        {
+            table.getTablePartitions().forEach( partition -> tableManager.dropTempTablePartition( partition ) );
+        }
     }
 
     /**


### PR DESCRIPTION
When adding a new column to the analytics events table, temporary partition tables are not being attached to the master table.

This happens because the master table is not being recreated if they already exist. So, when we add a new column it will fail at attachment time because the master table does not contain the new column (as it was not recreated).

When this error happens, it also leaves all temporary partitions populated, unattached and named with the "temp" suffixes. They stay in the DB as `orphan` objects.

Whit this PR, the master table will always be updated to ensure it gets any new column being added. It also prevents some SQL commands to fail when they actually could proceed.

These changes aim to fix those bugs and inconsistencies.

**_Backport from master/2.39_**