### PR TITLE
perf: speed dataElement deletes DHIS2-11100 (#10302) (#10366) (#10367)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionService.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.constant.Constant;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorValue;
@@ -191,15 +190,15 @@ public interface ExpressionService
     Set<String> getExpressionElementAndOptionComboIds( String expression, ParseType parseType );
 
     /**
-     * Returns all data elements found in the given expression string, including
-     * those found in data element operands. Returns an empty set if the given
-     * expression is null.
+     * Returns all data element ids found in the given expression string,
+     * including those found in data element operands. Returns an empty set if
+     * the given expression is null.
      *
      * @param expression the expression string.
      * @param parseType the type of expression to parse.
-     * @return a Set of data elements included in the expression string.
+     * @return a Set of data elements ids included in the expression string.
      */
-    Set<DataElement> getExpressionDataElements( String expression, ParseType parseType );
+    Set<String> getExpressionDataElementIds( String expression, ParseType parseType );
 
     /**
      * Returns, in data element operand format, all data elements and all data

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -79,7 +79,6 @@ import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.expression.dataitem.DimItemDataElementAndOperand;
@@ -476,11 +475,11 @@ public class DefaultExpressionService
     }
 
     @Override
-    public Set<DataElement> getExpressionDataElements( String expression, ParseType parseType )
+    public Set<String> getExpressionDataElementIds( String expression, ParseType parseType )
     {
         return getExpressionDimensionalItemIds( expression, parseType ).stream()
             .filter( DimensionalItemId::isDataElementOrOperand )
-            .map( i -> dataElementService.getDataElement( i.getId0() ) )
+            .map( DimensionalItemId::getId0 )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -477,31 +477,22 @@ public class ExpressionService2Test extends DhisSpringTest
     }
 
     @Test
-    public void testGetExpressionDataElements()
+    public void testGetExpressionDataElementIds()
     {
-        when( dataElementService.getDataElement( opA.getDimensionItem().split( "\\." )[0] ) )
-            .thenReturn( opA.getDataElement() );
-        when( dataElementService.getDataElement( opB.getDimensionItem().split( "\\." )[0] ) )
-            .thenReturn( opB.getDataElement() );
-        Set<DataElement> dataElements = target.getExpressionDataElements( expressionA, INDICATOR_EXPRESSION );
+        Set<String> dataElementIds = target.getExpressionDataElementIds( expressionA, INDICATOR_EXPRESSION );
 
-        assertThat( dataElements, hasSize( 2 ) );
-        assertThat( dataElements, hasItems( opA.getDataElement(), opB.getDataElement() ) );
+        assertThat( dataElementIds, hasSize( 2 ) );
+        assertThat( dataElementIds, hasItems( opA.getDataElement().getUid(), opB.getDataElement().getUid() ) );
 
-        // Expression G
-        when( dataElementService.getDataElement( deA.getUid() ) ).thenReturn( deA );
-        when( dataElementService.getDataElement( deB.getUid() ) ).thenReturn( deB );
-        when( dataElementService.getDataElement( deC.getUid() ) ).thenReturn( deC );
+        dataElementIds = target.getExpressionDataElementIds( expressionG, INDICATOR_EXPRESSION );
 
-        dataElements = target.getExpressionDataElements( expressionG, INDICATOR_EXPRESSION );
+        assertThat( dataElementIds, hasSize( 3 ) );
+        assertThat( dataElementIds, hasItems( deA.getUid(), deB.getUid(), deC.getUid() ) );
 
-        assertThat( dataElements, hasSize( 3 ) );
-        assertThat( dataElements, hasItems( deA, deB, deC ) );
+        dataElementIds = target.getExpressionDataElementIds( expressionM, INDICATOR_EXPRESSION );
 
-        dataElements = target.getExpressionDataElements( expressionM, INDICATOR_EXPRESSION );
-
-        assertThat( dataElements, hasSize( 2 ) );
-        assertThat( dataElements, hasItems( deA, deB ) );
+        assertThat( dataElementIds, hasSize( 2 ) );
+        assertThat( dataElementIds, hasItems( deA.getUid(), deB.getUid() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/indicator/IndicatorDeletionHandlerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/indicator/IndicatorDeletionHandlerTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.indicator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.DeleteNotAllowedException;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.legend.LegendSet;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.user.UserService;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class IndicatorDeletionHandlerTest
+    extends DhisSpringTest
+{
+    @Autowired
+    private IdentifiableObjectManager manager;
+
+    @Autowired
+    private PeriodService periodService;
+
+    @Autowired
+    private UserService _userService;
+
+    private Indicator indicator;
+
+    @Override
+    public void setUpTest()
+    {
+        userService = _userService;
+
+        IndicatorType type = new IndicatorType( "Type", 1, true );
+        manager.save( type );
+
+        indicator = createIndicator( 'A', type );
+        manager.save( indicator );
+    }
+
+    @Test
+    public void testAllowDeleteIndicatorType()
+    {
+        IndicatorType typeA = new IndicatorType( "TypeA", 1, true );
+        IndicatorType typeB = new IndicatorType( "TypeB", 1, true );
+
+        manager.save( typeA );
+        manager.save( typeB );
+
+        indicator.setIndicatorType( typeB );
+        manager.update( indicator );
+
+        manager.delete( typeA );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( typeB ) );
+    }
+
+    @Test
+    public void testDeleteIndicatorGroup()
+    {
+        IndicatorGroup groupA = createIndicatorGroup( 'A' );
+        groupA.addIndicator( indicator );
+        manager.save( groupA );
+
+        assertTrue( indicator.getGroups().contains( groupA ) );
+
+        manager.delete( groupA );
+
+        assertFalse( indicator.getGroups().contains( groupA ) );
+    }
+
+    @Test
+    public void testDeleteDataSet()
+    {
+        PeriodType monthly = PeriodType.getPeriodTypeByName( "Monthly" );
+        monthly = periodService.reloadPeriodType( monthly );
+
+        DataSet setA = createDataSet( 'A', monthly );
+        setA.addIndicator( indicator );
+        manager.save( setA );
+
+        assertTrue( indicator.getDataSets().contains( setA ) );
+
+        manager.delete( setA );
+
+        assertFalse( indicator.getDataSets().contains( setA ) );
+    }
+
+    @Test
+    public void testDeleteLegendSet()
+    {
+        LegendSet setA = createLegendSet( 'A' );
+        manager.save( setA );
+
+        indicator.getLegendSets().add( setA );
+        manager.update( indicator );
+
+        assertTrue( indicator.getLegendSets().contains( setA ) );
+
+        manager.delete( setA );
+
+        assertFalse( indicator.getLegendSets().contains( setA ) );
+    }
+
+    @Test
+    public void testAllowDeleteDataElement()
+    {
+        DataElement elementA = createDataElement( 'A' );
+        DataElement elementB = createDataElement( 'B' );
+        DataElement elementC = createDataElement( 'C' );
+
+        manager.save( elementA );
+        manager.save( elementB );
+        manager.save( elementC );
+
+        indicator.setNumerator( "#{" + elementB.getUid() + "}" );
+        indicator.setDenominator( "#{" + elementC.getUid() + "}" );
+        manager.update( indicator );
+
+        manager.delete( elementA );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( elementB ) );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( elementC ) );
+    }
+
+    @Test
+    public void testAllowDeleteCategoryCombo()
+    {
+        CategoryCombo comboA = createCategoryCombo( 'A' );
+        CategoryCombo comboB = createCategoryCombo( 'B' );
+        CategoryCombo comboC = createCategoryCombo( 'C' );
+
+        manager.save( comboA );
+        manager.save( comboB );
+        manager.save( comboC );
+
+        CategoryOptionCombo cocA = createCategoryOptionCombo( 'A' );
+        CategoryOptionCombo cocB = createCategoryOptionCombo( 'B' );
+        CategoryOptionCombo cocC = createCategoryOptionCombo( 'C' );
+
+        cocA.setCategoryCombo( comboA );
+        cocB.setCategoryCombo( comboB );
+        cocC.setCategoryCombo( comboC );
+
+        manager.save( cocA );
+        manager.save( cocB );
+        manager.save( cocC );
+
+        comboA.getOptionCombos().add( cocA );
+        comboB.getOptionCombos().add( cocB );
+        comboC.getOptionCombos().add( cocC );
+
+        manager.update( comboA );
+        manager.update( comboB );
+        manager.update( comboC );
+
+        indicator.setNumerator( "#{abcdefghijk." + cocB.getUid() + "}" );
+        indicator.setDenominator( "#{abcdefghijk." + cocC.getUid() + "}" );
+        manager.update( indicator );
+
+        manager.delete( comboA );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( comboB ) );
+        assertThrows( DeleteNotAllowedException.class, () -> manager.delete( comboC ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/DefaultValidationRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/DefaultValidationRuleService.java
@@ -37,6 +37,7 @@ import java.util.Set;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
@@ -69,17 +70,21 @@ public class DefaultValidationRuleService
 
     private final ExpressionService expressionService;
 
+    private final IdentifiableObjectManager idObjectManager;
+
     public DefaultValidationRuleService( ValidationRuleStore validationRuleStore,
         @Qualifier( "org.hisp.dhis.validation.ValidationRuleGroupStore" ) IdentifiableObjectStore<ValidationRuleGroup> validationRuleGroupStore,
-        ExpressionService expressionService )
+        ExpressionService expressionService, IdentifiableObjectManager idObjectManager )
     {
         checkNotNull( validationRuleGroupStore );
         checkNotNull( validationRuleStore );
         checkNotNull( expressionService );
+        checkNotNull( idObjectManager );
 
         this.validationRuleStore = validationRuleStore;
         this.validationRuleGroupStore = validationRuleGroupStore;
         this.expressionService = expressionService;
+        this.idObjectManager = idObjectManager;
     }
 
     // -------------------------------------------------------------------------
@@ -203,12 +208,12 @@ public class DefaultValidationRuleService
     @Override
     public Set<DataElement> getDataElements( ValidationRule validationRule )
     {
-        Set<DataElement> elements = new HashSet<>();
-        elements.addAll( expressionService.getExpressionDataElements( validationRule.getLeftSide().getExpression(),
+        Set<String> uids = new HashSet<>();
+        uids.addAll( expressionService.getExpressionDataElementIds( validationRule.getLeftSide().getExpression(),
             VALIDATION_RULE_EXPRESSION ) );
-        elements.addAll( expressionService.getExpressionDataElements( validationRule.getRightSide().getExpression(),
+        uids.addAll( expressionService.getExpressionDataElementIds( validationRule.getRightSide().getExpression(),
             VALIDATION_RULE_EXPRESSION ) );
-        return elements;
+        return new HashSet<>( idObjectManager.getByUid( DataElement.class, uids ) );
     }
 
     @Override


### PR DESCRIPTION
* perf: speed dataElement deletes DHIS2-11100 (#10302)

* perf: speed dataElement deletes DHIS2-11100

* fix: apache.commons.collections -> collections4

* fix: Remove unnecessary stubbing

* fix: Rename testGetExpressionDataElements -> testGetExpressionDataElementIds

(cherry picked from commit 8f8047d4ebfc480a961dfbaa9028751be8b0bb10)

* fix: retrofit IndicatorDeletionHandlerTest

* fix: retrofit ExpressionService2Test

(cherry picked from commit bc54ee512a0bb153fcd9813396e2a3d306342b75)
(cherry picked from commit 5d7142d0a8c8306182c60a03ec25ceb90404733a)