### PR TITLE
fix: Event import fails when data value is an option and sort_order has gaps [ DHIS2-12933 ] 

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.option;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -128,17 +129,17 @@ public class OptionSet
 
     public List<String> getOptionValues()
     {
-        return options.stream().map( Option::getName ).collect( Collectors.toList() );
+        return options.stream().filter( Objects::nonNull ).map( Option::getName ).collect( Collectors.toList() );
     }
 
     public List<String> getOptionCodes()
     {
-        return options.stream().map( Option::getCode ).collect( Collectors.toList() );
+        return options.stream().filter( Objects::nonNull ).map( Option::getCode ).collect( Collectors.toList() );
     }
 
     public Set<String> getOptionCodesAsSet()
     {
-        return options.stream().map( Option::getCode ).collect( Collectors.toSet() );
+        return options.stream().filter( Objects::nonNull ).map( Option::getCode ).collect( Collectors.toSet() );
     }
 
     public Option getOptionByCode( String code )
@@ -169,7 +170,8 @@ public class OptionSet
 
     public Map<String, String> getOptionCodePropertyMap( IdScheme idScheme )
     {
-        return options.stream().collect( Collectors.toMap( Option::getCode, o -> o.getPropertyValue( idScheme ) ) );
+        return options.stream().filter( Objects::nonNull )
+            .collect( Collectors.toMap( Option::getCode, o -> o.getPropertyValue( idScheme ) ) );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/validation/DataValueCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/importer/shared/validation/DataValueCheckTest.java
@@ -36,12 +36,18 @@ import static org.hisp.dhis.dxf2.events.importer.EventTestUtils.createEventDataV
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.importer.shared.ImmutableEvent;
 import org.hisp.dhis.dxf2.events.importer.validation.BaseValidationTest;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.option.Option;
+import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ValidationStrategy;
@@ -77,6 +83,31 @@ class DataValueCheckTest extends BaseValidationTest
     @Test
     void verifyNoErrorOnNoDataValues()
     {
+        assertNoError( rule.check( new ImmutableEvent( event ), this.workContext ) );
+    }
+
+    @Test
+    void verifyDataValuesWithOptionSetOk()
+    {
+        DataElement dataElement = createDataElement( 'A' );
+        dataElement.setValueType( ValueType.TEXT );
+
+        List<Option> optionList = new ArrayList<>();
+
+        Option option = new Option();
+        option.setCode( "CODE" );
+        optionList.add( option );
+        optionList.add( null );
+
+        OptionSet optionSet = new OptionSet( "OptionSet", ValueType.TEXT, optionList );
+
+        dataElement.setOptionSet( optionSet );
+
+        DataElement de1 = addToDataElementMap( dataElement );
+
+        DataValue dv1 = createDataValue( de1.getUid(), "CODE" );
+        event.setDataValues( Sets.newHashSet( dv1 ) );
+
         assertNoError( rule.check( new ImmutableEvent( event ), this.workContext ) );
     }
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12933
filter null potential options in option set