### PR TITLE
fix: /tracker/trackedEntities?fields with 2 nested fields DHIS2-12660

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerTrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerTrackedEntitiesExportControllerTest.java
@@ -170,12 +170,14 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
         relationship( from, to );
         this.switchContextToUser( user );
 
-        JsonObject json = GET( "/tracker/trackedEntities/{id}?fields=trackedEntity,orgUnit,relationships[relationship]",
+        JsonObject json = GET(
+            "/tracker/trackedEntities/{id}?fields=trackedEntity,orgUnit,relationships[relationship,relationshipType]",
             from.getUid() )
                 .content( HttpStatus.OK );
 
         assertFalse( json.isEmpty() );
         assertHasOnlyMembers( json, "trackedEntity", "orgUnit", "relationships" );
+        assertHasOnlyMembers( json.getArray( "relationships" ).getObject( 0 ), "relationship", "relationshipType" );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
@@ -29,8 +29,8 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,6 +39,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner;
@@ -171,7 +172,8 @@ class TrackedEntitiesSupportService
      */
     public static TrackedEntityInstanceParams getTrackedEntityInstanceParams( List<String> fields )
     {
-        List<FieldPath> fieldPaths = FieldFilterParser.parse( new HashSet<>( fields ) );
+        List<FieldPath> fieldPaths = FieldFilterParser
+            .parse( Collections.singleton( StringUtils.join( fields, "," ) ) );
         Map<String, FieldPath> roots = rootFields( fieldPaths );
 
         TrackedEntityInstanceParams params = initUsingAllOrNoFields( roots );


### PR DESCRIPTION
fixes errors when using fields filter like

     /tracker/trackedEntities/PQfMcpmXeFE?fields=enrollments[ou,trackedEntity]&program=IpHINAT79UW

Springs splitting of queryParameter fields into a List<String> and requirement for a Set in the parser lead to the field path being out of order.