### PR TITLE
fix: update media type for [DHIS2-12366]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SystemController.java
@@ -177,13 +177,13 @@ public class SystemController
     // Tasks
     // -------------------------------------------------------------------------
 
-    @GetMapping( value = "/tasks", produces = { "*/*", APPLICATION_JSON_VALUE } )
+    @GetMapping( value = "/tasks", produces = APPLICATION_JSON_VALUE )
     public ResponseEntity<Map<JobType, Map<String, Deque<Notification>>>> getTasksJson()
     {
         return ResponseEntity.ok().cacheControl( noStore() ).body( notifier.getNotifications() );
     }
 
-    @GetMapping( value = "/tasks/{jobType}", produces = { "*/*", APPLICATION_JSON_VALUE } )
+    @GetMapping( value = "/tasks/{jobType}", produces = APPLICATION_JSON_VALUE )
     public ResponseEntity<Map<String, Deque<Notification>>> getTasksExtendedJson(
         @PathVariable( "jobType" ) String jobType )
     {
@@ -194,7 +194,7 @@ public class SystemController
         return ResponseEntity.ok().cacheControl( noStore() ).body( notifications );
     }
 
-    @GetMapping( value = "/tasks/{jobType}/{jobId}", produces = { "*/*", APPLICATION_JSON_VALUE } )
+    @GetMapping( value = "/tasks/{jobType}/{jobId}", produces = APPLICATION_JSON_VALUE )
     public ResponseEntity<Collection<Notification>> getTaskJsonByUid( @PathVariable( "jobType" ) String jobType,
         @PathVariable( "jobId" ) String jobId )
     {
@@ -209,7 +209,7 @@ public class SystemController
     // Tasks summary
     // -------------------------------------------------------------------------
 
-    @GetMapping( value = "/taskSummaries/{jobType}", produces = { "*/*", APPLICATION_JSON_VALUE } )
+    @GetMapping( value = "/taskSummaries/{jobType}", produces = APPLICATION_JSON_VALUE )
     public ResponseEntity<Map<String, Object>> getTaskSummaryExtendedJson( @PathVariable( "jobType" ) String jobType )
     {
         if ( jobType != null )
@@ -224,7 +224,7 @@ public class SystemController
         return ResponseEntity.ok().cacheControl( noStore() ).build();
     }
 
-    @GetMapping( value = "/taskSummaries/{jobType}/{jobId}", produces = { "*/*", APPLICATION_JSON_VALUE } )
+    @GetMapping( value = "/taskSummaries/{jobType}/{jobId}", produces = APPLICATION_JSON_VALUE )
     public ResponseEntity<Object> getTaskSummaryJson( @PathVariable( "jobType" ) String jobType,
         @PathVariable( "jobId" ) String jobId )
     {


### PR DESCRIPTION
Fix for https://jira.dhis2.org/browse/DHIS2-12366

Underlying user issue is caused by information not rendering in browser, e.g. a browser request to `api/system/tasks/ANALYTICS_TABLE` on dev currently returns:
<img width="781" alt="image" src="https://user-images.githubusercontent.com/18490902/158207596-66e7283e-276d-464a-9517-63da59b853b2.png">

Updating media type resolves the issue:
<img width="670" alt="image" src="https://user-images.githubusercontent.com/18490902/158209833-4be272fe-14ea-4044-84e3-6135a400e877.png">

And will also make corresponding api/system/tasks/ANALYTICS_TABLE/:uid posts visible.