### PR TITLE
feat: provide job progress for data statistics job [DHIS2-12858]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsService.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import org.hisp.dhis.analytics.SortOrder;
 import org.hisp.dhis.datasummary.DataSummary;
+import org.hisp.dhis.scheduling.JobProgress;
 
 /**
  * @author Yrjan A. F. Fraschetti
@@ -58,14 +59,6 @@ public interface DataStatisticsService
     List<AggregatedStatistics> getReports( Date startDate, Date endDate, EventInterval eventInterval );
 
     /**
-     * Returns a DataStatistics instance for the given day.
-     *
-     * @param day the day to generate the DataStatistics instance for.
-     * @return a DataStatistics instance for the given day.
-     */
-    DataStatistics getDataStatisticsSnapshot( Date day );
-
-    /**
      * Saves a DataStatistics instance.
      *
      * @param dataStatistics the DataStatistics instance.
@@ -76,9 +69,10 @@ public interface DataStatisticsService
     /**
      * Gets all information and creates a DataStatistics object and persists it.
      *
+     * @param progress to track processing
      * @return identifier of the persisted DataStatistics object.
      */
-    long saveDataStatisticsSnapshot();
+    long saveDataStatisticsSnapshot( JobProgress progress );
 
     /**
      * Returns top favorites by views

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DataStatisticsJob.java
@@ -27,8 +27,7 @@
  */
 package org.hisp.dhis.datastatistics;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.scheduling.Job;
@@ -42,20 +41,11 @@ import org.springframework.stereotype.Component;
  * @author Julie Hill Roa
  */
 @Slf4j
-@Component( "dataStatisticsJob" )
+@Component
+@AllArgsConstructor
 public class DataStatisticsJob implements Job
 {
     private final DataStatisticsService dataStatisticsService;
-
-    public DataStatisticsJob( DataStatisticsService dataStatisticsService )
-    {
-        checkNotNull( dataStatisticsService );
-        this.dataStatisticsService = dataStatisticsService;
-    }
-
-    // -------------------------------------------------------------------------
-    // Implementation
-    // -------------------------------------------------------------------------
 
     @Override
     public JobType getJobType()
@@ -66,12 +56,16 @@ public class DataStatisticsJob implements Job
     @Override
     public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
-        long id = dataStatisticsService.saveDataStatisticsSnapshot();
+        progress.startingProcess( "Create data statistics snapshot" );
+        long id = dataStatisticsService.saveDataStatisticsSnapshot( progress );
 
         if ( id > 0 )
         {
-            log.info( "Saved data statistics snapshot" );
+            progress.completedProcess( "Saved data statistics snapshot" );
+        }
+        else
+        {
+            progress.failedProcess( "no snapshot created" );
         }
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationStore;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.program.ProgramStageInstanceService;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.statistics.StatisticsProvider;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserInvitationStatus;
@@ -123,8 +124,7 @@ public class DefaultDataStatisticsService
         return dataStatisticsStore.getSnapshotsInInterval( eventInterval, startDate, endDate );
     }
 
