### PR TITLE
fix: Dimension name in EventVisualization [DHIS2-12891]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimension.java
@@ -67,7 +67,7 @@ public class SimpleDimension implements Serializable
         ENROLLMENT_DATE( "enrollmentDate", PERIOD ),
         INCIDENT_DATE( "incidentDate", PERIOD ),
         SCHEDULE_DATE( "scheduledDate", PERIOD ),
-        LAST_UPDATE_DATE( "lastUpdatedDate", PERIOD ),
+        LAST_UPDATE_DATE( "lastUpdated", PERIOD ),
         EVENT_STATUS( "eventStatus", DATA_X ),
         PROGRAM_STATUS( "programStatus", DATA_X ),
         CREATED_BY( "createdBy", DATA_X ),


### PR DESCRIPTION
EventVisualization is using the wrong name for the last updated date.

Instead of `lastUpdatedDate`, it should be `lastUpdated`.