### PR TITLE
test: adds tests for /trackedEntityInstances/query (DHIS2-11702) 

### DIFF
--- a/dhis-2/dhis-e2e-test/pom.xml
+++ b/dhis-2/dhis-e2e-test/pom.xml
@@ -16,9 +16,19 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.17.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.17.2</version>
+    </dependency>
+    <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.3.1</version>
+      <version>5.0.0</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
@@ -104,7 +114,21 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.0.0-M6</version>
+          <dependencies>
+            <dependency>
+              <groupId>me.fabriciorby</groupId>
+              <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+              <version>0.1.0</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <reportFormat>plain</reportFormat>
+            <consoleOutputReporter>
+              <disable>true</disable>
+            </consoleOutputReporter>
+            <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter"/>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>io.committed</groupId>

--- a/dhis-2/dhis-e2e-test/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-e2e-test/src/main/resources/log4j2.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2004-2022, University of Oslo
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without
+  ~ modification, are permitted provided that the following conditions are met:
+  ~ Redistributions of source code must retain the above copyright notice, this
+  ~ list of conditions and the following disclaimer.
+  ~
+  ~ Redistributions in binary form must reproduce the above copyright notice,
+  ~ this list of conditions and the following disclaimer in the documentation
+  ~ and/or other materials provided with the distribution.
+  ~ Neither the name of the HISP project nor the names of its contributors may
+  ~ be used to endorse or promote products derived from this software without
+  ~ specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ~ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  ~ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  ~ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+  ~ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  ~ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  ~ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  ~ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  ~ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<Configuration status="INFO" >
+  <Appenders>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+      <PatternLayout
+              pattern="%d [%t] %-5level %logger{36} - %msg%n%throwable"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="ConsoleAppender"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/OnFailureLogAppender.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/extensions/OnFailureLogAppender.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.helpers.extensions;
+
+import io.restassured.internal.RestAssuredResponseImpl;
+import io.restassured.internal.log.LogRepository;
+import io.restassured.listener.ResponseValidationFailureListener;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.ResponseSpecification;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.TextStringBuilder;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
+ */
+public class OnFailureLogAppender
+    implements ResponseValidationFailureListener
+{
+    final String[] includedRequestParts = { "method", "URI", "Body" };
+
+    final String[] ignoredResponseParts = { "Cache-Control", "ETag", "X-Content-Type-Options", "X-XSS-Protection",
+        "X-Frame-Options", "Date", "Keep-Alive", "Connection" };
+
+    @Override
+    public void onFailure( RequestSpecification requestSpecification, ResponseSpecification responseSpecification,
+        Response response )
+    {
+        LogRepository logRepository = ((RestAssuredResponseImpl) response).getLogRepository();
+
+        TextStringBuilder builder = new TextStringBuilder();
+
+        builder.appendNewLine()
+            .appendln( filteredRequestLogs( logRepository ) )
+            .appendNewLine()
+            .appendln( filteredResponseLog( logRepository ) );
+
+        responseSpecification.onFailMessage( builder.build() );
+    }
+
+    private String filteredRequestLogs( LogRepository logRepository )
+    {
+        return Arrays.stream( logRepository.getRequestLog().split( System.lineSeparator() ) )
+            .filter( p -> StringUtils.containsAny( p, includedRequestParts ) )
+            .collect( Collectors.joining( System.lineSeparator() ) );
+    }
+
+    private String filteredResponseLog( LogRepository logRepository )
+    {
+        return Arrays.stream( logRepository.getResponseLog().split( System.lineSeparator() ) )
+            .filter( p -> !StringUtils.containsAny( p, ignoredResponseParts ) )
+            .collect( Collectors.joining( System.lineSeparator() ) );
+    }
+
+}

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/matchers/CustomMatchers.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/helpers/matchers/CustomMatchers.java
@@ -31,6 +31,7 @@ package org.hisp.dhis.helpers.matchers;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -80,6 +81,24 @@ public class CustomMatchers
             public void describeTo( Description description )
             {
                 description.appendText( "a string that contains one of " + strings.toString());
+            }
+        };
+    }
+
+    public static TypeSafeDiagnosingMatcher<Object> hasToStringContaining( List<String> substrings ) {
+        return new TypeSafeDiagnosingMatcher<Object>()
+        {
+            @Override
+            protected boolean matchesSafely( Object item, Description mismatchDescription )
+            {
+                String toString = item.toString();
+                return substrings.stream().allMatch( toString::contains);
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendValue( "a toString() that contains substrings in any order " + substrings );
             }
         };
     }

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/TrackedEntityInstanceQueryTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/TrackedEntityInstanceQueryTests.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.hisp.dhis.tracker;
+
+import com.google.gson.JsonObject;
+import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.ApiTest;
+import org.hisp.dhis.Constants;
+import org.hisp.dhis.actions.IdGenerator;
+import org.hisp.dhis.actions.LoginActions;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.actions.tracker.importer.TrackerActions;
+import org.hisp.dhis.helpers.QueryParamsBuilder;
+import org.hisp.dhis.tracker.importer.databuilder.EnrollmentDataBuilder;
+import org.hisp.dhis.tracker.importer.databuilder.TeiDataBuilder;
+import org.hisp.dhis.utils.DataGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hisp.dhis.helpers.matchers.CustomMatchers.hasToStringContaining;
+
+/**
+ * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
+ */
+class TrackedEntityInstanceQueryTests
+    extends ApiTest
+{
+    private TrackerActions trackerActions;
+
+    private RestApiActions trackedEntityInstanceQueryActions;
+
+    private final String ou = Constants.ORG_UNIT_IDS[0];
+
+    private final Pair<String, String> firstNameAttribute = Pair
+        .of( "dIVt4l5vIOa", "TrackedEntityInstanceQueryTests_Firstname" + DataGenerator.randomString( 4 ) );
+
+    private final Pair<String, String> lastNameAttribute = Pair
+        .of( "kZeSYCgaHTk", "TrackedEntityInstanceQueryTests_Lastname" + DataGenerator.randomString( 4 ) );
+
+    private final Pair<String, String> ageProgramAttribute = Pair.of(
+        "ypGAwVRNtVY", "11"
+    );
+
+    private String teiId;
+
+    @BeforeAll
+    public void beforeAll()
+    {
+        trackerActions = new TrackerActions();
+        trackedEntityInstanceQueryActions = new RestApiActions( "/trackedEntityInstances/query" );
+
+        new LoginActions().loginAsSuperUser();
+
+        teiId = createTei();
+    }
+
+    Stream<Arguments> queryShouldReturnTeisMatchingAttributeValue()
+    {
+        return Stream.of(
+            Arguments.of( "query=LIKE:first" ),
+            Arguments.of( String
+                .format( "attribute=%s:LIKE:%s", firstNameAttribute.getKey(), firstNameAttribute.getValue().substring( 0, 8 ) ) ),
+            Arguments.of( String.format( "attribute:%s&query=LIKE:%s", lastNameAttribute.getKey(),
+                lastNameAttribute.getValue().substring( 10, 15 ) ) ),
+            Arguments.of(
+                String.format( "attribute=%s:EQ:%s&attribute=%s:EQ:%s", lastNameAttribute.getKey(), lastNameAttribute.getValue(),
+                    firstNameAttribute.getKey(), firstNameAttribute.getValue() ) ),
+            Arguments.of(
+                String.format( "attribute=%s:EQ:%s", ageProgramAttribute.getKey(), ageProgramAttribute.getValue() )
+            )
+        );
+    }
+
+    @ParameterizedTest( name = "/query with params [{arguments}]" )
+    @MethodSource
+    public void queryShouldReturnTeisMatchingAttributeValue( String attributesQueryParams )
+    {
+
+        QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder()
+            .add( "trackedEntityType", Constants.TRACKED_ENTITY_TYPE )
+            .add( "ouMode", "ACCESSIBLE" );
+
+        trackedEntityInstanceQueryActions.get( String.format( "%s&%s", queryParamsBuilder.build(), attributesQueryParams ) )
+            .validate()
+            .statusCode( 200 )
+            .body( "height", equalTo( 1 ) )
+            .body( "rows", hasItem(
+                hasToStringContaining( Arrays.asList( teiId, lastNameAttribute.getValue(), firstNameAttribute.getValue() ) ) ) );
+    }
+
+    private String createTei()
+    {
+        String uid = new IdGenerator().generateUniqueId();
+
+        JsonObject tei = new TeiDataBuilder().setTeiType( Constants.TRACKED_ENTITY_TYPE )
+            .setOu( ou )
+            .addAttribute( firstNameAttribute.getKey(), firstNameAttribute.getValue() )
+            .addAttribute( lastNameAttribute.getKey(), lastNameAttribute.getValue() )
+            .addEnrollment( new EnrollmentDataBuilder()
+                .setProgram( Constants.TRACKER_PROGRAM_ID )
+                .setOu( ou )
+                .addAttribute( ageProgramAttribute.getKey(), ageProgramAttribute.getValue() )
+            )
+            .setId( uid )
+            .array();
+
+        trackerActions.postAndGetJobReport( tei ).validateSuccessfulImport();
+
+        return uid;
+    }
+}

