### PR TITLE
feat: Return only LINE_LIST, for EVs in Dashboard search [DHIS2-12871]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
@@ -65,6 +65,16 @@ public interface EventVisualizationStore extends
     List<EventVisualization> getReports( int first, int max );
 
     /**
+     * Query the EventVisualization collection and retrieve the
+     * EventVisualizations of type Line List ONLY.
+     *
+     * @param first the first result row
+     * @param max the maximum result row
+     * @return a list of EventVisualization containing only Line List
+     */
+    List<EventVisualization> getLineLists( int first, int max );
+
+    /**
      * Query the EventVisualization collection and retrieve only the
      * EventVisualizations of type Chart comparing the name using the given
      * "chars".

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
@@ -68,7 +68,8 @@ public class HibernateEventVisualizationStore extends
     private enum EventVisualizationSet
     {
         EVENT_CHART,
-        EVENT_REPORT
+        EVENT_REPORT,
+        EVENT_LINE_LIST
     }
 
     public HibernateEventVisualizationStore( final SessionFactory sessionFactory, final JdbcTemplate jdbcTemplate,
@@ -113,6 +114,12 @@ public class HibernateEventVisualizationStore extends
     public int countChartsCreated( final Date startingAt )
     {
         return countEventVisualizationCreated( startingAt, EventVisualizationSet.EVENT_CHART );
+    }
+
+    @Override
+    public List<EventVisualization> getLineLists( final int first, final int max )
+    {
+        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_LINE_LIST );
     }
 
     private int countEventVisualizationCreated( final Date startingAt,
@@ -182,10 +189,14 @@ public class HibernateEventVisualizationStore extends
             params.addPredicate( root -> builder.and( builder.notEqual( root.get( "type" ), PIVOT_TABLE ),
                 builder.notEqual( root.get( "type" ), LINE_LIST ) ) );
         }
-        else
+        else if ( eventVisualizationSet == EventVisualizationSet.EVENT_REPORT )
         {
             params.addPredicate( root -> builder.or( builder.equal( root.get( "type" ), PIVOT_TABLE ),
                 builder.equal( root.get( "type" ), LINE_LIST ) ) );
+        }
+        else
+        {
+            params.addPredicate( root -> builder.equal( root.get( "type" ), LINE_LIST ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/impl/DefaultDashboardService.java
@@ -176,9 +176,8 @@ public class DefaultDashboardService
 
         result.setVisualizations( convertFromVisualization( objectManager.getBetweenSorted( Visualization.class, 0,
             getMax( DashboardItemType.VISUALIZATION, maxTypes, count, maxCount ) ) ) );
-        result.setEventVisualizations(
-            convertFromEventVisualization( objectManager.getBetweenSorted( EventVisualization.class, 0,
-                getMax( DashboardItemType.EVENT_VISUALIZATION, maxTypes, count, maxCount ) ) ) );
+        result.setEventVisualizations( convertFromEventVisualization( eventVisualizationStore.getLineLists( 0,
+            getMax( DashboardItemType.EVENT_VISUALIZATION, maxTypes, count, maxCount ) ) ) );
         result.setEventCharts( eventVisualizationStore.getCharts( 0,
             getMax( DashboardItemType.EVENT_CHART, maxTypes, count, maxCount ) ) );
         result.setMaps( objectManager.getBetweenSorted( Map.class, 0,

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/dashboard/DashboardServiceTest.java
@@ -267,7 +267,7 @@ class DashboardServiceTest extends DhisSpringTest
         assertThat( result.getEventChartCount(), is( 3 ) );
         result = dashboardService.search( Sets.newHashSet( DashboardItemType.EVENT_VISUALIZATION ), 3, 29 );
         assertThat( result.getEventVisualizationCount(), is( 29 ) );
-        assertThat( result.getEventReportCount(), is( 0 ) );
+        assertThat( result.getEventReportCount(), is( 3 ) );
         result = dashboardService.search( Sets.newHashSet( DashboardItemType.EVENT_VISUALIZATION ), 3, 30 );
         assertThat( result.getEventVisualizationCount(), is( 30 ) );
         assertThat( result.getEventChartCount(), is( 3 ) );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1349,7 +1349,7 @@ public abstract class DhisConvenienceTest
         eventVisualization.setAutoFields();
         eventVisualization.setProgram( program );
         eventVisualization.setName( "EventVisualization" + uniqueCharacter );
-        eventVisualization.setType( EventVisualizationType.COLUMN );
+        eventVisualization.setType( EventVisualizationType.LINE_LIST );
 
         return eventVisualization;
     }


### PR DESCRIPTION
The `/dashboard/q` endpoint returns analytical objects including EventVisualization which is a combination of EventReport and EventChart. The intention of EventVisualization, at the current stage, is to store line lists only. So the response should contain only EventVisualizations of type LINE_LIST for now.