### PR TITLE
fix: return full relationship items DHIS2-12625 [2.38]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/databuilder/RelationshipDataBuilder.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/databuilder/RelationshipDataBuilder.java
@@ -28,8 +28,9 @@
 
 package org.hisp.dhis.tracker.importer.databuilder;
 
-import com.google.gson.JsonObject;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
+
+import com.google.gson.JsonObject;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -51,9 +52,7 @@ public class RelationshipDataBuilder implements TrackerImporterDataBuilder
 
     public RelationshipDataBuilder setFromEntity( String entityName, String entityId )
     {
-        this.jsonBuilder.addObject( "from", new JsonObjectBuilder()
-            .addProperty( entityName, entityId ) );
-
+        this.jsonBuilder.addObject( "from", relationshipItem(entityName, entityId));
         return this;
     }
 
@@ -64,15 +63,19 @@ public class RelationshipDataBuilder implements TrackerImporterDataBuilder
 
     public RelationshipDataBuilder setToEntity( String entityName, String entityId )
     {
-        this.jsonBuilder.addObject( "to", new JsonObjectBuilder()
-            .addProperty( entityName, entityId ) );
-
+        this.jsonBuilder.addObject( "to", relationshipItem( entityName, entityId ) );
         return this;
     }
 
     public RelationshipDataBuilder setToTrackedEntity( String trackedEntityId )
     {
         return setToEntity( "trackedEntity", trackedEntityId );
+    }
+
+    private JsonObjectBuilder relationshipItem(String type, String identifier) {
+        return JsonObjectBuilder.jsonObject()
+                .addObject(type, JsonObjectBuilder.jsonObject()
+                        .addProperty(type, identifier));
     }
 
     public RelationshipDataBuilder buildUniDirectionalRelationship( String teiA, String teiB )

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisAndRelationship.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisAndRelationship.json
@@ -43,10 +43,14 @@
     {
       "relationshipType": "xLmPUYJX8Ks",
       "from": {
-        "trackedEntity": "JjZ2Nwds92v"
+        "trackedEntity": {
+          "trackedEntity": "JjZ2Nwds92v"
+        }
       },
       "to": {
-        "trackedEntity": "JjZ2Nwds93v"
+        "trackedEntity": {
+         "trackedEntity": "JjZ2Nwds93v"
+        }
       }
     }
   ]

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisWithEnrollmentsAndEvents.json
@@ -61,10 +61,14 @@
         {
           "relationshipType": "xLmPUYJX8Ks",
           "from": {
-            "trackedEntity": "Kj6vYde4LHh"
+            "trackedEntity": {
+              "trackedEntity": "Kj6vYde4LHh"
+            }
           },
           "to": {
-            "trackedEntity": "Nav6inZRw1u"
+            "trackedEntity": {
+              "trackedEntity": "Nav6inZRw1u"
+            }
           }
         }
       ],

--- a/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisWithRelationship.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/tracker/importer/teis/teisWithRelationship.json
@@ -22,10 +22,14 @@
         {
           "relationshipType": "xLmPUYJX8Ks",
           "from": {
-            "trackedEntity": "JjZ2Nwds90v"
+            "trackedEntity": {
+              "trackedEntity": "JjZ2Nwds90v"
+            }
           },
           "to": {
-            "trackedEntity": "JjZ2Nwds89v"
+            "trackedEntity": {
+              "trackedEntity": "JjZ2Nwds89v"
+            }
           }
         }
       ]

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -80,7 +80,7 @@ import com.google.common.collect.ImmutableSet;
 @RequiredArgsConstructor
 public class TrackerIdentifierCollector
 {
-    public final static String ID_WILDCARD = "*";
+    public static final String ID_WILDCARD = "*";
 
     private final ProgramRuleService programRuleService;
 
@@ -205,15 +205,22 @@ public class TrackerIdentifierCollector
 
             if ( relationship.getFrom() != null )
             {
-                addIdentifier( identifiers, TrackedEntity.class, relationship.getFrom().getTrackedEntity() );
-                addIdentifier( identifiers, Enrollment.class, relationship.getFrom().getEnrollment() );
-                addIdentifier( identifiers, Event.class, relationship.getFrom().getEvent() );
+                addIdentifier( identifiers, TrackedEntity.class,
+                    relationship.getFrom().getTrackedEntity() == null ? null
+                        : relationship.getFrom().getTrackedEntity().getTrackedEntity() );
+                addIdentifier( identifiers, Enrollment.class, relationship.getFrom().getEnrollment() == null ? null
+                    : relationship.getFrom().getEnrollment().getEnrollment() );
+                addIdentifier( identifiers, Event.class,
+                    relationship.getFrom().getEvent() == null ? null : relationship.getFrom().getEvent().getEvent() );
             }
             if ( relationship.getTo() != null )
             {
-                addIdentifier( identifiers, TrackedEntity.class, relationship.getTo().getTrackedEntity() );
-                addIdentifier( identifiers, Enrollment.class, relationship.getTo().getEnrollment() );
-                addIdentifier( identifiers, Event.class, relationship.getTo().getEvent() );
+                addIdentifier( identifiers, TrackedEntity.class, relationship.getTo().getTrackedEntity() == null ? null
+                    : relationship.getTo().getTrackedEntity().getTrackedEntity() );
+                addIdentifier( identifiers, Enrollment.class, relationship.getTo().getEnrollment() == null ? null
+                    : relationship.getTo().getEnrollment().getEnrollment() );
+                addIdentifier( identifiers, Event.class,
+                    relationship.getTo().getEvent() == null ? null : relationship.getTo().getEvent().getEvent() );
             }
         } );
     }
@@ -225,11 +232,8 @@ public class TrackerIdentifierCollector
             return;
         }
 
-        if ( !identifiers.containsKey( klass ) )
-        {
-            identifiers.put( klass, new HashSet<>() );
-        }
-
-        identifiers.get( klass ).add( identifier );
+        identifiers
+            .computeIfAbsent( klass, k -> new HashSet<>() )
+            .add( identifier );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -87,11 +87,18 @@ public class RelationshipTrackerConverterService
     private RelationshipItem convertRelationshipType( org.hisp.dhis.relationship.RelationshipItem from )
     {
         RelationshipItem relationshipItem = new RelationshipItem();
-        relationshipItem.setEnrollment( from.getProgramInstance() != null ? from.getProgramInstance().getUid() : null );
-        relationshipItem
-            .setEvent( from.getProgramStageInstance() != null ? from.getProgramStageInstance().getUid() : null );
-        relationshipItem.setTrackedEntity(
-            from.getTrackedEntityInstance() != null ? from.getTrackedEntityInstance().getUid() : null );
+        RelationshipItem.Enrollment enrollment = RelationshipItem.Enrollment.builder()
+            .enrollment( from.getProgramInstance() != null ? from.getProgramInstance().getUid() : null )
+            .build();
+        relationshipItem.setEnrollment( enrollment );
+        RelationshipItem.Event event = RelationshipItem.Event.builder()
+            .event( from.getProgramStageInstance() != null ? from.getProgramStageInstance().getUid() : null )
+            .build();
+        relationshipItem.setEvent( event );
+        RelationshipItem.TrackedEntity trackedEntity = RelationshipItem.TrackedEntity.builder()
+            .trackedEntity( from.getTrackedEntityInstance() != null ? from.getTrackedEntityInstance().getUid() : null )
+            .build();
+        relationshipItem.setTrackedEntity( trackedEntity );
         return relationshipItem;
     }
 
