### PR TITLE
fix: interpretation missing access object from api response

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -232,7 +232,7 @@ public class FieldFilterService
 
         Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
 
-        if ( !schema.isMetadata() )
+        if ( !schema.isIdentifiableObject() )
         {
             return;
         }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -254,7 +254,7 @@ public class FieldPathHelper
 
         Schema schema = schemaService.getDynamicSchema( HibernateProxyUtils.getRealClass( object ) );
 
-        if ( !schema.isMetadata() )
+        if ( !schema.isIdentifiableObject() )
         {
             return;
         }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/InterpretationControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/InterpretationControllerTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.interpretation.Interpretation;
@@ -244,5 +245,15 @@ class InterpretationControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Conflict", 409, "ERROR",
             "Could not remove like, user had not previously liked interpretation",
             DELETE( "/interpretations/" + uid + "/like" ).content( HttpStatus.CONFLICT ) );
+    }
+
+    @Test
+    void testGetWithAccessObject()
+    {
+        assertWebMessage( "Created", 201, "OK", "Commented created",
+            POST( "/interpretations/" + uid + "/comments", "text/plain:comment" ).content( HttpStatus.CREATED ) );
+        JsonObject comments = GET( "/interpretations/{uid}/comments?fields=access,id", uid ).content( HttpStatus.OK );
+        assertEquals( 1, comments.getArray( "comments" ).size() );
+        assertNotNull( comments.getArray( "comments" ).getObject( 0 ).getString( "access" ) );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12843
- Interpretation is not metadata object so its ignored by the FieldFilterService when it try to apply some handler to populate the `access` object.

- This PR replace the `isMetadata()` check with `isIdentifiableObjet()`
- Add a controller test.
<img width="643" alt="Screen Shot 2022-03-15 at 4 15 20 PM" src="https://user-images.githubusercontent.com/766102/158345253-e038e2cd-ff33-4424-afdf-dd59353e3ec8.png">

