### PR TITLE
fix: Aggregated queries using wrong aliases [DHIS2-12947]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -33,6 +33,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
 import static org.hisp.dhis.analytics.SortOrder.ASC;
 import static org.hisp.dhis.analytics.SortOrder.DESC;
@@ -241,9 +242,9 @@ public abstract class AbstractJdbcEventAnalyticsManager
      * group clause, as non default boundaries is defining their own period
      * groups within their where clause.
      */
-    private List<String> getGroupByColumnNames( EventQueryParams params )
+    private List<String> getGroupByColumnNames( EventQueryParams params, boolean isAggregated )
     {
-        return getSelectColumns( params, true );
+        return getSelectColumns( params, true, isAggregated );
     }
 
     /**
@@ -253,9 +254,9 @@ public abstract class AbstractJdbcEventAnalyticsManager
      * boundaries{@link EventQueryParams#hasNonDefaultBoundaries}, the period is
      * hard coded into the select statement with "(isoPeriod) as (periodType)".
      */
-    protected List<String> getSelectColumns( EventQueryParams params )
+    protected List<String> getSelectColumns( EventQueryParams params, boolean isAggregated )
     {
-        return getSelectColumns( params, false );
+        return getSelectColumns( params, false, isAggregated );
     }
 
     /**
@@ -269,7 +270,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
      *        non-default boundaries where the column content would be hard
      *        coded. Used by the group-by calls.
      */
-    private List<String> getSelectColumns( EventQueryParams params, boolean isGroupByClause )
+    private List<String> getSelectColumns( EventQueryParams params, boolean isGroupByClause, boolean isAggregated )
     {
         List<String> columns = Lists.newArrayList();
 
@@ -347,9 +348,25 @@ public abstract class AbstractJdbcEventAnalyticsManager
             }
             else if ( queryItem.getValueType() == ValueType.NUMBER && !isGroupByClause )
             {
-                ColumnAndAlias columnAndAlias = getColumnAndAlias( queryItem, false, queryItem.getItemName() );
+                ColumnAndAlias columnAndAlias;
+
+                // For aggregated queries, we do not prefix the columns as they
+                // will be always "group by" queries.
+                if ( isAggregated )
+                {
+                    columnAndAlias = getColumnAndAlias( queryItem, true,
+                        queryItem.getItemName() );
+                }
+                else
+                {
+                    columnAndAlias = getColumnAndAlias( queryItem, false,
+                        queryItem.getItemName() );
+                }
+
+                // If the alias is null, we use the default "item name" as
+                // alias.
                 columns.add( "coalesce(" + columnAndAlias.getColumn() + ", double precision 'NaN') as "
-                    + columnAndAlias.getAlias() );
+                    + defaultIfNull( columnAndAlias.getAlias(), queryItem.getItemName() ) );
             }
             else
             {
@@ -384,7 +401,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
         String countClause = getAggregateClause( params );
 
         String sql = TextUtils.removeLastComma( "select " + countClause + " as value," +
-            StringUtils.join( getSelectColumns( params ), "," ) + " " );
+            StringUtils.join( getSelectColumns( params, true ), "," ) + " " );
 
         // ---------------------------------------------------------------------
         // Criteria
@@ -398,7 +415,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
         // Group by
         // ---------------------------------------------------------------------
 
-        List<String> selectColumnNames = getGroupByColumnNames( params );
+        List<String> selectColumnNames = getGroupByColumnNames( params, true );
 
         if ( selectColumnNames.size() > 0 )
         {
@@ -482,7 +499,10 @@ public abstract class AbstractJdbcEventAnalyticsManager
             {
                 for ( QueryItem queryItem : params.getItems() )
                 {
-
+                    /*
+                     * String columnName = getColumnAndAlias( queryItem, false,
+                     * getIdentifier( queryItem ) ) .getUnquotedAlias();
+                     */
                     String itemName = rowSet.getString( queryItem.getItemName() );
                     String itemValue = params.isCollapseDataDimensions()
                         ? QueryItemHelper.getCollapsedDataItemValue( queryItem, itemName )
@@ -852,7 +872,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
             .collect( groupingBy(
                 queryItem -> queryItem.hasRepeatableStageParams() && params.getEndpointItem() == ENROLLMENT ) );
 
-        // groups repeatable conditions based on PSID+DEID
+        // groups repeatable conditions based on PSID.DEID
         Map<String, List<String>> repeatableConditionsByIdentifier = asSqlCollection( itemsByRepeatableFlag.get( true ),
             params )
                 .collect( groupingBy(
@@ -937,7 +957,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
             .map( QueryItem::getProgramStage )
             .map( BaseIdentifiableObject::getUid )
             .orElse( "" );
-        return programStageId + queryItem.getItem().getUid();
+        return programStageId + "." + queryItem.getItem().getUid();
     }
 
     @Getter

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ColumnAndAlias.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/ColumnAndAlias.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -62,5 +64,10 @@ class ColumnAndAlias
         {
             return column;
         }
+    }
+
+    public String getUnquotedAlias()
+    {
+        return trimToEmpty( alias ).replaceAll( "\"", "" );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -344,7 +344,7 @@ public class JdbcEnrollmentAnalyticsManager
     @Override
     protected String getSelectClause( EventQueryParams params )
     {
-        List<String> selectCols = ListUtils.distinctUnion( COLUMNS, getSelectColumns( params ) );
+        List<String> selectCols = ListUtils.distinctUnion( COLUMNS, getSelectColumns( params, false ) );
 
         return "select " + StringUtils.join( selectCols, "," ) + " ";
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -358,7 +358,7 @@ public class JdbcEventAnalyticsManager
         cols.add( "ST_AsGeoJSON(psigeometry, 6) as geometry", "longitude", "latitude", "ouname", "oucode", "pistatus",
             "psistatus" );
 
-        List<String> selectCols = ListUtils.distinctUnion( cols.build(), getSelectColumns( params ) );
+        List<String> selectCols = ListUtils.distinctUnion( cols.build(), getSelectColumns( params, false ) );
 
         return "select " + StringUtils.join( selectCols, "," ) + " ";
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -316,7 +316,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
             .withSkipMeta( false )
             .build();
 
-        final List<String> columns = this.subject.getSelectColumns( params );
+        final List<String> columns = this.subject.getSelectColumns( params, false );
 
         // Then
 


### PR DESCRIPTION
Analytics events aggregated queries are failing because of invalid aliases.
Aggregated queries should always be treated as `group by` queries.