### PR TITLE
fix: add back csv for metadata export(2.38.0)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/serializers/CsvNodeSerializer.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/serializers/CsvNodeSerializer.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.node.serializers;
+
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.List;
+
+import org.hisp.dhis.node.AbstractNodeSerializer;
+import org.hisp.dhis.node.Node;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.ComplexNode;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.hisp.dhis.util.DateUtils;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.dataformat.csv.CsvFactory;
+import com.fasterxml.jackson.dataformat.csv.CsvGenerator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+@Component
+@Scope( value = "prototype", proxyMode = ScopedProxyMode.INTERFACES )
+public class CsvNodeSerializer extends AbstractNodeSerializer
+{
+    private static final String[] CONTENT_TYPES = { "application/csv", "text/csv" };
+
+    private static final CsvMapper CSV_MAPPER = new CsvMapper();
+
+    private static final CsvFactory CSV_FACTORY = CSV_MAPPER.getFactory();
+
+    private CsvGenerator csvGenerator;
+
+    @Override
+    public List<String> contentTypes()
+    {
+        return Lists.newArrayList( CONTENT_TYPES );
+    }
+
+    @Override
+    protected void startSerialize( RootNode rootNode, OutputStream outputStream )
+        throws Exception
+    {
+        csvGenerator = CSV_FACTORY.createGenerator( outputStream );
+
+        CsvSchema.Builder schemaBuilder = CsvSchema.builder()
+            .setUseHeader( true );
+
+        // build schema
+        for ( Node child : rootNode.getChildren() )
+        {
+            if ( child.isCollection() && !child.getChildren().isEmpty() )
+            {
+                Node node = child.getChildren().get( 0 );
+
+                for ( Node property : node.getChildren() )
+                {
+                    if ( property.isSimple() )
+                    {
+                        schemaBuilder.addColumn( property.getName() );
+                    }
+                }
+            }
+        }
+
+        csvGenerator.setSchema( schemaBuilder.build() );
+    }
+
+    @Override
+    protected void flushStream()
+        throws Exception
+    {
+        csvGenerator.flush();
+    }
+
+    @Override
+    protected void startWriteRootNode( RootNode rootNode )
+        throws Exception
+    {
+        for ( Node child : rootNode.getChildren() )
+        {
+            if ( child.isCollection() )
+            {
+                for ( Node node : child.getChildren() )
+                {
+                    csvGenerator.writeStartObject();
+
+                    for ( Node property : node.getChildren() )
+                    {
+                        if ( property.isSimple() )
+                        {
+                            writeSimpleNode( (SimpleNode) property );
+                        }
+                    }
+
+                    csvGenerator.writeEndObject();
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void endWriteRootNode( RootNode rootNode )
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected void startWriteSimpleNode( SimpleNode simpleNode )
+        throws Exception
+    {
+        String value = String.format( "%s", simpleNode.getValue() );
+
+        if ( Date.class.isAssignableFrom( simpleNode.getValue().getClass() ) )
+        {
+            value = DateUtils.getIso8601NoTz( (Date) simpleNode.getValue() );
+        }
+
+        csvGenerator.writeObjectField( simpleNode.getName(), value );
+    }
+
+    @Override
+    protected void endWriteSimpleNode( SimpleNode simpleNode )
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected void startWriteComplexNode( ComplexNode complexNode )
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected void endWriteComplexNode( ComplexNode complexNode )
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected void startWriteCollectionNode( CollectionNode collectionNode )
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected void endWriteCollectionNode( CollectionNode collectionNode )
+    {
+        // Do nothing
+    }
+
+    @Override
+    protected void dispatcher( Node node )
+        throws Exception
+    {
+        // Do nothing
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -31,9 +31,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.springframework.http.CacheControl.noCache;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -47,7 +45,6 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.Pager;
-import org.hisp.dhis.common.PrimaryKeyObject;
 import org.hisp.dhis.common.UserContext;
 import org.hisp.dhis.dxf2.common.OrderParams;
 import org.hisp.dhis.dxf2.common.TranslateParams;
@@ -68,11 +65,8 @@ import org.hisp.dhis.query.Pagination;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.query.QueryService;
-import org.hisp.dhis.schema.Property;
-import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.system.util.ReflectionUtils;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -86,16 +80,11 @@ import org.hisp.dhis.webapi.utils.PaginationUtils;
 import org.hisp.dhis.webapi.webdomain.WebMetadata;
 import org.hisp.dhis.webapi.webdomain.WebOptions;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.client.HttpClientErrorException;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.dataformat.csv.CsvMapper;
-import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import com.google.common.base.Enums;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
@@ -252,114 +241,6 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
         cachePrivate( response );
 
         return rootNode;
-    }
-
-    @GetMapping( produces = "application/csv" )
-    public void getObjectListCsv(
-        @RequestParam Map<String, String> rpParameters, OrderParams orderParams,
-        @CurrentUser User currentUser,
-        @RequestParam( defaultValue = "," ) char separator,
-        @RequestParam( defaultValue = ";" ) String arraySeparator,
-        @RequestParam( defaultValue = "false" ) boolean skipHeader,
-        HttpServletResponse response )
-        throws IOException
-    {
-        List<Order> orders = orderParams.getOrders( getSchema() );
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
-        List<String> filters = Lists.newArrayList( contextService.getParameterValues( "filter" ) );
-
-        WebOptions options = new WebOptions( rpParameters );
-        WebMetadata metadata = new WebMetadata();
-
-        if ( fields.isEmpty() || fields.contains( "*" ) || fields.contains( ":all" ) )
-        {
-            fields.addAll( Preset.defaultPreset().getFields() );
-        }
-
-        // only support metadata
-        if ( !getSchema().isMetadata() )
-        {
-            throw new HttpClientErrorException( HttpStatus.NOT_FOUND );
-        }
-
-        if ( !aclService.canRead( currentUser, getEntityClass() ) )
-        {
-            throw new ReadAccessDeniedException(
-                "You don't have the proper permissions to read objects of this type." );
-        }
-
-        List<T> entities = getEntityList( metadata, options, filters, orders );
-
-        CsvSchema schema;
-        CsvSchema.Builder schemaBuilder = CsvSchema.builder();
-        List<Property> properties = new ArrayList<>();
-
-        for ( String field : fields )
-        {
-            // We just split on ',' here, we do not try and deep dive into
-            // objects using [], if the client provides id,name,group[id]
-            // then the group[id] part is simply ignored.
-            for ( String splitField : field.split( "," ) )
-            {
-                Property property = getSchema().getProperty( splitField );
-
-                if ( property == null )
-                {
-                    continue;
-                }
-
-                if ( property.isSimple() && !property.isCollection() )
-                {
-                    schemaBuilder.addColumn( property.getName() );
-                    properties.add( property );
-                }
-                else if ( (property.isSimple() || property.itemIs( PropertyType.REFERENCE ))
-                    && property.isCollection() )
-                {
-                    schemaBuilder.addArrayColumn( property.getCollectionName() );
-                    properties.add( property );
-                }
-            }
-        }
-
-        schema = schemaBuilder.build()
-            .withColumnSeparator( separator )
-            .withArrayElementSeparator( arraySeparator );
-
-        if ( !skipHeader )
-        {
-            schema = schema.withHeader();
-        }
-
-        CsvMapper csvMapper = new CsvMapper();
-        csvMapper.configure( JsonGenerator.Feature.IGNORE_UNKNOWN, true );
-
-        List<Map<String, Object>> csvObjects = entities.stream().map( e -> {
-            Map<String, Object> map = new HashMap<>();
-
-            for ( Property property : properties )
-            {
-                Object value = ReflectionUtils.invokeMethod( e, property.getGetterMethod() );
-
-                if ( property.isCollection() && property.itemIs( PropertyType.REFERENCE ) )
-                {
-                    @SuppressWarnings( "unchecked" )
-                    Collection<IdentifiableObject> collection = (Collection<IdentifiableObject>) value;
-                    value = collection.stream().map( PrimaryKeyObject::getUid ).collect( toList() );
-                    map.put( property.getCollectionName(), value );
-                }
-                else
-                {
-                    map.put( property.getName(), value );
-                }
-            }
-
-            return map;
-        } )
-            .collect( toList() );
-
-        csvMapper.writer( schema ).writeValue( response.getWriter(), csvObjects );
-        response.flushBuffer();
     }
 
     @GetMapping( "/{uid}" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2021, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.mvc.messageconverter;
+
+import javax.annotation.Nonnull;
+
+import org.hisp.dhis.common.Compression;
+import org.hisp.dhis.node.NodeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
+ */
+public class CsvMessageConverter extends AbstractRootNodeMessageConverter
+{
+    private static final String MEDIA_TYPE_APPLICATION = "application";
+
+    public static final ImmutableList<MediaType> SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType> builder()
+        .add( new MediaType( MEDIA_TYPE_APPLICATION, "csv" ) )
+        .add( new MediaType( "text", "csv" ) )
+        .build();
+
+    public static final ImmutableList<MediaType> GZIP_SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType> builder()
+        .add( new MediaType( MEDIA_TYPE_APPLICATION, "csv+gzip" ) )
+        .build();
+
+    public static final ImmutableList<MediaType> ZIP_SUPPORTED_MEDIA_TYPES = ImmutableList.<MediaType> builder()
+        .add( new MediaType( MEDIA_TYPE_APPLICATION, "csv+zip" ) )
+        .build();
+
+    public CsvMessageConverter( @Autowired @Nonnull NodeService nodeService, Compression compression )
+    {
+        super( nodeService, "application/csv", "csv", compression );
+        switch ( getCompression() )
+        {
+        case NONE:
+            setSupportedMediaTypes( SUPPORTED_MEDIA_TYPES );
+            break;
+        case GZIP:
+            setSupportedMediaTypes( GZIP_SUPPORTED_MEDIA_TYPES );
+            break;
+        case ZIP:
+            setSupportedMediaTypes( ZIP_SUPPORTED_MEDIA_TYPES );
+        }
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
 import org.hisp.dhis.webapi.mvc.DhisApiVersionHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.interceptor.RequestInfoInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
+import org.hisp.dhis.webapi.mvc.messageconverter.CsvMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
@@ -174,6 +175,8 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration
             .forEach( compression -> converters.add( new JsonMessageConverter( nodeService(), compression ) ) );
         Arrays.stream( Compression.values() )
             .forEach( compression -> converters.add( new XmlMessageConverter( nodeService(), compression ) ) );
+        Arrays.stream( Compression.values() )
+            .forEach( compression -> converters.add( new CsvMessageConverter( nodeService(), compression ) ) );
 
         converters.add( new StringHttpMessageConverter( StandardCharsets.UTF_8 ) );
         converters.add( new ByteArrayHttpMessageConverter() );


### PR DESCRIPTION
backport https://github.com/dhis2/dhis2-core/pull/10269

- Add back the CSV metadata export

- Remove `@GetMapping( produces = "application/csv" )     public void getObjectListCsv()` . 

- Request with csv format will go through the old `public @ResponseBody RootNode getObjectList()`.