### PR TITLE
fix: Fix program rule variable migration when a misconfiguration is present [DHIS2-12884]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_19__Add_ValueType_column_into_programrulevariable.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_19__Add_ValueType_column_into_programrulevariable.sql
@@ -5,6 +5,7 @@
 alter table programrulevariable add column if not exists "valuetype" character varying(50);
 UPDATE programrulevariable prv SET valuetype = de.valuetype FROM dataelement de WHERE prv.dataelementid = de.dataelementid;
 UPDATE programrulevariable prv SET valuetype = attr.valuetype FROM trackedentityattribute attr WHERE prv.trackedentityattributeid = attr.trackedentityattributeid;
-UPDATE programrulevariable prv set valuetype = 'TEXT' where sourcetype = 'CALCULATED_VALUE';
+UPDATE programrulevariable prv SET valuetype = 'TEXT' WHERE sourcetype = 'CALCULATED_VALUE';
+UPDATE programrulevariable prv SET valuetype = 'TEXT' WHERE valuetype IS NULL;
 alter table programrulevariable alter column valuetype set not null;
 


### PR DESCRIPTION
@zubaira Does it make sense to have `TEXT` as the default value type in case of misconfiguration?

@ameenhere I am just changing the flyway script as it is not released yet. Is that ok?