### PR TITLE
fix: exclude job progress items info from notifier [DHIS2-12992]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -105,19 +105,13 @@ public class NotifierJobProgress implements JobProgress
     @Override
     public void startingWorkItem( String description )
     {
-        if ( isNotEmpty( description ) )
-        {
-            notifier.notify( jobId, NotificationLevel.INFO, description );
-        }
+        // intentionally not fowarded
     }
 
     @Override
     public void completedWorkItem( String summary )
     {
-        if ( isNotEmpty( summary ) )
-        {
-            notifier.notify( jobId, NotificationLevel.INFO, summary, false );
-        }
+        // intentionally not fowarded
     }
 
     @Override


### PR DESCRIPTION
As requested the start and complete "events" for items are excluded from the messages visible in the `Notifier` to avoid "overflowing" the notifiers limited buffer with details.