@@ -144,17 +151,18 @@ public class RelationshipTrackerConverterService
         if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
             fromItem.setTrackedEntityInstance( preheat.getTrackedEntity( TrackerIdScheme.UID,
-                fromRelationship.getFrom().getTrackedEntity() ) );
+                fromRelationship.getFrom().getTrackedEntity().getTrackedEntity() ) );
         }
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
         {
             fromItem.setProgramInstance(
-                preheat.getEnrollment( TrackerIdScheme.UID, fromRelationship.getFrom().getEnrollment() ) );
+                preheat.getEnrollment( TrackerIdScheme.UID,
+                    fromRelationship.getFrom().getEnrollment().getEnrollment() ) );
         }
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
             fromItem.setProgramStageInstance(
-                preheat.getEvent( TrackerIdScheme.UID, fromRelationship.getFrom().getEvent() ) );
+                preheat.getEvent( TrackerIdScheme.UID, fromRelationship.getFrom().getEvent().getEvent() ) );
         }
 
         // TO
@@ -163,17 +171,18 @@ public class RelationshipTrackerConverterService
         if ( relationshipType.getToConstraint().getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
             toItem.setTrackedEntityInstance( preheat.getTrackedEntity( TrackerIdScheme.UID,
-                fromRelationship.getTo().getTrackedEntity() ) );
+                fromRelationship.getTo().getTrackedEntity().getTrackedEntity() ) );
         }
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
         {
             toItem.setProgramInstance(
-                preheat.getEnrollment( TrackerIdScheme.UID, fromRelationship.getTo().getEnrollment() ) );
+                preheat.getEnrollment( TrackerIdScheme.UID,
+                    fromRelationship.getTo().getEnrollment().getEnrollment() ) );
         }
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
             toItem.setProgramStageInstance(
-                preheat.getEvent( TrackerIdScheme.UID, fromRelationship.getTo().getEvent() ) );
+                preheat.getEvent( TrackerIdScheme.UID, fromRelationship.getTo().getEvent().getEvent() ) );
         }
 
         toRelationship.setFrom( fromItem );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
@@ -27,10 +27,20 @@
  */
 package org.hisp.dhis.tracker.domain;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.tracker.TrackerType;
