### PR TITLE
perf: speed dataElement deletes DHIS2-11100

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.constant.Constant;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
@@ -222,15 +221,15 @@ public interface ExpressionService
     Set<String> getExpressionElementAndOptionComboIds( String expression, ParseType parseType );
 
     /**
-     * Returns all data elements found in the given expression string, including
-     * those found in data element operands. Returns an empty set if the given
-     * expression is null.
+     * Returns all data element ids found in the given expression string,
+     * including those found in data element operands. Returns an empty set if
+     * the given expression is null.
      *
      * @param expression the expression string.
      * @param parseType the type of expression to parse.
-     * @return a Set of data elements included in the expression string.
+     * @return a Set of data elements ids included in the expression string.
      */
-    Set<DataElement> getExpressionDataElements( String expression, ParseType parseType );
+    Set<String> getExpressionDataElementIds( String expression, ParseType parseType );
 
     /**
      * Returns all CategoryOptionCombo uids in the given expression string that

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -106,7 +106,6 @@ import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.expression.dataitem.DimItemDataElementAndOperand;
 import org.hisp.dhis.expression.dataitem.DimItemIndicator;
@@ -546,11 +545,11 @@ public class DefaultExpressionService
     }
 
     @Override
-    public Set<DataElement> getExpressionDataElements( String expression, ParseType parseType )
+    public Set<String> getExpressionDataElementIds( String expression, ParseType parseType )
     {
         return getExpressionDimensionalItemIds( expression, parseType ).stream()
             .filter( DimensionalItemId::isDataElementOrOperand )
-            .map( i -> idObjectManager.get( DataElement.class, i.getId0() ) )
+            .map( DimensionalItemId::getId0 )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.indicator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.commons.collections.CollectionUtils.containsAny;
+import static org.apache.commons.collections4.CollectionUtils.containsAny;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
@@ -28,9 +28,11 @@
 package org.hisp.dhis.indicator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.collections.CollectionUtils.containsAny;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
+import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -110,14 +112,13 @@ public class IndicatorDeletionHandler
     {
         for ( Indicator indicator : indicatorService.getAllIndicators() )
         {
-            for ( LegendSet ls : indicator.getLegendSets() )
+            for ( Iterator<LegendSet> itr = indicator.getLegendSets().iterator(); itr.hasNext(); )
             {
-                if ( legendSet.equals( ls ) )
+                if ( legendSet.equals( itr.next() ) )
                 {
-                    indicator.getLegendSets().remove( ls );
+                    itr.remove();
                     indicatorService.updateIndicator( indicator );
                 }
-
             }
         }
     }
@@ -126,23 +127,19 @@ public class IndicatorDeletionHandler
     {
         for ( Indicator indicator : indicatorService.getAllIndicators() )
         {
-            Set<DataElement> daels = expressionService.getExpressionDataElements( indicator.getNumerator(),
-                INDICATOR_EXPRESSION );
-
-            if ( daels != null && daels.contains( dataElement ) )
-            {
-                return new DeletionVeto( Indicator.class, indicator.getName() );
-            }
-
-            daels = expressionService.getExpressionDataElements( indicator.getDenominator(), INDICATOR_EXPRESSION );
-
-            if ( daels != null && daels.contains( dataElement ) )
+            if ( getElementIds( indicator.getNumerator() ).contains( dataElement.getUid() ) ||
+                getElementIds( indicator.getDenominator() ).contains( dataElement.getUid() ) )
             {
                 return new DeletionVeto( Indicator.class, indicator.getName() );
             }
         }
 
         return ACCEPT;
+    }
+
+    private Set<String> getElementIds( String expression )
+    {
+        return expressionService.getExpressionDataElementIds( expression, INDICATOR_EXPRESSION );
     }
 
     private DeletionVeto allowDeleteCategoryCombo( CategoryCombo categoryCombo )
@@ -152,25 +149,18 @@ public class IndicatorDeletionHandler
 
         for ( Indicator indicator : indicatorService.getAllIndicators() )
         {
-            Set<String> comboIds = expressionService.getExpressionOptionComboIds(
-                indicator.getNumerator(), INDICATOR_EXPRESSION );
-            comboIds.retainAll( optionComboIds );
-
-            if ( !comboIds.isEmpty() )
-            {
-                return new DeletionVeto( Indicator.class, indicator.getName() );
-            }
-
-            comboIds = expressionService.getExpressionOptionComboIds(
-                indicator.getDenominator(), INDICATOR_EXPRESSION );
-            comboIds.retainAll( optionComboIds );
-
-            if ( !comboIds.isEmpty() )
+            if ( containsAny( getOptionComboIds( indicator.getNumerator() ), optionComboIds ) ||
+                containsAny( getOptionComboIds( indicator.getDenominator() ), optionComboIds ) )
             {
                 return new DeletionVeto( Indicator.class, indicator.getName() );
             }
         }
 
         return ACCEPT;
+    }
+
+    private Set<String> getOptionComboIds( String expression )
+    {
+        return expressionService.getExpressionOptionComboIds( expression, INDICATOR_EXPRESSION );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -657,25 +657,25 @@ class ExpressionService2Test extends DhisSpringTest
             .thenReturn( opA.getDataElement() );
         when( idObjectManager.get( DataElement.class, opB.getDimensionItem().split( "\\." )[0] ) )
             .thenReturn( opB.getDataElement() );
-        Set<DataElement> dataElements = target.getExpressionDataElements( expressionA, INDICATOR_EXPRESSION );
+        Set<String> dataElementIds = target.getExpressionDataElementIds( expressionA, INDICATOR_EXPRESSION );
 
-        assertThat( dataElements, hasSize( 2 ) );
-        assertThat( dataElements, hasItems( opA.getDataElement(), opB.getDataElement() ) );
+        assertThat( dataElementIds, hasSize( 2 ) );
+        assertThat( dataElementIds, hasItems( opA.getDataElement().getUid(), opB.getDataElement().getUid() ) );
 
         // Expression G
         when( idObjectManager.get( DataElement.class, deA.getUid() ) ).thenReturn( deA );
         when( idObjectManager.get( DataElement.class, deB.getUid() ) ).thenReturn( deB );
         when( idObjectManager.get( DataElement.class, deC.getUid() ) ).thenReturn( deC );
 
-        dataElements = target.getExpressionDataElements( expressionG, INDICATOR_EXPRESSION );
+        dataElementIds = target.getExpressionDataElementIds( expressionG, INDICATOR_EXPRESSION );
 
-        assertThat( dataElements, hasSize( 3 ) );
-        assertThat( dataElements, hasItems( deA, deB, deC ) );
+        assertThat( dataElementIds, hasSize( 3 ) );
+        assertThat( dataElementIds, hasItems( deA.getUid(), deB.getUid(), deC.getUid() ) );
 
-        dataElements = target.getExpressionDataElements( expressionM, INDICATOR_EXPRESSION );
+        dataElementIds = target.getExpressionDataElementIds( expressionM, INDICATOR_EXPRESSION );
 
-        assertThat( dataElements, hasSize( 2 ) );
-        assertThat( dataElements, hasItems( deA, deB ) );
+        assertThat( dataElementIds, hasSize( 2 ) );
+        assertThat( dataElementIds, hasItems( deA.getUid(), deB.getUid() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -653,19 +653,10 @@ class ExpressionService2Test extends DhisSpringTest
     @Test
     void testGetExpressionDataElements()
     {
-        when( idObjectManager.get( DataElement.class, opA.getDimensionItem().split( "\\." )[0] ) )
-            .thenReturn( opA.getDataElement() );
-        when( idObjectManager.get( DataElement.class, opB.getDimensionItem().split( "\\." )[0] ) )
-            .thenReturn( opB.getDataElement() );
         Set<String> dataElementIds = target.getExpressionDataElementIds( expressionA, INDICATOR_EXPRESSION );
 
         assertThat( dataElementIds, hasSize( 2 ) );
         assertThat( dataElementIds, hasItems( opA.getDataElement().getUid(), opB.getDataElement().getUid() ) );
-
-        // Expression G
-        when( idObjectManager.get( DataElement.class, deA.getUid() ) ).thenReturn( deA );
-        when( idObjectManager.get( DataElement.class, deB.getUid() ) ).thenReturn( deB );
-        when( idObjectManager.get( DataElement.class, deC.getUid() ) ).thenReturn( deC );
 
         dataElementIds = target.getExpressionDataElementIds( expressionG, INDICATOR_EXPRESSION );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -651,7 +651,7 @@ class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    void testGetExpressionDataElements()
+    void testGetExpressionDataElementIds()
     {
         Set<String> dataElementIds = target.getExpressionDataElementIds( expressionA, INDICATOR_EXPRESSION );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/indicator/IndicatorDeletionHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/indicator/IndicatorDeletionHandlerTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.indicator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.DeleteNotAllowedException;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.legend.LegendSet;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class IndicatorDeletionHandlerTest
+    extends DhisSpringTest
+{
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    @Autowired
+    private PeriodService periodService;
+
+    @Autowired
+    private UserService _userService;
+
+    private Indicator indicator;
+
+    @Override
+    public void setUpTest()
+    {
+        userService = _userService;
+
+        IndicatorType type = new IndicatorType( "Type", 1, true );
+        manager.save( type );
+
+        indicator = createIndicator( 'A', type );
+        manager.save( indicator );
+    }
+
+    @Test
+    void testAllowDeleteIndicatorType()
+    {
+        IndicatorType typeA = new IndicatorType( "TypeA", 1, true );
+        IndicatorType typeB = new IndicatorType( "TypeB", 1, true );
+
+        manager.save( typeA );
+        manager.save( typeB );
+
+        indicator.setIndicatorType( typeB );
+        manager.update( indicator );
+
+        manager.delete( typeA );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( typeB ) );
+    }
+
+    @Test
+    void testDeleteIndicatorGroup()
+    {
+        IndicatorGroup groupA = createIndicatorGroup( 'A' );
+        groupA.addIndicator( indicator );
+        manager.save( groupA );
+
+        assertTrue( indicator.getGroups().contains( groupA ) );
+
+        manager.delete( groupA );
+
+        assertFalse( indicator.getGroups().contains( groupA ) );
+    }
+
+    @Test
+    void testDeleteDataSet()
+    {
+        PeriodType monthly = PeriodType.getPeriodTypeByName( "Monthly" );
+        monthly = periodService.reloadPeriodType( monthly );
+
+        DataSet setA = createDataSet( 'A', monthly );
+        setA.addIndicator( indicator );
+        manager.save( setA );
+
+        assertTrue( indicator.getDataSets().contains( setA ) );
+
+        manager.delete( setA );
+
+        assertFalse( indicator.getDataSets().contains( setA ) );
+    }
+
+    @Test
+    void testDeleteLegendSet()
+    {
+        LegendSet setA = createLegendSet( 'A' );
+        manager.save( setA );
+
+        indicator.getLegendSets().add( setA );
+        manager.update( indicator );
+
+        assertTrue( indicator.getLegendSets().contains( setA ) );
+
+        manager.delete( setA );
+
+        assertFalse( indicator.getLegendSets().contains( setA ) );
+    }
+
+    @Test
+    void testAllowDeleteDataElement()
+    {
+        DataElement elementA = createDataElement( 'A' );
+        DataElement elementB = createDataElement( 'B' );
+        DataElement elementC = createDataElement( 'C' );
+
+        manager.save( elementA );
+        manager.save( elementB );
+        manager.save( elementC );
+
+        indicator.setNumerator( "#{" + elementB.getUid() + "}" );
+        indicator.setDenominator( "#{" + elementC.getUid() + "}" );
+        manager.update( indicator );
+
+        manager.delete( elementA );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( elementB ) );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( elementC ) );
+    }
+
+    @Test
+    void testAllowDeleteCategoryCombo()
+    {
+        CategoryCombo comboA = createCategoryCombo( 'A' );
+        CategoryCombo comboB = createCategoryCombo( 'B' );
+        CategoryCombo comboC = createCategoryCombo( 'C' );
+
+        manager.save( comboA );
+        manager.save( comboB );
+        manager.save( comboC );
+
+        CategoryOptionCombo cocA = createCategoryOptionCombo( 'A' );
+        CategoryOptionCombo cocB = createCategoryOptionCombo( 'B' );
+        CategoryOptionCombo cocC = createCategoryOptionCombo( 'C' );
+
+        cocA.setCategoryCombo( comboA );
+        cocB.setCategoryCombo( comboB );
+        cocC.setCategoryCombo( comboC );
+
+        manager.save( cocA );
+        manager.save( cocB );
+        manager.save( cocC );
+
+        comboA.getOptionCombos().add( cocA );
+        comboB.getOptionCombos().add( cocB );
+        comboC.getOptionCombos().add( cocC );
+
+        manager.update( comboA );
+        manager.update( comboB );
+        manager.update( comboC );
+
+        indicator.setNumerator( "#{abcdefghijk." + cocB.getUid() + "}" );
+        indicator.setDenominator( "#{abcdefghijk." + cocC.getUid() + "}" );
+        manager.update( indicator );
+
+        manager.delete( comboA );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( comboB ) );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( comboC ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/DefaultValidationRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/DefaultValidationRuleService.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
@@ -69,17 +70,21 @@ public class DefaultValidationRuleService
 
     private final ExpressionService expressionService;
 
+    private final IdentifiableObjectManager idObjectManager;
+
     public DefaultValidationRuleService( ValidationRuleStore validationRuleStore,
         @Qualifier( "org.hisp.dhis.validation.ValidationRuleGroupStore" ) IdentifiableObjectStore<ValidationRuleGroup> validationRuleGroupStore,
-        ExpressionService expressionService )
+        ExpressionService expressionService, IdentifiableObjectManager idObjectManager )
     {
         checkNotNull( validationRuleGroupStore );
         checkNotNull( validationRuleStore );
         checkNotNull( expressionService );
+        checkNotNull( idObjectManager );
 
         this.validationRuleStore = validationRuleStore;
         this.validationRuleGroupStore = validationRuleGroupStore;
         this.expressionService = expressionService;
+        this.idObjectManager = idObjectManager;
     }
 
     // -------------------------------------------------------------------------
@@ -221,12 +226,12 @@ public class DefaultValidationRuleService
     @Override
     public Set<DataElement> getDataElements( ValidationRule validationRule )
     {
-        Set<DataElement> elements = new HashSet<>();
-        elements.addAll( expressionService.getExpressionDataElements( validationRule.getLeftSide().getExpression(),
+        Set<String> uids = new HashSet<>();
+        uids.addAll( expressionService.getExpressionDataElementIds( validationRule.getLeftSide().getExpression(),
             VALIDATION_RULE_EXPRESSION ) );
-        elements.addAll( expressionService.getExpressionDataElements( validationRule.getRightSide().getExpression(),
+        uids.addAll( expressionService.getExpressionDataElementIds( validationRule.getRightSide().getExpression(),
             VALIDATION_RULE_EXPRESSION ) );
-        return elements;
+        return new HashSet<>( idObjectManager.getByUid( DataElement.class, uids ) );
     }
 
     @Transactional( readOnly = true )


### PR DESCRIPTION
In coordination with @jbee, this is a more complete fix for [DHIS2-11100](https://jira.dhis2.org/browse/DHIS2-11100) than the "quick fix" PR [pull/10292](https://github.com/dhis2/dhis2-core/pull/10292).

Changes:

1. In `IndicatorDeletionHandler.allowDeleteDataElement`, all that is needed is to check for the data element UID in all the indicator formulas. To accomplish this, the `ExpressionService` method `getExpressionDataElements` was changed to `getExpressionDataElementIds` so that it just returns the `DataElement` UIDs without finding the corresponding `DataElement` objects.

2. `IndicatorDeletionHandler.allowDeleteDataElement` now just checks the data element UID against those found in each indicator. The method was also simplified.

3. Other uses of the changed `ExpressionService` method were modified as necessary in `DefaultValidationRuleService` and `ExpressionService2Test`.

4. `IndicatorDeletionHandler.allowDeleteCategoryCombo` was also simplified, following the new pattern of `allowDeleteDataElement`.

5. `IndicatorDeletionHandlerTest` was written to test all the `IndicatorDeletionHandler` methods.

6. In running the deletion handler test, I noticed that a stack trace was being generated each time for `deleteLegendSet` because it was removing an entry from a list while iterating through the list. I've refactored this method to use an `Iterator` to avoid the problem. (This wasn't actually preventing the method from succeeding because the problem occured after removing the `LegendSet` from the `Indicator` and after updating the `Indicator`.)