### PR TITLE
perf: bulk load data elements used in indicator expressions [DHIS2-11100]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.expression;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.Boolean.FALSE;
+import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castBoolean;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
@@ -548,10 +549,11 @@ public class DefaultExpressionService
     @Override
     public Set<DataElement> getExpressionDataElements( String expression, ParseType parseType )
     {
-        return getExpressionDimensionalItemIds( expression, parseType ).stream()
+        List<String> deIds = getExpressionDimensionalItemIds( expression, parseType ).stream()
             .filter( DimensionalItemId::isDataElementOrOperand )
-            .map( i -> idObjectManager.get( DataElement.class, i.getId0() ) )
-            .collect( Collectors.toSet() );
+            .map( DimensionalItemId::getId0 )
+            .collect( toList() );
+        return new HashSet<>( idObjectManager.getByUid( DataElement.class, deIds ) );
     }
 
     @Override


### PR DESCRIPTION
This is the low effort improvement where we load data elements in one go by their UIDs instead of loading them one at a time by UID.

Since the deletion handler calling this also has a loop over the indicators this still causes multiple queries but just as many as there are indicators. Further the loop in the deletion handler just wants to know if the data element is used. Loading data elements from the database is entirely not needed if a dedicated DB query can be used to find out if data elements exist given a set of UIDs. The proper solution should work that way:

1. collect all UIDs of data elements referenced in all indicators
2. make a single DB exists/count query checking for all data elements by UID

This hopefully will be done by another PR - this easy fix gives us a quick solution that should make the issue much smaller already. 