### PR TITLE
fix: PSI mapper missing program access level (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapper.java
@@ -82,5 +82,6 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage>
     @Mapping( target = "externalAccess" )
     @Mapping( target = "userGroupAccesses" )
     @Mapping( target = "userAccesses" )
+    @Mapping( target = "accessLevel" )
     Program mapProgram( Program p );
 }


### PR DESCRIPTION
Program mapper within ProgramStageMapper was not mapping accessLevel, which default to OPEN. This created issues during acl checks.