### PR TITLE
feat: job progress tracking for file resource cleanup job [DHIS2-12858]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -27,14 +27,16 @@
  */
 package org.hisp.dhis.fileresource;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.common.DeleteNotAllowedException;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -52,7 +54,7 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @AllArgsConstructor
-@Component( "fileResourceCleanUpJob" )
+@Component
 public class FileResourceCleanUpJob implements Job
 {
     private final FileResourceService fileResourceService;
@@ -60,10 +62,6 @@ public class FileResourceCleanUpJob implements Job
     private final SystemSettingManager systemSettingManager;
 
     private final FileResourceContentStore fileResourceContentStore;
-
-    // -------------------------------------------------------------------------
-    // Implementation
-    // -------------------------------------------------------------------------
 
     @Override
     public JobType getJobType()
@@ -74,26 +72,36 @@ public class FileResourceCleanUpJob implements Job
     @Override
     public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
+        progress.startingProcess( "Clean-up file resources" );
         FileResourceRetentionStrategy retentionStrategy = systemSettingManager
             .getSystemSetting( SettingKey.FILE_RESOURCE_RETENTION_STRATEGY, FileResourceRetentionStrategy.class );
 
-        List<Pair<String, String>> deletedOrphans = new ArrayList<>();
-
-        List<Pair<String, String>> deletedAuditFiles = new ArrayList<>();
+        List<Entry<String, String>> deletedOrphans = new ArrayList<>();
+        List<Entry<String, String>> deletedAuditFiles = new ArrayList<>();
 
         // Delete expired FRs
         if ( !FileResourceRetentionStrategy.FOREVER.equals( retentionStrategy ) )
         {
             List<FileResource> expired = fileResourceService.getExpiredFileResources( retentionStrategy );
-            expired.forEach( this::safeDelete );
-            expired.forEach( fr -> deletedAuditFiles.add( ImmutablePair.of( fr.getName(), fr.getUid() ) ) );
+            progress.startingStage( "Deleting expired file resources", expired.size() );
+            progress.runStage( expired, FileResourceCleanUpJob::toIdentifier, fr -> {
+                if ( safeDelete( fr ) )
+                {
+                    deletedAuditFiles.add( new SimpleEntry<>( fr.getName(), fr.getUid() ) );
+                }
+            } );
         }
 
         // Delete failed uploads
-        fileResourceService.getOrphanedFileResources().stream()
-            .filter( fr -> !isFileStored( fr ) )
-            .filter( this::safeDelete )
-            .forEach( fr -> deletedOrphans.add( ImmutablePair.of( fr.getName(), fr.getUid() ) ) );
+        List<FileResource> orphanedFileResources = fileResourceService.getOrphanedFileResources().stream()
+            .filter( fr -> !isFileStored( fr ) ).collect( toList() );
+        progress.startingStage( "Deleting failed uploads", orphanedFileResources.size() );
+        progress.runStage( orphanedFileResources, FileResourceCleanUpJob::toIdentifier, fr -> {
+            if ( safeDelete( fr ) )
+            {
+                deletedOrphans.add( new SimpleEntry<>( fr.getName(), fr.getUid() ) );
+            }
+        } );
 
         if ( !deletedOrphans.isEmpty() )
         {
@@ -106,9 +114,15 @@ public class FileResourceCleanUpJob implements Job
             log.info( String.format( "Deleted %d expired FileResource audits: %s", deletedAuditFiles.size(),
                 prettyPrint( deletedAuditFiles ) ) );
         }
+        progress.completedProcess( null );
     }
 
-    private String prettyPrint( List<Pair<String, String>> list )
+    private static String toIdentifier( FileResource fr )
+    {
+        return fr.getUid() + ":" + fr.getName();
+    }
+
+    private String prettyPrint( List<Entry<String, String>> list )
     {
         if ( list.isEmpty() )
         {
@@ -118,7 +132,7 @@ public class FileResourceCleanUpJob implements Job
         StringBuilder sb = new StringBuilder( "[ " );
 
         list.forEach(
-            pair -> sb.append( pair.getLeft() ).append( " , uid: " ).append( pair.getRight() ).append( ", " ) );
+            pair -> sb.append( pair.getKey() ).append( " , uid: " ).append( pair.getValue() ).append( ", " ) );
 
         sb.deleteCharAt( sb.lastIndexOf( "," ) ).append( "]" );
 


### PR DESCRIPTION
### Summary
Adds `JobProgress` tracking to the file resources cleanup job.


### Manual Testing
* use `/api/jobConfigurations` to find UID of file resources cleanup job
* run the job using `POST` `/api/jobConfigurations/<uid>/execute`
* check http://localhost:8080/api/scheduling/completed/FILE_RESOURCE_CLEANUP output shows success (ideally tested with existing files matched by the job)

Example output
```json
[
  {
    "status":"SUCCESS",
    "completedTime":"2022-03-17T15:20:50.465",
    "startedTime":"2022-03-17T15:20:50.347",
    "description":"Clean-up file resources",
    "stages":[
      {
        "status":"SUCCESS",
        "completedTime":"2022-03-17T15:20:50.448",
        "startedTime":"2022-03-17T15:20:50.447",
        "description":"Deleting expired file resources",
        "totalItems":0,
        "items":[
          
        ],
        "duration":1,
        "complete":true
      },
      {
        "status":"SUCCESS",
        "completedTime":"2022-03-17T15:20:50.465",
        "startedTime":"2022-03-17T15:20:50.464",
        "description":"Deleting failed uploads",
        "totalItems":0,
        "items":[
          
        ],
        "duration":1,
        "complete":true
      }
    ],
    "jobId":"pd6O228pqr0",
    "duration":118,
    "complete":true
  }
]
```