### PR TITLE
fix: exclude slf4j-simple from rule-engine

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -718,6 +718,11 @@
             </goals>
             <configuration>
               <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.slf4j:slf4j-simple</exclude>
+                  </excludes>
+                </bannedDependencies>
                 <banDuplicatePomDependencyVersions/>
                 <requireMavenVersion>
                   <version>${minimum-maven.version}</version>
@@ -905,6 +910,10 @@
           <exclusion>
             <groupId>org.hisp.dhis.parser</groupId>
             <artifactId>dhis-antlr-expression-parser</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
## Summary

* Excludes `slf4j-simple` from `rule-engine`

[DHIS2-12708](https://jira.dhis2.org/browse/DHIS2-12708)