### PR TITLE
fix: Change teiFilters to default private access (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityInstanceFilterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentityfilter/TrackedEntityInstanceFilterServiceTest.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.programstagefilter.DateFilterPeriod;
 import org.hisp.dhis.programstagefilter.DatePeriodType;
+import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.user.UserService;
@@ -99,6 +100,14 @@ class TrackedEntityInstanceFilterServiceTest extends DhisSpringTest
         assertEquals( idB, trackedEntityInstanceFilterB.getId() );
         assertEquals( trackedEntityInstanceFilterA, trackedEntityInstanceFilterService.get( idA ) );
         assertEquals( trackedEntityInstanceFilterB, trackedEntityInstanceFilterService.get( idB ) );
+    }
+
+    @Test
+    void testDefaultPrivateAccess()
+    {
+        long idA = trackedEntityInstanceFilterService.add( createTrackedEntityInstanceFilter( 'A', programA ) );
+        TrackedEntityInstanceFilter trackedEntityInstanceFilterA = trackedEntityInstanceFilterService.get( idA );
+        assertEquals( trackedEntityInstanceFilterA.getPublicAccess(), AccessStringHelper.DEFAULT );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/TrackedEntityInstanceFilterSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/TrackedEntityInstanceFilterSchemaDescriptor.java
@@ -52,6 +52,7 @@ public class TrackedEntityInstanceFilterSchemaDescriptor implements SchemaDescri
     {
         Schema schema = new Schema( TrackedEntityInstanceFilter.class, SINGULAR, PLURAL );
         schema.setRelativeApiEndpoint( API_ENDPOINT );
+        schema.setDefaultPrivate( true );
 
         schema.add( new Authority( AuthorityType.CREATE, Lists.newArrayList( "F_PROGRAMSTAGE_ADD" ) ) );
         schema.add( new Authority( AuthorityType.DELETE, Lists.newArrayList( "F_PROGRAMSTAGE_DELETE" ) ) );


### PR DESCRIPTION
Set default access to "no access" (access string = "--------") when saving TeiFilters