### PR TITLE
feat: job progress tracking for cleanup of reserved values job [DHIS2-12858]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveUsedOrExpiredReservedValuesJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/RemoveUsedOrExpiredReservedValuesJob.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Component;
 /**
  * @author Henning Håkonsen
  */
-@Component( "removeUsedOrExpiredReservedValuesJob" )
+@Component
 @RequiredArgsConstructor
 public class RemoveUsedOrExpiredReservedValuesJob implements Job
 {
@@ -53,6 +53,8 @@ public class RemoveUsedOrExpiredReservedValuesJob implements Job
     @Override
     public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
-        reservedValueService.removeUsedOrExpiredReservations();
+        progress.startingProcess( "Delete expired reserved values" );
+        progress.startingStage( "Deleting expired reserved values" );
+        progress.endingProcess( progress.runStage( reservedValueService::removeUsedOrExpiredReservations ) );
     }
 }


### PR DESCRIPTION
Adds `JobProgress` tracking to the `RemoveUsedOrExpiredReservedValuesJob`.

As this job does run a single DB delete there is no detail that could be tracked.