### PR TITLE
feat: add null and removeZeros() DHIS2-8061

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -636,27 +636,31 @@ public class DefaultExpressionService
             {
                 return null;
             }
+            break;
 
         case SKIP_IF_ALL_VALUES_MISSING:
             if ( itemsFound != 0 && itemValuesFound == 0 )
             {
                 return null;
             }
+            break;
 
         case NEVER_SKIP:
-            if ( value == null )
+            break;
+        }
+
+        if ( value == null && state.isReplaceNulls() )
+        {
+            switch ( params.getDataType() )
             {
-                switch ( params.getDataType() )
-                {
-                case NUMERIC:
-                    return 0d;
+            case NUMERIC:
+                return 0d;
 
-                case BOOLEAN:
-                    return FALSE;
+            case BOOLEAN:
+                return FALSE;
 
-                case TEXT:
-                    return "";
-                }
+            case TEXT:
+                return "";
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -1056,6 +1056,22 @@ class ExpressionServiceTest extends DhisSpringTest
     }
 
     @Test
+    void testNull()
+    {
+        assertEquals( "null", eval( "null" ) );
+        assertEquals( "null", eval( "1 - null" ) );
+    }
+
+    @Test
+    public void testRemoveZeros()
+    {
+        assertEquals( "null", eval( "removeZeros( 0 )" ) );
+        assertEquals( "null", eval( "removeZeros( 10 - 2 * 5 )" ) );
+        assertEquals( "10", eval( "removeZeros( 10 )" ) );
+        assertEquals( "8", eval( "removeZeros( 10 - 2 )" ) );
+    }
+
+    @Test
     void testDataElementAndDataElementOperand()
     {
         assertEquals( "HllvX50cXC0", categoryService.getDefaultCategoryOptionCombo().getUid() );

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -51,10 +51,12 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MOD;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MUL;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NOT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NULL;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.OR;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PAREN;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PLUS;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.POWER;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.REMOVE_ZEROS;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.VERTICAL_BAR_2;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 
@@ -70,6 +72,8 @@ import org.hisp.dhis.parser.expression.function.FunctionIsNull;
 import org.hisp.dhis.parser.expression.function.FunctionLeast;
 import org.hisp.dhis.parser.expression.function.FunctionLog;
 import org.hisp.dhis.parser.expression.function.FunctionLog10;
+import org.hisp.dhis.parser.expression.function.FunctionRemoveZeros;
+import org.hisp.dhis.parser.expression.literal.NullLiteral;
 import org.hisp.dhis.parser.expression.operator.OperatorCompareEqual;
 import org.hisp.dhis.parser.expression.operator.OperatorCompareGreaterThan;
 import org.hisp.dhis.parser.expression.operator.OperatorCompareGreaterThanOrEqual;
@@ -135,7 +139,7 @@ public class ParserUtils
         .put( GEQ, new OperatorCompareGreaterThanOrEqual() )
         .put( LEQ, new OperatorCompareLessThanOrEqual() )
 
-        // Functions
+        // Functions (alphabetical)
 
         .put( FIRST_NON_NULL, new FunctionFirstNonNull() )
         .put( GREATEST, new FunctionGreatest() )
@@ -145,10 +149,15 @@ public class ParserUtils
         .put( LEAST, new FunctionLeast() )
         .put( LOG, new FunctionLog() )
         .put( LOG10, new FunctionLog10() )
+        .put( REMOVE_ZEROS, new FunctionRemoveZeros() )
 
         // Data items
 
         .put( C_BRACE, new ItemConstant() )
+
+        // Literal
+
+        .put( NULL, new NullLiteral() )
 
         .build();
 

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionRemoveZeros.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionRemoveZeros.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
+
+/**
+ * Replace any zero value with a null
+ *
+ * @author Jim Grace
+ */
+public class FunctionRemoveZeros
+    implements ExpressionItem
+{
+    private static final Double ZERO = Double.valueOf( 0.0 );
+
+    @Override
+    public final Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        Object value = visitor.visit( ctx.expr( 0 ) );
+
+        if ( ZERO.equals( value ) )
+        {
+            // Don't replace this null with a zero:
+            visitor.getState().setReplaceNulls( false );
+
+            return null;
+        }
+
+        return value;
+    }
+
+    @Override
+    public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        String value = visitor.castStringVisit( ctx.expr( 0 ) );
+
+        return " case " + value + " when 0 then null else " + value + " end";
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/literal/NullLiteral.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/literal/NullLiteral.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.literal;
+
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.parser.expression.antlr.ExpressionParser;
+
+/**
+ * Provides a null value
+ *
+ * @author Jim Grace
+ */
+public class NullLiteral
+    implements ExpressionItem
+{
+    @Override
+    public final Object evaluate( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        // Don't replace this null with a zero:
+        visitor.getState().setReplaceNulls( false );
+
+        return null;
+    }
+
+    @Override
+    public Object getSql( ExpressionParser.ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        return "null";
+    }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -63,7 +63,7 @@
         <!-- *Dependencies* -->
 
         <!-- DHIS2 Rule Engine-->
-        <dhis2-rule-engine.version>2.0.37</dhis2-rule-engine.version>
+        <dhis2-rule-engine.version>2.0.38</dhis2-rule-engine.version>
 
         <!-- HISP Quick and Staxwax -->
         <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>
@@ -230,7 +230,7 @@
         <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <jrebel-x-maven-plugin.version>1.1.10</jrebel-x-maven-plugin.version>
-        <dhis-antlr-expression-parser.version>1.0.26</dhis-antlr-expression-parser.version>
+        <dhis-antlr-expression-parser.version>1.0.27</dhis-antlr-expression-parser.version>
         <jai-imageio.version>1.1.1</jai-imageio.version>
         <ow2.asm.version>9.2</ow2.asm.version>
         <gson.version>2.8.9</gson.version>


### PR DESCRIPTION
This PR implements the `null` expression keyword and the `removeZeros()` expression function as defined in [DHIS2-8061](https://jira.dhis2.org/browse/DHIS2-8061).

The `null` keyword is used when the user wants to show a blank result for an indicator or return a _missing value_ for a predictor or validation rule.

The `removeZeros()` function is used when the user wants to show a blank result instead of a zero for an indicator calculation, or return a _missing value_ instead of a zero for a predictor or validation rule. The expression:

```
missingValue( some calculation )
```

is equivalent to

```
if ( some calculation == 0, null, some calculation )
```

but it doesn't require that _some calculation_ be repeated in the expression.

In addition to passing the unit tests, the code has been tested in the backend and produces the results shown in the [DHIS2-8061](https://jira.dhis2.org/browse/DHIS2-8061) _Testing suggestions_.