### PR TITLE
fix: dataValue export file name to include start and end date

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -49,6 +50,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,12 +69,14 @@ import org.springframework.web.context.WebApplicationContext;
 @Transactional
 public abstract class DhisControllerConvenienceTest extends DhisMockMvcControllerTest
 {
-
     @Autowired
     private WebApplicationContext webApplicationContext;
 
     @Autowired
     private UserService _userService;
+
+    @Autowired
+    private IdentifiableObjectManager manager;
 
     private MockMvc mvc;
 
@@ -145,8 +149,21 @@ public abstract class DhisControllerConvenienceTest extends DhisMockMvcControlle
             toResponse( mvc.perform( request.session( session ) ).andReturn().getResponse() ) ) );
     }
 
+    protected final MvcResult webRequestWithMvcResult( MockHttpServletRequestBuilder request )
+    {
+        return failOnException( () -> mvc.perform( request.session( session ) ).andReturn() );
+    }
+
     protected final void assertJson( String expected, HttpResponse actual )
     {
         assertEquals( singleToDoubleQuotes( expected ), actual.content().toString() );
+    }
+
+    protected void switchToUserWithOrgUnitDataView( String userName, String orgUnitId )
+    {
+        User user = createUser( userName, "ALL" );
+        user.getDataViewOrganisationUnits().add( manager.get( orgUnitId ) );
+        userService.addUser( user );
+        switchContextToUser( user );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/DhisMockMvcControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/DhisMockMvcControllerTest.java
@@ -79,6 +79,13 @@ public abstract class DhisMockMvcControllerTest extends DhisConvenienceTest impl
     public HttpResponse webRequest( HttpMethod method, String url, List<Header> headers, MediaType contentType,
         String content )
     {
+        return webRequest( buildMockRequest( method, url, headers, contentType, content ) );
+    }
+
+    protected MockHttpServletRequestBuilder buildMockRequest( HttpMethod method, String url, List<Header> headers,
+        MediaType contentType,
+        String content )
+    {
         MockHttpServletRequestBuilder request = MockMvcRequestBuilders.request( method, url );
         for ( Header header : headers )
         {
@@ -92,7 +99,8 @@ public abstract class DhisMockMvcControllerTest extends DhisConvenienceTest impl
         {
             request.content( content );
         }
-        return webRequest( request );
+
+        return request;
     }
 
     protected abstract HttpResponse webRequest( MockHttpServletRequestBuilder request );


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12554
- This is to bring back a part of the old feature in import/export app. Previously in the old struts import/export app we return download file with the file name format `dataValuesStartDate_EndDate_facilityName.json.zip`
- However, when moved to new react app, this function is not included in the new controller.
- This PR added back just a part of the format  which includes start date and end date. The facility name/ orgUnit name is not added back because we allow user to select multiple orgUnits for exporting. Therefore, appending all the orgUnit names to the file name seems not a good solution. 
Example : `dataValues_2022-03-01_2022-03-30.json.zip`

Test
- Added mock test and controller test.