+import org.locationtech.jts.geom.Geometry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -43,12 +53,276 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @AllArgsConstructor
 public class RelationshipItem
 {
-    @JsonProperty
-    private String trackedEntity;
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TrackedEntity implements TrackerDto
+    {
+        @JsonProperty
+        private String trackedEntity;
+
+        @JsonProperty
+        private String trackedEntityType;
+
+        @JsonProperty
+        private Instant createdAt;
+
+        @JsonProperty
+        private Instant createdAtClient;
+
+        @JsonProperty
+        private Instant updatedAt;
+
+        @JsonProperty
+        private Instant updatedAtClient;
+
+        @JsonProperty
+        private String orgUnit;
+
+        @JsonProperty
+        private boolean inactive;
+
+        @JsonProperty
+        private boolean deleted;
+
+        @JsonProperty
+        private boolean potentialDuplicate;
+
+        @JsonProperty
+        private Geometry geometry;
+
+        @JsonProperty
+        private String storedBy;
+
+        @JsonProperty
+        private User createdBy;
+
+        @JsonProperty
+        private User updatedBy;
+
+        @JsonProperty
+        @Builder.Default
+        private List<Attribute> attributes = new ArrayList<>();
+
+        @JsonProperty
+        @Builder.Default
+        private List<Enrollment> enrollments = new ArrayList<>();
+
+        @JsonProperty
+        @Builder.Default
+        private List<ProgramOwner> programOwners = new ArrayList<>();
+
+        @Override
+        public String getUid()
+        {
+            return this.trackedEntity;
+        }
+
+        @Override
+        public TrackerType getTrackerType()
+        {
+            return TrackerType.TRACKED_ENTITY;
+        }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Enrollment implements TrackerDto
+    {
+        @JsonProperty
+        private String enrollment;
+
+        @JsonProperty
+        private Instant createdAt;
+
+        @JsonProperty
+        private Instant createdAtClient;
+
+        @JsonProperty
+        private Instant updatedAt;
+
+        @JsonProperty
+        private Instant updatedAtClient;
+
+        @JsonProperty
+        private String trackedEntity;
+
+        @JsonProperty
+        private String program;
+
+        @JsonProperty
+        private EnrollmentStatus status;
+
+        @JsonProperty
+        private String orgUnit;
+
+        @JsonProperty
+        private String orgUnitName;
+
+        @JsonProperty
+        private Instant enrolledAt;
+
+        @JsonProperty
+        private Instant occurredAt;
+
+        @JsonProperty
+        private boolean followUp;
+
+        @JsonProperty
+        private String completedBy;
+
+        @JsonProperty
+        private Instant completedAt;
+
+        @JsonProperty
+        private boolean deleted;
+
+        @JsonProperty
+        private String storedBy;
+
+        @JsonProperty
+        private User createdBy;
+
+        @JsonProperty
+        private User updatedBy;
+
+        @JsonProperty
+        private Geometry geometry;
+
+        @JsonProperty
+        @Builder.Default
+        private List<Event> events = new ArrayList<>();
+
+        @JsonProperty
+        @Builder.Default
+        private List<Attribute> attributes = new ArrayList<>();
+
+        @JsonProperty
+        @Builder.Default
+        private List<Note> notes = new ArrayList<>();
+
+        @Override
+        public String getUid()
+        {
+            return this.enrollment;
+        }
+
+        @Override
+        public TrackerType getTrackerType()
+        {
+            return TrackerType.ENROLLMENT;
+        }
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Event implements TrackerDto
+    {
+        @JsonProperty
+        private String event;
+
+        @JsonProperty
+        @Builder.Default
+        private EventStatus status = EventStatus.ACTIVE;
+
+        @JsonProperty
+        private String program;
+
+        @JsonProperty
+        private String programStage;
+
+        @JsonProperty
+        private String enrollment;
+
+        @JsonProperty
+        private String orgUnit;
+
+        @JsonProperty
+        private String orgUnitName;
+
+        @JsonProperty
+        private Instant occurredAt;
+
+        @JsonProperty
+        private Instant scheduledAt;
+
+        @JsonProperty
+        private String storedBy;
+
+        @JsonProperty
+        private boolean followup;
+
+        @JsonProperty
+        private boolean deleted;
+
+        @JsonProperty
+        private Instant createdAt;
+
+        @JsonProperty
+        private Instant createdAtClient;
+
+        @JsonProperty
+        private Instant updatedAt;
+
+        @JsonProperty
+        private Instant updatedAtClient;
+
+        @JsonProperty
+        private String attributeOptionCombo;
+
+        @JsonProperty
+        private String attributeCategoryOptions;
+
+        @JsonProperty
+        private String completedBy;
+
+        @JsonProperty
+        private Instant completedAt;
+
+        @JsonProperty
+        private Geometry geometry;
+
+        @JsonProperty
+        private User assignedUser;
+
+        @JsonProperty
+        private User createdBy;
+
+        @JsonProperty
+        private User updatedBy;
+
+        @JsonProperty
+        @Builder.Default
+        private Set<DataValue> dataValues = new HashSet<>();
+
+        @JsonProperty
+        @Builder.Default
+        private List<Note> notes = new ArrayList<>();
+
+        @Override
+        public String getUid()
+        {
+            return this.event;
+        }
+
+        @Override
+        public TrackerType getTrackerType()
+        {
+            return TrackerType.EVENT;
+        }
+    }
 
     @JsonProperty
-    private String enrollment;
+    private TrackedEntity trackedEntity;
 
     @JsonProperty
-    private String event;
+    private Enrollment enrollment;
+
+    @JsonProperty
+    private Event event;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/RelationshipPreheatKeySupport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/RelationshipPreheatKeySupport.java
@@ -72,9 +72,12 @@ public class RelationshipPreheatKeySupport
         if ( Objects.nonNull( relationshipItem ) )
         {
             return RelationshipKey.RelationshipItemKey.builder()
-                .trackedEntity( trimToEmpty( relationshipItem.getTrackedEntity() ) )
-                .enrollment( trimToEmpty( relationshipItem.getEnrollment() ) )
-                .event( trimToEmpty( relationshipItem.getEvent() ) )
+                .trackedEntity( trimToEmpty( relationshipItem.getTrackedEntity() == null ? null
+                    : relationshipItem.getTrackedEntity().getTrackedEntity() ) )
+                .enrollment( trimToEmpty( relationshipItem.getEnrollment() == null ? null
+                    : relationshipItem.getEnrollment().getEnrollment() ) )
+                .event(
+                    trimToEmpty( relationshipItem.getEvent() == null ? null : relationshipItem.getEvent().getEvent() ) )
                 .build();
         }
         throw new IllegalStateException( "Unable to determine uid for relationship item" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipValidationUtils.java
@@ -40,15 +40,15 @@ public class RelationshipValidationUtils
 {
     public static TrackerType relationshipItemValueType( RelationshipItem item )
     {
-        if ( StringUtils.isNotEmpty( item.getTrackedEntity() ) )
+        if ( item.getTrackedEntity() != null && StringUtils.isNotEmpty( item.getTrackedEntity().getTrackedEntity() ) )
         {
             return TrackerType.TRACKED_ENTITY;
         }
-        else if ( StringUtils.isNotEmpty( item.getEnrollment() ) )
+        else if ( item.getEnrollment() != null && StringUtils.isNotEmpty( item.getEnrollment().getEnrollment() ) )
         {
             return TrackerType.ENROLLMENT;
         }
-        else if ( StringUtils.isNotEmpty( item.getEvent() ) )
+        else if ( item.getEvent() != null && StringUtils.isNotEmpty( item.getEvent().getEvent() ) )
         {
             return TrackerType.EVENT;
         }
@@ -59,15 +59,15 @@ public class RelationshipValidationUtils
     {
         if ( item.getTrackedEntity() != null )
         {
-            return Optional.of( item.getTrackedEntity() );
+            return Optional.of( item.getTrackedEntity().getTrackedEntity() );
         }
         else if ( item.getEnrollment() != null )
         {
-            return Optional.of( item.getEnrollment() );
+            return Optional.of( item.getEnrollment().getEnrollment() );
         }
         else if ( item.getEvent() != null )
         {
-            return Optional.of( item.getEvent() );
+            return Optional.of( item.getEvent().getEvent() );
         }
         return Optional.empty();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_STAGE_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.TRACKED_ENTITY_INSTANCE;
@@ -41,7 +40,9 @@ import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.relationship.RelationshipConstraint;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -50,6 +51,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -92,11 +94,9 @@ public class RelationshipsValidationHook
     {
         // make sure that both Relationship Item only contain *one* reference
         // (tei, enrollment or event)
-        reporter.addErrorIf(
-            () -> relationship.getFrom() != null && countMatches( onlyValues( relationship.getFrom() ), "null" ) < 2,
+        reporter.addErrorIf( () -> hasMoreThanOneReference( relationship.getFrom() ),
             relationship, E4001, "from", relationship.getRelationship() );
-        reporter.addErrorIf(
-            () -> relationship.getTo() != null && countMatches( onlyValues( relationship.getTo() ), "null" ) < 2,
+        reporter.addErrorIf( () -> hasMoreThanOneReference( relationship.getTo() ),
             relationship, E4001, "to", relationship.getRelationship() );
     }
 
@@ -116,13 +116,13 @@ public class RelationshipsValidationHook
         List<RelationshipType> relationshipsTypes )
     {
         reporter.addErrorIf(
-            () -> !getRelationshipType( relationshipsTypes, relationship.getRelationshipType() ).isPresent(),
+            () -> getRelationshipType( relationshipsTypes, relationship.getRelationshipType() ).isEmpty(),
             relationship, E4009, relationship.getRelationshipType() );
 
         final Optional<TrackerErrorReport> any = reporter.getReportList().stream()
             .filter( r -> relationship.getRelationship().equals( r.getUid() ) ).findAny();
 
-        return !any.isPresent();
+        return any.isEmpty();
     }
 
     private Optional<RelationshipType> getRelationshipType( List<RelationshipType> relationshipsTypes,
@@ -164,16 +164,17 @@ public class RelationshipsValidationHook
                 // Check tracked entity type matches the type specified in the
                 // constraint
                 //
-                getRelationshipTypeUidFromTrackedEntity( reporter.getBundle(), item.getTrackedEntity() )
-                    .ifPresent( type -> {
+                getRelationshipTypeUidFromTrackedEntity( reporter.getBundle(),
+                    item.getTrackedEntity().getTrackedEntity() )
+                        .ifPresent( type -> {
 
-                        if ( !type.equals( constraint.getTrackedEntityType().getUid() ) )
-                        {
-                            reporter.addError( relationship,
-                                TrackerErrorCode.E4014, relSide, constraint.getTrackedEntityType().getUid(), type );
-                        }
+                            if ( !type.equals( constraint.getTrackedEntityType().getUid() ) )
+                            {
+                                reporter.addError( relationship,
+                                    TrackerErrorCode.E4014, relSide, constraint.getTrackedEntityType().getUid(), type );
+                            }
 
-                    } );
+                        } );
             }
         }
         else if ( constraint.getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
@@ -186,20 +187,23 @@ public class RelationshipsValidationHook
             }
 
         }
-        else if ( constraint.getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
+        else if ( constraint.getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) && item.getEvent() == null )
         {
-            if ( item.getEvent() == null )
-            {
-                reporter.addError( relationship, TrackerErrorCode.E4010, relSide,
-                    TrackerType.EVENT.getName(), relationshipItemValueType( item ).getName() );
-            }
+            reporter.addError( relationship, TrackerErrorCode.E4010, relSide,
+                TrackerType.EVENT.getName(), relationshipItemValueType( item ).getName() );
         }
     }
 
-    private String onlyValues( RelationshipItem item )
+    private boolean hasMoreThanOneReference( RelationshipItem item )
     {
-        return item != null ? item.getTrackedEntity() + "-" + item.getEnrollment() + "-" + item.getEvent()
-            : "null-null-null";
+        if ( item == null )
+        {
+            return false;
+        }
+        return Stream.of( item.getTrackedEntity(), item.getEnrollment(), item.getEvent() ).filter( Objects::nonNull )
+            .map( TrackerDto::getUid )
+            .filter( StringUtils::isNotBlank )
+            .count() > 1;
     }
 
     private void validateReferences( ValidationErrorReporter reporter, Relationship relationship,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessorTest.java
@@ -77,11 +77,11 @@ class DuplicateRelationshipsPreProcessorTest
         String fromTeiUid = CodeGenerator.generateUid();
         String toTeiUid = CodeGenerator.generateUid();
         Relationship relationship1 = Relationship.builder().relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType ).from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .relationshipType( relType ).from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         Relationship relationship2 = Relationship.builder().relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType ).from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .relationshipType( relType ).from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         TrackerBundle bundle = TrackerBundle.builder().preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
         preProcessor.process( bundle );
@@ -102,11 +102,11 @@ class DuplicateRelationshipsPreProcessorTest
         String fromTeiUid = CodeGenerator.generateUid();
         String toTeiUid = CodeGenerator.generateUid();
         Relationship relationship1 = Relationship.builder().relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType ).from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .relationshipType( relType ).from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         Relationship relationship2 = Relationship.builder().relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType ).from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .relationshipType( relType ).from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         TrackerBundle bundle = TrackerBundle.builder().preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
         preProcessor.process( bundle );
@@ -127,12 +127,12 @@ class DuplicateRelationshipsPreProcessorTest
         String toTeiUid = CodeGenerator.generateUid();
         Relationship relationship1 = Relationship.builder().relationship( CodeGenerator.generateUid() )
             .relationshipType( REL_TYPE_NONBIDIRECTIONAL_UID )
-            .from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         Relationship relationship2 = Relationship.builder().relationship( CodeGenerator.generateUid() )
             .relationshipType( REL_TYPE_NONBIDIRECTIONAL_UID )
-            .from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().enrollment( toTeiUid ).build() ).build();
+            .from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( enrollmentRelationshipItem( toTeiUid ) ).build();
         TrackerBundle bundle = TrackerBundle.builder().preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
         preProcessor.process( bundle );
@@ -154,12 +154,12 @@ class DuplicateRelationshipsPreProcessorTest
         String toTeiUid = CodeGenerator.generateUid();
         Relationship relationship1 = Relationship.builder().relationship( CodeGenerator.generateUid() )
             .relationshipType( relType ).bidirectional( false )
-            .from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         Relationship relationship2 = Relationship.builder().relationship( CodeGenerator.generateUid() )
             .relationshipType( relType ).bidirectional( false )
-            .from( RelationshipItem.builder().trackedEntity( toTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() ).build();
+            .from( trackedEntityRelationshipItem( toTeiUid ) )
+            .to( trackedEntityRelationshipItem( fromTeiUid ) ).build();
         TrackerBundle bundle = TrackerBundle.builder().preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
         preProcessor.process( bundle );
@@ -182,11 +182,11 @@ class DuplicateRelationshipsPreProcessorTest
         String fromTeiUid = CodeGenerator.generateUid();
         String toTeiUid = CodeGenerator.generateUid();
         Relationship relationship1 = Relationship.builder().relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType ).from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .relationshipType( relType ).from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         Relationship relationship2 = Relationship.builder().relationship( CodeGenerator.generateUid() )
-            .relationshipType( relType ).from( RelationshipItem.builder().trackedEntity( toTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() ).build();
+            .relationshipType( relType ).from( trackedEntityRelationshipItem( toTeiUid ) )
+            .to( trackedEntityRelationshipItem( fromTeiUid ) ).build();
         TrackerBundle bundle = TrackerBundle.builder().preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
         preProcessor.process( bundle );
@@ -210,15 +210,29 @@ class DuplicateRelationshipsPreProcessorTest
         String toTeiUid = CodeGenerator.generateUid();
         Relationship relationship1 = Relationship.builder().relationship( CodeGenerator.generateUid() )
             .relationshipType( relType ).bidirectional( true )
-            .from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         Relationship relationship2 = Relationship.builder().relationship( CodeGenerator.generateUid() )
             .relationshipType( relType ).bidirectional( true )
-            .from( RelationshipItem.builder().trackedEntity( fromTeiUid ).build() )
-            .to( RelationshipItem.builder().trackedEntity( toTeiUid ).build() ).build();
+            .from( trackedEntityRelationshipItem( fromTeiUid ) )
+            .to( trackedEntityRelationshipItem( toTeiUid ) ).build();
         TrackerBundle bundle = TrackerBundle.builder().preheat( this.preheat )
             .relationships( Lists.newArrayList( relationship1, relationship2 ) ).build();
         preProcessor.process( bundle );
         assertThat( bundle.getRelationships(), hasSize( 1 ) );
+    }
+
+    private RelationshipItem trackedEntityRelationshipItem( String trackedEntityUid )
+    {
+        return RelationshipItem.builder()
+            .trackedEntity( RelationshipItem.TrackedEntity.builder().trackedEntity( trackedEntityUid ).build() )
+            .build();
+    }
+
+    private RelationshipItem enrollmentRelationshipItem( String enrollmentUid )
+    {
+        return RelationshipItem.builder()
+            .enrollment( RelationshipItem.Enrollment.builder().enrollment( enrollmentUid ).build() )
+            .build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -914,12 +914,8 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( "validTrackedEntity" )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( "anotherValidTrackedEntity" )
-                .build() )
+            .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
+            .to( trackedEntityRelationshipItem( "anotherValidTrackedEntity" ) )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -952,12 +948,8 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( "validTrackedEntity" )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( "anotherValidTrackedEntity" )
-                .build() )
+            .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
+            .to( trackedEntityRelationshipItem( "anotherValidTrackedEntity" ) )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -1143,6 +1135,13 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         relType.setToConstraint( relationshipConstraintTo );
 
         return relType;
