### PR TITLE
fix: update tea query delimiters for [DHIS2-12369]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -137,6 +137,10 @@ public class HibernateTrackedEntityInstanceStore
 
     private static final String GT_EQUAL = " >= ";
 
+    private static final String UID_VALUE_SEPARATOR = ":";
+
+    private static final String UID_VALUE_PAIR_SEPARATOR = ";@//@;";
+
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -269,11 +273,11 @@ public class HibernateTrackedEntityInstanceStore
     {
         if ( teavString != null )
         {
-            String[] pairs = teavString.split( ";" );
+            String[] pairs = teavString.split( UID_VALUE_PAIR_SEPARATOR );
 
             for ( String pair : pairs )
             {
-                String[] teav = pair.split( ":" );
+                String[] teav = pair.split( UID_VALUE_SEPARATOR, 2 );
 
                 if ( teav.length == 2 )
                 {
@@ -430,8 +434,12 @@ public class HibernateTrackedEntityInstanceStore
             .append( "TET.uid AS " + TRACKED_ENTITY_ID + ", " )
             .append( "TEI.inactive AS " + INACTIVE_ID + ", " )
             .append( "TEI.potentialduplicate AS " + POTENTIAL_DUPLICATE )
-            .append( (params.isIncludeDeleted() ? ", TEI.deleted AS " + DELETED : "") )
-            .append( (params.hasAttributes() ? ", string_agg(TEA.uid || ':' || TEAV.value, ';') AS tea_values" : "") );
+            .append( params.isIncludeDeleted() ? ", TEI.deleted AS " + DELETED : "" )
+            .append(
+                params.hasAttributes()
+                    ? ", string_agg(TEA.uid || '" + UID_VALUE_SEPARATOR + "' || TEAV.value, '"
+                        + UID_VALUE_PAIR_SEPARATOR + "') AS tea_values"
+                    : "" );
 
         if ( !isGridQuery )
         {
@@ -822,7 +830,7 @@ public class HibernateTrackedEntityInstanceStore
         orgUnits
             .append( " INNER JOIN organisationunit OU " )
             .append( "ON OU.organisationunitid = " )
-            .append( (params.hasProgram() ? "PO.organisationunitid " : "TEI.organisationunitid ") );
+            .append( params.hasProgram() ? "PO.organisationunitid " : "TEI.organisationunitid " );
 
         if ( !params.hasOrganisationUnits() )
         {
@@ -1178,7 +1186,7 @@ public class HibernateTrackedEntityInstanceStore
             .append( "TET.uid, " )
             .append( "TEI.potentialduplicate, " )
             .append( "TEI.inactive " )
-            .append( (params.isIncludeDeleted() ? ", TEI.deleted " : "") );
+            .append( params.isIncludeDeleted() ? ", TEI.deleted " : "" );
 
         if ( !getOrderAttributes( params ).isEmpty() )
         {


### PR DESCRIPTION
This PR fixes issues with requests to trackedEntityInstances/query when underlying tracked entity attribute values have colons or semi-colons. 

Semicolon for separating pairs of uid:tea_value has been updated to less likely ';@//@;' to avoid collisions.

Colon for separating uid and tea_value has been updated to be split once at the first occurrence.