### PR TITLE
fix: set implicit private authority for teiFilters and eventFilters [DHIS2-12925] [DHIS2-12924] (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramStageInstanceFilterSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/ProgramStageInstanceFilterSchemaDescriptor.java
@@ -53,6 +53,7 @@ public class ProgramStageInstanceFilterSchemaDescriptor implements SchemaDescrip
         Schema schema = new Schema( ProgramStageInstanceFilter.class, SINGULAR, PLURAL );
         schema.setRelativeApiEndpoint( API_ENDPOINT );
         schema.setDefaultPrivate( true );
+        schema.setImplicitPrivateAuthority( true );
 
         schema.add( new Authority( AuthorityType.CREATE, Lists.newArrayList( "F_PROGRAMSTAGE_ADD" ) ) );
         schema.add( new Authority( AuthorityType.DELETE, Lists.newArrayList( "F_PROGRAMSTAGE_DELETE" ) ) );

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/TrackedEntityInstanceFilterSchemaDescriptor.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/descriptors/TrackedEntityInstanceFilterSchemaDescriptor.java
@@ -52,6 +52,7 @@ public class TrackedEntityInstanceFilterSchemaDescriptor implements SchemaDescri
     {
         Schema schema = new Schema( TrackedEntityInstanceFilter.class, SINGULAR, PLURAL );
         schema.setRelativeApiEndpoint( API_ENDPOINT );
+        schema.setImplicitPrivateAuthority( true );
         schema.setDefaultPrivate( true );
 
         schema.add( new Authority( AuthorityType.CREATE, Lists.newArrayList( "F_PROGRAMSTAGE_ADD" ) ) );


### PR DESCRIPTION
Implicit Private authority has to be set if the creator of the metadata object has to have the correct "Access" object with correct read/write/update/manage flags on that object.