-    @Override
-    public DataStatistics getDataStatisticsSnapshot( Date day )
+    private DataStatistics getDataStatisticsSnapshot( Date day, JobProgress progress )
     {
         Calendar cal = Calendar.getInstance();
         cal.setTime( day );
@@ -134,21 +134,41 @@ public class DefaultDataStatisticsService
         long diff = now.getTime() - startDate.getTime();
         int days = (int) TimeUnit.DAYS.convert( diff, TimeUnit.MILLISECONDS );
 
-        double savedMaps = idObjectManager.getCountByCreated( org.hisp.dhis.mapping.Map.class, startDate );
-        double savedVisualizations = idObjectManager.getCountByCreated( Visualization.class, startDate );
-        double savedEventReports = eventVisualizationStore.countReportsCreated( startDate );
-        double savedEventCharts = eventVisualizationStore.countChartsCreated( startDate );
-        double savedEventVisualizations = idObjectManager.getCountByCreated( EventVisualization.class, startDate );
-        double savedDashboards = idObjectManager.getCountByCreated( Dashboard.class, startDate );
-        double savedIndicators = idObjectManager.getCountByCreated( Indicator.class, startDate );
-        double savedDataValues = dataValueService.getDataValueCount( days );
-        int activeUsers = userService.getActiveUsersCount( 1 );
-        int users = idObjectManager.getCount( User.class );
+        progress.startingStage( "Counting maps" );
+        Integer savedMaps = progress.runStage( null,
+            () -> idObjectManager.getCountByCreated( org.hisp.dhis.mapping.Map.class, startDate ) );
+        progress.startingStage( "Counting visualisations" );
+        Integer savedVisualizations = progress.runStage( null,
+            () -> idObjectManager.getCountByCreated( Visualization.class, startDate ) );
+        progress.startingStage( "Counting event reports" );
+        Integer savedEventReports = progress.runStage( null,
+            () -> eventVisualizationStore.countReportsCreated( startDate ) );
+        progress.startingStage( "Counting event charts" );
+        Integer savedEventCharts = progress.runStage( null,
+            () -> eventVisualizationStore.countChartsCreated( startDate ) );
+        progress.startingStage( "Counting event visualisations" );
+        Integer savedEventVisualizations = progress.runStage( null,
+            () -> idObjectManager.getCountByCreated( EventVisualization.class, startDate ) );
+        progress.startingStage( "Counting dashboards" );
+        Integer savedDashboards = progress.runStage( null,
+            () -> idObjectManager.getCountByCreated( Dashboard.class, startDate ) );
+        progress.startingStage( "Counting indicators" );
+        Integer savedIndicators = progress.runStage( null,
+            () -> idObjectManager.getCountByCreated( Indicator.class, startDate ) );
+        progress.startingStage( "Counting data values" );
+        Integer savedDataValues = progress.runStage( null,
+            () -> dataValueService.getDataValueCount( days ) );
+        progress.startingStage( "Counting active users" );
+        Integer activeUsers = progress.runStage( null,
+            () -> userService.getActiveUsersCount( 1 ) );
+        progress.startingStage( "Counting users" );
+        Integer users = progress.runStage( null,
+            () -> idObjectManager.getCount( User.class ) );
+        progress.startingStage( "Counting views" );
+        Map<DataStatisticsEventType, Double> eventCountMap = progress.runStage( Map.of(),
+            () -> dataStatisticsEventStore.getDataStatisticsEventCount( startDate, day ) );
 
-        Map<DataStatisticsEventType, Double> eventCountMap = dataStatisticsEventStore
-            .getDataStatisticsEventCount( startDate, day );
-
-        DataStatistics dataStatistics = new DataStatistics(
+        return new DataStatistics(
             eventCountMap.get( DataStatisticsEventType.MAP_VIEW ),
             eventCountMap.get( DataStatisticsEventType.VISUALIZATION_VIEW ),
             eventCountMap.get( DataStatisticsEventType.EVENT_REPORT_VIEW ),
@@ -158,10 +178,14 @@ public class DefaultDataStatisticsService
             eventCountMap.get( DataStatisticsEventType.PASSIVE_DASHBOARD_VIEW ),
             eventCountMap.get( DataStatisticsEventType.DATA_SET_REPORT_VIEW ),
             eventCountMap.get( DataStatisticsEventType.TOTAL_VIEW ),
-            savedMaps, savedVisualizations, savedEventReports, savedEventCharts, savedEventVisualizations,
-            savedDashboards, savedIndicators, savedDataValues, activeUsers, users );
+            asDouble( savedMaps ), asDouble( savedVisualizations ), asDouble( savedEventReports ),
+            asDouble( savedEventCharts ), asDouble( savedEventVisualizations ), asDouble( savedDashboards ),
+            asDouble( savedIndicators ), asDouble( savedDataValues ), activeUsers, users );
+    }
 
-        return dataStatistics;
+    private Double asDouble( Integer count )
+    {
+        return count == null ? null : count.doubleValue();
     }
 
     @Override
@@ -173,9 +197,9 @@ public class DefaultDataStatisticsService
     }
 
     @Override
