### PR TITLE
fix: ignore flaky gist attribute field test (2.38)

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -190,6 +191,7 @@ class GistFieldsControllerTest extends AbstractGistControllerTest
     }
 
     @Test
+    @Disabled( "unstable for unknown reason - needs investigation" )
     void testField_Attribute()
     {
         // setup a DE with custom attribute value


### PR DESCRIPTION
This needs investigation why the test is flaky on CI.
For now we disable it so it does not fail CI.