### PR TITLE
chore: remove fields=** from NTI DHIS2-12660

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/TrackerExportTests.java
@@ -96,8 +96,6 @@ public class TrackerExportTests
             Arguments.of( "/trackedEntities/" + teiId, "enrollments[createdAt],relationships[from[trackedEntity[trackedEntity]],to[trackedEntity[trackedEntity]]]", "enrollments.createdAt,relationships.from.trackedEntity.trackedEntity,relationships.to.trackedEntity.trackedEntity"),
             Arguments.of( "/trackedEntities/" + teiId, "trackedEntity,enrollments", null),
             Arguments.of( "/enrollments/" + enrollmentId, "program,status,enrolledAt", null),
-                Arguments.of( "/trackedEntities/" + teiId, "**",
-                        "trackedEntity,trackedEntityType,createdAt,updatedAt,orgUnit,inactive,deleted,potentialDuplicate,updatedBy,attributes", null ),
             Arguments.of( "/trackedEntities/" + teiId, "*",
                 "trackedEntity,trackedEntityType,createdAt,updatedAt,orgUnit,inactive,deleted,potentialDuplicate,updatedBy,attributes", null ),
             Arguments.of( "/events/" + eventId, "enrollment,createdAt", null ),

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerEnrollmentsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerEnrollmentsExportControllerTest.java
@@ -99,16 +99,6 @@ class TrackerEnrollmentsExportControllerTest extends DhisControllerConvenienceTe
     }
 
     @Test
