### PR TITLE
fix: minDate/maxDate/aggregationType DHIS2-12836

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -83,6 +85,15 @@ public class BaseDimensionalItemObject
     // -------------------------------------------------------------------------
     // Logic
     // -------------------------------------------------------------------------
+
+    @Override
+    public String getDimensionItemWithQueryModsId()
+    {
+        return getDimensionItem()
+            + ((queryMods != null && queryMods.getQueryModsId() != null)
+                ? QUERY_MODS_ID_SEPARATOR + queryMods.getQueryModsId()
+                : "");
+    }
 
     @Override
     @JsonProperty
@@ -182,6 +193,7 @@ public class BaseDimensionalItemObject
         return queryMods;
     }
 
+    @Override
     public void setQueryMods( QueryModifiers queryMods )
     {
         this.queryMods = queryMods;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalItemObject.java
@@ -44,6 +44,11 @@ public interface DimensionalItemObject
     String getDimensionItem();
 
     /**
+     * Gets the dimension item identifier with queryModsId if present.
+     */
+    String getDimensionItemWithQueryModsId();
+
+    /**
      * Gets the dimension item identifier based on the given identifier scheme.
      *
      * @param idScheme the identifier scheme.
@@ -93,4 +98,9 @@ public interface DimensionalItemObject
      * Gets the query modifiers for an indicator expression.
      */
     QueryModifiers getQueryMods();
+
+    /**
+     * Sets the query modifiers for an indicator expression.
+     */
+    void setQueryMods( QueryModifiers queryMods );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObject.java
@@ -81,6 +81,8 @@ public interface DimensionalObject
 
     String PERIOD_FREE_RANGE_SEPARATOR = "_";
 
+    String QUERY_MODS_ID_SEPARATOR = "_";
+
     String OPTION_SEP = ";";
 
     String MULTI_CHOICES_OPTION_SEP = ",";

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -37,9 +37,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.comparator.ObjectStringValueComparator;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 
 import com.google.common.collect.Lists;
@@ -514,13 +512,7 @@ public class DimensionalObjectUtils
      */
     public static Set<DimensionalItemObject> getDataElements( Collection<DataElementOperand> operands )
     {
-        return operands.stream().map( o -> {
-
-            DataElement dataElement = o.getDataElement();
-            dataElement.setQueryMods( o.getQueryMods() );
-            return dataElement;
-
-        } ).collect( Collectors.toSet() );
+        return operands.stream().map( DataElementOperand::getDataElement ).collect( Collectors.toSet() );
     }
 
     /**
@@ -534,13 +526,7 @@ public class DimensionalObjectUtils
     {
         return operands.stream()
             .filter( o -> o.getCategoryOptionCombo() != null )
-            .map( o -> {
-
-                CategoryOptionCombo coc = o.getCategoryOptionCombo();
-                coc.setQueryMods( o.getQueryMods() );
-                return coc;
-
-            } )
+            .map( DataElementOperand::getCategoryOptionCombo )
             .collect( Collectors.toSet() );
     }
 
@@ -555,13 +541,7 @@ public class DimensionalObjectUtils
     {
         return operands.stream()
             .filter( o -> o.getAttributeOptionCombo() != null )
-            .map( o -> {
-
-                CategoryOptionCombo aoc = o.getAttributeOptionCombo();
-                aoc.setQueryMods( o.getQueryMods() );
-                return aoc;
-
-            } )
+            .map( DataElementOperand::getCategoryOptionCombo )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryModifiers.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryModifiers.java
@@ -50,6 +50,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @Builder( toBuilder = true )
 public class QueryModifiers
 {
+    private static final QueryModifiers DEFAULT = QueryModifiers.builder().build();
+
     /**
      * Overrides the default aggregation type of this object.
      */
@@ -75,4 +77,40 @@ public class QueryModifiers
      */
     @JsonProperty
     private final Date maxDate;
+
+    // -------------------------------------------------------------------------
+    // Logic
+    // -------------------------------------------------------------------------
+
+    /**
+     * Gets the query modifiers that matter for analytics grouping.
+     */
+    public QueryModifiers withQueryModsForAnalyticsGrouping()
+    {
+        return this.toBuilder().periodOffset( 0 ).build();
+    }
+
+    /**
+     * Gets an Id for these query modifiers that matter for analytics grouping.
+     */
+    public String getQueryModsId()
+    {
+        QueryModifiers analyticsQueryMods = withQueryModsForAnalyticsGrouping();
+
+        return analyticsQueryMods.isDefault()
+            ? null
+            : Integer.toHexString( analyticsQueryMods.hashCode() );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Checks if these query mods have all default values.
+     */
+    private boolean isDefault()
+    {
+        return this.equals( DEFAULT );
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -62,6 +62,15 @@ import org.hisp.dhis.program.Program;
 public class ExpressionParams
 {
     /**
+     * Dummy data for sample periods, so in the absence of real sampled data the
+     * parser will still traverse the contents of aggregation functions once for
+     * the purposes of such things as syntax checking and getting an expression
+     * description. The actual date doesn't matter; a date was chosen that is
+     * likely to not be confused with real data.
+     */
+    private static final List<Period> SAMPLE_PERIODS = List.of( PeriodType.getPeriodFromIsoString( "19990101" ) );
+
+    /**
      * The expression to parse
      */
     @ToString.Include
@@ -155,7 +164,7 @@ public class ExpressionParams
     @ToString.Include
     @EqualsAndHashCode.Include
     @Builder.Default
-    private final List<Period> samplePeriods = List.of( PeriodType.getPeriodFromIsoString( "19990101" ) );
+    private final List<Period> samplePeriods = SAMPLE_PERIODS;
 
     /**
      * For predictors, a value map from item to value, for each of the periods

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -42,6 +42,7 @@ import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getList;
 
@@ -414,6 +415,11 @@ public class DataQueryParams
     protected transient DataType dataType;
 
     /**
+     * Id of query modifiers affecting data in this query.
+     */
+    protected transient String queryModsId;
+
+    /**
      * The aggregation period type for this query.
      */
     protected transient String periodType;
@@ -577,6 +583,7 @@ public class DataQueryParams
         params.partitions = new Partitions( this.partitions );
         params.tableName = this.tableName;
         params.dataType = this.dataType;
+        params.queryModsId = this.queryModsId;
         params.periodType = this.periodType;
         params.dataPeriodType = this.dataPeriodType;
         params.skipPartitioning = this.skipPartitioning;
@@ -882,6 +889,17 @@ public class DataQueryParams
                 DimensionType.ORGANISATION_UNIT_LEVEL, PREFIX_ORG_UNIT_LEVEL + l.getLevel(), l.getName(),
                 Lists.newArrayList() ) )
             .collect( Collectors.toList() );
+    }
+
+    /**
+     * For the data dimension only: returns the query mods id prefixed by the
+     * separator, or an empty string if there is no query mods id.
+     */
+    public String getQueryModsId( DimensionalObject dimension )
+    {
+        return (dimension.getUid().equals( DATA_X_DIM_ID ) && queryModsId != null)
+            ? QUERY_MODS_ID_SEPARATOR + queryModsId
+            : "";
     }
 
     /**
@@ -3255,6 +3273,12 @@ public class DataQueryParams
         public Builder withDataType( DataType dataType )
         {
             this.params.dataType = dataType;
+            return this;
+        }
+
+        public Builder withQueryModsId( String queryModsId )
+        {
+            this.params.queryModsId = queryModsId;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultQueryPlanner.java
@@ -114,7 +114,7 @@ public class DefaultQueryPlanner
             .add( q -> groupByOrgUnitLevel( q ) )
             .add( q -> groupByPeriodType( q ) )
             .add( q -> groupByDataType( q ) )
-            .add( q -> groupByMinMaxDate( q ) )
+            .add( q -> groupByQueryMods( q ) )
             .add( q -> groupByAggregationType( q ) )
             .add( q -> groupByDaysInPeriod( q ) )
             .add( q -> groupByDataPeriodType( q ) )
@@ -439,26 +439,32 @@ public class DefaultQueryPlanner
     }
 
     /**
-     * Groups queries by their minDate/MaxDate query modifiers.
+     * Groups queries by their query modifiers Id.
      *
      * @param params the {@link DataQueryParams}.
      * @return a list of {@link DataQueryParams}.
      */
-    private List<DataQueryParams> groupByMinMaxDate( DataQueryParams params )
+    private List<DataQueryParams> groupByQueryMods( DataQueryParams params )
     {
         List<DataQueryParams> queries = new ArrayList<>();
 
         if ( !params.getDataElements().isEmpty() )
         {
-            ListMap<QueryModifiers, DimensionalItemObject> minMaxDateDateElementMap = QueryPlannerUtils
-                .getMinMaxDateDateElementMap( params.getDataElements() );
+            ListMap<QueryModifiers, DimensionalItemObject> queryModsElementMap = QueryPlannerUtils
+                .getQueryModsElementMap( params.getDataElements() );
 
-            for ( QueryModifiers queryMods : minMaxDateDateElementMap.keySet() )
+            for ( QueryModifiers queryMods : queryModsElementMap.keySet() )
             {
+                DataElement dataElement = (DataElement) queryModsElementMap.get( queryMods ).iterator().next();
+
                 DataQueryParams query = DataQueryParams.newBuilder( params )
-                    .withDataElements( minMaxDateDateElementMap.get( queryMods ) )
+                    .withDataElements( queryModsElementMap.get( queryMods ) )
+                    .withQueryModsId( queryMods.getQueryModsId() )
                     .withStartDate( getLatest( params.getStartDate(), queryMods.getMinDate() ) )
                     .withEndDate( getEarliest( params.getEndDate(), queryMods.getMaxDate() ) )
+                    .withAggregationType( (queryMods.getAggregationType() != null)
+                        ? AnalyticsAggregationType.fromAggregationType( queryMods.getAggregationType() )
+                        : params.getAggregationType() )
                     .build();
 
                 queries.add( query );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -712,7 +712,9 @@ public class JdbcAnalyticsManager
             {
                 String value = dim.isFixed() ? dim.getDimensionName() : rowSet.getString( dim.getDimensionName() );
 
-                key.append( value ).append( DIMENSION_SEP );
+                String queryModsId = params.getQueryModsId( dim );
+
+                key.append( value ).append( queryModsId ).append( DIMENSION_SEP );
             }
 
             key.deleteCharAt( key.length() - 1 );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/QueryPlannerUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/QueryPlannerUtils.java
@@ -114,26 +114,23 @@ public class QueryPlannerUtils
     }
 
     /**
-     * Creates a mapping between minDate/maxDate query modifiers and data
-     * elements for the given data elements.
+     * Creates a mapping between query modifiers and data elements for the given
+     * data elements.
      *
      * @param dataElements list of data elements.
      */
-    public static ListMap<QueryModifiers, DimensionalItemObject> getMinMaxDateDateElementMap(
+    public static ListMap<QueryModifiers, DimensionalItemObject> getQueryModsElementMap(
         List<DimensionalItemObject> dataElements )
     {
         ListMap<QueryModifiers, DimensionalItemObject> map = new ListMap<>();
 
         for ( DimensionalItemObject element : dataElements )
         {
-            QueryModifiers queryMods = element.getQueryMods();
+            QueryModifiers queryMods = (element.getQueryMods() != null)
+                ? element.getQueryMods().withQueryModsForAnalyticsGrouping()
+                : QueryModifiers.builder().build();
 
-            // Get QueryModifiers but only with min and max date, nothing else
-            QueryModifiers minMaxDateModifiers = (queryMods == null)
-                ? QueryModifiers.builder().build()
-                : QueryModifiers.builder().minDate( queryMods.getMinDate() ).maxDate( queryMods.getMaxDate() ).build();
-
-            map.putValue( minMaxDateModifiers, element );
+            map.putValue( queryMods, element );
         }
 
         return map;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.QUERY_MODS_ID_SEPARATOR;
 import static org.hisp.dhis.dataelement.DataElementOperand.TotalType;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
@@ -305,6 +306,9 @@ public class AnalyticsUtils
      * i.e. {@code deuid-cocuid} to {@code deuid.cocuid}. For
      * {@link TotalType#AOC_ONLY} a {@link ExpressionService#SYMBOL_WILDCARD}
      * symbol will be inserted after the data item.
+     * <p>
+     * Also transfers a queryModsId to the end of the operand identifier, i.e.
+     * {@code deuid_queryModsId-cocuid} to {@code deuid.cocuid_queryModsId}
      *
      * @param valueMap the value map to convert.
      * @param totalType the {@link TotalType}.
@@ -326,6 +330,16 @@ public class AnalyticsUtils
             if ( TotalType.AOC_ONLY == totalType )
             {
                 operands.add( 1, SYMBOL_WILDCARD );
+            }
+
+            // If the DataElement has a queryModsId, move it to end of operand
+
+            List<String> queryModsSplit = Lists.newArrayList( operands.get( 0 ).split( QUERY_MODS_ID_SEPARATOR ) );
+            if ( queryModsSplit.size() > 1 )
+            {
+                operands.set( 0, queryModsSplit.get( 0 ) );
+                int lastOp = operands.size() - 1;
+                operands.set( lastOp, operands.get( lastOp ) + QUERY_MODS_ID_SEPARATOR + queryModsSplit.get( 1 ) );
             }
 
             String operand = StringUtils.join( operands, DimensionalObjectUtils.COMPOSITE_DIM_OBJECT_PLAIN_SEP );
@@ -935,7 +949,8 @@ public class AnalyticsUtils
         List<DimensionalItemObject> items )
     {
         return items.stream()
-            .filter( dio -> dio.getDimensionItem() != null && dio.getDimensionItem().equals( dimensionIdentifier ) )
+            .filter( dio -> dio.getDimensionItem() != null &&
+                dio.getDimensionItemWithQueryModsId().equals( dimensionIdentifier ) )
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.data;
+
+import static org.hisp.dhis.util.DateUtils.parseDate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.IntegrationTestBase;
+import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.AnalyticsAggregationType;
+import org.hisp.dhis.analytics.AnalyticsService;
+import org.hisp.dhis.analytics.AnalyticsTableGenerator;
+import org.hisp.dhis.analytics.AnalyticsTableService;
+import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.OutputFormat;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorService;
+import org.hisp.dhis.indicator.IndicatorType;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.scheduling.NoopJobProgress;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests analytics with {@see QueryModifiers}.
+ *
+ * @author Jim Grace
+ */
+class AnalyticsServiceQueryModifiersTest
+    extends IntegrationTestBase
+{
+    @Autowired
+    private List<AnalyticsTableService> analyticsTableServices;
+
+    @Autowired
+    private DataElementService dataElementService;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private OrganisationUnitService organisationUnitService;
+
+    @Autowired
+    private PeriodService periodService;
+
+    @Autowired
+    private DataValueService dataValueService;
+
+    @Autowired
+    private AnalyticsTableGenerator analyticsTableGenerator;
+
+    @Autowired
+    private AnalyticsService analyticsService;
+
+    @Autowired
+    private IndicatorService indicatorService;
+
+    private Period jan;
+
+    private Period feb;
+
+    private Period mar;
+
+    private Period q1;
+
+    private OrganisationUnit ouA;
+
+    private Indicator indicatorA;
+
+    List<String> expected;
+
+    List<String> result;
+
+    // -------------------------------------------------------------------------
+    // Fixture
+    // -------------------------------------------------------------------------
+
+    @Override
+    public void setUpTest()
+        throws IOException,
+        InterruptedException
+    {
+        jan = createPeriod( "2022-01" );
+        feb = createPeriod( "2022-02" );
+        mar = createPeriod( "2022-03" );
+        q1 = createPeriod( "2022Q1" );
+        periodService.addPeriod( jan );
+        periodService.addPeriod( feb );
+        periodService.addPeriod( mar );
+        periodService.addPeriod( q1 );
+        jan = periodService.reloadPeriod( jan );
+        feb = periodService.reloadPeriod( feb );
+        mar = periodService.reloadPeriod( mar );
+        q1 = periodService.reloadPeriod( q1 );
+
+        DataElement deA = createDataElement( 'A', ValueType.INTEGER, AggregationType.SUM );
+        dataElementService.addDataElement( deA );
+
+        ouA = createOrganisationUnit( 'A' );
+        organisationUnitService.addOrganisationUnit( ouA );
+
+        CategoryOption optionA = new CategoryOption( "CategoryOptionA" );
+        CategoryOption optionB = new CategoryOption( "CategoryOptionB" );
+        categoryService.addCategoryOption( optionA );
+        categoryService.addCategoryOption( optionB );
+
+        Category categoryA = createCategory( 'A', optionA, optionB );
+        categoryService.addCategory( categoryA );
+
+        CategoryCombo categoryComboA = createCategoryCombo( 'A', categoryA );
+        categoryService.addCategoryCombo( categoryComboA );
+
+        CategoryOptionCombo cocA = createCategoryOptionCombo( categoryComboA, optionA );
+        CategoryOptionCombo cocB = createCategoryOptionCombo( categoryComboA, optionB );
+        cocA.setUid( "OptionCombA" );
+        cocB.setUid( "OptionCombB" );
+        categoryService.addCategoryOptionCombo( cocA );
+        categoryService.addCategoryOptionCombo( cocB );
+        CategoryOptionCombo aocA = categoryService.getDefaultCategoryOptionCombo();
+
+        categoryComboA.getOptionCombos().add( cocA );
+        categoryComboA.getOptionCombos().add( cocB );
+        categoryService.updateCategoryCombo( categoryComboA );
+
+        IndicatorType indicatorTypeA = createIndicatorType( 'A' );
+        indicatorTypeA.setFactor( 1 );
+        indicatorService.addIndicatorType( indicatorTypeA );
+
+        indicatorA = createIndicator( 'A', indicatorTypeA );
+        indicatorA.setNumerator( "1" ); // to be overwritten
+        indicatorA.setDenominator( "1" );
+        indicatorService.addIndicator( indicatorA );
+
+        dataValueService.addDataValue( newDataValue( deA, jan, ouA, cocA, aocA, "1" ) );
+        dataValueService.addDataValue( newDataValue( deA, feb, ouA, cocB, aocA, "2" ) );
+        dataValueService.addDataValue( newDataValue( deA, mar, ouA, cocA, aocA, "3" ) );
+
+        // Wait before generating analytics tables
+        Thread.sleep( 5000 );
+
+        // Generate analytics tables
+        analyticsTableGenerator.generateTables( AnalyticsTableUpdateParams.newBuilder().build(),
+            NoopJobProgress.INSTANCE );
+
+        // Wait after generating analytics tables
+        Thread.sleep( 8000 );
+    }
+
+    @Override
+    public void tearDownTest()
+    {
+        for ( AnalyticsTableService service : analyticsTableServices )
+        {
+            service.dropTables();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Test
+    // -------------------------------------------------------------------------
+
+    @Test
+    void queryModifiersTest()
+    {
+        // TODO: refactor IntegrationTestBase and/or BaseSpringTest to provide
+        // @BeforeAll and @AfterAll methods that can be overridden so the
+        // following be individual @Tests while analytics is built only once.
+
+        // aggregationType
+
+        testNoAggregationType();
+        testAverageAggregationType();
+        testLastAggregationType();
+        testWithAndWithoutAggregationType();
+        testMultipleAggregationTypes();
+        testGroupedAggregationType();
+        testOperandAggregationType();
+
+        // periodOffset
+
+        testSimplePeriodOffset();
+        testInsideAndOutsidePeriodOffset();
+        testOperandPeriodOffset();
+        testGroupedPeriodOffset();
+        testAdditivePeriodOffset();
+
+        // minDate and maxDate
+
+        testMinDate();
+        testMaxDate();
+        testMinAndMaxDate();
+    }
+
+    // -------------------------------------------------------------------------
+    // aggregationType
+    // -------------------------------------------------------------------------
+
+    private void testNoAggregationType()
+    {
+        expected = List.of(
+            "inabcdefghA-202201-1.0",
+            "inabcdefghA-202202-2.0",
+            "inabcdefghA-202203-3.0",
+            "inabcdefghA-2022Q1-6.0" );
+
+        result = query( "#{deabcdefghA}", jan, feb, mar, q1 );
+
+        assertEquals( expected, result );
+    }
+
+    private void testAverageAggregationType()
+    {
+        expected = List.of(
+            "inabcdefghA-2022Q1-2.0" );
+
+        result = query( "#{deabcdefghA}.aggregationType(AVERAGE)", q1 );
+
+        assertEquals( expected, result );
+    }
+
+    private void testLastAggregationType()
+    {
+        expected = List.of(
+            "inabcdefghA-2022Q1-3.0" );
+
+        result = query( "#{deabcdefghA.OptionCombA}.aggregationType(LAST)", q1 );
+
+        assertEquals( expected, result );
+    }
+
+    private void testWithAndWithoutAggregationType()
+    {
+        expected = List.of(
+            "inabcdefghA-2022Q1-8.0" );
+
+        result = query( "#{deabcdefghA} + #{deabcdefghA}.aggregationType(AVERAGE)", q1 );
+
+        assertEquals( expected, result );
+    }
+
+    private void testMultipleAggregationTypes()
+    {
+        expected = List.of(
+            "inabcdefghA-2022Q1-5.0" );
+
+        result = query( "#{deabcdefghA}.aggregationType(MAX) + #{deabcdefghA}.aggregationType(AVERAGE)", q1 );
+
+        assertEquals( expected, result );
+    }
+
+    private void testGroupedAggregationType()
+    {
+        expected = List.of(
+            "inabcdefghA-2022Q1-6.0" );
+
+        result = query( "(2*#{deabcdefghA} + #{deabcdefghA}).aggregationType(AVERAGE)", q1 );
+
+        assertEquals( expected, result );
+    }
+
+    private void testOperandAggregationType()
+    {
+        expected = List.of(
+            "inabcdefghA-2022Q1-4.0" );
+
+        result = query( "#{deabcdefghA.OptionCombA}.aggregationType(AVERAGE) + #{deabcdefghA.OptionCombB}", q1 );
+
+        assertEquals( expected, result );
+    }
+
+    // -------------------------------------------------------------------------
+    // periodOffset
+    // -------------------------------------------------------------------------
+
+    private void testSimplePeriodOffset()
+    {
+        expected = List.of(
+            "inabcdefghA-202202-1.0",
+            "inabcdefghA-202203-2.0" );
+
+        result = query( "#{deabcdefghA}.periodOffset(-1)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    private void testInsideAndOutsidePeriodOffset()
+    {
+        expected = List.of(
+            "inabcdefghA-202201-3.0",
+            "inabcdefghA-202202-5.0",
+            "inabcdefghA-202203-3.0" );
+
+        result = query( "#{deabcdefghA} + #{deabcdefghA}.periodOffset(1)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    private void testGroupedPeriodOffset()
+    {
+        expected = List.of(
+            "inabcdefghA-202202-2.0",
+            "inabcdefghA-202203-4.0" );
+
+        result = query( "(#{deabcdefghA} + #{deabcdefghA}).periodOffset(-1)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    private void testAdditivePeriodOffset()
+    {
+        expected = List.of(
+            "inabcdefghA-202202-1.0",
+            "inabcdefghA-202203-3.0" );
+
+        result = query( "(#{deabcdefghA}.periodOffset(-1) + #{deabcdefghA}).periodOffset(-1)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    private void testOperandPeriodOffset()
+    {
+        expected = List.of(
+            "inabcdefghA-202201-4.0",
+            "inabcdefghA-202202-1.0" );
+
+        result = query( "#{deabcdefghA.OptionCombA}.periodOffset(-1) + 2*#{deabcdefghA.OptionCombB}.periodOffset(1)",
+            jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    // -------------------------------------------------------------------------
+    // minDate and maxDate
+    // -------------------------------------------------------------------------
+
+    private void testMinDate()
+    {
+        expected = List.of(
+            "inabcdefghA-202202-2.0",
+            "inabcdefghA-202203-3.0" );
+
+        result = query( "#{deabcdefghA}.minDate(2022-2-1)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    private void testMaxDate()
+    {
+        expected = List.of(
+            "inabcdefghA-202201-1.0",
+            "inabcdefghA-202202-2.0" );
+
+        result = query( "#{deabcdefghA}.maxDate(2022-2-28)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    private void testMinAndMaxDate()
+    {
+        expected = List.of(
+            "inabcdefghA-202202-2.0" );
+
+        result = query( "#{deabcdefghA}.minDate(2022-2-1).maxDate(2022-2-28)", jan, feb, mar );
+
+        assertEquals( expected, result );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a data value. Sets the last updated time to something in the past
+     * because at the time of this writing analytics won't include the value if
+     * it was last updated within the same second as the analytics update.
+     */
+    private DataValue newDataValue( DataElement de, Period pe, OrganisationUnit ou,
+        CategoryOptionCombo coc, CategoryOptionCombo aoc, String value )
+    {
+        return new DataValue( de, pe, ou, coc, aoc, value, null, parseDate( "2022-01-01" ), null );
+    }
+
+    /**
+     * Queries analytics with an indicator expression.
+     */
+    private List<String> query( String expression, Period... periods )
+    {
+        indicatorA.setNumerator( expression );
+        indicatorService.updateIndicator( indicatorA );
+
+        DataQueryParams params = DataQueryParams.newBuilder()
+            .withIndicators( List.of( indicatorA ) )
+            .withAggregationType( AnalyticsAggregationType.SUM )
+            .withFilterOrganisationUnits( List.of( ouA ) )
+            .withPeriods( List.of( periods ) )
+            .withOutputFormat( OutputFormat.ANALYTICS )
+            .build();
+
+        Map<String, Object> map = analyticsService.getAggregatedDataValueMapping( params );
+
+        return map.entrySet().stream()
+            .map( e -> e.getKey() + '-' + e.getValue() )
+            .sorted().collect( Collectors.toList() );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionExtractor.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dimension;
 
 import static org.apache.commons.lang3.EnumUtils.isValidEnum;
+import static org.apache.commons.lang3.ObjectUtils.allNotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -202,12 +203,11 @@ public class DataDimensionExtractor
         {
             if ( id.hasValidIds() )
             {
-                final BaseDimensionalItemObject dimensionalItemObject = getBaseDimensionalItemObject( atomicObjects,
+                final DimensionalItemObject dimensionalItemObject = getDimensionalItemObject( atomicObjects,
                     id );
 
                 if ( dimensionalItemObject != null )
                 {
-                    dimensionalItemObject.setQueryMods( id.getQueryMods() );
                     itemObjectMap.put( id, dimensionalItemObject );
                 }
             }
@@ -279,7 +279,7 @@ public class DataDimensionExtractor
         return new ProgramDataElementDimensionItem( program, dataElement );
     }
 
-    private BaseDimensionalItemObject getBaseDimensionalItemObject(
+    private DimensionalItemObject getDimensionalItemObject(
         final MapMap<Class<? extends IdentifiableObject>, String, IdentifiableObject> atomicObjects,
         final DimensionalItemId id )
     {
@@ -289,18 +289,12 @@ public class DataDimensionExtractor
         {
         case DATA_ELEMENT:
             DataElement dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId0() );
-            if ( dataElement != null )
-            {
-                dimensionalItemObject = cloneIfNeeded( dataElement, id );
-            }
+            dimensionalItemObject = withQueryMods( dataElement, id );
             break;
 
         case INDICATOR:
             final Indicator indicator = (Indicator) atomicObjects.getValue( Indicator.class, id.getId0() );
-            if ( indicator != null )
-            {
-                dimensionalItemObject = cloneIfNeeded( indicator, id );
-            }
+            dimensionalItemObject = withQueryMods( indicator, id );
             break;
 
         case DATA_ELEMENT_OPERAND:
@@ -313,8 +307,9 @@ public class DataDimensionExtractor
                 (id.getId1() != null) == (categoryOptionCombo != null) &&
                 (id.getId2() != null) == (attributeOptionCombo != null) )
             {
-                dimensionalItemObject = new DataElementOperand( dataElement, categoryOptionCombo,
-                    attributeOptionCombo );
+                dimensionalItemObject = new DataElementOperand( (DataElement) withQueryMods( dataElement, id ),
+                    categoryOptionCombo, attributeOptionCombo );
+                dimensionalItemObject.setQueryMods( id.getQueryMods() );
             }
             break;
 
@@ -329,7 +324,7 @@ public class DataDimensionExtractor
         case PROGRAM_DATA_ELEMENT:
             Program program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
             dataElement = (DataElement) atomicObjects.getValue( DataElement.class, id.getId1() );
-            if ( program != null && dataElement != null )
+            if ( allNotNull( program, dataElement ) )
             {
                 dimensionalItemObject = new ProgramDataElementDimensionItem( program, dataElement );
             }
@@ -339,19 +334,14 @@ public class DataDimensionExtractor
             program = (Program) atomicObjects.getValue( Program.class, id.getId0() );
             final TrackedEntityAttribute attribute = (TrackedEntityAttribute) atomicObjects
                 .getValue( TrackedEntityAttribute.class, id.getId1() );
-            if ( program != null && attribute != null )
+            if ( allNotNull( program, attribute ) )
             {
                 dimensionalItemObject = new ProgramTrackedEntityAttributeDimensionItem( program, attribute );
             }
             break;
 
         case PROGRAM_INDICATOR:
-            final ProgramIndicator programIndicator = (ProgramIndicator) atomicObjects
-                .getValue( ProgramIndicator.class, id.getId0() );
-            if ( programIndicator != null )
-            {
-                dimensionalItemObject = cloneIfNeeded( programIndicator, id );
-            }
+            dimensionalItemObject = (ProgramIndicator) atomicObjects.getValue( ProgramIndicator.class, id.getId0() );
             break;
 
         default:
@@ -370,20 +360,22 @@ public class DataDimensionExtractor
      * @param id the item id that may have non-default query modifiers.
      * @return the item or its clone.
      */
-    private BaseDimensionalItemObject cloneIfNeeded( final BaseDimensionalItemObject item, final DimensionalItemId id )
+    private BaseDimensionalItemObject withQueryMods( final BaseDimensionalItemObject item, final DimensionalItemId id )
     {
-        if ( id.getQueryMods() != null )
+        if ( item == null || id.getQueryMods() == null )
         {
-            try
-            {
-                return (BaseDimensionalItemObject) BeanUtils.cloneBean( item );
-            }
-            catch ( Exception e )
-            {
-                return null;
-            }
+            return item;
         }
 
-        return item;
+        try
+        {
+            BaseDimensionalItemObject clone = (BaseDimensionalItemObject) BeanUtils.cloneBean( item );
+            clone.setQueryMods( id.getQueryMods() );
+            return clone;
+        }
+        catch ( Exception e )
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
This PR contains fixes to the new 2.38 indicator expression functions `minDate`, `maxDate`, and `aggregationType` as described in [DHIS2-12836](https://jira.dhis2.org/browse/DHIS2-12836). It is a subset of the code in [pull/9923](https://github.com/dhis2/dhis2-core/pull/9923) (Indicator sub-expressions), as it does not have the new feature, but contains only the fixes to existing (2.38) features.

It also contains the simple `ExpressionParams.samplePeriods` speedup as described in the **Performance** section of [pull/9923](https://github.com/dhis2/dhis2-core/pull/9923). (This speeds up _all_ indicators.)

The fix is as follows (adapted from pull/9923):

While testing subexpressions, a design flaw was discovered that affected these three functions: `DefaultQueryPlanner` correctly made different queries for `DataElements` with different `QueryModifiers` such as aggregationType override and start/end dates. The returned values were correctly assigned to the corresponding `DimensionalItemObjects` as long as the same `DataElement` was not used with multiple different modifiers. The problem happened when the same `DataElement` (or `DataElementOperand`) was used both with and without these `QueryModifiers`, or used with different `QueryModifiers` in different places in the expression or in different expressions in the same query. There was no way for the query result values with different modifiers to be correctly assigned to the `DimensionalItemObjects` with corresponding modifiers in the expressions.

This was solved by generating a `String queryModsId` that is the hex value of the hashCode() of the `QueryModifiers` fields that must be done in different queries. (This is all the `QueryModifiers` fields except `periodOffset`, because different period offsets can already be done in the same analytics query.) `DefaultQueryPlanner.groupByQueryMods` now insures that a different query will be done for each incompatible `QueryModifiers` object, and it stores the `queryModsId` in the `DataQueryParams` for each query having those modifiers. (No `queryModsId` is stored if there are no such modifiers.) This replaces the recently-developed `groupByMinMaxDate` and provides a superset of that functionality.

`JdbcAnalyticsManager.getKeyValueMap` appends an underscore with the `queryModsId` to the data dimension id (with help from `DataQueryParams.getQueryModsId`). This encodes the dimensions of a data item with no modifiers in the same way that it always has, such as `deabcdefghA-202202`. But a data element with `QueryModifiers` (other than `periodOffset`) will have the `queryModsId` added to the data dimension such as `deabcdefghA_5cd4a04f-202202`. This allows `AnalyticsUtils.findDimensionalItems` to match up the value tagged with the hex `queryModsId` to the correct `DimensionalItemObject` with modifiers (with help from `DimensionalItemObject.getDimensionItemWithQueryModsId`).

### Testing

`AnalyticsServiceQueryModifiersTest` is an end-to-end integration test for these three functions that generate `QueryModifiers`.

The code passes the suggested testing in [DHIS2-12836](https://jira.dhis2.org/browse/DHIS2-12836).

The SL Demo dashboards display the same data as with the unmodified code.