### PR TITLE
fix: [D]"last value" aggregation type is broken in later versions for data elements and program indicators in the analytics API [2.39.0-dhis2-12989]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -140,7 +140,25 @@ public class ProgramIndicator
      */
     public AggregationType getAggregationTypeFallback()
     {
-        return aggregationType != null ? aggregationType : AggregationType.AVERAGE;
+        if ( aggregationType == null )
+        {
+            return AggregationType.AVERAGE;
+        }
+
+        switch ( aggregationType )
+        {
+        case AVERAGE_SUM_ORG_UNIT:
+        case FIRST:
+        case LAST:
+        case LAST_IN_PERIOD:
+            return AggregationType.SUM;
+        case FIRST_AVERAGE_ORG_UNIT:
+        case LAST_AVERAGE_ORG_UNIT:
+        case LAST_IN_PERIOD_AVERAGE_ORG_UNIT:
+            return AggregationType.AVERAGE;
+        default:
+            return aggregationType;
+        }
     }
 
     public void addProgramIndicatorGroup( ProgramIndicatorGroup group )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -136,7 +136,8 @@ public class ProgramIndicator
     }
 
     /**
-     * Returns aggregation type, if not exists returns AVERAGE.
+     * Returns aggregation type (aggregation function supported by postgres), if
+     * not exists returns AVERAGE.
      */
     public AggregationType getAggregationTypeFallback()
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -156,6 +156,7 @@ public class ProgramIndicator
         case FIRST_AVERAGE_ORG_UNIT:
         case LAST_AVERAGE_ORG_UNIT:
         case LAST_IN_PERIOD_AVERAGE_ORG_UNIT:
+        case DEFAULT:
             return AggregationType.AVERAGE;
         default:
             return aggregationType;

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -534,7 +534,7 @@ class DataIntegrityServiceTest
         // arrange
         ProgramIndicator programIndicator = new ProgramIndicator();
         programIndicator.setName( "Test-PI" );
-        programIndicator.setExpression( "A{someuid} + 1" );
+        programIndicator.setExpression( "#{someuid} + 1" );
 
         // act
         // assert

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -61,6 +61,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryService;
@@ -525,6 +526,65 @@ class DataIntegrityServiceTest
         DataIntegrityIssue issue = issues.get( 0 );
         assertEquals( issueName( programIndicator ), issue.getName() );
         assertEquals( INVALID_EXPRESSION, issue.getComment() );
+    }
+
+    @Test
+    void programIndicatorGetAggregationTypeFallbackReturnsRelatedAggregationType()
+    {
+        // arrange
+        ProgramIndicator programIndicator = new ProgramIndicator();
+        programIndicator.setName( "Test-PI" );
+        programIndicator.setExpression( "A{someuid} + 1" );
+
+        // act
+        // assert
+        programIndicator.setAggregationType( AggregationType.AVERAGE_SUM_ORG_UNIT );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST_IN_PERIOD );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.FIRST );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.FIRST_AVERAGE_ORG_UNIT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST_AVERAGE_ORG_UNIT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( null );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.CUSTOM );
+        assertEquals( AggregationType.CUSTOM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.AVERAGE );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.SUM );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.STDDEV );
+        assertEquals( AggregationType.STDDEV, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.COUNT );
+        assertEquals( AggregationType.COUNT, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.MAX );
+        assertEquals( AggregationType.MAX, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.MIN );
+        assertEquals( AggregationType.MIN, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.DEFAULT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
     }
 
     @Test


### PR DESCRIPTION
[D]"last value" aggregation type is broken in later versions for data elements and program indicators in the analytics API,
see https://jira.dhis2.org/browse/DHIS2-12989

The behavior of program indicator AggregationType, get fallback aggregation type is consistent with data element one.

for AVERAGE_SUM_ORG_UNIT, FIRST, LAST, LAST_IN_PERIOD: AggregationType.SUM
for FIRST_AVERAGE_ORG_UNIT, LAST_AVERAGE_ORG_UNIT, LAST_IN_PERIOD_AVERAGE_ORG_UNIT, DEFAULT:
            AggregationType.AVERAGE
for the rest  stays the type untouched