### PR TITLE
fix: JpaCriteriaQueryEngine query non-persisted field OrgUnit level ( 2.36 )

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -659,6 +659,7 @@ public class OrganisationUnit
         return set;
     }
 
+    @Property( persistedAs = "hierarchyLevel" )
     @JsonProperty( value = "level", access = JsonProperty.Access.READ_ONLY )
     @JacksonXmlProperty( localName = "level", isAttribute = true )
     public int getLevel()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/annotation/Property.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/schema/annotation/Property.java
@@ -49,6 +49,17 @@ public @interface Property
 
     Access access() default Access.READ_WRITE;
 
+    /**
+     * This is essentially a manual override to specify the
+     * {@link org.hisp.dhis.schema.Property#getFieldName()} of the annotated
+     * member.
+     *
+     * @return Name of the field this property is persisted as in case this is a
+     *         non persistent property which has a corresponding persistent
+     *         member.
+     */
+    String persistedAs() default "";
+
     enum Value
     {
         TRUE,

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/CriteriaQueryEngineTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/query/CriteriaQueryEngineTest.java
@@ -29,9 +29,7 @@ package org.hisp.dhis.query;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Collection;
 import java.util.List;
@@ -43,6 +41,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementGroup;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.query.operators.MatchMode;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
@@ -739,6 +738,42 @@ public class CriteriaQueryEngineTest extends TransactionalIntegrationTest
         assertEquals( 0, queryEngine.count( query ) );
         assertEquals( 0, queryEngine.query( query ).size() );
 
+    }
+
+    @Test
+    public void testOrderByNonPersistedFieldNameAsc()
+    {
+        OrganisationUnit parent = createOrganisationUnit( "parent" );
+        identifiableObjectManager.save( parent );
+
+        OrganisationUnit child = createOrganisationUnit( "child" );
+        child.setParent( parent );
+        identifiableObjectManager.save( child );
+
+        Schema schema = schemaService.getDynamicSchema( OrganisationUnit.class );
+        Query query = Query.from( schema );
+        query.addOrder( Order.asc( schema.getProperty( "level" ) ) );
+        List<? extends IdentifiableObject> orgUnits = queryEngine.query( query );
+        assertEquals( "parent", orgUnits.get( 0 ).getName() );
+        assertEquals( "child", orgUnits.get( 1 ).getName() );
+    }
+
+    @Test
+    public void testOrderByNonPersistedFieldNameDesc()
+    {
+        OrganisationUnit parent = createOrganisationUnit( "parent" );
+        identifiableObjectManager.save( parent );
+
+        OrganisationUnit child = createOrganisationUnit( "child" );
+        child.setParent( parent );
+        identifiableObjectManager.save( child );
+
+        Schema schema = schemaService.getDynamicSchema( OrganisationUnit.class );
+        Query query = Query.from( schema );
+        query.addOrder( Order.desc( schema.getProperty( "level" ) ) );
+        List<? extends IdentifiableObject> orgUnits = queryEngine.query( query );
+        assertEquals( "child", orgUnits.get( 0 ).getName() );
+        assertEquals( "parent", orgUnits.get( 1 ).getName() );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/PropertyPropertyIntrospector.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/introspection/PropertyPropertyIntrospector.java
@@ -207,6 +207,11 @@ public class PropertyPropertyIntrospector implements PropertyIntrospector
             {
                 property.setReadable( false );
             }
+
+            if ( !pAnnotation.persistedAs().isEmpty() )
+            {
+                property.setFieldName( pAnnotation.persistedAs() );
+            }
         }
     }
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12541
Add annotation `@Property( persistedAs = "hierarchyLevel" )` to allow overwrite `getLevel` by `getHierarchyLevel` which is used by `JpaCriteriaQueryEngine`
This is fixed  for 2.37+  by another developer but was not back-ported.