### PR TITLE
fix: Add missing transactional annotation 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
@@ -56,6 +56,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.vdurmont.semver4j.Semver;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Svanaes
@@ -201,6 +202,7 @@ public class SystemUpdateService
         return versionsAndMessage;
     }
 
+    @Transactional
     public void sendMessageForEachVersion( Map<Semver, Map<String, String>> patchVersions )
     {
         Set<User> recipients = getRecipients();
@@ -231,6 +233,7 @@ public class SystemUpdateService
         }
     }
 
+    @Transactional
     private Set<User> getRecipients()
     {
         Set<User> recipients = messageService.getSystemUpdateNotificationRecipients();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
@@ -51,12 +51,12 @@ import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.user.UserStore;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.vdurmont.semver4j.Semver;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Morten Svanaes
@@ -233,7 +233,6 @@ public class SystemUpdateService
         }
     }
 
-    @Transactional
     private Set<User> getRecipients()
     {
         Set<User> recipients = messageService.getSystemUpdateNotificationRecipients();


### PR DESCRIPTION
The system update notification job would fail due to missing hibernate session.
This PR adds the @Transactional annotation to the service method being called in the job.