### PR TITLE
fix: Conditions: time with "before" conditions returns values matching "before or including" [2.39-DHIS2-12985]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -500,11 +500,24 @@ public class DefaultEventDataQueryService
             {
                 QueryOperator operator = QueryOperator.fromString( split[i] );
                 QueryFilter filter = new QueryFilter( operator, split[i + 1] );
+                // FE uses HH.MM time format instead of HH:MM. This is not
+                // compatible with db table/cell values
+                modifyFilterWhenTimeQueryItem( queryItem, filter );
                 queryItem.addFilter( filter );
             }
         }
 
         return queryItem;
+    }
+
+    private static void modifyFilterWhenTimeQueryItem( QueryItem queryItem, QueryFilter filter )
+    {
+        if ( queryItem.getItem() instanceof DataElement
+            && ((DataElement) queryItem.getItem()).getValueType() == ValueType.TIME )
+        {
+            filter.setFilter( filter.getFilter().replace( ".", ":" ) );
+        }
+
     }
 
     private QueryItem getSortItem( String item, Program program, EventOutputType type,


### PR DESCRIPTION
Conditions that don’t work with Time: exactly, is not, after or including, before

api requests

“Exactly”. Expected: return 1 row. Actual: no rows returned. (condition EQ:14.50)

https://debug.dhis2.org/tracker_dev/api/39/analytics/events/query/vBOHFvxlYPJ?dimension=ou%3AUSER_ORGUNIT,Xd6cKnFMO4L.v5e0tyyxNq6%3AEQ%3A14.50&headers=ouname,eventdate,Xd6cKnFMO4L.v5e0tyyxNq6&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&asc=ouname

“Is not” Expected: returns 5 rows. Actual: 6 rows returned (condition !EQ:14.50)

https://debug.dhis2.org/tracker_dev/api/39/analytics/events/query/vBOHFvxlYPJ?dimension=ou%3AUSER_ORGUNIT,Xd6cKnFMO4L.v5e0tyyxNq6%3A!EQ%3A14.50&headers=ouname,eventdate,Xd6cKnFMO4L.v5e0tyyxNq6&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&asc=ouname

“After or including”. Expected: 4 rows. Actual: 3 rows (condition GE:14.01)

https://debug.dhis2.org/tracker_dev/api/39/analytics/events/query/vBOHFvxlYPJ?dimension=ou%3AUSER_ORGUNIT,Xd6cKnFMO4L.v5e0tyyxNq6%3AGE%3A14.01&headers=ouname,eventdate,Xd6cKnFMO4L.v5e0tyyxNq6&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&asc=ouname

“Before”. Expected 3 rows. Actual: 4 rows (condition LT:14.02)

https://debug.dhis2.org/tracker_dev/api/39/analytics/events/query/vBOHFvxlYPJ?dimension=ou%3AUSER_ORGUNIT,Xd6cKnFMO4L.v5e0tyyxNq6%3ALT%3A14.02&headers=ouname,eventdate,Xd6cKnFMO4L.v5e0tyyxNq6&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&asc=ouname