--- a/dhis-2/dhis-e2e-test/src/test/resources/setup/tracker_metadata.json
+++ b/dhis-2/dhis-e2e-test/src/test/resources/setup/tracker_metadata.json
@@ -755,7 +755,7 @@
       "name": "TA Last name",
       "shortName": "TA Last name",
       "aggregationType": "NONE",
-      "displayInListNoProgram": false,
+      "displayInListNoProgram": true,
       "pattern": "",
       "skipSynchronization": false,
       "generated": false,
@@ -851,7 +851,7 @@
       "name": "TA First name",
       "shortName": "TA First name",
       "aggregationType": "NONE",
-      "displayInListNoProgram": false,
+      "displayInListNoProgram": true,
       "pattern": "",
       "skipSynchronization": false,
       "generated": false,
@@ -1844,7 +1844,7 @@
       "maxTeiCountToReturn": 0,
       "allowAuditLog": true,
       "featureType": "POLYGON",
-      "minAttributesRequiredToSearch": 1,
+      "minAttributesRequiredToSearch": 0,
       "sharing": {
         "owner": "M5zQapPyTZI",
         "userGroups": {
@@ -1867,8 +1867,8 @@
           "displayShortName": "null TA First name",
           "externalAccess": false,
           "valueType": "TEXT",
-          "searchable": false,
-          "displayInList": false,
+          "searchable": true,
+          "displayInList": true,
           "name": "TA Person TA First name",
           "favorite": false,
           "access": {
@@ -1904,8 +1904,8 @@
           "displayShortName": "null TA Last name",
           "externalAccess": false,
           "valueType": "TEXT",
-          "searchable": false,
-          "displayInList": false,
+          "searchable": true,
+          "displayInList": true,
           "name": "TA Person TA Last name",
           "favorite": false,
           "access": {


### PR DESCRIPTION
- added a few tests to cover the bug fixed in DHIS2-11702
- configured surefire maven plugin conf to display test report in tree view. This is especially useful for listing parametrized tests. 

  Prev: 
  ```
  org.hisp.dhis.tracker.TrackedEntityInstanceQueryTests.queryShouldReturnTeisMatchingAttributeValue(String)[1]
  org.hisp.dhis.tracker.TrackedEntityInstanceQueryTests.queryShouldReturnTeisMatchingAttributeValue(String)[2]
  org.hisp.dhis.tracker.TrackedEntityInstanceQueryTests.queryShouldReturnTeisMatchingAttributeValue(String)[3]
  org.hisp.dhis.tracker.TrackedEntityInstanceQueryTests.queryShouldReturnTeisMatchingAttributeValue(String)[4]
  
  ```
  
  Now: 
  ```
  - org.hisp.dhis.tracker.TrackedEntityInstanceQueryTests
  [INFO] | +-- [XX] queryShouldReturnTeisMatchingAttributeValue(String) /query with params [query=LIKE:first] - 0.11s
  [INFO] | +-- [XX] queryShouldReturnTeisMatchingAttributeValue(String) /query with params [attribute=dIVt4l5vIOa:LIKE:TrackedE] - 0.047s
  [INFO] | +-- [XX] queryShouldReturnTeisMatchingAttributeValue(String) /query with params [attribute:kZeSYCgaHTk&query=LIKE:ityIn] - 0.062s
  [INFO] | +-- [XX] queryShouldReturnTeisMatchingAttributeValue(String) /query with params [attribute=kZeSYCgaHTk:EQ:TrackedEntityInstanceQueryTests_LastnameQWkw&attribute=dIVt4l5vIOa:EQ:TrackedEntityInstanceQueryTests_FirstnamewwhC] - 0.046s
  [INFO] | +-- [XX] queryShouldReturnTeisMatchingAttributeValue(String) /query with params [attribute=ypGAwVRNtVY:EQ:11] - 0.048s
  ```

- expanded the failure messages. Rest assured logs validation errors, but are usually buried in the long list of logs and it's difficult to associate the failure with the test. 

  Prev:
  ```
  [ERROR]   TrackedEntityInstanceQueryTests.queryShouldReturnTeisMatchingAttributeValue:118 1 expectation failed.
  Expected status code <200> but was <500>.
  
  ```
    Now: 
  ```
    [ERROR]   TrackedEntityInstanceQueryTests.queryShouldReturnTeisMatchingAttributeValue:118 1 expectation failed.
    Expected status code <200> but was <500>.
    
    On fail message: 
    Request method: GET
    Request URI:    http://localhost:8080/api/trackedEntityInstances/query/?trackedEntityType=Q9GufDoplCL&ouMode=ACCESSIBLE&query=LIKE:first
    Body:                   <none>
    
    HTTP/1.1 500 
    Content-Type: application/json;charset=UTF-8
    Content-Length: 162
    
    {
        "httpStatus": "Internal Server Error",
        "httpStatusCode": 500,
        "status": "ERROR",
        "message": "An unexpected error has occured. Please contact your system administrator"
    }
  
  ```
