### PR TITLE
feat: replace certain notifier messages instead of append [DHIS2-13035]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -48,6 +48,10 @@ public class NotifierJobProgress implements JobProgress
 
     private final JobConfiguration jobId;
 
+    private int stageItems;
+
+    private int stageItem;
+
     @Override
     public boolean isCancellationRequested()
     {
@@ -78,6 +82,8 @@ public class NotifierJobProgress implements JobProgress
     @Override
     public void startingStage( String description, int workItems )
     {
+        stageItems = workItems;
+        stageItem = 0;
         if ( isNotEmpty( description ) )
         {
             notifier.notify( jobId, description );
@@ -105,13 +111,22 @@ public class NotifierJobProgress implements JobProgress
     @Override
     public void startingWorkItem( String description )
     {
-        // intentionally not fowarded
+        if ( isNotEmpty( description ) )
+        {
+            String nOf = "[" + (stageItems > 0 ? stageItem + "/" + stageItems : "" + stageItem) + "] ";
+            notifier.notify( jobId, NotificationLevel.LOOP, nOf + description, false );
+        }
+        stageItem++;
     }
 
     @Override
     public void completedWorkItem( String summary )
     {
-        // intentionally not fowarded
+        if ( isNotEmpty( summary ) )
+        {
+            String nOf = "[" + (stageItems > 0 ? stageItem + "/" + stageItems : "" + stageItem) + "] ";
+            notifier.notify( jobId, NotificationLevel.LOOP, nOf + summary, false );
+        }
     }
 
     @Override

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
@@ -47,10 +47,6 @@ public class InMemoryNotifier implements Notifier
 
     private final NotificationMap notificationMap = new NotificationMap( MAX_POOL_TYPE_SIZE );
 
-    // -------------------------------------------------------------------------
-    // Notifier implementation
-    // -------------------------------------------------------------------------
-
     @Override
     public Notifier notify( JobConfiguration id, String message )
     {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLevel.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLevel.java
@@ -34,6 +34,11 @@ public enum NotificationLevel
 {
     OFF,
     DEBUG,
+    /**
+     * Similar to {@link #DEBUG} but is replaced (not appended) by any later
+     * message including messages of type {@code LOOP}.
+     */
+    LOOP,
     INFO,
     WARN,
     ERROR;

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLoggerUtil.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLoggerUtil.java
@@ -42,6 +42,7 @@ public class NotificationLoggerUtil
     {
         switch ( notificationLevel )
         {
+        case LOOP:
         case DEBUG:
             logger.debug( message );
             break;

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
@@ -89,7 +89,7 @@ public class NotificationMap
 
         synchronized void add( String jobId, UnaryOperator<T> limit, ToIntFunction<T> size, UnaryOperator<T> adder )
         {
-            if ( jobIdsInOrder.size() > capacity )
+            if ( jobIdsInOrder.size() >= capacity )
             {
                 String jobIdToShorten = jobIdsInOrder.removeLast();
                 valuesByJobId.compute( jobIdToShorten, ( key, values ) -> limit.apply( values ) );

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationMap.java
@@ -38,7 +38,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.ToIntFunction;
+import java.util.function.UnaryOperator;
+
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
@@ -48,7 +51,7 @@ import org.hisp.dhis.scheduling.JobType;
  * per {@link JobType} and {@link JobConfiguration} UID.
  * <p>
  * For each {@link Pool} the capacity of entries is capped at a fixed maximum
- * {@link #capacity}.
+ * capacity.
  * <p>
  * If maximum capacity is reached and another entry is added for that
  * {@link JobType}'s {@link Pool} the overall oldest entry is removed and the
@@ -60,54 +63,70 @@ import org.hisp.dhis.scheduling.JobType;
  */
 public class NotificationMap
 {
-    private final Map<JobType, Pool<Deque<Notification>>> notifications = new EnumMap<>( JobType.class );
+    private final Map<JobType, Pool<Deque<Notification>>> notificationsByJobType = new EnumMap<>( JobType.class );
 
-    private final Map<JobType, Pool<Object>> summaries = new EnumMap<>( JobType.class );
+    private final Map<JobType, Pool<Object>> summariesByJobType = new EnumMap<>( JobType.class );
 
+    @RequiredArgsConstructor
     static final class Pool<T>
     {
+        private final int capacity;
 
-        final AtomicInteger size = new AtomicInteger();
+        /**
+         * Remembers the job IDs in the order messages came in, so we know what
+         * job ID has the oldest message. When {@link #capacity} is exceeded
+         * that value is responsible for clearing memory.
+         */
+        private final Deque<String> jobIdsInOrder = new ConcurrentLinkedDeque<>();
 
-        final Deque<String> jobIdsInOrder = new ConcurrentLinkedDeque<>();
+        private final Map<String, T> valuesByJobId = new ConcurrentHashMap<>();
 
-        final Map<String, T> valuesByJobId = new ConcurrentHashMap<>();
-
-        private synchronized void remove( String jobId )
+        synchronized void remove( String jobId )
         {
-            size.set( jobIdsInOrder.size() );
             jobIdsInOrder.removeIf( jobId::equals );
             valuesByJobId.remove( jobId );
         }
-    }
 
-    private final int capacity;
+        synchronized void add( String jobId, UnaryOperator<T> limit, ToIntFunction<T> size, UnaryOperator<T> adder )
+        {
+            if ( jobIdsInOrder.size() > capacity )
+            {
+                String jobIdToShorten = jobIdsInOrder.removeLast();
+                valuesByJobId.compute( jobIdToShorten, ( key, values ) -> limit.apply( values ) );
+            }
+            int sizeBefore = size.applyAsInt( valuesByJobId.get( jobId ) );
+            int sizeAfter = size.applyAsInt( valuesByJobId.compute( jobId, ( key, values ) -> adder.apply( values ) ) );
+            if ( sizeAfter > sizeBefore )
+            {
+                jobIdsInOrder.addFirst( jobId );
+            }
+        }
+    }
 
     NotificationMap( int capacity )
     {
-        this.capacity = capacity;
         stream( JobType.values() ).forEach( jobType -> {
-            notifications.put( jobType, new Pool<>() );
-            summaries.put( jobType, new Pool<>() );
+            notificationsByJobType.put( jobType, new Pool<>( capacity ) );
+            summariesByJobType.put( jobType, new Pool<>( capacity ) );
         } );
     }
 
     public Map<JobType, Map<String, Deque<Notification>>> getNotifications()
     {
-        return notifications.entrySet().stream()
+        return notificationsByJobType.entrySet().stream()
             .collect( toMap( Entry::getKey, e -> e.getValue().valuesByJobId ) );
     }
 
     public Deque<Notification> getNotificationsByJobId( JobType jobType, String jobId )
     {
-        Deque<Notification> res = notifications.get( jobType ).valuesByJobId.get( jobId );
+        Deque<Notification> res = notificationsByJobType.get( jobType ).valuesByJobId.get( jobId );
         // return a defensive copy
         return res == null ? new LinkedList<>() : new LinkedList<>( res );
     }
 
     public Map<String, Deque<Notification>> getNotificationsWithType( JobType jobType )
     {
-        return unmodifiableMap( notifications.get( jobType ).valuesByJobId );
+        return unmodifiableMap( notificationsByJobType.get( jobType ).valuesByJobId );
     }
 
     public void add( JobConfiguration configuration, Notification notification )
@@ -117,26 +136,10 @@ public class NotificationMap
         {
             return;
         }
-        Pool<Deque<Notification>> pool = notifications.get( configuration.getJobType() );
-        if ( pool.size.incrementAndGet() > capacity )
-        {
-            String jobIdToShorten = pool.jobIdsInOrder.removeLast();
-            pool.valuesByJobId.compute( jobIdToShorten, ( key, value ) -> {
-                if ( value != null )
-                {
-                    value.removeLast();
-                    if ( value.isEmpty() )
-                    {
-                        return null;
-                    }
-                }
-                return value;
-            } );
-        }
-        pool.jobIdsInOrder.addFirst( jobId );
-        pool.valuesByJobId
-            .computeIfAbsent( jobId, key -> new ConcurrentLinkedDeque<>() )
-            .addFirst( notification );
+        notificationsByJobType.get( configuration.getJobType() ).add( jobId,
+            NotificationMap::withLimit,
+            notifications -> notifications == null ? 0 : notifications.size(),
+            notifications -> withAdded( notifications, notification ) );
     }
 
     public void addSummary( JobConfiguration configuration, Object summary )
@@ -146,30 +149,63 @@ public class NotificationMap
         {
             return;
         }
-        Pool<Object> pool = summaries.get( configuration.getJobType() );
-        if ( pool.size.incrementAndGet() > capacity )
-        {
-            pool.valuesByJobId.remove( pool.jobIdsInOrder.removeLast() );
-        }
-        pool.jobIdsInOrder.addFirst( jobId );
-        pool.valuesByJobId.put( jobId, summary );
+        summariesByJobType.get( configuration.getJobType() ).add( jobId,
+            currentSummary -> null,
+            currentSummary -> currentSummary == null ? 0 : 1,
+            currentSummary -> summary );
     }
 
     public Object getSummary( JobType jobType, String jobId )
     {
-        return summaries.get( jobType ).valuesByJobId.get( jobId );
+        return summariesByJobType.get( jobType ).valuesByJobId.get( jobId );
     }
 
     public Map<String, Object> getJobSummariesForJobType( JobType jobType )
     {
-        return unmodifiableMap( summaries.get( jobType ).valuesByJobId );
+        return unmodifiableMap( summariesByJobType.get( jobType ).valuesByJobId );
     }
 
     public void clear( JobConfiguration configuration )
     {
         JobType jobType = configuration.getJobType();
         String jobId = configuration.getUid();
-        notifications.get( jobType ).remove( jobId );
-        summaries.get( jobType ).remove( jobId );
+        notificationsByJobType.get( jobType ).remove( jobId );
+        summariesByJobType.get( jobType ).remove( jobId );
+    }
+
+    private static Deque<Notification> withAdded( Deque<Notification> notifications, Notification item )
+    {
+        if ( notifications == null )
+        {
+            notifications = new ConcurrentLinkedDeque<>();
+        }
+        Notification mostRecent = notifications.peekFirst();
+        if ( mostRecent != null && mostRecent.getLevel() == NotificationLevel.LOOP )
+        {
+            notifications.pollFirst();
+        }
+        notifications.addFirst( item );
+        return notifications;
+    }
+
+    private static Deque<Notification> withLimit( Deque<Notification> notifications )
+    {
+        if ( notifications != null )
+        {
+            Notification mostRecent = notifications.peekFirst();
+            if ( mostRecent != null && mostRecent.getLevel() == NotificationLevel.LOOP )
+            {
+                notifications.pollFirst();
+            }
+            else
+            {
+                notifications.pollLast();
+            }
+            if ( notifications.isEmpty() )
+            {
+                return null;
+            }
+        }
+        return notifications;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.scheduling.JobType.DATAVALUE_IMPORT;
 import static org.hisp.dhis.scheduling.JobType.METADATA_IMPORT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Deque;
 import java.util.Map;
@@ -221,7 +222,9 @@ class NotifierTest extends DhisSpringTest
             } );
         } );
         awaitTermination( e );
-        assertEquals( 500, notifier.getNotificationsByJobType( METADATA_IMPORT ).size() );
+        int actualSize = notifier.getNotificationsByJobType( METADATA_IMPORT ).size();
+        int delta = actualSize - 500;
+        assertTrue( delta <= 5, "delta should not be larger than number of workers but was: " + delta );
     }
 
     private JobConfiguration createJobConfig( int i )


### PR DESCRIPTION
### Summary
Re-adds the notifications of item level that had been removed to not overflow the in-memory notifier's buffer with details forcing stage messages out. To not have the same issue a new `NotificationLevel` was added `LOOP` which is treated like `DEBUG` except that when found as the most recent notification in a buffer it is replaced by the newest message instead of append it.
Thereby the item level messages do not grow the number of notifications kept in memory. 

For users this appears as if the item level is updated while the process and stage level messages are appended.

To better give the user an orientation where in the loop we are the message is prefixed with a `[<n>/<m>]` counter.

As a consequence the limit bookkeeping needed to be adjusted.
As two or three collections of a  `Pool` need to be modified "atomically" to be truly thread-safe the modifying operations on a `Pool` were made `synchronized`. As each `JobType` has it own pool it is very unlikely that multiple threads would even work with the same `Pool` instance. This is only possible when a single job uses multi-threading as part of its execution and within that execution messages would be sent to the notifier.

### Automatic Testing
I relaxed the assert for size in the existing tests. While the implementation should not allow to actually grow past the limit this limit always was a soft limit. We do not care if the limit is exceeded temporary as long as it will count correctly eventually. To make room for this the tests allows n more (but not less) items than the limit with n being the number of threads used in the test.

### Manual Testing
* open _Analytics tables management_ in the _Data Administration_ app: http://localhost:8080/dhis-web-data-administration/index.html#/analytics
* run the analytics table generation and observe the shown messages
* notice the "updating" loop items with the `[<n>/<m>]` counts before the message