### PR TITLE
fix: change createAuditEntry error log to debug

### DIFF
--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/AbstractHibernateListener.java
@@ -231,7 +231,7 @@ public abstract class AbstractHibernateListener
         }
         catch ( Exception ex )
         {
-            log.error( "Couldn't create proxy " + ex );
+            log.debug( "Couldn't create proxy " + DebugUtils.getStackTrace( ex ) );
         }
 
         return null;


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12841

- The method `persister.createProxy( id, session )` may failed if the property is not an entity and can't be used to create proxy, so the error log here is useless.