### PR TITLE
fix: metadata import corrupts option sort order

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -154,6 +154,19 @@ public class OptionSet
         return null;
     }
 
+    public Option getOptionByUid( String uid )
+    {
+        for ( Option option : options )
+        {
+            if ( option != null && option.getUid().equals( uid ) )
+            {
+                return option;
+            }
+        }
+
+        return null;
+    }
+
     public Map<String, String> getOptionCodePropertyMap( IdScheme idScheme )
     {
         return options.stream().collect( Collectors.toMap( Option::getCode, o -> o.getPropertyValue( idScheme ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -63,13 +63,14 @@ public class OptionObjectBundleHook extends AbstractObjectBundleHook<Option>
         // the option here
         // (will be done automatically later and option set may contain raw
         // value already)
-        if ( option.getOptionSet() != null && !bundle.containsObject( option.getOptionSet() ) )
+        if ( option.getOptionSet() != null && bundle.containsObject( option.getOptionSet() ) )
         {
             OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
                 option.getOptionSet() );
 
-            if ( optionSet != null )
+            if ( optionSet != null && option.getSortOrder() == null )
             {
+                optionSet.getOptions().remove( option );
                 optionSet.addOption( option );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -59,20 +59,20 @@ public class OptionObjectBundleHook extends AbstractObjectBundleHook<Option>
     @Override
     public void preCreate( Option option, ObjectBundle bundle )
     {
-        // if the bundle contains also the option set there is no need to add
-        // the option here
-        // (will be done automatically later and option set may contain raw
-        // value already)
-        if ( option.getOptionSet() != null && bundle.containsObject( option.getOptionSet() ) )
+        if ( option.getOptionSet() == null )
         {
-            OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
-                option.getOptionSet() );
+            return;
+        }
 
-            if ( optionSet != null && option.getSortOrder() == null )
-            {
-                optionSet.getOptions().remove( option );
-                optionSet.addOption( option );
-            }
+        // If OptionSet doesn't contains Option but Option has reference to
+        // OptionSet
+        // then we need to update OptionSet.options collection.
+        OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
+            option.getOptionSet().getUid() );
+
+        if ( optionSet != null && optionSet.getOptionByUid( option.getUid() ) == null )
+        {
+            optionSet.addOption( option );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
@@ -37,15 +37,15 @@ import org.springframework.stereotype.Component;
 public class OptionSetObjectBundleHook extends AbstractObjectBundleHook<OptionSet>
 {
     @Override
-    public void preCreate( OptionSet optionSet, ObjectBundle bundle )
+    public void postCreate( OptionSet optionSet, ObjectBundle bundle )
     {
         updateOption( optionSet );
     }
 
     @Override
-    public void preUpdate( OptionSet optionSet, OptionSet persistedObject, ObjectBundle bundle )
+    public void postUpdate( OptionSet persistedObject, ObjectBundle bundle )
     {
-        updateOption( optionSet );
+        updateOption( persistedObject );
     }
 
     private void updateOption( OptionSet optionSet )
@@ -61,5 +61,7 @@ public class OptionSetObjectBundleHook extends AbstractObjectBundleHook<OptionSe
                 option.setOptionSet( optionSet );
             }
         } );
+
+        sessionFactory.getCurrentSession().refresh( optionSet );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionSetObjectBundleHook.java
@@ -37,15 +37,15 @@ import org.springframework.stereotype.Component;
 public class OptionSetObjectBundleHook extends AbstractObjectBundleHook<OptionSet>
 {
     @Override
-    public void postCreate( OptionSet persistedObject, ObjectBundle bundle )
+    public void preCreate( OptionSet optionSet, ObjectBundle bundle )
     {
-        updateOption( persistedObject );
+        updateOption( optionSet );
     }
 
     @Override
-    public void postUpdate( OptionSet persistedObject, ObjectBundle bundle )
+    public void preUpdate( OptionSet optionSet, OptionSet persistedObject, ObjectBundle bundle )
     {
-        updateOption( persistedObject );
+        updateOption( optionSet );
     }
 
     private void updateOption( OptionSet optionSet )
@@ -61,7 +61,5 @@ public class OptionSetObjectBundleHook extends AbstractObjectBundleHook<OptionSe
                 option.setOptionSet( optionSet );
             }
         } );
-
-        sessionFactory.getCurrentSession().refresh( optionSet );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -289,4 +289,23 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
         assertNotNull( response.get( "options[0].sortOrder" ) );
         assertNotNull( response.get( "options[1].sortOrder" ) );
     }
+
+    @Test
+    void testImportOptionSetWithNoLinkOptions()
+    {
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\"}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"sortOrder\": 2,\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"sortOrder\": 3,\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertNotNull( response.get( "options[0].sortOrder" ) );
+        assertNotNull( response.get( "options[1].sortOrder" ) );
+    }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MetadataImportExportControllerTest.java
@@ -39,6 +39,7 @@ import org.geojson.GeoJsonObject;
 import org.geojson.Polygon;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonAttributeValue;
 import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
@@ -198,5 +199,94 @@ class MetadataImportExportControllerTest extends DhisControllerConvenienceTest
                 + "\"attributes\":[{\"id\":\"RRH9IFiZZYN\",\"valueType\":\"GEOJSON\",\"organisationUnitAttribute\":true,\"name\":\"testgeojson\"}]}" )
                     .content( HttpStatus.CONFLICT ).as( JsonWebMessage.class );
         assertNotNull( message.find( JsonErrorReport.class, report -> report.getErrorCode() == ErrorCode.E6004 ) );
+    }
+
+    /**
+     * Import OptionSet with two Options, sort orders are 2 and 3.
+     */
+    @Test
+    void testImportOptionSetWithOptions()
+    {
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 2,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertNotNull( response.get( "options[0].sortOrder" ) );
+        assertNotNull( response.get( "options[1].sortOrder" ) );
+    }
+
+    /**
+     * Import OptionSet with two Options, one has sortOrder and the other
+     * doesn't
+     */
+    @Test
+    void testImportOptionSetWithOptionsOneSortOrder()
+    {
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 3,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertNotNull( response.get( "options[0].sortOrder" ) );
+        assertNotNull( response.get( "options[1].sortOrder" ) );
+    }
+
+    /**
+     * Import OptionSet with two Options, both doesn't have sortOrder
+     */
+    @Test
+    void testImportOptionSetWithOptionsNoSortOrder()
+    {
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertNotNull( response.get( "options[0].sortOrder" ) );
+        assertNotNull( response.get( "options[1].sortOrder" ) );
+    }
+
+    /**
+     * Import OptionSet with two Options, both have same sortOrder
+     */
+    @Test
+    void testImportOptionSetWithOptionsDuplicateSortOrder()
+    {
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"sortOrder\": 2,\"id\": \"BQMei56UBl6\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"sortOrder\": 2,\"id\": \"Uh4HvjK6zg3\",\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertNotNull( response.get( "options[0].sortOrder" ) );
+        assertNotNull( response.get( "options[1].sortOrder" ) );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12831

There are issues with `OptionObjectBundleHook` and `OptionSetObjectBundleHook`. Both seem overwrite each others.

Fixed and add some controller tests to make sure OptionSets.options imported correctly now.
Feel free to suggest more test cases if any.