### PR TITLE
fix: NotificationMap capacity cap does not accidentially clear entries [DHIS2-12992]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
@@ -43,7 +43,9 @@ import org.hisp.dhis.scheduling.JobType;
 @Slf4j
 public class InMemoryNotifier implements Notifier
 {
-    private final NotificationMap notificationMap = new NotificationMap();
+    public static final int MAX_POOL_TYPE_SIZE = 500;
+
+    private final NotificationMap notificationMap = new NotificationMap( MAX_POOL_TYPE_SIZE );
 
     // -------------------------------------------------------------------------
     // Notifier implementation

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationMapTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationMapTest.java
@@ -28,42 +28,85 @@
 package org.hisp.dhis.system.notification;
 
 import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
-import static org.hisp.dhis.system.notification.NotificationMap.MAX_POOL_TYPE_SIZE;
+import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Optional;
+import java.util.Date;
+import java.util.Deque;
+import java.util.Map;
 
 import org.hisp.dhis.scheduling.JobConfiguration;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class NotificationMapTest
 {
-
-    private final NotificationMap mapToTest = new NotificationMap();
+    private final NotificationMap notifications = new NotificationMap( 50 );
 
     @Test
     void testFirstSummaryToBeCreatedIsTheFirstOneToBeRemoved()
     {
+        final int maxSize = 50;
         // Fill the map with jobs
-        JobConfiguration jobConfiguration = new JobConfiguration( null, DATAVALUE_IMPORT, "userId", false );
-        for ( int i = 0; i < MAX_POOL_TYPE_SIZE; i++ )
+        JobConfiguration config = new JobConfiguration( null, DATAVALUE_IMPORT, "userId", false );
+        addSummaryEntries( config, maxSize );
+        // Add one more
+        config.setUid( String.valueOf( maxSize ) );
+        notifications.addSummary( config, maxSize );
+        // Check that oldest job is not in the map anymore
+        assertFalse( notifications.getJobSummariesForJobType( config.getJobType() ).containsKey( "0" ) );
+        // Add one more
+        config.setUid( String.valueOf( maxSize + 1 ) );
+        notifications.addSummary( config, maxSize + 1 );
+        // Check that oldest job is not in the map anymore
+        assertFalse( notifications.getJobSummariesForJobType( config.getJobType() ).containsKey( "1" ) );
+    }
+
+    @Test
+    void testFirstNotificationToBeCreatedIsTheFirstOneToBeRemoved()
+    {
+        final int maxSize = 50;
+        // Fill the map with jobs
+        JobConfiguration config = new JobConfiguration( null, DATAVALUE_IMPORT, "userId", false );
+        config.setUid( "1" );
+        addNotificationEntries( config, maxSize );
+
+        Map<String, Deque<Notification>> typeNotification = notifications
+            .getNotificationsWithType( config.getJobType() );
+        Deque<Notification> jobNotifications = typeNotification.get( config.getUid() );
+        assertNotNull( jobNotifications );
+        assertEquals( maxSize, jobNotifications.size() );
+        // Add one more
+        notifications.add( config, newNotification( config, maxSize ) );
+        // Check that oldest job is not in the map anymore
+        assertFalse( jobNotifications.stream().anyMatch( n -> "0".equals( n.getMessage() ) ) );
+        assertTrue( jobNotifications.stream().anyMatch( n -> (maxSize + "").equals( n.getMessage() ) ) );
+        assertEquals( maxSize, jobNotifications.size() );
+        // Add one more
+        notifications.add( config, newNotification( config, maxSize + 1 ) );
+        // Check that oldest job is not in the map anymore
+        assertFalse( jobNotifications.stream().anyMatch( n -> "1".equals( n.getMessage() ) ) );
+        assertTrue( jobNotifications.stream().anyMatch( n -> ((maxSize + 1) + "").equals( n.getMessage() ) ) );
+        assertEquals( maxSize, jobNotifications.size() );
+    }
+
+    private void addSummaryEntries( JobConfiguration config, int n )
+    {
+        for ( int i = 0; i < n; i++ )
         {
-            jobConfiguration.setUid( String.valueOf( i ) );
-            mapToTest.addSummary( jobConfiguration, i );
+            config.setUid( String.valueOf( i ) );
+            notifications.addSummary( config, i );
         }
-        // Add one more
-        jobConfiguration.setUid( String.valueOf( MAX_POOL_TYPE_SIZE ) );
-        mapToTest.addSummary( jobConfiguration, MAX_POOL_TYPE_SIZE );
-        // Check that oldest job is not in the map anymore
-        Optional<String> notPresentSummary = mapToTest.getJobSummariesForJobType( DATAVALUE_IMPORT ).keySet().stream()
-            .filter( object -> object.equals( "0" ) ).findAny();
-        Assertions.assertFalse( notPresentSummary.isPresent() );
-        // Add one more
-        jobConfiguration.setUid( String.valueOf( MAX_POOL_TYPE_SIZE + 1 ) );
-        mapToTest.addSummary( jobConfiguration, MAX_POOL_TYPE_SIZE + 1 );
-        // Check that oldest job is not in the map anymore
-        notPresentSummary = mapToTest.getJobSummariesForJobType( DATAVALUE_IMPORT ).keySet().stream()
-            .filter( object -> object.equals( "1" ) ).findAny();
-        Assertions.assertFalse( notPresentSummary.isPresent() );
+    }
+
+    private void addNotificationEntries( JobConfiguration config, int n )
+    {
+        for ( int i = 0; i < n; i++ )
+        {
+            notifications.add( config, newNotification( config, i ) );
+        }
+    }
+
+    private Notification newNotification( JobConfiguration config, int no )
+    {
+        return new Notification( NotificationLevel.INFO, config.getJobType(), new Date(), "" + no, false );
     }
 }


### PR DESCRIPTION
### Summary
The issue was that when capacity was reached for a `JobType` entry list the `removeLast()` to remove the oldest entry was called on the wrong collection. Instead of removing an entry from the list of a particular `JobConfiguration` for that `JobType` the complete list was removed from the map.

This affected the `Notification`s but not the summary objects.

### Automatic Testing
This seemed an issue best tested using unit tests. 
I added a new test for this. 
To allow better testing I also made the capacity a parameter.