### PR TITLE
fix: Conditions: time with "before" conditions returns values matching "before or including" [2.36-DHIS2-12985-backport]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventDataQueryService.java
@@ -374,11 +374,24 @@ public class DefaultEventDataQueryService
             {
                 QueryOperator operator = QueryOperator.fromString( split[i] );
                 QueryFilter filter = new QueryFilter( operator, split[i + 1] );
+                // FE uses HH.MM time format instead of HH:MM. This is not
+                // compatible with db table/cell values
+                modifyFilterWhenTimeQueryItem( queryItem, filter );
                 queryItem.addFilter( filter );
             }
         }
 
         return queryItem;
+    }
+
+    private static void modifyFilterWhenTimeQueryItem( QueryItem queryItem, QueryFilter filter )
+    {
+        if ( queryItem.getItem() instanceof DataElement
+            && ((DataElement) queryItem.getItem()).getValueType() == ValueType.TIME )
+        {
+            filter.setFilter( filter.getFilter().replace( ".", ":" ) );
+        }
+
     }
 
     private DimensionalItemObject getSortItem( String item, Program program, EventOutputType type )


### PR DESCRIPTION
…g "before or including" [2.36-DHIS2-12985-backport]