### PR TITLE
chore: reduce coupling and mutabilty DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerImportParams.java
@@ -73,7 +73,7 @@ public class TrackerImportParams
      */
     @JsonProperty
     @Builder.Default
-    private TrackerBundleMode importMode = TrackerBundleMode.COMMIT;
+    private final TrackerBundleMode importMode = TrackerBundleMode.COMMIT;
 
     /**
      * IdSchemes to match metadata
@@ -83,7 +83,7 @@ public class TrackerImportParams
                                 // during 2.39; remove in 2.40
     @JsonProperty
     @Builder.Default
-    private TrackerIdSchemeParams idSchemes = new TrackerIdSchemeParams();
+    private final TrackerIdSchemeParams idSchemes = new TrackerIdSchemeParams();
 
     /**
      * Sets import strategy (create, update, etc).
@@ -104,32 +104,35 @@ public class TrackerImportParams
      */
     @JsonProperty
     @Builder.Default
-    private FlushMode flushMode = FlushMode.AUTO;
+    private final FlushMode flushMode = FlushMode.AUTO;
 
     /**
      * Validation mode to use, defaults to fully validated objects.
      */
     @JsonProperty
     @Builder.Default
-    private ValidationMode validationMode = ValidationMode.FULL;
+    private final ValidationMode validationMode = ValidationMode.FULL;
 
     /**
      * Should text pattern validation be skipped or not, default is not.
      */
     @JsonProperty
-    private boolean skipPatternValidation;
+    @Builder.Default
+    private final boolean skipPatternValidation = false;
 
     /**
      * Should side effects be skipped or not, default is not.
      */
     @JsonProperty
-    private boolean skipSideEffects;
+    @Builder.Default
+    private final boolean skipSideEffects = false;
 
     /**
      * Should rule engine call be skipped or not, default is to skip.
      */
     @JsonProperty
-    private boolean skipRuleEngine;
+    @Builder.Default
+    private final boolean skipRuleEngine = false;
 
     /**
      * Name of file that was used for import (if available).
@@ -147,28 +150,28 @@ public class TrackerImportParams
      */
     @JsonProperty
     @Builder.Default
-    private List<TrackedEntity> trackedEntities = new ArrayList<>();
+    private final List<TrackedEntity> trackedEntities = new ArrayList<>();
 
     /**
      * Enrollments to import.
      */
     @JsonProperty
     @Builder.Default
-    private List<Enrollment> enrollments = new ArrayList<>();
+    private final List<Enrollment> enrollments = new ArrayList<>();
 
     /**
      * Events to import.
      */
     @JsonProperty
     @Builder.Default
-    private List<Event> events = new ArrayList<>();
+    private final List<Event> events = new ArrayList<>();
 
     /**
      * Relationships to import.
      */
     @JsonProperty
     @Builder.Default
-    private List<Relationship> relationships = new ArrayList<>();
+    private final List<Relationship> relationships = new ArrayList<>();
 
     public TrackerImportParams setUser( User user )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerImportParams.java
@@ -138,7 +138,8 @@ public class TrackerImportParams
      * Name of file that was used for import (if available).
      */
     @JsonProperty