+    }
+
+    private RelationshipItem trackedEntityRelationshipItem( String trackedEntityUid )
+    {
+        return RelationshipItem.builder()
+            .trackedEntity( RelationshipItem.TrackedEntity.builder().trackedEntity( trackedEntityUid ).build() )
+            .build();
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -289,10 +289,10 @@ class PreCheckMandatoryFieldsValidationHookTest
             .relationship( CodeGenerator.generateUid() )
             .relationshipType( CodeGenerator.generateUid() )
             .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
                 .build() )
             .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
                 .build() )
             .build();
 
@@ -309,7 +309,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .relationship( CodeGenerator.generateUid() )
             .relationshipType( CodeGenerator.generateUid() )
             .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
                 .build() )
             .build();
 
@@ -326,7 +326,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .relationship( CodeGenerator.generateUid() )
             .relationshipType( CodeGenerator.generateUid() )
             .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
                 .build() )
             .build();
 
@@ -342,10 +342,10 @@ class PreCheckMandatoryFieldsValidationHookTest
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
                 .build() )
             .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
                 .build() )
             .build();
 
@@ -384,5 +384,10 @@ class PreCheckMandatoryFieldsValidationHookTest
         hasTrackerError( reporter, errorCode, type, uid );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
             is( "Missing required " + entity + " property: `" + property + "`." ) );
