### PR TITLE
fix: Missing optionSet for TrackedEntityAttribute [DHIS2-12959]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/BaseDimensionalItemObjectMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/analytics/dimension/mappers/BaseDimensionalItemObjectMapper.java
@@ -59,8 +59,12 @@ public class BaseDimensionalItemObjectMapper extends BaseDimensionMapper
         {
             ValueTypedDimensionalItemObject valueTypedDimensionalItemObject = (ValueTypedDimensionalItemObject) dimension;
             return responseWithDimensionType
-                .withValueType( valueTypedDimensionalItemObject.getValueType().name() );
+                .withValueType( valueTypedDimensionalItemObject.getValueType().name() )
+                .withOptionSet( valueTypedDimensionalItemObject.getOptionSet() != null
+                    ? valueTypedDimensionalItemObject.getOptionSet().getUid()
+                    : null );
         }
+
         return responseWithDimensionType;
     }
 


### PR DESCRIPTION
Small fix to bring the `optionSet` as part of the response for TrackedEntityAttribute.