-    private String filename;
+    @Builder.Default
+    private final String filename = null;
 
     /**
      * Job configuration

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/job/TrackerMessage.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/job/TrackerMessage.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.tracker.job;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
 import org.hisp.dhis.artemis.MessageType;
 import org.hisp.dhis.artemis.SerializableMessage;
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Data
+@Value
 @Builder( builderClassName = "TrackerMessageBuilder" )
 @JsonDeserialize( builder = TrackerMessage.TrackerMessageBuilder.class )
 public class TrackerMessage implements SerializableMessage
@@ -53,7 +53,7 @@ public class TrackerMessage implements SerializableMessage
     private final String uid;
 
     @JsonProperty
-    private String authentication;
+    private final String authentication;
 
     @JsonProperty
     private final TrackerImportParams trackerImportParams;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerImportParamsSerdeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerImportParamsSerdeTest.java
@@ -72,7 +72,7 @@ class TrackerImportParamsSerdeTest extends TrackerTest
             .validationMode( ValidationMode.SKIP )
             .build();
         String json = renderService.toJsonAsString( trackerImportParams );
-        JSONAssert.assertEquals( json,
+        JSONAssert.assertEquals(
             "" + "{\"importMode\":\"COMMIT\"," + "\"idSchemes\":{\"dataElementIdScheme\":{\"idScheme\":\"UID\"},"
                 + "\"orgUnitIdScheme\":{\"idScheme\":\"UID\"},"
                 + "\"programIdScheme\":{\"idScheme\":\"ATTRIBUTE\",\"value\":\"aaaa\"},"
@@ -83,6 +83,7 @@ class TrackerImportParamsSerdeTest extends TrackerTest
                 + "\"skipPatternValidation\":false," + "\"skipSideEffects\":false," + "\"skipRuleEngine\":true,"
                 + "\"trackedEntities\":[]," + "\"enrollments\":[]," + "\"events\":[]," + "\"relationships\":[],"
                 + "\"username\":\"system-process\"}",
+            json,
             JSONCompareMode.LENIENT );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerImportParamsSerdeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerImportParamsSerdeTest.java
@@ -63,9 +63,14 @@ class TrackerImportParamsSerdeTest extends TrackerTest
             .programIdScheme(
                 TrackerIdSchemeParam.builder().idScheme( TrackerIdScheme.ATTRIBUTE ).value( "aaaa" ).build() )
             .build();
-        TrackerImportParams trackerImportParams = TrackerImportParams.builder().idSchemes( identifierParams )
-            .atomicMode( AtomicMode.OBJECT ).flushMode( FlushMode.OBJECT ).skipRuleEngine( true )
-            .importStrategy( TrackerImportStrategy.DELETE ).validationMode( ValidationMode.SKIP ).build();
+        TrackerImportParams trackerImportParams = TrackerImportParams.builder()
+            .idSchemes( identifierParams )
+            .atomicMode( AtomicMode.OBJECT )
+            .flushMode( FlushMode.OBJECT )
+            .skipRuleEngine( true )
+            .importStrategy( TrackerImportStrategy.DELETE )
+            .validationMode( ValidationMode.SKIP )
+            .build();
         String json = renderService.toJsonAsString( trackerImportParams );
         JSONAssert.assertEquals( json,
             "" + "{\"importMode\":\"COMMIT\"," + "\"idSchemes\":{\"dataElementIdScheme\":{\"idScheme\":\"UID\"},"

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -148,9 +148,11 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
 
     private TrackerImportParams buildParams( Event event, TrackerIdSchemeParams idParams )
     {
-        TrackerImportParams params = TrackerImportParams.builder().events( Collections.singletonList( event ) )
-            .user( currentUserService.getCurrentUser() ).build();
-        params.setIdSchemes( idParams );
+        TrackerImportParams params = TrackerImportParams.builder()
+            .events( Collections.singletonList( event ) )
+            .user( currentUserService.getCurrentUser() )
+            .idSchemes( idParams )
+            .build();
         return params;
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DefaultTrackerImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DefaultTrackerImporter.java
@@ -27,62 +27,65 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Luca Cambi <luca@dhis2.org>
  */
 @Component
