### PR TITLE
fix: Event update should only check ownership orgunit for tracker programs [DHIS2-12732] (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -330,9 +330,9 @@ public class PreCheckSecurityOwnershipValidationHook
 
         checkEventWriteAccess( reporter, event, programStage, organisationUnit, ownerOrgUnit,
             categoryOptionCombo,
-            teiUid, isCreatableInSearchScope, reporter.getBundle().getStrategy( event ) ); // TODO:
-                                                                                           // calculate
-                                                                                           // correct
+            teiUid, isCreatableInSearchScope ); // TODO:
+                                                // calculate
+                                                // correct
         // isCreatableInSearchScope
         // value
     }
@@ -351,7 +351,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkEventWriteAccess( reporter, event, programStageInstance.getProgramStage(),
             programStageInstance.getOrganisationUnit(), ownerOrgUnit,
             programStageInstance.getAttributeOptionCombo(),
-            teiUid, programStageInstance.isCreatableInSearchScope(), strategy );
+            teiUid, programStageInstance.isCreatableInSearchScope() );
 
         if ( strategy.isUpdate()
             && EventStatus.COMPLETED == programStageInstance.getStatus()
@@ -512,7 +512,7 @@ public class PreCheckSecurityOwnershipValidationHook
     private void checkEventWriteAccess( ValidationErrorReporter reporter, Event event, ProgramStage programStage,
         OrganisationUnit eventOrgUnit, OrganisationUnit ownerOrgUnit,
         CategoryOptionCombo categoryOptionCombo,
-        String trackedEntity, boolean isCreatableInSearchScope, TrackerImportStrategy strategy )
+        String trackedEntity, boolean isCreatableInSearchScope )
     {
         TrackerBundle bundle = reporter.getBundle();
         User user = bundle.getUser();
@@ -521,7 +521,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( programStage, PROGRAM_STAGE_CANT_BE_NULL );
         checkNotNull( programStage.getProgram(), PROGRAM_CANT_BE_NULL );
 
-        if ( strategy != TrackerImportStrategy.UPDATE )
+        if ( reporter.getBundle().getStrategy( event ) != TrackerImportStrategy.UPDATE )
         {
             checkEventOrgUnitWriteAccess( reporter, bundle, event, eventOrgUnit, isCreatableInSearchScope, user );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -330,7 +330,9 @@ public class PreCheckSecurityOwnershipValidationHook
 
         checkEventWriteAccess( reporter, event, programStage, organisationUnit, ownerOrgUnit,
             categoryOptionCombo,
-            teiUid, isCreatableInSearchScope ); // TODO: calculate correct
+            teiUid, isCreatableInSearchScope, reporter.getBundle().getStrategy( event ) ); // TODO:
+                                                                                           // calculate
+                                                                                           // correct
         // isCreatableInSearchScope
         // value
     }
@@ -349,7 +351,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkEventWriteAccess( reporter, event, programStageInstance.getProgramStage(),
             programStageInstance.getOrganisationUnit(), ownerOrgUnit,
             programStageInstance.getAttributeOptionCombo(),
-            teiUid, programStageInstance.isCreatableInSearchScope() );
+            teiUid, programStageInstance.isCreatableInSearchScope(), strategy );
 
         if ( strategy.isUpdate()
             && EventStatus.COMPLETED == programStageInstance.getStatus()
@@ -510,7 +512,7 @@ public class PreCheckSecurityOwnershipValidationHook
     private void checkEventWriteAccess( ValidationErrorReporter reporter, Event event, ProgramStage programStage,
         OrganisationUnit eventOrgUnit, OrganisationUnit ownerOrgUnit,
         CategoryOptionCombo categoryOptionCombo,
-        String trackedEntity, boolean isCreatableInSearchScope )
+        String trackedEntity, boolean isCreatableInSearchScope, TrackerImportStrategy strategy )
     {
         TrackerBundle bundle = reporter.getBundle();
         User user = bundle.getUser();
@@ -519,7 +521,10 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( programStage, PROGRAM_STAGE_CANT_BE_NULL );
         checkNotNull( programStage.getProgram(), PROGRAM_CANT_BE_NULL );
 
-        checkEventOrgUnitWriteAccess( reporter, bundle, event, eventOrgUnit, isCreatableInSearchScope, user );
+        if ( strategy != TrackerImportStrategy.UPDATE )
+        {
+            checkEventOrgUnitWriteAccess( reporter, bundle, event, eventOrgUnit, isCreatableInSearchScope, user );
+        }
 
         if ( programStage.getProgram().isWithoutRegistration() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -805,8 +805,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
         when( preheat.getProgram( PROGRAM_ID ) ).thenReturn( program );
         when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
-        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
-            .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
@@ -881,8 +879,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
-            .thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, event );
@@ -970,8 +966,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
-            .thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, event );


### PR DESCRIPTION
Skip checking event organisation unit in case of event update. Ownership org unit is only required to be checked. 