### PR TITLE
fix: Gist API use inner join for object collection property listings [DHIS2-12972]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -325,7 +325,7 @@ final class GistBuilder
         if ( !query.isInverse() )
         {
             return String.format(
-                "select %s from %s o left join o.%s as e where o.uid = :OwnerId and (%s) and (%s) order by %s",
+                "select %s from %s o inner join o.%s as e where o.uid = :OwnerId and (%s) and (%s) order by %s",
                 fields, ownerTable, collectionName, userFilters, accessFilters, orders );
         }
         return String.format(


### PR DESCRIPTION
### Summary
Once more got confused by HQL join names. This should have been an `inner` not a `left` join.

### Manual Testing
The issue exists for any type of metadata using gist API on a collection property.
The case that was reported and that I tested was:

* create a new empty user group
* goto `/api/userGroups/<user group ID>/users/gist?fields=name` 
* check you get an empty result (no users) as opposed to a single result of "null null"  