### PR TITLE
refactor: Create SingleSetupIntegrationTestBase

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceQueryModifiersTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.IntegrationTestBase;
+import org.hisp.dhis.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.AnalyticsService;
@@ -71,7 +71,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Jim Grace
  */
 class AnalyticsServiceQueryModifiersTest
-    extends IntegrationTestBase
+    extends SingleSetupIntegrationTestBase
 {
     @Autowired
     private List<AnalyticsTableService> analyticsTableServices;
@@ -205,55 +205,11 @@ class AnalyticsServiceQueryModifiersTest
     }
 
     // -------------------------------------------------------------------------
-    // Test
-    // -------------------------------------------------------------------------
-
-    @Test
-    void queryModifiersTest()
-    {
-        // TODO: refactor IntegrationTestBase and/or BaseSpringTest to provide
-        // @BeforeAll and @AfterAll methods that can be overridden so the
-        // following be individual @Tests while analytics is built only once.
-
-        // aggregationType
-
-        testNoAggregationType();
-        testAverageAggregationType();
-        testLastAggregationType();
-        testWithAndWithoutAggregationType();
-        testMultipleAggregationTypes();
-        testGroupedAggregationType();
-        testOperandAggregationType();
-
-        // periodOffset
-
-        testSimplePeriodOffset();
-        testInsideAndOutsidePeriodOffset();
-        testOperandPeriodOffset();
-        testGroupedPeriodOffset();
-        testAdditivePeriodOffset();
-
-        // minDate and maxDate
-
-        testMinDate();
-        testMaxDate();
-        testMinAndMaxDate();
-
-        // subExpression
-
-        testSimpleSubExpression();
-        testMultipleReferenceSubExpression();
-        testSubExpressionConversionFromTextToNumeric();
-        testReferencesInsideAndOutsideOfSubExpression();
-        testTwoSubExpressions();
-        testOperandSubExpression();
-    }
-
-    // -------------------------------------------------------------------------
     // aggregationType
     // -------------------------------------------------------------------------
 