-    void getEnrollmentByIdWithFieldsDoubleStar()
-    {
-
-        JsonObject json = GET( "/tracker/enrollments/{id}?fields=**", programInstance.getUid() )
-            .content( HttpStatus.OK );
-
-        assertDefaultResponse( json );
-    }
-
-    @Test
     void getEnrollmentByIdWithFields()
     {
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerEventsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerEventsExportControllerTest.java
@@ -133,19 +133,6 @@ class TrackerEventsExportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void getEventByIdWithFieldsDoubleStar()
-    {
-        TrackedEntityInstance to = trackedEntityInstance();
-        ProgramStageInstance from = programStageInstance( programInstance( to ) );
-        relationship( from, to );
-
-        JsonObject json = GET( "/tracker/events/{id}?fields=**", from.getUid() )
-            .content( HttpStatus.OK );
-
-        assertDefaultResponse( json, from );
-    }
-
-    @Test
     void getEventByIdWithFields()
     {
         TrackedEntityInstance tei = trackedEntityInstance();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerRelationshipsExportControllerTest.java
@@ -135,22 +135,6 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
     }
 
     @Test
-    void getRelationshipsByIdWithFieldsDoubleStar()
-    {
-        TrackedEntityInstance to = trackedEntityInstance();
-        ProgramStageInstance from = programStageInstance( programInstance( to ) );
-        Relationship r = relationship( from, to );
-
-        JsonObject relationship = GET( "/tracker/relationships/{uid}?fields=**", r.getUid() )
-            .content( HttpStatus.OK );
-
-        assertHasOnlyMembers( relationship, "relationship", "relationshipType", "from", "to" );
-        assertRelationship( r, relationship );
-        assertHasOnlyUid( from.getUid(), "event", relationship.getObject( "from" ) );
-        assertHasOnlyUid( to.getUid(), "trackedEntity", relationship.getObject( "to" ) );
-    }
-
-    @Test
     void getRelationshipsByIdWithFieldsAll()
     {
         TrackedEntityInstance to = trackedEntityInstance();
@@ -217,24 +201,6 @@ class TrackerRelationshipsExportControllerTest extends DhisControllerConvenience
         Relationship r = relationship( from, to );
 
         JsonObject json = GET( "/tracker/relationships?event={uid}", from.getUid() )
-            .content( HttpStatus.OK );
-
-        assertFalse( json.isEmpty() );
-        JsonArray relationships = json.getArray( "instances" );
-        JsonObject jsonRelationship = assertFirstRelationship( r, relationships );
-        assertHasOnlyMembers( jsonRelationship, "relationship", "relationshipType", "from", "to" );
-        assertHasOnlyUid( from.getUid(), "event", jsonRelationship.getObject( "from" ) );
-        assertHasOnlyUid( to.getUid(), "trackedEntity", jsonRelationship.getObject( "to" ) );
-    }
-
-    @Test
-    void getRelationshipsByEventWithFieldsDoubleStar()
-    {
-        TrackedEntityInstance to = trackedEntityInstance();
-        ProgramStageInstance from = programStageInstance( programInstance( to ) );
-        Relationship r = relationship( from, to );
-
-        JsonObject json = GET( "/tracker/relationships?event={uid}&fields=**", from.getUid() )
             .content( HttpStatus.OK );
 
         assertFalse( json.isEmpty() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerTrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerTrackedEntitiesExportControllerTest.java
@@ -163,30 +163,6 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
     }
 
     @Test
-    void getTrackedEntityByIdWithFieldsDoubleStar()
-    {
-        TrackedEntityInstance from = trackedEntityInstance();
-        TrackedEntityInstance to = trackedEntityInstance();
-        relationship( from, to );
-        this.switchContextToUser( user );
-
-        JsonObject json = GET( "/tracker/trackedEntities/{id}?fields=**", from.getUid() )
-            .content( HttpStatus.OK );
-
-        assertFalse( json.isEmpty() );
-        assertEquals( from.getUid(), json.getString( "trackedEntity" ).string() );
-        assertEquals( from.getTrackedEntityType().getUid(), json.getString( "trackedEntityType" ).string() );
-        assertEquals( from.getOrganisationUnit().getUid(), json.getString( "orgUnit" ).string() );
-        assertHasMember( json, "createdAt" );
-        assertHasMember( json, "createdAtClient" );
-        assertHasMember( json, "updatedAtClient" );
-        assertHasNoMember( json, "relationships" );
-        assertHasNoMember( json, "enrollments" );
-        assertHasNoMember( json, "events" );
-        assertHasNoMember( json, "programOwners" );
-    }
-
-    @Test
     void getTrackedEntityByIdWithFields()
     {
         TrackedEntityInstance from = trackedEntityInstance();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -68,11 +68,7 @@ public class TrackerEnrollmentsExportController
 {
     protected static final String ENROLLMENTS = "enrollments";
 
-    private static final String DONT_FILTER_FIELDS = "**";
-
     private static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!events,!attributes";
-
-    private static final List<String> DEFAULT_FIELDS = List.of( "*", "!relationships", "!events", "!attributes" );
 
     private static final EnrollmentMapper ENROLLMENT_MAPPER = Mappers.getMapper( EnrollmentMapper.class );
 
@@ -90,7 +86,6 @@ public class TrackerEnrollmentsExportController
         TrackerEnrollmentCriteria trackerEnrollmentCriteria,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
     {
-        fields = fieldsOrDefault( fields );
         PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
 
         List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollmentList;
@@ -130,7 +125,6 @@ public class TrackerEnrollmentsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
         throws NotFoundException
     {
-        fields = fieldsOrDefault( fields );
 
         Enrollment enrollment = ENROLLMENT_MAPPER.from( enrollmentService.getEnrollment( id ) );
         if ( enrollment == null )
@@ -138,18 +132,5 @@ public class TrackerEnrollmentsExportController
             throw new NotFoundException( "Enrollment", id );
         }
         return ResponseEntity.ok( fieldFilterService.toObjectNode( enrollment, fields ) );
-    }
-
-    /**
-     * Passing in fields=** is the same as not passing in a fields query
-     * parameter. Thus, fallback to the default field param.
-     */
-    private List<String> fieldsOrDefault( List<String> fields )
-    {
-        if ( !fields.contains( DONT_FILTER_FIELDS ) )
-        {
-            return fields;
-        }
-        return DEFAULT_FIELDS;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -83,11 +83,7 @@ public class TrackerEventsExportController
 {
     protected static final String EVENTS = "events";
 
-    private static final String DONT_FILTER_FIELDS = "**";
-
     private static final String DEFAULT_FIELDS_PARAM = "*,!relationships";
-
-    private static final List<String> DEFAULT_FIELDS = List.of( "*", "!relationships" );
 
     private static final EventMapper EVENTS_MAPPER = Mappers.getMapper( EventMapper.class );
 
@@ -115,7 +111,6 @@ public class TrackerEventsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
         throws WebMessageException
     {
-        fields = fieldsOrDefault( fields );
 
         EventSearchParams eventSearchParams = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -227,7 +222,6 @@ public class TrackerEventsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
         throws NotFoundException
     {
-        fields = fieldsOrDefault( fields );
 
         Event event = eventService.getEvent( programStageInstanceService.getProgramStageInstance( uid ) );
         if ( event == null )
@@ -237,18 +231,5 @@ public class TrackerEventsExportController
 
         event.setHref( getUri( uid, request ) );
         return ResponseEntity.ok( fieldFilterService.toObjectNode( EVENTS_MAPPER.from( event ), fields ) );
-    }
-
-    /**
-     * Passing in fields=** is the same as not passing in a fields query
-     * parameter. Thus, fallback to the default field param.
-     */
-    private List<String> fieldsOrDefault( List<String> fields )
-    {
-        if ( !fields.contains( DONT_FILTER_FIELDS ) )
-        {
-            return fields;
-        }
-        return DEFAULT_FIELDS;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
@@ -81,14 +81,7 @@ public class TrackerRelationshipsExportController
 {
     protected static final String RELATIONSHIPS = "relationships";
 
-    private static final String DONT_FILTER_FIELDS = "**";
-
     private static final String DEFAULT_FIELDS_PARAM = "relationship,relationshipType,from[trackedEntity[trackedEntity],enrollment[enrollment],event[event]],to[trackedEntity[trackedEntity],enrollment[enrollment],event[event]]";
-
-    private static final List<String> DEFAULT_FIELDS = List.of( "relationship", "relationshipType",
-        "from[trackedEntity[trackedEntity]",
-        "enrollment[enrollment]", "event[event]]", "to[trackedEntity[trackedEntity]", "enrollment[enrollment]",
-        "event[event]]" );
 
     private static final org.hisp.dhis.webapi.controller.tracker.export.RelationshipMapper RELATIONSHIP_MAPPER = Mappers
         .getMapper( org.hisp.dhis.webapi.controller.tracker.export.RelationshipMapper.class );
@@ -141,7 +134,6 @@ public class TrackerRelationshipsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
         throws WebMessageException
     {
-        fields = fieldsOrDefault( fields );
 
         String identifier = criteria.getIdentifierParam();
         String identifierName = criteria.getIdentifierName();
@@ -171,7 +163,6 @@ public class TrackerRelationshipsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
         throws NotFoundException
     {
-        fields = fieldsOrDefault( fields );
 
         org.hisp.dhis.tracker.domain.Relationship relationship = RELATIONSHIP_MAPPER
             .from( relationshipService.getRelationshipByUid( id ) );
@@ -219,18 +210,5 @@ public class TrackerRelationshipsExportController
         return Optional.ofNullable( type )
             .map( objectRetrievers::get )
             .orElseThrow( () -> new IllegalArgumentException( "Unable to detect object retriever from " + type ) );
-    }
-
-    /**
-     * Passing in fields=** is the same as not passing in a fields query
-     * parameter. Thus, fallback to the default field param.
-     */
-    private List<String> fieldsOrDefault( List<String> fields )
-    {
-        if ( !fields.contains( DONT_FILTER_FIELDS ) )
-        {
-            return fields;
-        }
-        return DEFAULT_FIELDS;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -62,12 +62,7 @@ public class TrackerTrackedEntitiesExportController
 {
     protected static final String TRACKED_ENTITIES = "trackedEntities";
 
-    private static final String DONT_FILTER_FIELDS = "**";
-
     private static final String DEFAULT_FIELDS_PARAM = "*,!relationships,!enrollments,!events,!programOwners";
-
-    private static final List<String> DEFAULT_FIELDS = List.of( "*", "!relationships", "!enrollments", "!events",
-        "!programOwners" );
 
     private static final TrackedEntityMapper TRACKED_ENTITY_MAPPER = Mappers.getMapper( TrackedEntityMapper.class );
 
@@ -87,7 +82,6 @@ public class TrackerTrackedEntitiesExportController
     PagingWrapper<ObjectNode> getInstances( TrackerTrackedEntityCriteria criteria,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
     {
-        fields = fieldsOrDefault( fields );
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
@@ -120,23 +114,9 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( required = false ) String program,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
     {
-        fields = fieldsOrDefault( fields );
 
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
             trackedEntitiesSupportService.getTrackedEntityInstance( id, program, fields ) );
         return ResponseEntity.ok( fieldFilterService.toObjectNode( trackedEntity, fields ) );
-    }
-
-    /**
-     * Passing in fields=** is the same as not passing in a fields query
-     * parameter. Thus, fallback to the default field param.
-     */
-    private List<String> fieldsOrDefault( List<String> fields )
-    {
-        if ( !fields.contains( DONT_FILTER_FIELDS ) )
-        {
-            return fields;
-        }
-        return DEFAULT_FIELDS;
     }
 }


### PR DESCRIPTION
as discussed in the design meeting. fields=** was only supported in the NTI export endpoints and does not add any value