### PR TITLE
chore: prevent mutation of TrackerPreheat.map DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -103,7 +103,6 @@ public class TrackerPreheat
      * value of each id can be either the metadata object's uid, code, name or
      * attribute value
      */
-    @Getter
     private Map<Class<? extends IdentifiableObject>, Map<String, IdentifiableObject>> map = new HashMap<>();
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOrgUnitsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOrgUnitsSupplier.java
@@ -62,9 +62,7 @@ public class ProgramOrgUnitsSupplier extends JdbcAbstractPreheatSupplier
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
         // fetch all existing Org Units from payload
-        final List<Long> orgUnitIds = preheat.getMap()
-            .getOrDefault( OrganisationUnit.class, Collections.emptyMap() )
-            .values()
+        final List<Long> orgUnitIds = preheat.getAll( OrganisationUnit.class )
             .stream()
             .map( IdentifiableObject::getId )
             .distinct()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.preheat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hisp.dhis.TransactionalIntegrationTest;
@@ -46,16 +47,20 @@ import org.hisp.dhis.tracker.TrackerIdentifierParams;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-class TrackerPreheatServiceIntegration extends TransactionalIntegrationTest
+class TrackerPreheatServiceIntegrationTest extends TransactionalIntegrationTest
 {
+
+    private final String TET_UID = "TET12345678";
+
+    private final String ATTRIBUTE_UID = "ATTR1234567";
 
     @Autowired
     private TrackerPreheatService trackerPreheatService;
@@ -72,28 +77,29 @@ class TrackerPreheatServiceIntegration extends TransactionalIntegrationTest
     @Autowired
     private AttributeService attributeService;
 
-    private final String TET_UID = "TET12345678";
-
-    private final String TE_UID = "TE123456789";
-
-    private final String ATTRIBUTE_UID = "ATTR1234567";
-
     @Autowired
     private UserService _userService;
+
+    private User currentUser;
+
+    private Program program;
+
+    private String programAttribute;
 
     @Override
     public void setUpTest()
         throws Exception
     {
         userService = _userService;
+        currentUser = createAndInjectAdminUser( "ALL" );
         // Set up placeholder OU; We add Code for testing idScheme.
-        OrganisationUnit ouA = createOrganisationUnit( 'A' );
-        ouA.setCode( "OUA" );
-        organisationUnitService.addOrganisationUnit( ouA );
+        OrganisationUnit orgUnit = createOrganisationUnit( 'A' );
+        orgUnit.setCode( "OUA" );
+        organisationUnitService.addOrganisationUnit( orgUnit );
         // Set up placeholder TET
-        TrackedEntityType tetA = createTrackedEntityType( 'A' );
-        tetA.setUid( TET_UID );
-        trackedEntityTypeService.addTrackedEntityType( tetA );
+        TrackedEntityType trackedEntityType = createTrackedEntityType( 'A' );
+        trackedEntityType.setUid( TET_UID );
+        trackedEntityTypeService.addTrackedEntityType( trackedEntityType );
         // Set up attribute for program, to be used for testing idScheme.
         Attribute attributeA = createAttribute( 'A' );
         attributeA.setUid( ATTRIBUTE_UID );
@@ -101,31 +107,49 @@ class TrackerPreheatServiceIntegration extends TransactionalIntegrationTest
         attributeA.setProgramAttribute( true );
         attributeService.addAttribute( attributeA );
         // Set up placeholder Program, with attributeValue
-        Program programA = createProgram( 'A' );
-        programA.addOrganisationUnit( ouA );
-        programA.setTrackedEntityType( tetA );
-        programA.setProgramType( ProgramType.WITH_REGISTRATION );
-        programA.setAttributeValues( Sets.newHashSet( new AttributeValue( "PROGRAM1", attributeA ) ) );
-        programService.addProgram( programA );
+        program = createProgram( 'A' );
+        program.addOrganisationUnit( orgUnit );
+        program.setTrackedEntityType( trackedEntityType );
+        program.setProgramType( ProgramType.WITH_REGISTRATION );
+        programAttribute = "PROGRAM1";
+        program.setAttributeValues( Sets.newHashSet( new AttributeValue( programAttribute, attributeA ) ) );
+        programService.addProgram( program );
     }
 
     @Test
-    @Disabled
     void testPreheatWithDifferentIdSchemes()
     {
-        TrackedEntity teA = TrackedEntity.builder().orgUnit( "OUA" ).trackedEntityType( TET_UID ).build();
-        Enrollment enrollmentA = Enrollment.builder().orgUnit( "OUA" ).program( "PROGRAM1" ).trackedEntity( TE_UID )
+        TrackedEntity teA = TrackedEntity.builder()
+            .orgUnit( "OUA" )
+            .trackedEntityType( TET_UID )
             .build();
-        TrackerImportParams trackerPreheatParams = TrackerImportParams.builder()
-            .trackedEntities( Lists.newArrayList( teA ) ).enrollments( Lists.newArrayList( enrollmentA ) )
-            .identifiers( TrackerIdentifierParams.builder().idScheme( TrackerIdentifier.UID )
+        Enrollment enrollmentA = Enrollment.builder()
+            .orgUnit( "OUA" )
+            .program( "PROGRAM1" )
+            .trackedEntity( "TE123456789" )
+            .build();
+
+        TrackerImportParams params = TrackerImportParams.builder()
+            .user( currentUser )
+            .trackedEntities( Lists.newArrayList( teA ) )
+            .enrollments( Lists.newArrayList( enrollmentA ) )
+            .identifiers( TrackerIdentifierParams.builder()
+                .idScheme( TrackerIdentifier.UID )
                 .orgUnitIdScheme( TrackerIdentifier.CODE )
-                .programIdScheme(
-                    TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
+                    .programIdScheme(
+                            TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
                 .build() )
             .build();
-        TrackerPreheat preheat = trackerPreheatService.preheat( trackerPreheatParams );
+
+        TrackerPreheat preheat = trackerPreheatService.preheat( params );
+
         assertNotNull( preheat );
-        assertNotNull( preheat.getMap() );
+        // asserting on specific fields instead of plain assertEquals since
+        // PreheatMappers are not mapping all fields
+        assertEquals( "OUA", preheat.getOrganisationUnit( "OUA" ).getCode() );
+        assertEquals( TET_UID, preheat.getTrackedEntityType( TET_UID ).getUid() );
+        Program actualProgram = preheat.getProgram( programAttribute );
+        assertNotNull( actualProgram );
+        assertEquals( program.getUid(), actualProgram.getUid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
@@ -136,8 +136,8 @@ class TrackerPreheatServiceIntegrationTest extends TransactionalIntegrationTest
             .identifiers( TrackerIdentifierParams.builder()
                 .idScheme( TrackerIdentifier.UID )
                 .orgUnitIdScheme( TrackerIdentifier.CODE )
-                    .programIdScheme(
-                            TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
+                .programIdScheme(
+                    TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
                 .build() )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -78,7 +78,7 @@ class TrackerPreheatServiceTest extends TrackerTest
     {
         TrackerImportParams params = new TrackerImportParams();
         Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
-        assertEquals( collectedMap.keySet().size(), 2 );
+        assertEquals( 2, collectedMap.keySet().size() );
         assertTrue( collectedMap.containsKey( TrackedEntityType.class ) );
         assertTrue( collectedMap.containsKey( RelationshipType.class ) );
     }
@@ -167,13 +167,14 @@ class TrackerPreheatServiceTest extends TrackerTest
         assertTrue( params.getTrackedEntities().isEmpty() );
         assertTrue( params.getEnrollments().isEmpty() );
         assertFalse( params.getEvents().isEmpty() );
+
         TrackerPreheat preheat = trackerPreheatService.preheat( params );
+
         assertNotNull( preheat );
-        assertNotNull( preheat.getMap() );
-        assertNotNull( preheat.getMap().get( DataElement.class ) );
-        assertNotNull( preheat.getMap().get( OrganisationUnit.class ) );
-        assertNotNull( preheat.getMap().get( ProgramStage.class ) );
-        assertNotNull( preheat.getMap().get( CategoryOptionCombo.class ) );
+        assertFalse( preheat.getAll( DataElement.class ).isEmpty() );
+        assertFalse( preheat.getAll( OrganisationUnit.class ).isEmpty() );
+        assertFalse( preheat.getAll( ProgramStage.class ).isEmpty() );
+        assertFalse( preheat.getAll( CategoryOptionCombo.class ).isEmpty() );
         assertNotNull( preheat.get( CategoryOptionCombo.class, "XXXvX50cXC0" ) );
         assertNotNull( preheat.get( CategoryOption.class, "XXXrKDKCefk" ) );
     }


### PR DESCRIPTION
We should not expose our collections using getters that do not make copies (ideally the elements themselves would be immutable as well).

* remove `@Getter` from TrackerPreheat.map
* enable a TrackerPreheat integration test