### PR TITLE
feat: check DHIS2 is running on JDK 11+ [DHIS2-12931]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/Dhis2EnvCompatibilityCheck.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/Dhis2EnvCompatibilityCheck.java
@@ -41,7 +41,7 @@ import org.springframework.web.WebApplicationInitializer;
  */
 @Slf4j
 @Order( 1 )
-public class DisEnvCompatibilityCheck implements WebApplicationInitializer
+public class Dhis2EnvCompatibilityCheck implements WebApplicationInitializer
 {
     @Override
     public void onStartup( ServletContext context )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DisEnvCompatibilityCheck.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DisEnvCompatibilityCheck.java
@@ -52,7 +52,7 @@ public class DisEnvCompatibilityCheck implements WebApplicationInitializer
             || javaVersion.startsWith( "9" )
             || javaVersion.startsWith( "10" ) )
         {
-            log.error( "DHIS2 requires Java 11+" );
+            log.error( "DHIS 2 requires Java 11+. Please upgrade your JDK version. Startup process was aborted." );
             System.exit( 1 );
         }
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DisEnvCompatibilityCheck.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/servlet/DisEnvCompatibilityCheck.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.servlet;
+
+import javax.servlet.ServletContext;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.web.WebApplicationInitializer;
+
+/**
+ * Checks environment compatibility for DHIS2 at startup.
+ *
+ * @author Jan Bernitt
+ */
+@Slf4j
+@Order( 1 )
+public class DisEnvCompatibilityCheck implements WebApplicationInitializer
+{
+    @Override
+    public void onStartup( ServletContext context )
+    {
+        String javaVersion = System.getProperty( "java.version" );
+        log.info( "Java Version: " + javaVersion );
+        if ( javaVersion.startsWith( "1." )
+            || javaVersion.startsWith( "9" )
+            || javaVersion.startsWith( "10" ) )
+        {
+            log.error( "DHIS2 requires Java 11+" );
+            System.exit( 1 );
+        }
+    }
+}


### PR DESCRIPTION
Intent here is to check at startup if the java version is sufficient to run DHIS2.

The odd thing is that usually a JVM should already reject running `.class` files compiled for a target to does not support.
Not sure how anyone gets past that point but this might be early enough to detect it and end with an error message that is helpful.

Needs testing by those that have the issue. I don't know how they got to have it.