+    }
+
+    private RelationshipItem.TrackedEntity trackedEntity()
+    {
+        return RelationshipItem.TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -57,7 +57,6 @@ import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -72,13 +71,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 /**
  * @author Luciano Fiandesio
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
 class RelationshipsValidationHookTest
 {
@@ -98,7 +94,6 @@ class RelationshipsValidationHookTest
     {
         validationHook = new RelationshipsValidationHook();
 
-        when( bundle.getImportStrategy() ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( bundle.getPreheat() ).thenReturn( preheat );
     }
@@ -109,12 +104,8 @@ class RelationshipsValidationHookTest
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .relationshipType( "do-not-exist" )
-            .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
+            .from( trackedEntityRelationshipItem() )
+            .to( trackedEntityRelationshipItem() )
             .build();
 
         reporter = new ValidationErrorReporter( bundle );
@@ -131,12 +122,10 @@ class RelationshipsValidationHookTest
             .relationship( relationshipUid )
             .relationshipType( CodeGenerator.generateUid() )
             .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .enrollment( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
+                .enrollment( enrollment() )
                 .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
+            .to( trackedEntityRelationshipItem() )
             .build();
 
         RelationshipType relationshipType = new RelationshipType();
@@ -164,11 +153,8 @@ class RelationshipsValidationHookTest
         Relationship relationship = Relationship.builder()
             .relationship( relationshipUid )
             .relationshipType( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
+            .from( RelationshipItem.builder().build() )
+            .to( trackedEntityRelationshipItem() )
             .build();
 
         RelationshipType relationshipType = new RelationshipType();
@@ -195,12 +181,10 @@ class RelationshipsValidationHookTest
         Relationship relationship = Relationship.builder()
             .relationship( relationshipUid )
             .relationshipType( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
+            .from( trackedEntityRelationshipItem() )
             .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .enrollment( CodeGenerator.generateUid() )
+                .trackedEntity( trackedEntity() )
+                .enrollment( enrollment() )
                 .build() )
             .build();
 
@@ -228,12 +212,8 @@ class RelationshipsValidationHookTest
 
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
-            .to( RelationshipItem.builder()
-                .enrollment( CodeGenerator.generateUid() )
-                .build() )
+            .from( trackedEntityRelationshipItem() )
+            .to( enrollmentRelationshipItem() )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -255,12 +235,8 @@ class RelationshipsValidationHookTest
 
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
-            .to( RelationshipItem.builder()
-                .enrollment( CodeGenerator.generateUid() )
-                .build() )
+            .from( trackedEntityRelationshipItem() )
+            .to( enrollmentRelationshipItem() )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -283,11 +259,9 @@ class RelationshipsValidationHookTest
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .from( RelationshipItem.builder()
-                .event( CodeGenerator.generateUid() )
+                .event( event() )
                 .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( CodeGenerator.generateUid() )
-                .build() )
+            .to( trackedEntityRelationshipItem() )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -314,12 +288,8 @@ class RelationshipsValidationHookTest
 
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .enrollment( CodeGenerator.generateUid() )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( trackedEntityUid )
-                .build() )
+            .from( enrollmentRelationshipItem() )
+            .to( trackedEntityRelationshipItem( trackedEntityUid ) )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -356,12 +326,8 @@ class RelationshipsValidationHookTest
 
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( trackedEntityUid )
-                .build() )
-            .to( RelationshipItem.builder()
-                .enrollment( CodeGenerator.generateUid() )
-                .build() )
+            .from( trackedEntityRelationshipItem( trackedEntityUid ) )
+            .to( enrollmentRelationshipItem() )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -397,16 +363,12 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( bundle );
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( "validTrackedEntity" )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( "notValidTrackedEntity" )
-                .build() )
+            .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
+            .to( trackedEntityRelationshipItem( "notValidTrackedEntity" ) )
             .relationshipType( relType.getUid() )
             .build();
         TrackerErrorReport error = TrackerErrorReport.builder()
-            .uid( relationship.getTo().getTrackedEntity() )
+            .uid( relationship.getTo().getTrackedEntity().getTrackedEntity() )
             .trackerType( TRACKED_ENTITY )
             .errorCode( TrackerErrorCode.E9999 )
             .build( bundle );
@@ -431,12 +393,8 @@ class RelationshipsValidationHookTest
         reporter = new ValidationErrorReporter( bundle );
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( "validTrackedEntity" )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( "anotherValidTrackedEntity" )
-                .build() )
+            .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
+            .to( trackedEntityRelationshipItem( "anotherValidTrackedEntity" ) )
             .relationshipType( relType.getUid() )
             .build();
         TrackerErrorReport error = TrackerErrorReport.builder()
@@ -461,12 +419,8 @@ class RelationshipsValidationHookTest
         String uid = CodeGenerator.generateUid();
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
-            .from( RelationshipItem.builder()
-                .trackedEntity( uid )
-                .build() )
-            .to( RelationshipItem.builder()
-                .trackedEntity( uid )
-                .build() )
+            .from( trackedEntityRelationshipItem( uid ) )
+            .to( trackedEntityRelationshipItem( uid ) )
             .relationshipType( relType.getUid() )
             .build();
 
@@ -494,5 +448,46 @@ class RelationshipsValidationHookTest
         relType.setToConstraint( relationshipConstraintTo );
 
         return relType;
+    }
+
+    private RelationshipItem trackedEntityRelationshipItem( String trackedEntityUid )
+    {
+        return RelationshipItem.builder()
+            .trackedEntity( trackedEntity( trackedEntityUid ) )
+            .build();
+    }
+
+    private RelationshipItem trackedEntityRelationshipItem()
+    {
+        return RelationshipItem.builder()
+            .trackedEntity( trackedEntity() )
+            .build();
+    }
+
+    private RelationshipItem enrollmentRelationshipItem()
+    {
+        return RelationshipItem.builder()
+            .enrollment( enrollment() )
+            .build();
+    }
+
+    private RelationshipItem.TrackedEntity trackedEntity()
+    {
+        return trackedEntity( CodeGenerator.generateUid() );
+    }
+
+    private RelationshipItem.TrackedEntity trackedEntity( String uid )
+    {
+        return RelationshipItem.TrackedEntity.builder().trackedEntity( uid ).build();
+    }
+
+    private RelationshipItem.Enrollment enrollment()
+    {
+        return RelationshipItem.Enrollment.builder().enrollment( CodeGenerator.generateUid() ).build();
+    }
+
+    private RelationshipItem.Event event()
+    {
+        return RelationshipItem.Event.builder().event( CodeGenerator.generateUid() ).build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationshipToUpdate.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationshipToUpdate.json
@@ -5,10 +5,15 @@
       "relationship": "Nva3Xj2j75W",
       "bidirectional": false,
       "from": {
-        "trackedEntity": "IOR1AXXl24H"
+        "trackedEntity": {
+          "trackedEntity": "IOR1AXXl24H"
+        }
       },
       "to": {
-        "enrollment": "TvctPPhpD8u"
+        "enrollment":
+        {
+          "enrollment": "TvctPPhpD8u"
+        }
       },
       "createdAt": "2019-10-01T12:17:30.163",
       "updatedAt": "2019-10-01T12:17:30.163"

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationships.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationships.json
@@ -5,10 +5,14 @@
       "relationship": "Nva3Xj2j75W",
       "bidirectional": false,
       "from": {
-        "trackedEntity": "IOR1AXXl24H"
+        "trackedEntity": {
+          "trackedEntity": "IOR1AXXl24H"
+        }
       },
       "to": {
-        "enrollment": "TvctPPhpD8u"
+        "enrollment": {
+          "enrollment": "TvctPPhpD8u"
+        }
       },
       "createdAt": "2018-10-01T12:17:30.163",
       "updatedAt": "2018-10-01T12:17:30.163"
@@ -18,10 +22,14 @@
       "relationship": "HiXiipNGsxT",
       "bidirectional": false,
       "from": {
-        "trackedEntity": "IOR1AXXl24H"
+        "trackedEntity": {
+          "trackedEntity": "IOR1AXXl24H"
+        }
       },
       "to": {
-        "event": "D9PbzJY8bJO"
+        "event":{
+          "event": "D9PbzJY8bJO"
+        }
       },
       "createdAt": "2018-10-01T12:17:30.163",
       "updatedAt": "2018-10-01T12:17:30.163"

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
@@ -320,16 +320,33 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
 
     private void assertEvent( JsonObject json, ProgramStageInstance programStageInstance )
     {
-        assertEquals( programStageInstance.getUid(), json.getString( "event" ).string() );
+        JsonObject jsonEvent = json.getObject( "event" );
+        assertEquals( programStageInstance.getUid(), jsonEvent.getString( "event" ).string() );
+        assertEquals( programStageInstance.getStatus().toString(), jsonEvent.getString( "status" ).string() );
+        assertEquals( programStageInstance.getProgramStage().getUid(), jsonEvent.getString( "programStage" ).string() );
+        assertEquals( programStageInstance.getProgramInstance().getUid(),
+            jsonEvent.getString( "enrollment" ).string() );
+        assertFalse( jsonEvent.has( "relationships" ) );
     }
 
     private void assertTrackedEntity( JsonObject json, TrackedEntityInstance tei )
     {
-        assertEquals( tei.getUid(), json.getString( "trackedEntity" ).string() );
+        JsonObject jsonTEI = json.getObject( "trackedEntity" );
+        assertEquals( tei.getUid(), jsonTEI.getString( "trackedEntity" ).string() );
+        assertEquals( tei.getTrackedEntityType().getUid(), jsonTEI.getString( "trackedEntityType" ).string() );
+        assertEquals( tei.getOrganisationUnit().getUid(), jsonTEI.getString( "orgUnit" ).string() );
+        assertFalse( jsonTEI.has( "relationships" ) );
     }
 
     private void assertEnrollment( JsonObject json, ProgramInstance programInstance )
     {
-        assertEquals( programInstance.getUid(), json.getString( "enrollment" ).string() );
+        JsonObject jsonEnrollment = json.getObject( "enrollment" );
+        assertEquals( programInstance.getUid(), jsonEnrollment.getString( "enrollment" ).string() );
+        assertEquals( programInstance.getEntityInstance().getUid(),
+            jsonEnrollment.getString( "trackedEntity" ).string() );
+        assertEquals( programInstance.getProgram().getUid(), jsonEnrollment.getString( "program" ).string() );
+        assertEquals( programInstance.getOrganisationUnit().getUid(), jsonEnrollment.getString( "orgUnit" ).string() );
+        assertTrue( jsonEnrollment.getArray( "events" ).isEmpty() );
+        assertFalse( jsonEnrollment.has( "relationships" ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/AttributeMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/AttributeMapper.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.mapstruct.Mapper;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/DataValueMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/DataValueMapper.java
@@ -25,14 +25,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.program.UserInfoSnapshot;
-import org.hisp.dhis.tracker.domain.User;
+import org.hisp.dhis.tracker.domain.DataValue;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper
-public interface UserMapper extends DomainMapper<UserInfoSnapshot, User>
+@Mapper( uses = { InstantMapper.class, UserMapper.class } )
+public interface DataValueMapper extends DomainMapper<org.hisp.dhis.dxf2.events.event.DataValue, DataValue>
 {
-    User from( UserInfoSnapshot snapshot );
+    @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "createdBy", source = "createdByUserInfo" )
+    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
+    DataValue from( org.hisp.dhis.dxf2.events.event.DataValue dataValue );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/DomainMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/DomainMapper.java
@@ -25,32 +25,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
-@Mapper( uses = {
-    RelationshipMapper.class,
-    AttributeMapper.class,
-    NoteMapper.class,
-    EventMapper.class,
-    InstantMapper.class,
-    UserMapper.class } )
-public interface EnrollmentMapper extends DomainMapper<org.hisp.dhis.dxf2.events.enrollment.Enrollment, Enrollment>
+public interface DomainMapper<FROM, TO>
 {
-    @Mapping( target = "enrollment", source = "enrollment" )
-    @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
-    @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
-    @Mapping( target = "enrolledAt", source = "enrollmentDate" )
-    @Mapping( target = "occurredAt", source = "incidentDate" )
-    @Mapping( target = "followUp", source = "followup" )
-    @Mapping( target = "completedAt", source = "completedDate" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    Enrollment from( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment );
+    TO from( FROM from );
+
+    default List<TO> fromCollection( Collection<FROM> froms )
+    {
+        return Optional.ofNullable( froms )
+            .orElse( Collections.emptySet() )
+            .stream()
+            .map( this::from )
+            .collect( Collectors.toList() );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EnrollmentMapper.java
@@ -25,19 +25,32 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.Enrollment;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper( uses = {
-    RelationshipItemMapper.class,
-    InstantMapper.class } )
-public interface RelationshipMapper
-    extends DomainMapper<org.hisp.dhis.dxf2.events.trackedentity.Relationship, Relationship>
+    RelationshipMapper.class,
+    AttributeMapper.class,
+    NoteMapper.class,
+    EventMapper.class,
+    InstantMapper.class,
+    UserMapper.class } )
+interface EnrollmentMapper extends DomainMapper<org.hisp.dhis.dxf2.events.enrollment.Enrollment, Enrollment>
 {
+    @Mapping( target = "enrollment", source = "enrollment" )
     @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "createdAtClient", source = "createdAtClient" )
     @Mapping( target = "updatedAt", source = "lastUpdated" )
-    Relationship from( org.hisp.dhis.dxf2.events.trackedentity.Relationship relationship );
+    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "enrolledAt", source = "enrollmentDate" )
+    @Mapping( target = "occurredAt", source = "incidentDate" )
+    @Mapping( target = "followUp", source = "followup" )
+    @Mapping( target = "completedAt", source = "completedDate" )
+    @Mapping( target = "createdBy", source = "createdByUserInfo" )
+    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
+    Enrollment from( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/InstantMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/InstantMapper.java
@@ -25,16 +25,42 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.Note;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.chrono.ChronoZonedDateTime;
+import java.util.Date;
+import java.util.Optional;
+
+import org.hisp.dhis.util.DateUtils;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
-@Mapper( uses = { InstantMapper.class, UserMapper.class } )
-public interface NoteMapper extends DomainMapper<org.hisp.dhis.dxf2.events.event.Note, Note>
+@Mapper
+public interface InstantMapper
 {
-    @Mapping( target = "storedAt", source = "storedDate" )
-    @Mapping( target = "createdBy", source = "lastUpdatedBy" )
-    Note from( org.hisp.dhis.dxf2.events.event.Note note );
+
+    default Instant fromString( String dateAsString )
+    {
+        return DateUtils.instantFromDateAsString( dateAsString );
+    }
+
+    default Instant fromDate( Date date )
+    {
+        if ( date instanceof java.sql.Date )
+        {
+            return fromSqlDate( (java.sql.Date) date );
+        }
+        return DateUtils.instantFromDate( date );
+    }
+
+    default Instant fromSqlDate( java.sql.Date date )
+    {
+        return Optional.ofNullable( date )
+            .map( java.sql.Date::toLocalDate )
+            .map( localDate -> localDate.atStartOfDay( ZoneId.systemDefault() ) )
+            .map( ChronoZonedDateTime::toInstant )
+            .orElse( null );
+    }
+
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/NoteMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/NoteMapper.java
@@ -25,17 +25,16 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.ProgramOwner;
+import org.hisp.dhis.tracker.domain.Note;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper
-public interface ProgramOwnerMapper
-    extends DomainMapper<org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner, ProgramOwner>
+@Mapper( uses = { InstantMapper.class, UserMapper.class } )
+public interface NoteMapper extends DomainMapper<org.hisp.dhis.dxf2.events.event.Note, Note>
 {
-    @Mapping( target = "orgUnit", source = "ownerOrgUnit" )
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
-    ProgramOwner from( org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner programOwner );
+    @Mapping( target = "storedAt", source = "storedDate" )
+    @Mapping( target = "createdBy", source = "lastUpdatedBy" )
+    Note from( org.hisp.dhis.dxf2.events.event.Note note );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ProgramOwnerMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/ProgramOwnerMapper.java
@@ -25,24 +25,17 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import org.hisp.dhis.tracker.domain.ProgramOwner;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-public interface DomainMapper<FROM, TO>
+@Mapper
+public interface ProgramOwnerMapper
+    extends DomainMapper<org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner, ProgramOwner>
 {
-    TO from( FROM from );
-
-    default List<TO> fromCollection( Collection<FROM> froms )
-    {
-        return Optional.ofNullable( froms )
-            .orElse( Collections.emptySet() )
-            .stream()
-            .map( this::from )
-            .collect( Collectors.toList() );
-    }
+    @Mapping( target = "orgUnit", source = "ownerOrgUnit" )
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    ProgramOwner from( org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner programOwner );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RelationshipItemMapper.java
@@ -25,22 +25,54 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.User;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
 @Mapper( uses = {
-    RelationshipMapper.class,
-    NoteMapper.class,
+    AttributeMapper.class,
     DataValueMapper.class,
+    ProgramOwnerMapper.class,
+    NoteMapper.class,
     InstantMapper.class,
-    UserMapper.class } )
-public interface EventMapper extends DomainMapper<org.hisp.dhis.dxf2.events.event.Event, Event>
+    UserMapper.class,
+} )
+interface RelationshipItemMapper
+    extends DomainMapper<org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem, RelationshipItem>
 {
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "enrollment", source = "enrollment" )
+    @Mapping( target = "event", source = "event" )
+    RelationshipItem from( org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem relationshipItem );
+
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "createdAtClient", source = "createdAtClient" )
+    @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
+    @Mapping( target = "createdBy", source = "createdByUserInfo" )
+    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
+    RelationshipItem.TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+
+    @Mapping( target = "enrollment", source = "enrollment" )
+    @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "createdAtClient", source = "createdAtClient" )
+    @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
+    @Mapping( target = "enrolledAt", source = "enrollmentDate" )
+    @Mapping( target = "occurredAt", source = "incidentDate" )
+    @Mapping( target = "followUp", source = "followup" )
+    @Mapping( target = "completedAt", source = "completedDate" )
+    @Mapping( target = "createdBy", source = "createdByUserInfo" )
+    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
+    RelationshipItem.Enrollment from( org.hisp.dhis.dxf2.events.enrollment.Enrollment enrollment );
+
     @Mapping( target = "occurredAt", source = "eventDate" )
     @Mapping( target = "scheduledAt", source = "dueDate" )
     @Mapping( target = "createdAt", source = "created" )
@@ -51,7 +83,7 @@ public interface EventMapper extends DomainMapper<org.hisp.dhis.dxf2.events.even
     @Mapping( target = "createdBy", source = "createdByUserInfo" )
     @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
     @Mapping( target = "assignedUser", source = ".", qualifiedByName = "toUserInfo" )
-    Event from( org.hisp.dhis.dxf2.events.event.Event event );
+    RelationshipItem.Event from( org.hisp.dhis.dxf2.events.event.Event event );
 
     @Named( "toUserInfo" )
     default User buildUserInfo( org.hisp.dhis.dxf2.events.event.Event event )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RelationshipMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RelationshipMapper.java
@@ -25,28 +25,19 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.domain.Relationship;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper( uses = {
-    RelationshipMapper.class,
-    AttributeMapper.class,
-    EnrollmentMapper.class,
-    ProgramOwnerMapper.class,
-    InstantMapper.class,
-    UserMapper.class } )
-public interface TrackedEntityMapper extends DomainMapper<TrackedEntityInstance, TrackedEntity>
+    RelationshipItemMapper.class,
+    InstantMapper.class } )
+interface RelationshipMapper
+    extends DomainMapper<org.hisp.dhis.dxf2.events.trackedentity.Relationship, Relationship>
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
     @Mapping( target = "createdAt", source = "created" )
-    @Mapping( target = "createdAtClient", source = "createdAtClient" )
     @Mapping( target = "updatedAt", source = "lastUpdated" )
-    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
-    @Mapping( target = "createdBy", source = "createdByUserInfo" )
-    @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
+    Relationship from( org.hisp.dhis.dxf2.events.trackedentity.Relationship relationship );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntityMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntityMapper.java
@@ -25,18 +25,28 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.DataValue;
+import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper( uses = { InstantMapper.class, UserMapper.class } )
-public interface DataValueMapper extends DomainMapper<org.hisp.dhis.dxf2.events.event.DataValue, DataValue>
+@Mapper( uses = {
+    RelationshipMapper.class,
+    AttributeMapper.class,
+    EnrollmentMapper.class,
+    ProgramOwnerMapper.class,
+    InstantMapper.class,
+    UserMapper.class } )
+interface TrackedEntityMapper extends DomainMapper<TrackedEntityInstance, TrackedEntity>
 {
+    @Mapping( target = "trackedEntity", source = "trackedEntityInstance" )
     @Mapping( target = "createdAt", source = "created" )
+    @Mapping( target = "createdAtClient", source = "createdAtClient" )
     @Mapping( target = "updatedAt", source = "lastUpdated" )
+    @Mapping( target = "updatedAtClient", source = "lastUpdatedAtClient" )
     @Mapping( target = "createdBy", source = "createdByUserInfo" )
     @Mapping( target = "updatedBy", source = "lastUpdatedByUserInfo" )
-    DataValue from( org.hisp.dhis.dxf2.events.event.DataValue dataValue );
+    TrackedEntity from( TrackedEntityInstance trackedEntityInstance );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollments;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.mapper.EnrollmentMapper;
 import org.hisp.dhis.webapi.controller.event.mapper.EnrollmentCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerEnrollmentCriteria;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -56,7 +56,6 @@ import org.hisp.dhis.dxf2.events.event.csv.CsvEventService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.node.Preset;
 import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.tracker.domain.mapper.EventMapper;
 import org.hisp.dhis.webapi.controller.event.mapper.RequestToSearchParamsMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerEventCriteria;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
@@ -54,7 +54,6 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
-import org.hisp.dhis.tracker.domain.mapper.RelationshipMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerRelationshipCriteria;
@@ -84,7 +83,8 @@ public class TrackerRelationshipsExportController
 
     private final RelationshipService relationshipService;
 
-    private static final RelationshipMapper RELATIONSHIP_MAPPER = Mappers.getMapper( RelationshipMapper.class );
+    private static final org.hisp.dhis.webapi.controller.tracker.export.RelationshipMapper RELATIONSHIP_MAPPER = Mappers
+        .getMapper( org.hisp.dhis.webapi.controller.tracker.export.RelationshipMapper.class );
 
     private Map<Class<?>, Function<String, ?>> objectRetrievers;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -39,7 +39,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.domain.mapper.TrackedEntityMapper;
 import org.hisp.dhis.webapi.controller.event.mapper.TrackedEntityCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerTrackedEntityCriteria;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/UserMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/UserMapper.java
@@ -25,18 +25,14 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.domain.mapper;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
-import org.hisp.dhis.tracker.domain.RelationshipItem;
+import org.hisp.dhis.program.UserInfoSnapshot;
+import org.hisp.dhis.tracker.domain.User;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 @Mapper
-public interface RelationshipItemMapper
-    extends DomainMapper<org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem, RelationshipItem>
+public interface UserMapper extends DomainMapper<UserInfoSnapshot, User>
 {
-    @Mapping( target = "trackedEntity", source = "trackedEntityInstance.trackedEntityInstance" )
-    @Mapping( target = "enrollment", source = "enrollment.enrollment" )
-    @Mapping( target = "event", source = "event.event" )
-    RelationshipItem from( org.hisp.dhis.dxf2.events.trackedentity.RelationshipItem relationshipItem );
+    User from( UserInfoSnapshot snapshot );
 }


### PR DESCRIPTION
backport of (#9996)

* chore: move export mappers to its usage

since these mappers purpose is to define what the exported payloads look like,
they should live with the controllers using them

* fix: return full relationship items

relationship.from/to will now return the entire tei, enrollment, event
instead of only their uids. their relationship fields will be ignored,
since that would cause a StackOverflow due to the recursive structure.

imports of relationships will thus also require nested from/to
relationship items i.e

    "from": { "trackedEntity": { "trackedEntity": "qwerw1243"}}

* chore: prevent encoding RelationsipItem relationships

by using dedicated classes for TrackedEntity, Enrollment, Event inside of RelationshipItems