-    private void testNoAggregationType()
+    @Test
+    void testNoAggregationType()
     {
         expected = List.of(
             "inabcdefghA-202201-1.0",
@@ -266,7 +222,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testAverageAggregationType()
+    @Test
+    void testAverageAggregationType()
     {
         expected = List.of(
             "inabcdefghA-2022Q1-2.0" );
@@ -276,7 +233,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testLastAggregationType()
+    @Test
+    void testLastAggregationType()
     {
         expected = List.of(
             "inabcdefghA-2022Q1-3.0" );
@@ -286,7 +244,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testWithAndWithoutAggregationType()
+    @Test
+    void testWithAndWithoutAggregationType()
     {
         expected = List.of(
             "inabcdefghA-2022Q1-8.0" );
@@ -296,7 +255,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testMultipleAggregationTypes()
+    @Test
+    void testMultipleAggregationTypes()
     {
         expected = List.of(
             "inabcdefghA-2022Q1-5.0" );
@@ -306,7 +266,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testGroupedAggregationType()
+    @Test
+    void testGroupedAggregationType()
     {
         expected = List.of(
             "inabcdefghA-2022Q1-6.0" );
@@ -316,7 +277,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testOperandAggregationType()
+    @Test
+    void testOperandAggregationType()
     {
         expected = List.of(
             "inabcdefghA-2022Q1-4.0" );
@@ -330,7 +292,8 @@ class AnalyticsServiceQueryModifiersTest
     // periodOffset
     // -------------------------------------------------------------------------
 
-    private void testSimplePeriodOffset()
+    @Test
+    void testSimplePeriodOffset()
     {
         expected = List.of(
             "inabcdefghA-202202-1.0",
@@ -341,7 +304,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testInsideAndOutsidePeriodOffset()
+    @Test
+    void testInsideAndOutsidePeriodOffset()
     {
         expected = List.of(
             "inabcdefghA-202201-3.0",
@@ -353,7 +317,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testGroupedPeriodOffset()
+    @Test
+    void testGroupedPeriodOffset()
     {
         expected = List.of(
             "inabcdefghA-202202-2.0",
@@ -364,7 +329,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testAdditivePeriodOffset()
+    @Test
+    void testAdditivePeriodOffset()
     {
         expected = List.of(
             "inabcdefghA-202202-1.0",
@@ -375,7 +341,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testOperandPeriodOffset()
+    @Test
+    void testOperandPeriodOffset()
     {
         expected = List.of(
             "inabcdefghA-202201-4.0",
@@ -391,7 +358,8 @@ class AnalyticsServiceQueryModifiersTest
     // minDate and maxDate
     // -------------------------------------------------------------------------
 
-    private void testMinDate()
+    @Test
+    void testMinDate()
     {
         expected = List.of(
             "inabcdefghA-202202-2.0",
@@ -402,7 +370,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testMaxDate()
+    @Test
+    void testMaxDate()
     {
         expected = List.of(
             "inabcdefghA-202201-1.0",
@@ -413,7 +382,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testMinAndMaxDate()
+    @Test
+    void testMinAndMaxDate()
     {
         expected = List.of(
             "inabcdefghA-202202-2.0" );
@@ -427,7 +397,8 @@ class AnalyticsServiceQueryModifiersTest
     // subExpression
     // -------------------------------------------------------------------------
 
-    private void testSimpleSubExpression()
+    @Test
+    void testSimpleSubExpression()
     {
         expected = List.of(
             "inabcdefghA-202201-4.0",
@@ -440,7 +411,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testMultipleReferenceSubExpression()
+    @Test
+    void testMultipleReferenceSubExpression()
     {
         expected = List.of(
             "inabcdefghA-202201-0.0",
@@ -451,7 +423,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testSubExpressionConversionFromTextToNumeric()
+    @Test
+    void testSubExpressionConversionFromTextToNumeric()
     {
         expected = List.of(
             "inabcdefghA-202201-3.0",
@@ -462,7 +435,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testReferencesInsideAndOutsideOfSubExpression()
+    @Test
+    void testReferencesInsideAndOutsideOfSubExpression()
     {
         expected = List.of(
             "inabcdefghA-202201-3.0",
@@ -473,7 +447,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testTwoSubExpressions()
+    @Test
+    void testTwoSubExpressions()
     {
         expected = List.of(
             "inabcdefghA-202201-10.0",
@@ -485,7 +460,8 @@ class AnalyticsServiceQueryModifiersTest
         assertEquals( expected, result );
     }
 
-    private void testOperandSubExpression()
+    @Test
+    void testOperandSubExpression()
     {
         expected = List.of(
             "inabcdefghA-202201-3.0",

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationTestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationTestBase.java
@@ -60,6 +60,7 @@ public abstract class IntegrationTestBase extends BaseSpringTest
         nonTransactionalAfter();
     }
 
+    @Override
     protected boolean emptyDatabaseAfterTest()
     {
         return true;

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/SingleSetupIntegrationTestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/SingleSetupIntegrationTestBase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis;
+
+import org.hisp.dhis.config.IntegrationTestConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+/**
+ * Base for integration tests that use a single setup for the class instead of a
+ * setup for each individual test.
+ *
+ * @author Jim Grace
+ */
+@ExtendWith( SpringExtension.class )
+@ContextConfiguration( classes = { IntegrationTestConfig.class } )
+@IntegrationTest
+@ActiveProfiles( profiles = { "test-postgres" } )
+@TestInstance( TestInstance.Lifecycle.PER_CLASS )
+public abstract class SingleSetupIntegrationTestBase
+    extends BaseSpringTest
+{
+    @BeforeAll
+    public final void before()
+        throws Exception
+    {
+        bindSession();
+
+        integrationTestBefore();
+    }
+
+    @AfterAll
+    public final void after()
+        throws Exception
+    {
+        nonTransactionalAfter();
+    }
+
+    protected boolean emptyDatabaseAfterTest()
+    {
+        return true;
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/SingleSetupIntegrationTestBase.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/SingleSetupIntegrationTestBase.java
@@ -66,6 +66,7 @@ public abstract class SingleSetupIntegrationTestBase
         nonTransactionalAfter();
     }
 
+    @Override
     protected boolean emptyDatabaseAfterTest()
     {
         return true;


### PR DESCRIPTION
This PR creates `SingleSetupIntegrationTestBase`, a base class for integration tests that have a single setup for the entire class instead of a setup per test.

The use case for this is for tests that need a resource-intensive setup (such as building analytics tables) that is sufficient for all the tests.

As part of this PR, `AnalyticsServiceQueryModifiersTest` has been refactored to use this base class. In the future, tests such as `AnalyticsServiceTest` and `EventAnalyticsServiceTest` can also be refactored to use this base. This will greatly simplify them and make their test cases much easier to add and maintain.