### PR TITLE
refactor: Overhaul AnalyticsServiceTest

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -175,12 +175,12 @@ class EventAnalyticsServiceTest extends IntegrationTestBase
             .withOrganisationUnits( Lists.newArrayList( ouA ) ).withStartDate( getDate( 2017, 1, 1 ) )
             .withEndDate( getDate( 2017, 12, 31 ) ).withProgram( programA ).build();
         // The results
-        Map<String, Double> events_2017_keyValue = new HashMap<>();
+        Map<String, Object> events_2017_keyValue = new HashMap<>();
         events_2017_keyValue.put( "ouabcdefghA", 6.0 );
         // When
         Grid aggregatedDataValueGrid = eventAnalyticsService.getAggregatedEventData( events_2017_params );
         // Then
-        AnalyticsTestUtils.assertResultGrid( "events_2017", aggregatedDataValueGrid, events_2017_keyValue );
+        AnalyticsTestUtils.assertResultGrid( events_2017_keyValue, aggregatedDataValueGrid );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsTestUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsTestUtils.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.analytics.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Map;
 
@@ -71,13 +70,12 @@ public class AnalyticsTestUtils
      * Test if values from keyValue corresponds with values in
      * aggregatedResultMapping. Also test for null values.
      *
-     * @param scenario test scenario being run
-     * @param aggregatedResultData aggregated results
      * @param keyValue expected results
+     * @param aggregatedResultData aggregated results
      */
-    public static void assertResultGrid( String scenario, Grid aggregatedResultData, Map<String, Double> keyValue )
+    public static void assertResultGrid( Map<String, Object> keyValue, Grid aggregatedResultData )
     {
-        assertNotNull( aggregatedResultData, "Scenario '" + scenario + "' returned null Grid" );
+        assertNotNull( aggregatedResultData );
         for ( int i = 0; i < aggregatedResultData.getRows().size(); i++ )
         {
             int numberOfDimensions = aggregatedResultData.getRows().get( 0 ).size() - 1;
@@ -90,38 +88,12 @@ public class AnalyticsTestUtils
                     key.append( "-" );
                 }
             }
-            Double expected = keyValue.get( key.toString() );
+            Double expected = (Double) keyValue.get( key.toString() );
             Double actual = Double.parseDouble( aggregatedResultData.getValue( i, numberOfDimensions ).toString() );
-            assertNotNull( expected, "Scenario " + scenario + " did not find " + key + " in provided results" );
+            assertNotNull( expected, "Did not find " + key + " in provided results" );
             assertNotNull( aggregatedResultData.getRow( i ) );
             assertEquals( expected, actual,
-                "Scenario " + scenario + " value for " + key + " was " + actual + ", not expected " + expected );
-        }
-    }
-
-    /**
-     * Test if values from keyValue corresponds with values in
-     * aggregatedDataValueMapping. Also test for null values, and "" as key in
-     * aggregatedDataValueMapping
-     *
-     * @param scenario test scenario being run
-     * @param aggregatedResultMapping aggregated values
-     * @param keyValue expected results
-     */
-    public static void assertResultMapping( String scenario, Map<String, Object> aggregatedResultMapping,
-        Map<String, Double> keyValue )
-    {
-        assertNotNull( aggregatedResultMapping );
-        assertNull( aggregatedResultMapping.get( "testNull" ) );
-        assertNull( aggregatedResultMapping.get( "" ) );
-        for ( Map.Entry<String, Object> entry : aggregatedResultMapping.entrySet() )
-        {
-            String key = entry.getKey();
-            Double expected = keyValue.get( key );
-            Double actual = (Double) entry.getValue();
-            assertNotNull( expected, "Scenario " + scenario + " did not find " + key + " in provided results" );
-            assertEquals( expected, actual,
-                "Scenario " + scenario + " value for " + key + " was " + actual + ", not expected " + expected );
+                "Value for " + key + " was " + actual + ", not expected " + expected );
         }
     }
 
