### PR TITLE
fix: Wrong name for lastPage element [DHIS2-12895]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
@@ -60,7 +60,7 @@ public class SlimPager extends Pager
      *
      * @return true if this is the last page, false otherwise
      */
-    @JsonProperty
+    @JsonProperty( "isLastPage" )
     @JacksonXmlProperty( namespace = DXF_2_0 )
     public Boolean isLastPage()
     {


### PR DESCRIPTION
In the original PR (https://github.com/dhis2/dhis2-core/pull/9719) I forgot to set the name of this attribute, which should be returned as `isLastPage` to the client.

This small fix will address that mistake.

**### Already approved by the Change Control board.**