### PR TITLE
fix: nested conditions are now always AND [DHIS2-12839]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -835,11 +836,13 @@ public abstract class AbstractJdbcEventAnalyticsManager
         Collection<String> repeatableSqlConditions = asSqlCollection( itemsByRepeatableFlag.get( true ), params );
         Collection<String> nonRepeatableSqlConditions = asSqlCollection( itemsByRepeatableFlag.get( false ), params );
 
-        return (!repeatableSqlConditions.isEmpty() || !nonRepeatableSqlConditions.isEmpty() ? hlp.whereAnd()
+        return (!repeatableSqlConditions.isEmpty() || !nonRepeatableSqlConditions.isEmpty() ? hlp.whereAnd() + " "
             : "") +
-            String.join( " and ",
+            Stream.of(
                 joinSql( repeatableSqlConditions, joining( " or ", "(", ")" ) ),
-                joinSql( nonRepeatableSqlConditions, joining( " and " ) ) );
+                joinSql( nonRepeatableSqlConditions, joining( " and " ) ) )
+                .filter( StringUtils::isNotEmpty )
+                .collect( joining( " and " ) );
     }
 
     private String joinSql( Collection<String> conditions, Collector<CharSequence, ?, String> joiner )


### PR DESCRIPTION
We had
```
Repeatable QueryItem1( dataelement1, GT 5, LT 10)
Repeatable QueryItem2( dataelement2, GT 6, LT 11)
QueryItem3( dataelement3, EQ, "test")
```

it was converted into:
```
(DE1>5 OR DE1<10 OR DE2>6 OR DE2<11) and DE3="TEST"
```

now it is like this:
```
((DE1>5 AND DE1<10) OR (DE2>6 AND DE2<11)) AND DE3="TEST"
```