### PR TITLE
fix: Indicator attributeOptionCombo DHIS2-12874

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DimensionalObjectUtils.java
@@ -541,7 +541,7 @@ public class DimensionalObjectUtils
     {
         return operands.stream()
             .filter( o -> o.getAttributeOptionCombo() != null )
-            .map( DataElementOperand::getCategoryOptionCombo )
+            .map( DataElementOperand::getAttributeOptionCombo )
             .collect( Collectors.toSet() );
     }
 


### PR DESCRIPTION
See [DHIS2-12874](https://jira.dhis2.org/browse/DHIS2-12874). The visualizations in the ticket had indicators with attribute option combos. The AOC wasn't getting set because a _copy-paste-edit_ change in [pull/10091](https://github.com/dhis2/dhis2-core/pull/10091) missed the _edit_.

With the fix, the visualizations in the ticket work.