### PR TITLE
chore: Create separate workflow for integration h2 tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,12 +35,6 @@ jobs:
           cache: maven
       - name: Run integration tests
         run: mvn --threads 2C test --batch-mode --no-transfer-progress -Pintegration -DexcludeAnalyticsTests=true -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
-      - name: Archive surefire reports
-        uses: actions/upload-artifact@v2
-        with:
-          name: surefire-reports
-          path: "**/target/surefire-reports/TEST-*.xml"
-          retention-days: 10
 
   integration-h2-test:
     runs-on: ubuntu-latest
@@ -54,12 +48,6 @@ jobs:
           cache: maven
       - name: Run integration h2 tests
         run: mvn --threads 2C test --batch-mode --no-transfer-progress -PintegrationH2 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
-      - name: Archive surefire reports
-        uses: actions/upload-artifact@v2
-        with:
-          name: surefire-reports
-          path: "**/target/surefire-reports/TEST-*.xml"
-          retention-days: 10
 
   integration-test-analytics:
     runs-on: ubuntu-latest
@@ -79,9 +67,3 @@ jobs:
         env:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
         run: mvn test -Pintegration --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml
-      - name: Archive surefire reports
-        uses: actions/upload-artifact@v2
-        with:
-          name: surefire-reports-analytics
-          path: "**/target/surefire-reports/TEST-*.xml"
-          retention-days: 10

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,6 +35,12 @@ jobs:
           cache: maven
       - name: Run integration tests
         run: mvn --threads 2C test --batch-mode --no-transfer-progress -Pintegration -DexcludeAnalyticsTests=true -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+      - name: Archive surefire reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/TEST-*.xml"
+          retention-days: 10
 
   integration-h2-test:
     runs-on: ubuntu-latest
@@ -48,6 +54,12 @@ jobs:
           cache: maven
       - name: Run integration h2 tests
         run: mvn --threads 2C test --batch-mode --no-transfer-progress -PintegrationH2 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+      - name: Archive surefire reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/TEST-*.xml"
+          retention-days: 10
 
   integration-test-analytics:
     runs-on: ubuntu-latest
@@ -67,3 +79,9 @@ jobs:
         env:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
         run: mvn test -Pintegration --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml
+      - name: Archive surefire reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: surefire-reports-analytics
+          path: "**/target/surefire-reports/TEST-*.xml"
+          retention-days: 10

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,6 +42,25 @@ jobs:
           path: "**/target/surefire-reports/TEST-*.xml"
           retention-days: 10
 
+  integration-h2-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: 11
+          distribution: temurin
+          cache: maven
+      - name: Run integration h2 tests
+        run: mvn --threads 2C test --batch-mode --no-transfer-progress -PintegrationH2 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+      - name: Archive surefire reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: surefire-reports
+          path: "**/target/surefire-reports/TEST-*.xml"
+          retention-days: 10
+
   integration-test-analytics:
     runs-on: ubuntu-latest
     steps:

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisSpringTest.java
@@ -51,6 +51,7 @@ import org.springframework.transaction.annotation.Transactional;
 @ExtendWith( SpringExtension.class )
 @ContextConfiguration( classes = UnitTestConfig.class )
 @ActiveProfiles( profiles = { "test-h2" } )
