### PR TITLE
fix: Make metaData element backward compatible [DHIS2-12712]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -373,8 +373,7 @@ public abstract class AbstractAnalyticsService
 
         params.getItemsAndItemFilters().stream()
             .filter( Objects::nonNull )
-            .forEach( item -> metadataItemMap.put( getItemIdMaybeWithProgramStageIdPrefix( item ),
-                new MetadataItem( item.getItem().getDisplayName(), includeDetails ? item.getItem() : null ) ) );
+            .forEach( item -> addItemIntoMetadata( metadataItemMap, item, includeDetails ) );
 
         if ( hasPeriodKeywords( periodKeywords ) )
         {
@@ -388,6 +387,20 @@ public abstract class AbstractAnalyticsService
         }
 
         return metadataItemMap;
+    }
+
+    private void addItemIntoMetadata( final Map<String, MetadataItem> metadataItemMap, final QueryItem item,
+        final boolean includeDetails )
+    {
+        final MetadataItem metadataItem = new MetadataItem( item.getItem().getDisplayName(),
+            includeDetails ? item.getItem() : null );
+
+        metadataItemMap.put( getItemIdMaybeWithProgramStageIdPrefix( item ), metadataItem );
+
+        // This is done for backward compatibility reason. It should remain here
+        // while the New Event Report is living along with its "classic"
+        // version.
+        metadataItemMap.put( item.getItemId(), metadataItem );
     }
 
     /**


### PR DESCRIPTION
This is a small change to bring it back the old behaviour regarding the `metaData` element.
It means that from now on, until the "classic" Event Report table is fully removed, we will need to support both elements as part of the response:

```
...
  "metaData": {
    "pager": {
      "page": 1,
      "pageSize": 100,
      "lastPage": false
    },
    "items": {
      "A03MvHHogjR.a3kGcGDCuk6": {
        "uid": "a3kGcGDCuk6",
        "code": "DE_2006098",
        "name": "MCH Apgar Score",
        "description": "Apgar is a quick test performed on a baby at 1 and 5 minutes after birth. The 1-minute score determines how well the baby tolerated the birthing process. The 5-minute score tells the doctor how well the baby is doing outside the mother's womb.",
        "dimensionItemType": "DATA_ELEMENT",
        "valueType": "NUMBER",
        "aggregationType": "AVERAGE",
        "totalAggregationType": "SUM"
      },
      "a3kGcGDCuk6": {
        "uid": "a3kGcGDCuk6",
        "code": "DE_2006098",
        "name": "MCH Apgar Score",
        "description": "Apgar is a quick test performed on a baby at 1 and 5 minutes after birth. The 1-minute score determines how well the baby tolerated the birthing process. The 5-minute score tells the doctor how well the baby is doing outside the mother's womb.",
        "dimensionItemType": "DATA_ELEMENT",
        "valueType": "NUMBER",
        "aggregationType": "AVERAGE",
        "totalAggregationType": "SUM"
      },
...
```
Note that the `dataElement` will be returned as a single id `a3kGcGDCuk6` as well as a prefixed id `A03MvHHogjR.a3kGcGDCuk6`. The prefix refers to the id of the associated program stage.

This relates to the events analytics endpoint.

ie:
```
http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou%3AUSER_ORGUNIT,p2Zxg0wcPQ3,A03MvHHogjR.a3kGcGDCuk6&headers=ouname,eventdate,p2Zxg0wcPQ3,A03MvHHogjR.a3kGcGDCuk6&totalPages=false&eventDate=THIS_MONTH,LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&asc=ouname
```

**_Backport from master/2.39_**