### PR TITLE
feat: log deprecation notice when using XmlObjectMapper (#10435)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/render/DefaultRenderService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/render/DefaultRenderService.java
@@ -143,6 +143,7 @@ public class DefaultRenderService
     public <T> void toXml( OutputStream output, T value )
         throws IOException
     {
+        log.info( "Deprecation-Notice: XML support will be removed in 2.39" );
         xmlMapper.writeValue( output, value );
     }
 
@@ -150,6 +151,7 @@ public class DefaultRenderService
     public <T> T fromXml( InputStream input, Class<T> klass )
         throws IOException
     {
+        log.info( "Deprecation-Notice: XML support will be removed in 2.39" );
         return xmlMapper.readValue( input, klass );
     }
 
@@ -157,6 +159,7 @@ public class DefaultRenderService
     public <T> T fromXml( String input, Class<T> klass )
         throws IOException
     {
+        log.info( "Deprecation-Notice: XML support will be removed in 2.39" );
         return xmlMapper.readValue( input, klass );
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
@@ -48,8 +48,8 @@ import org.hisp.dhis.webapi.mvc.DhisApiVersionHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.interceptor.RequestInfoInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
+import org.hisp.dhis.webapi.mvc.messageconverter.XmlDeprecationNoticeHttpMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
 import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -177,7 +177,7 @@ public class MvcTestConfig implements WebMvcConfigurer
     @Bean
     public MappingJackson2XmlHttpMessageConverter mappingJackson2XmlHttpMessageConverter()
     {
-        XmlPathMappingJackson2XmlHttpMessageConverter messageConverter = new XmlPathMappingJackson2XmlHttpMessageConverter(
+        XmlDeprecationNoticeHttpMessageConverter messageConverter = new XmlDeprecationNoticeHttpMessageConverter(
             xmlMapper );
 
         messageConverter.setSupportedMediaTypes( Arrays.asList(

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/MetadataImportExportController.java
@@ -212,6 +212,26 @@ public class MetadataImportExportController
         return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
+    @PostMapping( value = "", consumes = APPLICATION_XML_VALUE )
+    @ResponseBody
+    public WebMessage postXmlMetadata( HttpServletRequest request )
+        throws IOException
+    {
+        MetadataImportParams params = metadataImportService.getParamsFromMap( contextService.getParameterValuesMap() );
+        Metadata metadata = renderService
+            .fromXml( StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() ), Metadata.class );
+        params.addMetadata( schemaService.getMetadataSchemas(), metadata );
+
+        if ( params.hasJobId() )
+        {
+            return startAsyncMetadata( params );
+        }
+
+        ImportReport importReport = metadataImportService.importMetadata( params );
+
+        return importReport( importReport ).withPlainResponseBefore( DhisApiVersion.V38 );
+    }
+
     @GetMapping( "/csvImportClasses" )
     public @ResponseBody List<CsvImportClass> getCsvImportClasses()
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlDeprecationNoticeHttpMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlDeprecationNoticeHttpMessageConverter.java
@@ -27,70 +27,48 @@
  */
 package org.hisp.dhis.webapi.mvc.messageconverter;
 
-import java.util.List;
-import java.util.regex.Pattern;
+import java.io.IOException;
+import java.lang.reflect.Type;
 
-import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.webapi.utils.ContextUtils;
-import org.springframework.http.MediaType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * Custom {@link MappingJackson2XmlHttpMessageConverter} that only supports XML
- * for certain endpoints.
+ * Custom {@link MappingJackson2XmlHttpMessageConverter} that logs deprecation
+ * notice when XML support is given through an ObjectMapper.
  *
  * @author Morten Olav Hansen
  */
-public class XmlPathMappingJackson2XmlHttpMessageConverter extends MappingJackson2XmlHttpMessageConverter
+@Slf4j
+public class XmlDeprecationNoticeHttpMessageConverter extends MappingJackson2XmlHttpMessageConverter
 {
-    private static final List<Pattern> XML_PATTERNS = List.of(
-        Pattern.compile( "/(\\d\\d/)?relationships(/?$|/.+)" ),
-        Pattern.compile( "/(\\d\\d/)?enrollments(/?$|/.+)" ),
-        Pattern.compile( "/(\\d\\d/)?events(/?$|/.+)" ),
-        Pattern.compile( "/(\\d\\d/)?trackedEntityInstances(/?$|/.+)" ),
-        Pattern.compile( "/(\\d\\d/)?dataValueSets(/?$|/.+)" ),
-        Pattern.compile( "/(\\d\\d/)?analytics(/?$|/.+)" ),
-        Pattern.compile( "/(\\d\\d/)?completeDataSetRegistrations(/?$|/.+)" ) );
-
-    public XmlPathMappingJackson2XmlHttpMessageConverter( ObjectMapper objectMapper )
+    public XmlDeprecationNoticeHttpMessageConverter( ObjectMapper objectMapper )
     {
         super( objectMapper );
     }
 
     @Override
-    public boolean canRead( Class<?> clazz, MediaType mediaType )
+    protected Object readInternal( Class<?> clazz, HttpInputMessage inputMessage )
+        throws IOException,
+        HttpMessageNotReadableException
     {
-        HttpServletRequest request = ContextUtils.getRequest();
-        String pathInfo = request.getPathInfo();
-
-        for ( var pathPattern : XML_PATTERNS )
-        {
-            if ( pathPattern.matcher( pathInfo ).matches() )
-            {
-                return super.canRead( clazz, mediaType );
-            }
-        }
-
-        return false;
+        log.info( "Deprecation-Notice: XML support will be removed in 2.39" );
+        return super.readInternal( clazz, inputMessage );
     }
 
     @Override
-    public boolean canWrite( Class<?> clazz, MediaType mediaType )
+    protected void writeInternal( Object object, Type type, HttpOutputMessage outputMessage )
+        throws IOException,
+        HttpMessageNotWritableException
     {
-        HttpServletRequest request = ContextUtils.getRequest();
-        String pathInfo = request.getPathInfo();
-
-        for ( var pathPattern : XML_PATTERNS )
-        {
-            if ( pathPattern.matcher( pathInfo ).matches() )
-            {
-                return super.canWrite( clazz, mediaType );
-            }
-        }
-
-        return false;
+        log.info( "Deprecation-Notice: XML support will be removed in 2.39" );
+        super.writeInternal( object, type, outputMessage );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -48,8 +48,8 @@ import org.hisp.dhis.webapi.mvc.interceptor.RequestInfoInterceptor;
 import org.hisp.dhis.webapi.mvc.interceptor.UserContextInterceptor;
 import org.hisp.dhis.webapi.mvc.messageconverter.CsvMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
+import org.hisp.dhis.webapi.mvc.messageconverter.XmlDeprecationNoticeHttpMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
-import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
 import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -157,7 +157,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration
     @Bean
     public MappingJackson2XmlHttpMessageConverter mappingJackson2XmlHttpMessageConverter()
     {
-        XmlPathMappingJackson2XmlHttpMessageConverter messageConverter = new XmlPathMappingJackson2XmlHttpMessageConverter(
+        XmlDeprecationNoticeHttpMessageConverter messageConverter = new XmlDeprecationNoticeHttpMessageConverter(
             xmlMapper );
 
         messageConverter.setSupportedMediaTypes( Arrays.asList(


### PR DESCRIPTION
## Summary

* Logs deprecation notice whenever a direct usage of `XmlObjectMapper` happens
* Adds back support for XML in `/api/metadata`

[DHIS2-13045](https://jira.dhis2.org/browse/DHIS2-13045)