+@IntegrationH2Test
 @Transactional
 public abstract class DhisSpringTest extends BaseSpringTest
 {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationH2Test.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationH2Test.java
@@ -27,52 +27,19 @@
  */
 package org.hisp.dhis;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
-import org.hisp.dhis.config.UnitTestConfig;
-import org.hisp.dhis.external.conf.ConfigurationKey;
-import org.hisp.dhis.utils.TestUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Tag;
 
 /**
- * @author Lars Helge Overland
+ * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@ExtendWith( SpringExtension.class )
-@ActiveProfiles( "test-h2" )
-@ContextConfiguration( classes = { UnitTestConfig.class } )
-@IntegrationH2Test
-public abstract class DhisTest extends BaseSpringTest
+@Target( { ElementType.TYPE, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Tag( "integrationH2" )
+public @interface IntegrationH2Test
 {
-
-    protected boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @BeforeEach
-    final void before()
-        throws Exception
-    {
-        bindSession();
-        TestUtils.executeStartupRoutines( applicationContext );
-        boolean enableQueryLogging = dhisConfigurationProvider.isEnabled( ConfigurationKey.ENABLE_QUERY_LOGGING );
-        if ( enableQueryLogging )
-        {
-            Configurator.setLevel( "org.hisp.dhis.datasource.query", Level.INFO );
-            Configurator.setRootLevel( Level.INFO );
-        }
-        setUpTest();
-    }
-
-    @AfterEach
-    final void after()
-        throws Exception
-    {
-        nonTransactionalAfter();
-    }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationH2Test.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/IntegrationH2Test.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 
 /**
- * @author Morten Olav Hansen <mortenoh@gmail.com>
+ * @author Enrico Colasante
  */
 @Target( { ElementType.TYPE, ElementType.METHOD } )
 @Retention( RetentionPolicy.RUNTIME )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 
+import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.User;
@@ -67,6 +68,7 @@ import org.springframework.web.context.WebApplicationContext;
 @ContextConfiguration( classes = { ConfigProviderConfiguration.class, MvcTestConfig.class,
     WebTestConfiguration.class } )
 @ActiveProfiles( "test-h2" )
+@IntegrationH2Test
 @Transactional
 public abstract class DhisControllerConvenienceTest extends DhisMockMvcControllerTest
 {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithApiTokenAuthTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithApiTokenAuthTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 
+import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
@@ -62,6 +63,7 @@ import org.springframework.web.context.WebApplicationContext;
 @WebAppConfiguration
 @ContextConfiguration( classes = { WebMvcConfig.class } )
 @ActiveProfiles( "test-h2" )
+@IntegrationH2Test
 @Transactional
 public abstract class DhisControllerWithApiTokenAuthTest extends DhisMockMvcControllerTest
 {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerWithJwtTokenAuthTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi;
 
 import static org.hisp.dhis.webapi.utils.WebClientUtils.failOnException;
 
+import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.UserService;
 import org.hisp.dhis.utils.TestUtils;
@@ -58,6 +59,7 @@ import org.springframework.web.context.WebApplicationContext;
 @WebAppConfiguration
 @ContextConfiguration( classes = { JwtConfigProviderConfiguration.class, WebMvcConfig.class } )
 @ActiveProfiles( "test-h2" )
+@IntegrationH2Test
 @Transactional
 public abstract class DhisControllerWithJwtTokenAuthTest extends DhisMockMvcControllerTest
 {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisWebSpringTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisWebSpringTest.java
@@ -34,6 +34,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.IntegrationH2Test;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.schema.SchemaService;
@@ -67,6 +68,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @ContextConfiguration( classes = { ConfigProviderConfiguration.class, MvcTestConfig.class,
     WebTestConfiguration.class } )
 @ActiveProfiles( "test-h2" )
+@IntegrationH2Test
 @Transactional
 public abstract class DhisWebSpringTest extends DhisConvenienceTest
 {

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -363,7 +363,7 @@
                             <skipTests>${skipTests}</skipTests>
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>${surefireArgLine}</argLine>
-                            <excludedGroups>integration</excludedGroups>
+                            <excludedGroups>integration,integrationH2</excludedGroups>
                         </configuration>
                         <dependencies>
                             <dependency>
@@ -403,7 +403,31 @@
             </build>
         </profile>
 
-
+        <!-- IntegrationH2 test profile, this runs all the integrations tests with H2, but not the unit tests -->
+        <profile>
+            <id>integrationH2</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>false</skipTests>
+                            <trimStackTrace>false</trimStackTrace>
+                            <argLine>${surefireArgLine}</argLine>
+                            <groups>integrationH2</groups>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.ow2.asm</groupId>
+                                <artifactId>asm</artifactId>
+                                <version>${ow2.asm.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
         <profile>
             <id>sonarqube</id>
@@ -468,7 +492,7 @@
                             <skipTests>true</skipTests>
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>${surefireArgLine}</argLine>
-                            <excludedGroups>integration</excludedGroups>
+                            <excludedGroups>integration,integrationH2</excludedGroups>
                         </configuration>
                         <dependencies>
                             <dependency>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -360,6 +360,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <parallel>all</parallel>
+                            <threadCount>10</threadCount>
                             <skipTests>${skipTests}</skipTests>
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>${surefireArgLine}</argLine>


### PR DESCRIPTION
This is one first attempt to reduce the running time of tests in the build.
At the moment we are including tests that are using h2 as a DB in the unit tests.
The idea is to review the h2 tests (understand if they need the DB at all and how we can reduce Spring scanning of the classes to create the Context) and run the h2 tests in a separate workflow so it is easier to see if we are making progress reducing the running time.

Separating the workflow reduces the overall time to run a PR, it should be around 12 minutes now, against 15-16 minutes before but of course we have one more job that is running and consuming resources.