### PR TITLE
fix: Revert "chore(deps): bump spring.version from 5.3.13 to 5.3.16 in /dhis-2 (#9858)"

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -79,7 +79,7 @@
         <cglib.version>3.3.0</cglib.version>
 
         <!-- Spring-->
-        <spring.version>5.3.16</spring.version>
+        <spring.version>5.3.13</spring.version>
         <spring-data-redis.version>2.6.0</spring-data-redis.version>
         <spring-session-data-redis.version>2.6.2</spring-session-data-redis.version>
         <spring-mobile-device.version>1.1.5.RELEASE</spring-mobile-device.version>


### PR DESCRIPTION
This reverts commit afbd1f1b1a63e51f33a01181c7ce8e0672ea3fc1.

Bumping the version was causing a circular dependency