-    public long saveDataStatisticsSnapshot()
+    public long saveDataStatisticsSnapshot( JobProgress progress )
     {
-        return saveDataStatistics( getDataStatisticsSnapshot( new Date() ) );
+        return saveDataStatistics( getDataStatisticsSnapshot( new Date(), progress ) );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/datastatistics/DataStatisticsServiceTest.java
@@ -34,6 +34,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -106,7 +107,7 @@ class DataStatisticsServiceTest extends DhisSpringTest
         dse1 = new DataStatisticsEvent( DataStatisticsEventType.VISUALIZATION_VIEW, startDate, "TestUser" );
         dataStatisticsService.addEvent( dse1 );
         dataStatisticsService.addEvent( dse2 );
-        long snapId2 = dataStatisticsService.saveDataStatisticsSnapshot();
+        long snapId2 = dataStatisticsService.saveDataStatisticsSnapshot( NoopJobProgress.INSTANCE );
         assertTrue( snapId2 != 0 );
         assertTrue( snapId1 != snapId2 );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datastatistics/DataStatisticsController.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.datastatistics.DataStatisticsService;
 import org.hisp.dhis.datastatistics.EventInterval;
 import org.hisp.dhis.datastatistics.FavoriteStatistics;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
@@ -160,6 +161,6 @@ public class DataStatisticsController
     @PostMapping( "/snapshot" )
     public void saveSnapshot()
     {
-        dataStatisticsService.saveDataStatisticsSnapshot();
+        dataStatisticsService.saveDataStatisticsSnapshot( NoopJobProgress.INSTANCE );
     }
 }


### PR DESCRIPTION
### Summary
Adds the `JobProgress` tracking for data statistics job.

A nice by-effect of running the counting though the progress tracking is that should a count fail with an exception that count is just excluded (`null`) from the statistics and other counts are still provided.

### Manual Testing
* run job manually using `POST` http://localhost:8080/api/jobConfigurations/BFa3jDsbtdO/execute (UID for demo database)
* check output from http://localhost:8080/api/scheduling/completed/DATA_STATISTICS (see below)
* check a database entry was created http://localhost:8080/api/dataStatistics?startDate=2022-03-14&endDate=2023-03-17&interval=DAY (dates should just contain the current day when the new snapshort was created)

Example for tracked info:
```json
[
  {
    "summary": "Saved data statistics snapshot",
    "status": "SUCCESS",
    "completedTime": "2022-03-17T12:15:37.300",
    "startedTime": "2022-03-17T12:15:37.141",
    "description": "Create data statistics snapshot",
    "stages": [
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.149",
        "startedTime": "2022-03-17T12:15:37.142",
        "description": "Counting maps",
        "totalItems": 0,
        "items": [],
        "duration": 7,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.160",
        "startedTime": "2022-03-17T12:15:37.149",
        "description": "Counting visualisations",
        "totalItems": 0,
        "items": [],
        "duration": 11,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.175",
        "startedTime": "2022-03-17T12:15:37.160",
        "description": "Counting event reports",
        "totalItems": 0,
        "items": [],
        "duration": 15,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.182",
        "startedTime": "2022-03-17T12:15:37.175",
        "description": "Counting event charts",
        "totalItems": 0,
        "items": [],
        "duration": 7,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.190",
        "startedTime": "2022-03-17T12:15:37.182",
        "description": "Counting event visualisations",
        "totalItems": 0,
        "items": [],
        "duration": 8,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.195",
        "startedTime": "2022-03-17T12:15:37.190",
        "description": "Counting dashboards",
        "totalItems": 0,
        "items": [],
        "duration": 5,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.204",
        "startedTime": "2022-03-17T12:15:37.195",
        "description": "Counting indicators",
        "totalItems": 0,
        "items": [],
        "duration": 9,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.216",
        "startedTime": "2022-03-17T12:15:37.204",
        "description": "Counting data values",
        "totalItems": 0,
        "items": [],
        "duration": 12,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.230",
        "startedTime": "2022-03-17T12:15:37.216",
        "description": "Counting active users",
        "totalItems": 0,
        "items": [],
        "duration": 14,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.240",
        "startedTime": "2022-03-17T12:15:37.230",
        "description": "Counting users",
        "totalItems": 0,
        "items": [],
        "duration": 10,
        "complete": true
      },
      {
        "status": "SUCCESS",
        "completedTime": "2022-03-17T12:15:37.277",
        "startedTime": "2022-03-17T12:15:37.241",
        "description": "Counting views",
        "totalItems": 0,
        "items": [],
        "duration": 36,
        "complete": true
      }
    ],
    "jobId": "BFa3jDsbtdO",
    "duration": 159,
    "complete": true
  }
]
```