### PR TITLE
fix: NPE in analytics continuous job [DHIS2-12094]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.setting;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -185,7 +186,7 @@ public class DefaultSystemSettingManager
         SerializableOptional value = settingCache.get( key.getName(),
             k -> getSystemSettingOptional( k, defaultValue ) );
 
-        return (T) value.get();
+        return defaultIfNull( (T) value.get(), defaultValue );
     }
 
     /**


### PR DESCRIPTION
This fixes a known issue in analytics continuous job.
It's required because the caching layer does not deal with Optionals, so the default value should be handled at the application level (which makes more sense).

Backport from master/2.39