-@Primary
 @RequiredArgsConstructor
 public class DefaultTrackerImporter implements TrackerImporter
 {
 
+    @NonNull
     private final TrackerSyncImporter syncImporter;
 
+    @NonNull
     private final TrackerAsyncImporter asyncImporter;
 
     @Override
     public TrackerImportReport importTracker( TrackerImportRequest request )
     {
-        setTrackerImportParams( request );
+        TrackerImportParams params = setTrackerImportParams( request );
 
         if ( request.isAsync() )
         {
-            return asyncImporter.importTracker( request );
+            return asyncImporter.importTracker( params, request.getAuthentication(),
+                request.getUid() );
         }
 
-        JobConfiguration jobConfiguration = new JobConfiguration(
-            "",
-            JobType.TRACKER_IMPORT_JOB,
-            request.getUserUid(),
-            request.isAsync() );
-        jobConfiguration.setUid( request.getUid() );
-        request.getTrackerImportParams().setJobConfiguration( jobConfiguration );
-
-        return syncImporter.importTracker( request );
+        return syncImporter.importTracker( params, request.getTrackerBundleReportMode() );
     }
 
-    private void setTrackerImportParams( TrackerImportRequest trackerImportRequest )
+    private TrackerImportParams setTrackerImportParams( TrackerImportRequest request )
     {
         TrackerImportParams.TrackerImportParamsBuilder paramsBuilder = TrackerImportParamsBuilder
-            .builder( trackerImportRequest.getContextService().getParameterValuesMap() );
+            .builder( request.getContextService().getParameterValuesMap() )
+            .userId( request.getUserUid() )
+            .trackedEntities( request.getTrackerBundleParams().getTrackedEntities() )
+            .enrollments( request.getTrackerBundleParams().getEnrollments() )
+            .events( request.getTrackerBundleParams().getEvents() )
+            .relationships( request.getTrackerBundleParams().getRelationships() );
 
-        trackerImportRequest.setTrackerImportParams(
-            paramsBuilder
-                .userId( trackerImportRequest.getUserUid() )
-                .trackedEntities( trackerImportRequest.getTrackerBundleParams().getTrackedEntities() )
-                .enrollments( trackerImportRequest.getTrackerBundleParams().getEnrollments() )
-                .events( trackerImportRequest.getTrackerBundleParams().getEvents() )
-                .relationships( trackerImportRequest.getTrackerBundleParams().getRelationships() )
-                .build() );
+        if ( !request.isAsync() )
+        {
+            JobConfiguration jobConfiguration = new JobConfiguration(
+                "",
+                JobType.TRACKER_IMPORT_JOB,
+                request.getUserUid(),
+                request.isAsync() );
+            jobConfiguration.setUid( request.getUid() );
+            paramsBuilder.jobConfiguration( jobConfiguration );
+        }
+
+        return paramsBuilder.build();
     }
 
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DefaultTrackerImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DefaultTrackerImporter.java
@@ -53,7 +53,7 @@ public class DefaultTrackerImporter implements TrackerImporter
     @Override
     public TrackerImportReport importTracker( TrackerImportRequest request )
     {
-        TrackerImportParams params = setTrackerImportParams( request );
+        TrackerImportParams params = trackerImportParams( request );
 
         if ( request.isAsync() )
         {
@@ -64,7 +64,7 @@ public class DefaultTrackerImporter implements TrackerImporter
         return syncImporter.importTracker( params, request.getTrackerBundleReportMode() );
     }
 
-    private TrackerImportParams setTrackerImportParams( TrackerImportRequest request )
+    private TrackerImportParams trackerImportParams( TrackerImportRequest request )
     {
         TrackerImportParams.TrackerImportParamsBuilder paramsBuilder = TrackerImportParamsBuilder
             .builder( request.getContextService().getParameterValuesMap() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerAsyncImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerAsyncImporter.java
@@ -27,13 +27,16 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.artemis.MessageManager;
 import org.hisp.dhis.artemis.Topics;
 import org.hisp.dhis.security.AuthenticationSerializer;
+import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.job.TrackerMessage;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 /**
@@ -41,17 +44,17 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class TrackerAsyncImporter implements TrackerImporter
+public class TrackerAsyncImporter
 {
+    @NonNull
     private final MessageManager messageManager;
 
-    @Override
-    public TrackerImportReport importTracker( TrackerImportRequest trackerImportRequest )
+    public TrackerImportReport importTracker( TrackerImportParams params, Authentication authentication, String uid )
     {
         TrackerMessage trackerMessage = TrackerMessage.builder()
-            .trackerImportParams( trackerImportRequest.getTrackerImportParams() )
-            .authentication( AuthenticationSerializer.serialize( trackerImportRequest.getAuthentication() ) )
-            .uid( trackerImportRequest.getUid() )
+            .trackerImportParams( params )
+            .authentication( AuthenticationSerializer.serialize( authentication ) )
+            .uid( uid )
             .build();
 
         messageManager.sendQueue( Topics.TRACKER_IMPORT_JOB_TOPIC_NAME, trackerMessage );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -104,16 +104,17 @@ public class TrackerImportController
         @CurrentUser User currentUser,
         @RequestBody TrackerBundleParams trackerBundleParams )
     {
-        String jobId = CodeGenerator.generateUid();
 
+        String jobId = CodeGenerator.generateUid();
         TrackerImportRequest trackerImportRequest = TrackerImportRequest.builder()
-            .trackerBundleParams( trackerBundleParams ).contextService( contextService ).userUid( currentUser.getUid() )
-            .isAsync( true ).uid( jobId )
+            .trackerBundleParams( trackerBundleParams )
+            .contextService( contextService )
+            .userUid( currentUser.getUid() )
+            .isAsync( true )
+            .uid( jobId )
             .authentication( SecurityContextHolder.getContext().getAuthentication() )
             .build();
-
-        trackerImporter
-            .importTracker( trackerImportRequest );
+        trackerImporter.importTracker( trackerImportRequest );
 
         String location = ContextUtils.getRootPath( request ) + "/tracker/jobs/" + jobId;
 
@@ -127,15 +128,15 @@ public class TrackerImportController
         @RequestParam( defaultValue = "errors", required = false ) String reportMode, @CurrentUser User currentUser,
         @RequestBody TrackerBundleParams trackerBundleParams )
     {
+
         TrackerImportRequest trackerImportRequest = TrackerImportRequest.builder()
-            .trackerBundleParams( trackerBundleParams ).contextService( contextService ).userUid( currentUser.getUid() )
-            .trackerBundleReportMode( TrackerBundleReportMode
-                .getTrackerBundleReportMode( reportMode ) )
+            .trackerBundleParams( trackerBundleParams )
+            .contextService( contextService )
+            .userUid( currentUser.getUid() )
+            .trackerBundleReportMode( TrackerBundleReportMode.getTrackerBundleReportMode( reportMode ) )
             .uid( CodeGenerator.generateUid() )
             .build();
-
-        TrackerImportReport trackerImportReport = trackerImporter
-            .importTracker( trackerImportRequest );
+        TrackerImportReport trackerImportReport = trackerImporter.importTracker( trackerImportRequest );
 
         ResponseEntity.BodyBuilder builder = trackerImportReport.getStatus() == TrackerStatus.ERROR
             ? ResponseEntity.status( HttpStatus.CONFLICT )
@@ -156,10 +157,10 @@ public class TrackerImportController
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
 
         List<Event> events = csvEventService.readEvents( inputStream, skipFirst );
+
         TrackerBundleParams trackerBundleParams = TrackerBundleParams.builder()
             .events( events )
             .build();
-
         TrackerImportRequest trackerImportRequest = TrackerImportRequest.builder()
             .trackerBundleParams( trackerBundleParams )
             .contextService( contextService )
@@ -168,7 +169,6 @@ public class TrackerImportController
             .uid( jobId )
             .authentication( SecurityContextHolder.getContext().getAuthentication() )
             .build();
-
         trackerImporter.importTracker( trackerImportRequest );
 
         String location = ContextUtils.getRootPath( request ) + "/tracker/jobs/" + jobId;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportRequest.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportRequest.java
@@ -31,7 +31,6 @@ import lombok.Builder;
 import lombok.Data;
 
 import org.hisp.dhis.tracker.TrackerBundleReportMode;
-import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.security.core.Authentication;
 
@@ -49,9 +48,7 @@ public class TrackerImportRequest
 
     private TrackerBundleParams trackerBundleParams;
 
-    private TrackerImportParams trackerImportParams;
-
-    boolean isAsync;
+    private final boolean isAsync;
 
     private TrackerBundleReportMode trackerBundleReportMode;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportRequest.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportRequest.java
@@ -28,27 +28,27 @@
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
 import org.hisp.dhis.tracker.TrackerBundleReportMode;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.security.core.Authentication;
 
-@Data
+@Value
 @Builder
 public class TrackerImportRequest
 {
-    private Authentication authentication;
+    private final Authentication authentication;
 
-    private String uid;
+    private final String uid;
 
-    private String userUid;
+    private final String userUid;
 
-    private ContextService contextService;
+    private final ContextService contextService;
 
-    private TrackerBundleParams trackerBundleParams;
+    private final TrackerBundleParams trackerBundleParams;
 
     private final boolean isAsync;
 
-    private TrackerBundleReportMode trackerBundleReportMode;
+    private final TrackerBundleReportMode trackerBundleReportMode;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerSyncImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerSyncImporter.java
@@ -27,8 +27,11 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import org.hisp.dhis.tracker.TrackerBundleReportMode;
+import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.springframework.stereotype.Component;
@@ -38,17 +41,16 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class TrackerSyncImporter implements TrackerImporter
+public class TrackerSyncImporter
 {
+
+    @NonNull
     private final TrackerImportService trackerImportService;
 
-    @Override
-    public TrackerImportReport importTracker( TrackerImportRequest trackerImportRequest )
+    public TrackerImportReport importTracker( TrackerImportParams params, TrackerBundleReportMode reportMode )
     {
-        TrackerImportReport trackerImportReport = trackerImportService
-            .importTracker( trackerImportRequest.getTrackerImportParams() );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        return trackerImportService.buildImportReport( trackerImportReport,
-            trackerImportRequest.getTrackerBundleReportMode() );
+        return trackerImportService.buildImportReport( trackerImportReport, reportMode );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImporterTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImporterTest.java
@@ -28,9 +28,11 @@
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import org.hisp.dhis.tracker.TrackerBundleReportMode;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,7 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TrackerImporterTest
 {
     @InjectMocks
-    DefaultTrackerImporter importStrategy;
+    DefaultTrackerImporter defaultTrackerImporter;
 
     @Mock
     TrackerAsyncImporter asyncImporter;
@@ -65,14 +67,14 @@ class TrackerImporterTest
             .isAsync( true )
             .build();
 
-        importStrategy.importTracker( trackerImportRequest );
+        defaultTrackerImporter.importTracker( trackerImportRequest );
 
-        verify( asyncImporter ).importTracker( any() );
-        verify( syncImporter, times( 0 ) ).importTracker( any() );
+        verify( asyncImporter ).importTracker( any(), any(), eq( "uid" ) );
+        verify( syncImporter, times( 0 ) ).importTracker( any(), any() );
     }
 
     @Test
-    void shouldNotImportAsync()
+    void shouldImportSync()
     {
         TrackerImportRequest trackerImportRequest = TrackerImportRequest
             .builder()
@@ -80,11 +82,12 @@ class TrackerImporterTest
             .userUid( "userUid" )
             .uid( "uid" )
             .trackerBundleParams( TrackerBundleParams.builder().build() )
+            .trackerBundleReportMode( TrackerBundleReportMode.ERRORS )
             .build();
 
-        importStrategy.importTracker( trackerImportRequest );
+        defaultTrackerImporter.importTracker( trackerImportRequest );
 
-        verify( asyncImporter, times( 0 ) ).importTracker( any() );
-        verify( syncImporter ).importTracker( any() );
+        verify( asyncImporter, times( 0 ) ).importTracker( any(), any(), any() );
+        verify( syncImporter ).importTracker( any(), eq( TrackerBundleReportMode.ERRORS ) );
     }
 }


### PR DESCRIPTION
* use `@Value` instead of `@Data` where possible. TrackerMessage for example represents the import defined by a user with some additional information. We do not want anyone from mutating this message once its created. Default to `@Value` for any code.
* use Builders for classes with a lot of optional values. Builders will only return the fully constructed class at the end.
* TrackerAsyncImporter and TrackerSyncImporter shared the same interface. The data they need is not exactly the same. By not implementing the interface in those two classes we can reduce this artificial coupling. Remove TrackerImportParams from the TrackerImportRequest.