@@ -129,17 +101,17 @@ public class AnalyticsTestUtils
      * Test if values from keyValue corresponds with values in
      * aggregatedDataValueSet. Also test for null values.
      *
-     * @param aggregatedResultSet aggregated values
      * @param keyValue expected results
+     * @param aggregatedResultSet aggregated values
      */
-    public static void assertResultSet( DataValueSet aggregatedResultSet, Map<String, Double> keyValue )
+    public static void assertResultSet( Map<String, Object> keyValue, DataValueSet aggregatedResultSet )
     {
         for ( org.hisp.dhis.dxf2.datavalue.DataValue dataValue : aggregatedResultSet.getDataValues() )
         {
             String key = dataValue.getDataElement() + "-" + dataValue.getOrgUnit() + "-" + dataValue.getPeriod();
             assertNotNull( keyValue.get( key ) );
             Double actual = Double.parseDouble( dataValue.getValue() );
-            Double expected = keyValue.get( key );
+            Double expected = (Double) keyValue.get( key );
             assertEquals( expected, actual,
                 "Value for key: '" + key + "' not matching expected value: '" + expected + "'" );
         }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -760,6 +760,18 @@ public abstract class DhisConvenienceTest
      */
     public static Indicator createIndicator( char uniqueCharacter, IndicatorType type )
     {
+        return createIndicator( uniqueCharacter, type, "Numerator", "Denominator" );
+    }
+
+    /**
+     * @param uniqueCharacter A unique character to identify the object.
+     * @param type The type.
+     * @param numerator The numerator.
+     * @param denominator The denominator.
+     */
+    public static Indicator createIndicator( char uniqueCharacter, IndicatorType type,
+        String numerator, String denominator )
+    {
         Indicator indicator = new Indicator();
         indicator.setAutoFields();
 
@@ -770,9 +782,9 @@ public abstract class DhisConvenienceTest
         indicator.setDescription( "IndicatorDescription" + uniqueCharacter );
         indicator.setAnnualized( false );
         indicator.setIndicatorType( type );
-        indicator.setNumerator( "Numerator" );
+        indicator.setNumerator( numerator );
         indicator.setNumeratorDescription( "NumeratorDescription" );
-        indicator.setDenominator( "Denominator" );
+        indicator.setDenominator( denominator );
         indicator.setDenominatorDescription( "DenominatorDescription" );
 
         return indicator;


### PR DESCRIPTION
This refactor makes `AnalyticsServiceTest` easier to maintain and extend. It keeps exactly the same test cases as before. Other tests may be added in the future in a much simpler way.

### Former design

There were formerly four tests. (Each caused all the analytics tables to be rebuilt):

1. `queryValidationResultTable` counted the validation results in analytics.

2. `testMappingAggregation` covered many test cases, so as not to rebuild the analytics tables for each case. It used the _dataQueryParams_ map (keyed by a string test case name) to hold parameters that could be passed to `analyticsService.getAggregatedDataValueMapping( DataQueryParams params )`. The output was compared with the _results_ map using the same key. It also used the _analyticalObjectHashMap_ map for three test cases that also tested `analyticsService.getAggregatedDataValueMapping( AnalyticalObject object )` by comparing with the same _results_ map.

3. `testGridAggregation` iterated over the same _dataQueryParams_ and _results_ maps as `testMappingAggregation`, but tested `analyticsService.getAggregatedDataValues` instead, using `AnalyticsTestUtils.assertResultGrid` to see if the Grid had the same expected _results_.

4. `testSetAggregation` chose two of the test cases from the _dataQueryParams_ map to test with `analyticsService.getAggregatedDataValueSet` for expected results.

### New design

The new design uses `SingleSetupIntegrationTestBase` as introduced in [pull/10289](https://github.com/dhis2/dhis2-core/pull/10289). A single analytics table build is done for all tests.

The `queryValidationResultTable` test is unchanged.

The other three tests have been refactored into one `@Test` per test case. The test method names include the original test case key strings so that the lineage of each test can be traced to the old code (except that two test names have been corrected, see below). Notes:

- Objects that are needed by two or more tests and/or are needed for the analytics build are created during setup. Objects that can be created after the analytics build and are used by only one test are created within that test (`Indicators` and `Visualizations`).

- All these tests call `assertDataValues`, which tests both `analyticsService.getAggregatedDataValueMapping` (formerly by `testMappingAggregation`) and `analyticsService.getAggregatedDataValues` (formerly by `testGridAggregation`).

- The three test cases that had also `analyticalObjectHashMap` entries now call `getDataValueMapping` which calls `analyticsService.getAggregatedDataValueMapping( AnalyticalObject object )`

- The two test cases that were referenced by the old `testSetAggregation` now call `getDataValueSet` which calls `analyticsService.getAggregatedDataValueSet`.

### Other details

- `AnalyticsTestUtils.assertResultMapping` was only used by the old _AnalyticsServiceTest_. It has been removed and `dhis.utils.Assertions.assertMapEquals` is used in its place. A major flaw of _assertResultMapping_ was that it tested only in one direction. It made sure that each result was expected. However it did not check to see that each expected value was in the results. This included the extreme case where a test with no results would be a success!

  The reason for this unfortunate behavior is that the value keys returned by the two overloads of `analyticsService.getAggregatedDataValueMapping` are encoded differently depending on whether the argument is `DataQueryParams` or `AnalyticalObject`. There are three test cases test that call both overloads: `deC_ouB_2017_03`, `deA_ouA_2017_Q01`, and `inC_deB_deC_2017_Q01`. What they had done before is to put two value keys in the _results_ map with the same expected value. _AnalyticsTestUtils.assertResultMapping_ would find one value key for one call, and the other value key for the other call, but would never find both keys in any test. In the refactor, these three test methods now explicitly specify the different value key they expect for each of the two different calls. This allows _AnalyticsTestUtils.assertResultMapping_ to be replaced by _assertMapEquals_ which checks in both directions. This closes a major testing loophole.

- Expected results are now coded as `Map<String, Object>` rather than `Map<String, Double>`, so `assertMapEquals` can be used because analytics returns results as `Map<String, Object>`.

- The parameters for `AnalyticsTestUtils` methods `assertResultGrid` and `assertResultSet` are reordered so the expected value is first, following the usual convention.

- The `scenario` string parameter was removed from `AnalyticsTestUtils.assertResultGrid` since it is no longer needed, and from its caller in `EventAnalyticsServiceTest`. (Each scenario is now a different method, and the stack trace now shows which test had the error.)

- Minor changes were made to `EventAnalyticsServiceTest` to accommodate the minor changes in `AnalyticsTestUtils`. Otherwise `EventAnalyticsServiceTest` has not been changed, although it could also be refactored to use `SingleSetupIntegrationTestBase` in the future as well if that is desired. (Currently `EventAnalyticsServiceTest` only builds analytics once, and doesn't have the test case maps the way `AnalyticsServiceTest` did.)

- Two test names were corrected:
. `inE_deA_reRateA_2017_Q01` was renamed to `inE_deA_reRateB_2017_Q01` because it uses reporting rate B.
. `inF_deA_reRateB_2017_Q01` was renamed to `inF_deA_reRateA_2017_Q01` because it uses reporting rate A.

- `Periods` had been created at different points within `setUpTest`. `y2017_mar` duplicated `peMar` and was merged. `y2017` was renamed to `year` for consistency with the other period names.

- `DataQueryParams` are now built one parameter per line which makes them easier to read. This made it more obvious that the former `deA_deB_deD_ouC_ouE_2017_04_params` was built with two identical calls to `withOutputFormat` in different places. This has been fixed.

### Other benefits

The number of tests has increased from 4 to 19, so a failing test will not block as much subsequent testing.

Since analytics tables are only built once instead of four times, the module runs much faster. On my machine it now takes around 2:45 m:ss instead of 7:25.

Although the line count has increased from 719 to 855 lines, the java file size has shrunk from 40K to 33K. This means less code to look at with a more generous use of white space.