### PR TITLE
fix: datastore numeric sorting [DHIS2-12748]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/DatastoreQueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datastore/hibernate/DatastoreQueryBuilder.java
@@ -103,17 +103,23 @@ public class DatastoreQueryBuilder
     {
         Order order = query.getOrder();
         String dir = order.getDirection().toString().replace( "n", "" );
+        if ( "desc".equals( dir ) )
+        {
+            dir += " nulls last";
+        }
         if ( order.isKeyPath() )
         {
             return "key " + dir;
         }
         if ( order.isValuePath() )
         {
-            return "cast(jbPlainValue as text) " + dir;
+            return order.getDirection().isNumeric()
+                ? "cast(cast(jbPlainValue as text) as double) " + dir
+                : "cast(jbPlainValue as text) " + dir;
         }
         String path = toValueAtPathHQL( order.getPath() );
         return order.getDirection().isNumeric()
-            ? "cast(" + path + " as double) " + dir
+            ? "cast(cast(" + path + " as text) as double) " + dir
             : path + " " + dir;
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/JsonWriter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/JsonWriter.java
@@ -78,7 +78,7 @@ public final class JsonWriter implements AutoCloseable
             {
                 out.write( "," );
             }
-            out.write( "{" );
+            out.write( "\n{" );
             out.write( "\"key\":\"" );
             out.write( entry.getKey() );
             out.write( '"' );
@@ -93,7 +93,7 @@ public final class JsonWriter implements AutoCloseable
             }
             out.write( "}" );
         } );
-        out.write( "]" );
+        out.write( "\n]" );
     }
 
     private static List<String> memberOpening( List<String> members )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/JsonWriter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/JsonWriter.java
@@ -78,7 +78,7 @@ public final class JsonWriter implements AutoCloseable
             {
                 out.write( "," );
             }
-            out.write( "\n{" );
+            out.write( "{" );
             out.write( "\"key\":\"" );
             out.write( entry.getKey() );
             out.write( '"' );
@@ -93,7 +93,7 @@ public final class JsonWriter implements AutoCloseable
             }
             out.write( "}" );
         } );
-        out.write( "\n]" );
+        out.write( "]" );
     }
 
     private static List<String> memberOpening( List<String> members )


### PR DESCRIPTION
### Summary
Couple of issues:
* root (`.`) path would always use text sorting
* when casting to `double` to cause numeric sorting we first need to cast jsonb to text

Bonus was adding the `nulls last` so any result always lists those matches last that do not have the property ordered by.

### Manual Testing
Remember the `fields` parameter is needed, just use `fields=.` for all tests.

* add some entries to a new namespace, one entry for each of the following values: `17`, `9`, `4`, `{"age":17}`,`{"age":9}`,`{"age":4}`.
* check `filter=.:gt:1&order=.:nasc` vs. `order=.:asc` vs. `&order=.:nasc` (no filter) => 400 error
* check `filter=.:gt:1&order=.:ndesc` vs. `order=.:desc` vs. `&order=.:ndesc` (no filter) => 400 error
* check `filter=age:gt:1&order=age:nasc` vs. `order=age:asc` vs. `&order=age:nasc` => fine as "nothing" apparently can be sorted as "null" even when sorting numerically
* check `filter=age:gt:1&order=age:ndesc` vs. `order=age:desc` vs. `&order=age:ndesc` => fine as "nothing" apparently can be sorted as "null" even when sorting numerically
* check for `&order=age:desc` entries without `age` are last in list