### PR TITLE
chore: tracker entities only support idScheme UID DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -250,7 +250,7 @@ public class TrackerBundle
 
     public TrackedEntityInstance getTrackedEntityInstance( String id )
     {
-        return getPreheat().getTrackedEntity( getIdentifier(), id );
+        return getPreheat().getTrackedEntity( id );
     }
 
     public ProgramInstance getProgramInstance( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -255,7 +255,7 @@ public class TrackerBundle
 
     public ProgramInstance getProgramInstance( String id )
     {
-        return getPreheat().getEnrollment( getIdentifier(), id );
+        return getPreheat().getEnrollment( id );
     }
 
     public ProgramStageInstance getProgramStageInstance( String event )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -260,6 +260,6 @@ public class TrackerBundle
 
     public ProgramStageInstance getProgramStageInstance( String event )
     {
-        return getPreheat().getEvent( getIdentifier(), event );
+        return getPreheat().getEvent( event );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
@@ -82,7 +82,7 @@ public class EnrollmentPersister extends AbstractTrackerPersister<Enrollment, Pr
         Enrollment enrollment, ProgramInstance programInstance )
     {
         handleTrackedEntityAttributeValues( session, preheat, enrollment.getAttributes(),
-            preheat.getTrackedEntity( TrackerIdScheme.UID, programInstance.getEntityInstance().getUid() ) );
+            preheat.getTrackedEntity( programInstance.getEntityInstance().getUid() ) );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EnrollmentPersister.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueAuditService;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
@@ -110,7 +109,7 @@ public class EnrollmentPersister extends AbstractTrackerPersister<Enrollment, Pr
     @Override
     protected void updatePreheat( TrackerPreheat preheat, ProgramInstance programInstance )
     {
-        preheat.putEnrollments( TrackerIdScheme.UID, Collections.singletonList( programInstance ) );
+        preheat.putEnrollments( Collections.singletonList( programInstance ) );
         preheat.addProgramOwner( programInstance.getEntityInstance().getUid(), programInstance.getProgram().getUid(),
             programInstance.getOrganisationUnit() );
     }
@@ -118,7 +117,7 @@ public class EnrollmentPersister extends AbstractTrackerPersister<Enrollment, Pr
     @Override
     protected boolean isNew( TrackerPreheat preheat, String uid )
     {
-        return preheat.getEnrollment( TrackerIdScheme.UID, uid ) == null;
+        return preheat.getEnrollment( uid ) == null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/EventPersister.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityCommentService;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
@@ -110,13 +109,13 @@ public class EventPersister extends AbstractTrackerPersister<Event, ProgramStage
     @Override
     protected void updatePreheat( TrackerPreheat preheat, ProgramStageInstance programStageInstance )
     {
-        preheat.putEvents( TrackerIdScheme.UID, Collections.singletonList( programStageInstance ) );
+        preheat.putEvents( Collections.singletonList( programStageInstance ) );
     }
 
     @Override
     protected boolean isNew( TrackerPreheat preheat, String uid )
     {
-        return preheat.getEvent( TrackerIdScheme.UID, uid ) == null;
+        return preheat.getEvent( uid ) == null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/RelationshipPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/RelationshipPersister.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.bundle.persister;
 import org.hibernate.Session;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueAuditService;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
@@ -102,7 +101,7 @@ public class RelationshipPersister
     @Override
     protected boolean isNew( TrackerPreheat preheat, Relationship trackerDto )
     {
-        return preheat.getRelationship( TrackerIdScheme.UID, trackerDto ) == null;
+        return preheat.getRelationship( trackerDto ) == null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/TrackedEntityPersister.java
@@ -35,7 +35,6 @@ import org.hibernate.Session;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueAuditService;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.TrackerConverterService;
@@ -84,7 +83,7 @@ public class TrackedEntityPersister extends AbstractTrackerPersister<TrackedEnti
     @Override
     protected void updatePreheat( TrackerPreheat preheat, TrackedEntityInstance dto )
     {
-        preheat.putTrackedEntities( TrackerIdScheme.UID, Collections.singletonList( dto ) );
+        preheat.putTrackedEntities( Collections.singletonList( dto ) );
     }
 
     @Override
@@ -102,7 +101,7 @@ public class TrackedEntityPersister extends AbstractTrackerPersister<TrackedEnti
     @Override
     protected boolean isNew( TrackerPreheat preheat, String uid )
     {
-        return preheat.getTrackedEntity( TrackerIdScheme.UID, uid ) == null;
+        return preheat.getTrackedEntity( uid ) == null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -128,7 +128,7 @@ public class EnrollmentTrackerConverterService
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 
         TrackedEntityInstance trackedEntityInstance = preheat
-            .getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() );
+            .getTrackedEntity( enrollment.getTrackedEntity() );
 
         Date now = new Date();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -97,7 +96,7 @@ public class EnrollmentTrackerConverterService
     @Override
     public ProgramInstance from( TrackerPreheat preheat, Enrollment enrollment )
     {
-        ProgramInstance programInstance = preheat.getEnrollment( TrackerIdScheme.UID, enrollment.getEnrollment() );
+        ProgramInstance programInstance = preheat.getEnrollment( enrollment.getEnrollment() );
         return from( preheat, enrollment, programInstance );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -301,7 +301,7 @@ public class EventTrackerConverterService
     {
         if ( ProgramType.WITH_REGISTRATION == program.getProgramType() )
         {
-            return preheat.getEnrollment( identifier, enrollment );
+            return preheat.getEnrollment( enrollment );
         }
 
         if ( ProgramType.WITHOUT_REGISTRATION == program.getProgramType() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.program.UserInfoSnapshot;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.User;
@@ -224,7 +223,7 @@ public class EventTrackerConverterService
         programStageInstance.setCreatedAtClient( DateUtils.fromInstant( event.getCreatedAtClient() ) );
         programStageInstance.setLastUpdatedAtClient( DateUtils.fromInstant( event.getUpdatedAtClient() ) );
         programStageInstance.setProgramInstance(
-            getProgramInstance( preheat, TrackerIdScheme.UID, event.getEnrollment(), program ) );
+            getProgramInstance( preheat, event.getEnrollment(), program ) );
 
         programStageInstance.setProgramStage( programStage );
         programStageInstance.setOrganisationUnit( organisationUnit );
@@ -296,8 +295,7 @@ public class EventTrackerConverterService
         return programStageInstance;
     }
 
-    private ProgramInstance getProgramInstance( TrackerPreheat preheat, TrackerIdScheme identifier, String enrollment,
-        Program program )
+    private ProgramInstance getProgramInstance( TrackerPreheat preheat, String enrollment, Program program )
     {
         if ( ProgramType.WITH_REGISTRATION == program.getProgramType() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -157,7 +157,7 @@ public class EventTrackerConverterService
     @Override
     public ProgramStageInstance from( TrackerPreheat preheat, Event event )
     {
-        ProgramStageInstance programStageInstance = preheat.getEvent( TrackerIdScheme.UID, event.getEvent() );
+        ProgramStageInstance programStageInstance = preheat.getEvent( event.getEvent() );
         return from( preheat, event, programStageInstance );
     }
 
@@ -182,7 +182,7 @@ public class EventTrackerConverterService
     private List<EventDataValue> getProgramStageInstanceDataValues( TrackerPreheat preheat, Event event )
     {
         List<EventDataValue> eventDataValues = new ArrayList<>();
-        ProgramStageInstance programStageInstance = preheat.getEvent( TrackerIdScheme.UID, event.getEvent() );
+        ProgramStageInstance programStageInstance = preheat.getEvent( event.getEvent() );
         if ( programStageInstance == null )
         {
             return eventDataValues;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -150,7 +150,7 @@ public class RelationshipTrackerConverterService
 
         if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
-            fromItem.setTrackedEntityInstance( preheat.getTrackedEntity( TrackerIdScheme.UID,
+            fromItem.setTrackedEntityInstance( preheat.getTrackedEntity(
                 fromRelationship.getFrom().getTrackedEntity().getTrackedEntity() ) );
         }
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
@@ -170,7 +170,7 @@ public class RelationshipTrackerConverterService
 
         if ( relationshipType.getToConstraint().getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
-            toItem.setTrackedEntityInstance( preheat.getTrackedEntity( TrackerIdScheme.UID,
+            toItem.setTrackedEntityInstance( preheat.getTrackedEntity(
                 fromRelationship.getTo().getTrackedEntity().getTrackedEntity() ) );
         }
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -156,7 +156,7 @@ public class RelationshipTrackerConverterService
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
         {
             fromItem.setProgramInstance(
-                preheat.getEnrollment( TrackerIdScheme.UID,
+                preheat.getEnrollment(
                     fromRelationship.getFrom().getEnrollment().getEnrollment() ) );
         }
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
@@ -176,7 +176,7 @@ public class RelationshipTrackerConverterService
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
         {
             toItem.setProgramInstance(
-                preheat.getEnrollment( TrackerIdScheme.UID,
+                preheat.getEnrollment(
                     fromRelationship.getTo().getEnrollment().getEnrollment() ) );
         }
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.commons.util.RelationshipUtils;
 import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -106,7 +105,7 @@ public class RelationshipTrackerConverterService
     public org.hisp.dhis.relationship.Relationship from( TrackerPreheat preheat, Relationship fromRelationship )
     {
         org.hisp.dhis.relationship.Relationship toRelationship = preheat
-            .getRelationship( TrackerIdScheme.UID, fromRelationship );
+            .getRelationship( fromRelationship );
         return from( preheat, fromRelationship, toRelationship );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -162,7 +162,7 @@ public class RelationshipTrackerConverterService
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
             fromItem.setProgramStageInstance(
-                preheat.getEvent( TrackerIdScheme.UID, fromRelationship.getFrom().getEvent().getEvent() ) );
+                preheat.getEvent( fromRelationship.getFrom().getEvent().getEvent() ) );
         }
 
         // TO
@@ -182,7 +182,7 @@ public class RelationshipTrackerConverterService
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
             toItem.setProgramStageInstance(
-                preheat.getEvent( TrackerIdScheme.UID, fromRelationship.getTo().getEvent().getEvent() ) );
+                preheat.getEvent( fromRelationship.getTo().getEvent().getEvent() ) );
         }
 
         toRelationship.setFrom( fromItem );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/TrackedEntityTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/TrackedEntityTrackerConverterService.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.util.DateUtils;
@@ -77,7 +76,7 @@ public class TrackedEntityTrackerConverterService
     public TrackedEntityInstance from( TrackerPreheat preheat,
         TrackedEntity trackedEntity )
     {
-        TrackedEntityInstance tei = preheat.getTrackedEntity( TrackerIdScheme.UID,
+        TrackedEntityInstance tei = preheat.getTrackedEntity(
             trackedEntity.getTrackedEntity() );
         return from( preheat, trackedEntity, tei );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -261,8 +261,7 @@ public class TrackerPreheat
      * confirming existence for updates, and used for object merging.
      */
     @Getter
-    @Setter
-    private Map<TrackerIdScheme, Map<String, TrackedEntityInstance>> trackedEntities = new HashMap<>();
+    private final Map<String, TrackedEntityInstance> trackedEntities = new HashMap<>();
 
     /**
      * Internal map of all preheated tracked entity attributes, mainly used for
@@ -481,20 +480,14 @@ public class TrackerPreheat
         return this;
     }
 
-    public TrackedEntityInstance getTrackedEntity( TrackerIdScheme identifier, String trackedEntity )
+    public TrackedEntityInstance getTrackedEntity( String trackedEntity )
     {
-        if ( !trackedEntities.containsKey( identifier ) )
-        {
-            return null;
-        }
-
-        return trackedEntities.get( identifier ).get( trackedEntity );
+        return trackedEntities.get( trackedEntity );
     }
 
-    public void putTrackedEntities( TrackerIdScheme identifier, List<TrackedEntityInstance> trackedEntityInstances,
-        List<String> allEntities )
+    public void putTrackedEntities( List<TrackedEntityInstance> trackedEntityInstances, List<String> allEntities )
     {
-        putTrackedEntities( identifier, trackedEntityInstances );
+        putTrackedEntities( trackedEntityInstances );
 
         List<String> uidOnDB = trackedEntityInstances.stream()
             .map( BaseIdentifiableObject::getUid )
@@ -507,21 +500,16 @@ public class TrackerPreheat
             .forEach( u -> this.addReference( TrackerType.TRACKED_ENTITY, u ) );
     }
 
-    public void putTrackedEntities( TrackerIdScheme identifier, List<TrackedEntityInstance> trackedEntityInstances )
+    public void putTrackedEntities( List<TrackedEntityInstance> trackedEntityInstances )
     {
 
-        trackedEntityInstances.forEach( te -> putTrackedEntity( identifier, te.getUid(), te ) );
+        trackedEntityInstances.forEach( te -> putTrackedEntity( te.getUid(), te ) );
     }
 
-    private void putTrackedEntity( TrackerIdScheme identifier, String trackedEntity,
+    private void putTrackedEntity( String trackedEntity,
         TrackedEntityInstance trackedEntityInstance )
     {
-        if ( !trackedEntities.containsKey( identifier ) )
-        {
-            trackedEntities.put( identifier, new HashMap<>() );
-        }
-
-        trackedEntities.get( identifier ).put( trackedEntity, trackedEntityInstance );
+        trackedEntities.put( trackedEntity, trackedEntityInstance );
     }
 
     public ProgramInstance getEnrollment( TrackerIdScheme identifier, String enrollment )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.tracker.preheat.RelationshipPreheatKeySupport.getRel
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -294,7 +293,7 @@ public class TrackerPreheat
     /**
      * Internal map of all preheated notes (events and enrollments)
      */
-    private Map<TrackerIdScheme, Map<String, TrackedEntityComment>> notes = new EnumMap<>( TrackerIdScheme.class );
+    private Map<String, TrackedEntityComment> notes = new HashMap<>();
 
     /**
      * Internal map of all existing TrackedEntityProgramOwner. Used for
@@ -566,14 +565,17 @@ public class TrackerPreheat
 
     public void putNotes( List<TrackedEntityComment> trackedEntityComments )
     {
-        // Notes are always using UID scheme
-        notes.put( TrackerIdScheme.UID, trackedEntityComments.stream().collect(
-            Collectors.toMap( TrackedEntityComment::getUid, Function.identity() ) ) );
+        trackedEntityComments.forEach( c -> putNote( c.getUid(), c ) );
+    }
+
+    public void putNote( String uid, TrackedEntityComment comment )
+    {
+        notes.put( uid, comment );
     }
 
     public Optional<TrackedEntityComment> getNote( String uid )
     {
-        return Optional.ofNullable( notes.getOrDefault( TrackerIdScheme.UID, new HashMap<>() ).get( uid ) );
+        return Optional.ofNullable( notes.get( uid ) );
     }
 
     public Relationship getRelationship( org.hisp.dhis.tracker.domain.Relationship relationship )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -263,13 +263,6 @@ public class TrackerPreheat
     private final Map<String, TrackedEntityInstance> trackedEntities = new HashMap<>();
 
     /**
-     * Internal map of all preheated tracked entity attributes, mainly used for
-     * confirming existence for updates, and used for object merging.
-     */
-    @Getter
-    private final Map<TrackerIdScheme, Map<String, TrackedEntityAttributeValue>> trackedEntityAttributes = new HashMap<>();
-
-    /**
      * Internal map of all preheated enrollments, mainly used for confirming
      * existence for updates, and used for object merging.
      */
@@ -294,6 +287,13 @@ public class TrackerPreheat
      * Internal map of all preheated notes (events and enrollments)
      */
     private Map<String, TrackedEntityComment> notes = new HashMap<>();
+
+    /**
+     * Internal map of all preheated tracked entity attributes, mainly used for
+     * confirming existence for updates, and used for object merging.
+     */
+    @Getter
+    private final Map<TrackerIdScheme, Map<String, TrackedEntityAttributeValue>> trackedEntityAttributes = new HashMap<>();
 
     /**
      * Internal map of all existing TrackedEntityProgramOwner. Used for
@@ -474,9 +474,9 @@ public class TrackerPreheat
         return this;
     }
 
-    public TrackedEntityInstance getTrackedEntity( String trackedEntity )
+    public TrackedEntityInstance getTrackedEntity( String uid )
     {
-        return trackedEntities.get( trackedEntity );
+        return trackedEntities.get( uid );
     }
 
     public void putTrackedEntities( List<TrackedEntityInstance> trackedEntityInstances, List<String> allEntities )
@@ -500,15 +500,14 @@ public class TrackerPreheat
         trackedEntityInstances.forEach( te -> putTrackedEntity( te.getUid(), te ) );
     }
 
-    private void putTrackedEntity( String trackedEntity,
-        TrackedEntityInstance trackedEntityInstance )
+    private void putTrackedEntity( String uid, TrackedEntityInstance trackedEntityInstance )
     {
-        trackedEntities.put( trackedEntity, trackedEntityInstance );
+        trackedEntities.put( uid, trackedEntityInstance );
     }
 
-    public ProgramInstance getEnrollment( String enrollment )
+    public ProgramInstance getEnrollment( String uid )
     {
-        return enrollments.get( enrollment );
+        return enrollments.get( uid );
     }
 
     public void putEnrollments( List<ProgramInstance> programInstances, List<Enrollment> allEntities )
@@ -529,14 +528,14 @@ public class TrackerPreheat
         programInstances.forEach( pi -> putEnrollment( pi.getUid(), pi ) );
     }
 
-    public void putEnrollment( String enrollment, ProgramInstance programInstance )
+    public void putEnrollment( String uid, ProgramInstance programInstance )
     {
-        enrollments.put( enrollment, programInstance );
+        enrollments.put( uid, programInstance );
     }
 
-    public ProgramStageInstance getEvent( String event )
+    public ProgramStageInstance getEvent( String uid )
     {
-        return events.get( event );
+        return events.get( uid );
     }
 
     public void putEvents( List<ProgramStageInstance> programStageInstances, List<Event> allEntities )
@@ -558,9 +557,9 @@ public class TrackerPreheat
         programStageInstances.forEach( psi -> putEvent( psi.getUid(), psi ) );
     }
 
-    public void putEvent( String event, ProgramStageInstance programStageInstance )
+    public void putEvent( String uid, ProgramStageInstance programStageInstance )
     {
-        events.put( event, programStageInstance );
+        events.put( uid, programStageInstance );
     }
 
     public void putNotes( List<TrackedEntityComment> trackedEntityComments )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -268,32 +268,29 @@ public class TrackerPreheat
      * confirming existence for updates, and used for object merging.
      */
     @Getter
-    @Setter
-    private Map<TrackerIdScheme, Map<String, TrackedEntityAttributeValue>> trackedEntityAttributes = new HashMap<>();
+    private final Map<TrackerIdScheme, Map<String, TrackedEntityAttributeValue>> trackedEntityAttributes = new HashMap<>();
 
     /**
      * Internal map of all preheated enrollments, mainly used for confirming
      * existence for updates, and used for object merging.
      */
     @Getter
-    @Setter
-    private Map<TrackerIdScheme, Map<String, ProgramInstance>> enrollments = new HashMap<>();
+    private final Map<TrackerIdScheme, Map<String, ProgramInstance>> enrollments = new HashMap<>();
 
     /**
      * Internal map of all preheated events, mainly used for confirming
      * existence for updates, and used for object merging.
      */
     @Getter
-    @Setter
-    private Map<TrackerIdScheme, Map<String, ProgramStageInstance>> events = new HashMap<>();
+    private final Map<TrackerIdScheme, Map<String, ProgramStageInstance>> events = new HashMap<>();
 
     /**
      * Internal map of all preheated relationships, mainly used for confirming
      * existence for updates, and used for object merging.
      */
     @Getter
-    @Setter
-    private Map<TrackerIdScheme, Map<String, Relationship>> relationships = new EnumMap<>( TrackerIdScheme.class );
+    private final Map<TrackerIdScheme, Map<String, Relationship>> relationships = new EnumMap<>(
+        TrackerIdScheme.class );
 
     /**
      * Internal map of all preheated notes (events and enrollments)
@@ -309,8 +306,7 @@ public class TrackerPreheat
      * the ownership OrganisationUnit
      */
     @Getter
-    @Setter
-    private Map<String, Map<String, TrackedEntityProgramOwnerOrgUnit>> programOwner = new HashMap<>();
+    private final Map<String, Map<String, TrackedEntityProgramOwnerOrgUnit>> programOwner = new HashMap<>();
 
     /**
      * A Map of trackedEntity uid connected to Program Instances

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -275,7 +275,7 @@ public class TrackerPreheat
      * existence for updates, and used for object merging.
      */
     @Getter
-    private final Map<TrackerIdScheme, Map<String, ProgramInstance>> enrollments = new HashMap<>();
+    private final Map<String, ProgramInstance> enrollments = new HashMap<>();
 
     /**
      * Internal map of all preheated events, mainly used for confirming
@@ -508,20 +508,14 @@ public class TrackerPreheat
         trackedEntities.put( trackedEntity, trackedEntityInstance );
     }
 
-    public ProgramInstance getEnrollment( TrackerIdScheme identifier, String enrollment )
+    public ProgramInstance getEnrollment( String enrollment )
     {
-        if ( !enrollments.containsKey( identifier ) )
-        {
-            return null;
-        }
-
-        return enrollments.get( identifier ).get( enrollment );
+        return enrollments.get( enrollment );
     }
 
-    public void putEnrollments( TrackerIdScheme identifier, List<ProgramInstance> programInstances,
-        List<Enrollment> allEntities )
+    public void putEnrollments( List<ProgramInstance> programInstances, List<Enrollment> allEntities )
     {
-        putEnrollments( identifier, programInstances );
+        putEnrollments( programInstances );
         List<String> uidOnDB = programInstances.stream().map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toList() );
 
@@ -532,19 +526,14 @@ public class TrackerPreheat
             .forEach( pi -> this.addReference( TrackerType.ENROLLMENT, pi ) );
     }
 
-    public void putEnrollments( TrackerIdScheme identifier, List<ProgramInstance> programInstances )
+    public void putEnrollments( List<ProgramInstance> programInstances )
     {
-        programInstances.forEach( pi -> putEnrollment( identifier, pi.getUid(), pi ) );
+        programInstances.forEach( pi -> putEnrollment( pi.getUid(), pi ) );
     }
 
-    public void putEnrollment( TrackerIdScheme identifier, String enrollment, ProgramInstance programInstance )
+    public void putEnrollment( String enrollment, ProgramInstance programInstance )
     {
-        if ( !enrollments.containsKey( identifier ) )
-        {
-            enrollments.put( identifier, new HashMap<>() );
-        }
-
-        enrollments.get( identifier ).put( enrollment, programInstance );
+        enrollments.put( enrollment, programInstance );
     }
 
     public ProgramStageInstance getEvent( TrackerIdScheme identifier, String event )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -282,7 +282,7 @@ public class TrackerPreheat
      * existence for updates, and used for object merging.
      */
     @Getter
-    private final Map<TrackerIdScheme, Map<String, ProgramStageInstance>> events = new HashMap<>();
+    private final Map<String, ProgramStageInstance> events = new HashMap<>();
 
     /**
      * Internal map of all preheated relationships, mainly used for confirming
@@ -536,20 +536,14 @@ public class TrackerPreheat
         enrollments.put( enrollment, programInstance );
     }
 
-    public ProgramStageInstance getEvent( TrackerIdScheme identifier, String event )
+    public ProgramStageInstance getEvent( String event )
     {
-        if ( !events.containsKey( identifier ) )
-        {
-            return null;
-        }
-
-        return events.get( identifier ).get( event );
+        return events.get( event );
     }
 
-    public void putEvents( TrackerIdScheme identifier, List<ProgramStageInstance> programStageInstances,
-        List<Event> allEntities )
+    public void putEvents( List<ProgramStageInstance> programStageInstances, List<Event> allEntities )
     {
-        putEvents( identifier, programStageInstances );
+        putEvents( programStageInstances );
 
         List<String> uidOnDB = programStageInstances.stream().map( BaseIdentifiableObject::getUid )
             .collect( Collectors.toList() );
@@ -561,19 +555,14 @@ public class TrackerPreheat
             .forEach( psi -> this.addReference( TrackerType.EVENT, psi ) );
     }
 
-    public void putEvents( TrackerIdScheme identifier, List<ProgramStageInstance> programStageInstances )
+    public void putEvents( List<ProgramStageInstance> programStageInstances )
     {
-        programStageInstances.forEach( psi -> putEvent( identifier, psi.getUid(), psi ) );
+        programStageInstances.forEach( psi -> putEvent( psi.getUid(), psi ) );
     }
 
-    public void putEvent( TrackerIdScheme identifier, String event, ProgramStageInstance programStageInstance )
+    public void putEvent( String event, ProgramStageInstance programStageInstance )
     {
-        if ( !events.containsKey( identifier ) )
-        {
-            events.put( identifier, new HashMap<>() );
-        }
-
-        events.get( identifier ).put( event, programStageInstance );
+        events.put( event, programStageInstance );
     }
 
     public void putNotes( List<TrackedEntityComment> trackedEntityComments )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -102,14 +102,14 @@ public class TrackerPreheat
      * value of each id can be either the metadata object's uid, code, name or
      * attribute value
      */
-    private Map<Class<? extends IdentifiableObject>, Map<String, IdentifiableObject>> map = new HashMap<>();
+    private final Map<Class<? extends IdentifiableObject>, Map<String, IdentifiableObject>> map = new HashMap<>();
 
     /**
      * List of all payload references by tracker type which are not present in
      * the database. This will be used to create the reference tree that
      * represents the hierarchical structure of the references.
      */
-    private ArrayListMultimap<TrackerType, ReferenceTrackerEntity> referenceTrackerEntities = ArrayListMultimap
+    private final ArrayListMultimap<TrackerType, ReferenceTrackerEntity> referenceTrackerEntities = ArrayListMultimap
         .create();
 
     /**
@@ -118,7 +118,7 @@ public class TrackerPreheat
      * root objects (TEI, PS, PSI) which are present in the payload but not
      * stored in the pre-heat object (since they do not exist in the db yet).
      */
-    private TreeNode<String> referenceTree = new ArrayMultiTreeNode<>( "ROOT" );
+    private final TreeNode<String> referenceTree = new ArrayMultiTreeNode<>( "ROOT" );
 
     /**
      * Internal map of all default object (like category option combo, etc).
@@ -131,13 +131,13 @@ public class TrackerPreheat
      * All periods available.
      */
     @Getter
-    private Map<String, Period> periodMap = new HashMap<>();
+    private final Map<String, Period> periodMap = new HashMap<>();
 
     /**
      * All periodTypes available.
      */
     @Getter
-    private Map<String, PeriodType> periodTypeMap = new HashMap<>();
+    private final Map<String, PeriodType> periodTypeMap = new HashMap<>();
 
     /**
      * Internal map of category combo + category options (key) to category
@@ -286,7 +286,7 @@ public class TrackerPreheat
     /**
      * Internal map of all preheated notes (events and enrollments)
      */
-    private Map<String, TrackedEntityComment> notes = new HashMap<>();
+    private final Map<String, TrackedEntityComment> notes = new HashMap<>();
 
     /**
      * Internal map of all preheated tracked entity attributes, mainly used for
@@ -316,7 +316,7 @@ public class TrackerPreheat
     /**
      * A Map of program uid and without registration {@see ProgramInstance}.
      */
-    private Map<String, ProgramInstance> programInstancesWithoutRegistration = new HashMap<>();
+    private final Map<String, ProgramInstance> programInstancesWithoutRegistration = new HashMap<>();
 
     /**
      * A map of valid users by username that are present in the payload. A user
@@ -325,7 +325,7 @@ public class TrackerPreheat
      * tracked entity attributes and assignedUser fields in events used in
      * validation and persistence.
      */
-    private Map<String, User> users = Maps.newHashMap();
+    private final Map<String, User> users = Maps.newHashMap();
 
     /**
      * A list of all unique attribute values that are both present in the

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -69,9 +69,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerIdentifierParams;
 import org.hisp.dhis.tracker.TrackerType;
@@ -287,13 +285,6 @@ public class TrackerPreheat
      * Internal map of all preheated notes (events and enrollments)
      */
     private final Map<String, TrackedEntityComment> notes = new HashMap<>();
-
-    /**
-     * Internal map of all preheated tracked entity attributes, mainly used for
-     * confirming existence for updates, and used for object merging.
-     */
-    @Getter
-    private final Map<TrackerIdScheme, Map<String, TrackedEntityAttributeValue>> trackedEntityAttributes = new HashMap<>();
 
     /**
      * Internal map of all existing TrackedEntityProgramOwner. Used for

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -289,8 +289,7 @@ public class TrackerPreheat
      * existence for updates, and used for object merging.
      */
     @Getter
-    private final Map<TrackerIdScheme, Map<String, Relationship>> relationships = new EnumMap<>(
-        TrackerIdScheme.class );
+    private final Map<String, Relationship> relationships = new HashMap<>();
 
     /**
      * Internal map of all preheated notes (events and enrollments)
@@ -577,14 +576,8 @@ public class TrackerPreheat
         return Optional.ofNullable( notes.getOrDefault( TrackerIdScheme.UID, new HashMap<>() ).get( uid ) );
     }
 
-    public Relationship getRelationship( TrackerIdScheme identifier,
-        org.hisp.dhis.tracker.domain.Relationship relationship )
+    public Relationship getRelationship( org.hisp.dhis.tracker.domain.Relationship relationship )
     {
-        if ( !relationships.containsKey( identifier ) )
-        {
-            return null;
-        }
-
         RelationshipType relationshipType = get( RelationshipType.class, relationship.getRelationshipType() );
 
         if ( Objects.nonNull( relationshipType ) )
@@ -599,7 +592,7 @@ public class TrackerPreheat
             }
             return Stream.of( relationshipKey, inverseKey )
                 .filter( Objects::nonNull )
-                .map( key -> relationships.get( identifier ).get( key.asString() ) )
+                .map( key -> relationships.get( key.asString() ) )
                 .filter( Objects::nonNull )
                 .findFirst()
                 .orElse( null );
@@ -607,27 +600,23 @@ public class TrackerPreheat
         return null;
     }
 
-    public void putRelationships( TrackerIdScheme identifier, List<Relationship> relationships )
+    public void putRelationships( List<Relationship> relationships )
     {
-        relationships.forEach( r -> putRelationship( identifier, r ) );
+        relationships.forEach( r -> putRelationship( r ) );
     }
 
-    public void putRelationship( TrackerIdScheme identifier, Relationship relationship )
+    public void putRelationship( Relationship relationship )
     {
-        if ( !relationships.containsKey( identifier ) )
-        {
-            relationships.put( identifier, new HashMap<>() );
-        }
         if ( Objects.nonNull( relationship ) )
         {
             RelationshipKey relationshipKey = getRelationshipKey( relationship );
 
             if ( relationship.getRelationshipType().isBidirectional() )
             {
-                relationships.get( identifier ).put( relationshipKey.inverseKey().asString(), relationship );
+                relationships.put( relationshipKey.inverseKey().asString(), relationship );
             }
 
-            relationships.get( identifier ).put( relationshipKey.asString(), relationship );
+            relationships.put( relationshipKey.asString(), relationship );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -212,8 +212,8 @@ public class TrackerPreheat
 
     /**
      * Get the identifier of a category option combo for given category combo
-     * and semi-colon separated list of category options. For the category
-     * option combo to exist it has to be stored before using
+     * and semicolon separated list of category options. For the category option
+     * combo to exist it has to be stored before using
      * {@link #putCategoryOptionCombo}.
      *
      * Category option identifiers needs to match the idScheme used when storing
@@ -222,7 +222,7 @@ public class TrackerPreheat
      * import.
      *
      * @param categoryCombo category combo
-     * @param categoryOptions semi-colon separated list of category options
+     * @param categoryOptions semicolon separated list of category options
      * @return category option combo identifier
      */
     public String getCategoryOptionComboIdentifier( CategoryCombo categoryCombo, String categoryOptions )
@@ -368,7 +368,7 @@ public class TrackerPreheat
     }
 
     /**
-     * Get a default value from the Preheat
+     * Get a default value from the preheat
      *
      * @param defaultClass The type of object to retrieve
      * @return The default object of the class provided
@@ -431,10 +431,7 @@ public class TrackerPreheat
 
         Class<? extends IdentifiableObject> klass = HibernateProxyUtils.getRealClass( object );
 
-        if ( !map.containsKey( klass ) )
-        {
-            map.put( klass, new HashMap<>() );
-        }
+        map.computeIfAbsent( klass, k -> new HashMap<>() );
 
         if ( User.class.isAssignableFrom( klass ) )
         {
@@ -594,7 +591,7 @@ public class TrackerPreheat
 
     public void putRelationships( List<Relationship> relationships )
     {
-        relationships.forEach( r -> putRelationship( r ) );
+        relationships.forEach( this::putRelationship );
     }
 
     public void putRelationship( Relationship relationship )
@@ -672,21 +669,15 @@ public class TrackerPreheat
     private void addProgramOwner( String teiUid, String programUid,
         TrackedEntityProgramOwnerOrgUnit tepo )
     {
-        if ( !programOwner.containsKey( teiUid ) )
-        {
-            programOwner.put( teiUid, new HashMap<>() );
-        }
-
-        programOwner.get( teiUid ).put( programUid, tepo );
+        programOwner
+            .computeIfAbsent( teiUid, k -> new HashMap<>() )
+            .put( programUid, tepo );
     }
 
     public void addProgramOwner( String teiUid, String programUid,
         OrganisationUnit orgUnit )
     {
-        if ( !programOwner.containsKey( teiUid ) )
-        {
-            programOwner.put( teiUid, new HashMap<>() );
-        }
+        programOwner.computeIfAbsent( teiUid, k -> new HashMap<>() );
         if ( !programOwner.get( teiUid ).containsKey( programUid ) )
         {
             TrackedEntityProgramOwnerOrgUnit tepo = new TrackedEntityProgramOwnerOrgUnit( teiUid, programUid,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
@@ -81,13 +81,6 @@ public abstract class AbstractPreheatSupplier implements PreheatSupplier
      */
     public abstract void preheatAdd( TrackerImportParams params, TrackerPreheat preheat );
 
-    protected void addToCache( PreheatCacheService cache, List<? extends IdentifiableObject> objects, int ttl,
-        long capacity )
-    {
-        objects.forEach(
-            rt -> cache.put( HibernateProxyUtils.getRealClass( rt ).getName(), rt.getUid(), rt, ttl, capacity ) );
-    }
-
     protected void addToCache( PreheatCacheService cache, List<? extends IdentifiableObject> objects )
     {
         objects.forEach( rt -> cache.put( HibernateProxyUtils.getRealClass( rt ).getName(), rt.getUid(), rt, CACHE_TTL,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/AbstractPreheatSupplier.java
@@ -35,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.time.StopWatch;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
-import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
@@ -81,11 +80,6 @@ public abstract class AbstractPreheatSupplier implements PreheatSupplier
      * Template method: executes preheat logic from the subclass
      */
     public abstract void preheatAdd( TrackerImportParams params, TrackerPreheat preheat );
-
-    protected void addToPreheat( TrackerPreheat preheat, List<? extends IdentifiableObject> relationshipTypes )
-    {
-        preheat.put( TrackerIdentifier.UID, relationshipTypes );
-    }
 
     protected void addToCache( PreheatCacheService cache, List<? extends IdentifiableObject> objects, int ttl,
         long capacity )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
@@ -67,7 +67,7 @@ public class ClassBasedSupplier
     private final TrackerIdentifierCollector identifierCollector;
 
     /**
-     * A Map correlating a Tracker class name to the Preheat strategy class name
+     * A Map correlating a Tracker class name to the preheat strategy class name
      * to use to load the data
      */
     @Qualifier( "preheatStrategies" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplier.java
@@ -36,6 +36,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodStore;
+import org.hisp.dhis.tracker.TrackerIdentifier;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
@@ -59,7 +60,7 @@ public class PeriodTypeSupplier extends AbstractPreheatSupplier
     {
         if ( cache.hasKey( Period.class.getName() ) )
         {
-            addToPreheat( preheat, cache.getAll( Period.class.getName() ) );
+            preheat.put( TrackerIdentifier.UID, cache.getAll( Period.class.getName() ) );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstancesWithAtLeastOneEventSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstancesWithAtLeastOneEventSupplier.java
@@ -28,14 +28,12 @@
 package org.hisp.dhis.tracker.preheat.supplier;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -70,9 +68,7 @@ public class ProgramInstancesWithAtLeastOneEventSupplier extends JdbcAbstractPre
     @Override
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
-        final Map<TrackerIdScheme, Map<String, ProgramInstance>> enrollmentsMap = preheat.getEnrollments();
-        final Map<String, ProgramInstance> enrollments = enrollmentsMap.getOrDefault( TrackerIdScheme.UID,
-            new HashMap<>() );
+        final Map<String, ProgramInstance> enrollments = preheat.getEnrollments();
         List<Long> programStageIds = enrollments.values().stream().map( BaseIdentifiableObject::getId )
             .collect( Collectors.toList() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
@@ -61,9 +61,7 @@ public class ProgramOwnerSupplier extends AbstractPreheatSupplier
     @Override
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
-        final Map<String, TrackedEntityInstance> preheatedTrackedEntities = preheat.getTrackedEntities().getOrDefault(
-            TrackerIdScheme.UID,
-            new HashMap<>() );
+        final Map<String, TrackedEntityInstance> preheatedTrackedEntities = preheat.getTrackedEntities();
         final Map<String, ProgramInstance> preheatedEnrollments = preheat.getEnrollments().getOrDefault(
             TrackerIdScheme.UID,
             new HashMap<>() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.preheat.supplier;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +40,6 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerStore;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.mappers.OrganisationUnitMapper;
@@ -62,9 +60,7 @@ public class ProgramOwnerSupplier extends AbstractPreheatSupplier
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
         final Map<String, TrackedEntityInstance> preheatedTrackedEntities = preheat.getTrackedEntities();
-        final Map<String, ProgramInstance> preheatedEnrollments = preheat.getEnrollments().getOrDefault(
-            TrackerIdScheme.UID,
-            new HashMap<>() );
+        final Map<String, ProgramInstance> preheatedEnrollments = preheat.getEnrollments();
         Set<Long> teiIds = new HashSet<>();
         params.getEnrollments().stream().forEach( en -> {
             TrackedEntityInstance tei = preheatedTrackedEntities.get( en.getTrackedEntity() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
@@ -51,7 +51,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
@@ -125,7 +124,7 @@ public class UniqueAttributesSupplier extends AbstractPreheatSupplier
 
     private TrackedEntity getEntityForEnrollment( TrackerImportParams params, TrackerPreheat preheat, String teiUid )
     {
-        TrackedEntityInstance trackedEntity = preheat.getTrackedEntity( TrackerIdScheme.UID, teiUid );
+        TrackedEntityInstance trackedEntity = preheat.getTrackedEntity( teiUid );
 
         // Get tei from Preheat
         Optional<TrackedEntity> optionalTei = params.getTrackedEntities()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EnrollmentStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EnrollmentStrategy.java
@@ -35,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramInstanceStore;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
@@ -64,7 +63,7 @@ public class EnrollmentStrategy implements ClassBasedSupplierStrategy
             final List<String> rootEntities = params.getEnrollments().stream().map( Enrollment::getEnrollment )
                 .collect( Collectors.toList() );
 
-            preheat.putEnrollments( TrackerIdScheme.UID,
+            preheat.putEnrollments(
                 DetachUtils.detach( this.getClass().getAnnotation( StrategyFor.class ).mapper(), programInstances ),
                 params.getEnrollments().stream().filter(
                     e -> RootEntitiesUtils.filterOutNonRootEntities( ids, rootEntities ).contains( e.getEnrollment() ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EventStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EventStrategy.java
@@ -35,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceStore;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
@@ -64,7 +63,7 @@ public class EventStrategy implements ClassBasedSupplierStrategy
             final List<String> rootEntities = params.getEvents().stream().map( Event::getEvent )
                 .collect( Collectors.toList() );
 
-            preheat.putEvents( TrackerIdScheme.UID,
+            preheat.putEvents(
                 DetachUtils.detach( this.getClass().getAnnotation( StrategyFor.class ).mapper(),
                     programStageInstances ),
                 params.getEvents().stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/RelationshipStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/RelationshipStrategy.java
@@ -35,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.relationship.RelationshipStore;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
@@ -59,7 +58,7 @@ public class RelationshipStrategy implements ClassBasedSupplierStrategy
     {
         List<org.hisp.dhis.relationship.Relationship> relationships = retrieveRelationships( splitList );
 
-        preheat.putRelationships( TrackerIdScheme.UID,
+        preheat.putRelationships(
             DetachUtils.detach( this.getClass().getAnnotation( StrategyFor.class ).mapper(), relationships ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategy.java
@@ -35,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceStore;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.DetachUtils;
@@ -70,7 +69,7 @@ public class TrackerEntityInstanceStrategy implements ClassBasedSupplierStrategy
                 .collect( Collectors.toList() );
 
             // Add to preheat
-            preheat.putTrackedEntities( TrackerIdScheme.UID,
+            preheat.putTrackedEntities(
                 DetachUtils.detach( this.getClass().getAnnotation( StrategyFor.class ).mapper(),
                     trackedEntityInstances ),
                 RootEntitiesUtils.filterOutNonRootEntities( ids, rootEntities ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
@@ -64,7 +64,7 @@ public class StrategyPreProcessor
         {
             TrackerImportStrategy importStrategy = bundle.getImportStrategy();
 
-            TrackedEntityInstance existingTei = bundle.getPreheat().getTrackedEntity( TrackerIdScheme.UID,
+            TrackedEntityInstance existingTei = bundle.getPreheat().getTrackedEntity(
                 tei.getTrackedEntity() );
 
             if ( importStrategy.isCreateAndUpdate() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.preprocess;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -144,7 +143,7 @@ public class StrategyPreProcessor
         {
             TrackerImportStrategy importStrategy = bundle.getImportStrategy();
             org.hisp.dhis.relationship.Relationship existingRelationship = bundle.getPreheat()
-                .getRelationship( TrackerIdScheme.UID, relationship );
+                .getRelationship( relationship );
 
             if ( importStrategy.isCreateAndUpdate() )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
@@ -91,7 +91,7 @@ public class StrategyPreProcessor
         {
             TrackerImportStrategy importStrategy = bundle.getImportStrategy();
 
-            ProgramInstance existingPI = bundle.getPreheat().getEnrollment( TrackerIdScheme.UID,
+            ProgramInstance existingPI = bundle.getPreheat().getEnrollment(
                 enrollment.getEnrollment() );
 
             if ( importStrategy.isCreateAndUpdate() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessor.java
@@ -118,7 +118,7 @@ public class StrategyPreProcessor
         {
             TrackerImportStrategy importStrategy = bundle.getImportStrategy();
 
-            ProgramStageInstance existingPsi = bundle.getPreheat().getEvent( TrackerIdScheme.UID, event.getEvent() );
+            ProgramStageInstance existingPsi = bundle.getPreheat().getEvent( event.getEvent() );
 
             if ( importStrategy.isCreateAndUpdate() )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -123,7 +123,7 @@ public class DefaultTrackerProgramRuleService
             .from( bundle.getPreheat(), enrollment.getAttributes() );
 
         TrackedEntityInstance trackedEntity = bundle.getPreheat()
-            .getTrackedEntity( bundle.getIdentifier(), enrollment.getTrackedEntity() );
+            .getTrackedEntity( enrollment.getTrackedEntity() );
 
         List<TrackedEntityAttributeValue> payloadAttributeValues = bundle
             .getTrackedEntity( enrollment.getTrackedEntity() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -205,7 +205,6 @@ public class DefaultTrackerProgramRuleService
         // and are not present in the payload
         Stream<ProgramStageInstance> programStageInstances = bundle.getPreheat().getEvents().values()
             .stream()
-            .flatMap( psi -> psi.values().stream() )
             .filter( e -> e.getProgramInstance().getUid().equals( enrollment ) )
             .filter( e -> !bundleEventUids.contains( e.getUid() ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.programrule.engine.ProgramRuleEngine;
 import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerProgramRuleService;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.converter.RuleEngineConverterService;
@@ -194,7 +193,7 @@ public class DefaultTrackerProgramRuleService
 
     private ProgramInstance getEnrollment( TrackerBundle bundle, String enrollmentUid )
     {
-        return bundle.getPreheat().getEnrollment( TrackerIdScheme.UID, enrollmentUid );
+        return bundle.getPreheat().getEnrollment( enrollmentUid );
     }
 
     private Set<ProgramStageInstance> getEventsFromEnrollment( String enrollment, TrackerBundle bundle )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -41,7 +41,6 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionAttribute;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.DataValue;
@@ -189,7 +188,7 @@ abstract public class AbstractRuleActionImplementer<T extends RuleAction>
                 e -> {
                     Enrollment enrollment = getEnrollment( bundle, e.getKey() ).get();
                     TrackedEntityInstance tei = bundle.getPreheat()
-                        .getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() );
+                        .getTrackedEntity( enrollment.getTrackedEntity() );
 
                     List<Attribute> payloadTeiAttributes = getTrackedEntity( bundle, enrollment.getTrackedEntity() )
                         .map( te -> te.getAttributes() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
@@ -189,7 +188,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         return Optional.of( reporter )
             .map( ValidationErrorReporter::getBundle )
             .map( TrackerBundle::getPreheat )
-            .map( trackerPreheat -> trackerPreheat.getTrackedEntity( TrackerIdScheme.UID, trackedEntityInstanceUid ) )
+            .map( trackerPreheat -> trackerPreheat.getTrackedEntity( trackedEntityInstanceUid ) )
             .map( TrackedEntityInstance::getTrackedEntityAttributeValues )
             .orElse( Collections.emptySet() )
             .stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -136,7 +136,7 @@ public class PreCheckExistenceValidationHook
     {
         TrackerBundle bundle = reporter.getBundle();
         TrackerPreheat preheat = bundle.getPreheat();
-        org.hisp.dhis.relationship.Relationship existingRelationship = preheat.getRelationship( bundle.getIdentifier(),
+        org.hisp.dhis.relationship.Relationship existingRelationship = preheat.getRelationship(
             relationship );
 
         if ( existingRelationship != null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.User;
@@ -220,7 +219,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         // dataValues will be merged
         DataValue newDataValue = dataValue( dataElement.getUid(), "900" );
         Event event = event( existingPsi.getUid(), newDataValue );
-        when( preheat.getEvent( TrackerIdScheme.UID, existingPsi.getUid() ) ).thenReturn( existingPsi );
+        when( preheat.getEvent( existingPsi.getUid() ) ).thenReturn( existingPsi );
 
         ProgramStageInstance programStageInstance = converter.fromForRuleEngine( preheat, event );
 
@@ -250,7 +249,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         // to UID
         DataValue updatedValue = dataValue( dataElement.getUid(), "900" );
         Event event = event( existingPsi.getUid(), updatedValue );
-        when( preheat.getEvent( TrackerIdScheme.UID, event.getEvent() ) ).thenReturn( existingPsi );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( existingPsi );
 
         ProgramStageInstance programStageInstance = converter.fromForRuleEngine( preheat, event );
 
@@ -283,7 +282,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         // to CODE
         DataValue updatedValue = dataValue( dataElement.getCode(), "900" );
         Event event = event( existingPsi.getUid(), updatedValue );
-        when( preheat.getEvent( TrackerIdScheme.UID, event.getEvent() ) ).thenReturn( existingPsi );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( existingPsi );
 
         ProgramStageInstance programStageInstance = converter.fromForRuleEngine( preheat, event );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
@@ -136,8 +136,8 @@ class TrackerPreheatServiceIntegrationTest extends TransactionalIntegrationTest
             .identifiers( TrackerIdentifierParams.builder()
                 .idScheme( TrackerIdentifier.UID )
                 .orgUnitIdScheme( TrackerIdentifier.CODE )
-                .programIdScheme(
-                    TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
+                    .programIdScheme(
+                            TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
                 .build() )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
@@ -136,8 +136,8 @@ class TrackerPreheatServiceIntegrationTest extends TransactionalIntegrationTest
             .identifiers( TrackerIdentifierParams.builder()
                 .idScheme( TrackerIdentifier.UID )
                 .orgUnitIdScheme( TrackerIdentifier.CODE )
-                    .programIdScheme(
-                            TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
+                .programIdScheme(
+                    TrackerIdentifier.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( ATTRIBUTE_UID ).build() )
                 .build() )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -312,7 +312,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
         teiList.add( tei );
         List<String> allEntities = new ArrayList<>();
         allEntities.add( CodeGenerator.generateUid() );
-        preheat.putTrackedEntities( TrackerIdScheme.UID, teiList, allEntities );
+        preheat.putTrackedEntities( teiList, allEntities );
         // Create 2 Enrollments, where TEI is parent
         ProgramInstance programInstance = new ProgramInstance();
         programInstance.setUid( CodeGenerator.generateUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -380,7 +380,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
                 setEnrollment( allPs.get( 1 ).getEnrollment() );
             }
         } );
-        preheat.putEvents( TrackerIdScheme.UID, psiList, allEvents );
+        preheat.putEvents( psiList, allEvents );
         preheat.createReferenceTree();
         Optional<ReferenceTrackerEntity> reference = preheat.getReference( allEvents.get( 0 ).getUid() );
         assertThat( reference.get().getUid(), is( allEvents.get( 0 ).getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -337,7 +337,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
                 setTrackedEntity( allEntities.get( 0 ) );
             }
         } );
-        preheat.putEnrollments( TrackerIdScheme.UID, psList, allPs );
+        preheat.putEnrollments( psList, allPs );
         // Create 4 Enrollments, where TEI is parent
         ProgramStageInstance psi = new ProgramStageInstance();
         psi.setUid( CodeGenerator.generateUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
@@ -128,7 +128,7 @@ class StrategyPreProcessorTest extends DhisConvenienceTest
         payloadRelationship.setRelationship( RELATIONSHIP_UID );
         newPayloadRelationship = new org.hisp.dhis.tracker.domain.Relationship();
         newPayloadRelationship.setRelationship( NEW_RELATIONSHIP_UID );
-        Mockito.when( preheat.getTrackedEntity( TrackerIdScheme.UID, TEI_UID ) ).thenReturn( tei );
+        Mockito.when( preheat.getTrackedEntity( TEI_UID ) ).thenReturn( tei );
         Mockito.when( preheat.getEnrollment( TrackerIdScheme.UID, ENROLLMENT_UID ) ).thenReturn( pi );
         Mockito.when( preheat.getEvent( TrackerIdScheme.UID, EVENT_UID ) ).thenReturn( psi );
         Mockito.when( preheat.getRelationship( TrackerIdScheme.UID, payloadRelationship ) ).thenReturn( relationship );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -131,7 +130,7 @@ class StrategyPreProcessorTest extends DhisConvenienceTest
         Mockito.when( preheat.getTrackedEntity( TEI_UID ) ).thenReturn( tei );
         Mockito.when( preheat.getEnrollment( ENROLLMENT_UID ) ).thenReturn( pi );
         Mockito.when( preheat.getEvent( EVENT_UID ) ).thenReturn( psi );
-        Mockito.when( preheat.getRelationship( TrackerIdScheme.UID, payloadRelationship ) ).thenReturn( relationship );
+        Mockito.when( preheat.getRelationship( payloadRelationship ) ).thenReturn( relationship );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
@@ -129,7 +129,7 @@ class StrategyPreProcessorTest extends DhisConvenienceTest
         newPayloadRelationship = new org.hisp.dhis.tracker.domain.Relationship();
         newPayloadRelationship.setRelationship( NEW_RELATIONSHIP_UID );
         Mockito.when( preheat.getTrackedEntity( TEI_UID ) ).thenReturn( tei );
-        Mockito.when( preheat.getEnrollment( TrackerIdScheme.UID, ENROLLMENT_UID ) ).thenReturn( pi );
+        Mockito.when( preheat.getEnrollment( ENROLLMENT_UID ) ).thenReturn( pi );
         Mockito.when( preheat.getEvent( TrackerIdScheme.UID, EVENT_UID ) ).thenReturn( psi );
         Mockito.when( preheat.getRelationship( TrackerIdScheme.UID, payloadRelationship ) ).thenReturn( relationship );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/StrategyPreProcessorTest.java
@@ -130,7 +130,7 @@ class StrategyPreProcessorTest extends DhisConvenienceTest
         newPayloadRelationship.setRelationship( NEW_RELATIONSHIP_UID );
         Mockito.when( preheat.getTrackedEntity( TEI_UID ) ).thenReturn( tei );
         Mockito.when( preheat.getEnrollment( ENROLLMENT_UID ) ).thenReturn( pi );
-        Mockito.when( preheat.getEvent( TrackerIdScheme.UID, EVENT_UID ) ).thenReturn( psi );
+        Mockito.when( preheat.getEvent( EVENT_UID ) ).thenReturn( psi );
         Mockito.when( preheat.getRelationship( TrackerIdScheme.UID, payloadRelationship ) ).thenReturn( relationship );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
@@ -142,7 +141,7 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( new HashSet<>(
                 Arrays.asList( new TrackedEntityAttributeValue( trackedEntityAttribute, trackedEntityInstance ),
                     new TrackedEntityAttributeValue( trackedEntityAttribute1, trackedEntityInstance ) ) ) );
-        when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
+        when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -170,7 +169,7 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( new HashSet<>(
                 Arrays.asList( new TrackedEntityAttributeValue( trackedEntityAttribute, trackedEntityInstance ),
                     new TrackedEntityAttributeValue( trackedEntityAttribute1, trackedEntityInstance ) ) ) );
-        when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
+        when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -196,7 +195,7 @@ class EnrollmentAttributeValidationHookTest
         when( trackedEntityInstance.getTrackedEntityAttributeValues() )
             .thenReturn( new HashSet<>( Collections
                 .singletonList( new TrackedEntityAttributeValue( trackedEntityAttribute, trackedEntityInstance ) ) ) );
-        when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
+        when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -222,7 +221,7 @@ class EnrollmentAttributeValidationHookTest
         when( trackedEntityInstance.getTrackedEntityAttributeValues() )
             .thenReturn( new HashSet<>( Collections
                 .singletonList( new TrackedEntityAttributeValue( trackedEntityAttribute, trackedEntityInstance ) ) ) );
-        when( preheat.getTrackedEntity( TrackerIdScheme.UID, enrollment.getTrackedEntity() ) )
+        when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -121,7 +121,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
         when( bundle.getProgramStageInstance( SOFT_DELETED_EVENT_UID ) ).thenReturn( getSoftDeletedEvent() );
         when( bundle.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
-        when( preheat.getRelationship( bundle.getIdentifier(), getPayloadRelationship() ) )
+        when( preheat.getRelationship( getPayloadRelationship() ) )
             .thenReturn( getRelationship() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -122,7 +121,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         // when
         bundle.setStrategy( event, TrackerImportStrategy.CREATE );
 
-        when( preheat.getEnrollment( TrackerIdScheme.UID, event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
         when( preheat.getProgramStageWithEvents() )
             .thenReturn( Lists.newArrayList( Pair.of( event.getProgramStage(), event.getEnrollment() ) ) );
         bundle.setEvents( Lists.newArrayList( event ) );


### PR DESCRIPTION
TrackerPreheat does not need to keep track of tracker entities per idScheme as they are only identified using UIDs.

additionally:
* fixed some linting issues
* removed unused methods