### PR TITLE
fix: ORG_UNIT_CODE Generation fails [ DHIS2-13032 ]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/textpattern/StringMethodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/textpattern/StringMethodType.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.textpattern;
 
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * @author Stian Sandvold
  */
@@ -56,7 +58,7 @@ public class StringMethodType
     @Override
     public boolean validateText( String format, String text )
     {
-        if ( format.isEmpty() )
+        if ( StringUtils.isEmpty( format ) )
         {
             return true;
         }
@@ -67,7 +69,7 @@ public class StringMethodType
     @Override
     public String getFormattedText( String format, String value )
     {
-        if ( format.isEmpty() )
+        if ( StringUtils.isEmpty( format ) )
         {
             return value;
         }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
@@ -77,8 +77,6 @@ class TrackedEntityAttributeControllerTest extends DhisWebSpringTest
             .content( TestUtils.convertObjectToJsonBytes( trackedEntityAttribute ) ) )
             .andExpect( status().is( HttpStatus.SC_CREATED ) );
 
-        dbmsManager.clearSession();
-
         mvc.perform( get( TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT + "/" + trackedEntityAttribute.getUid()
             + "/generateAndReserve" ).param( "ORG_UNIT_CODE", "A030101" ).session( session ) )
             .andExpect( status().isOk() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
@@ -43,15 +43,14 @@ import org.hisp.dhis.webapi.utils.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.transaction.support.TransactionTemplate;
 
+/**
+ * @author Luca Cambi
+ */
 class TrackedEntityAttributeControllerTest extends DhisWebSpringTest
 {
     @Autowired
     protected DbmsManager dbmsManager;
-
-    @Autowired
-    protected TransactionTemplate transactionTemplate;
 
     @Test
     void shouldGenerateRandomValuesOrgUnitCodeAndRandom()

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
@@ -33,7 +33,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.apache.http.HttpStatus;
 import org.hisp.dhis.common.Objects;
-import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.schema.descriptors.TrackedEntityAttributeSchemaDescriptor;
 import org.hisp.dhis.textpattern.TextPattern;
 import org.hisp.dhis.textpattern.TextPatternParser;
@@ -41,7 +40,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
 import org.hisp.dhis.webapi.utils.TestUtils;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
 
 /**
@@ -49,9 +47,6 @@ import org.springframework.mock.web.MockHttpSession;
  */
 class TrackedEntityAttributeControllerTest extends DhisWebSpringTest
 {
-    @Autowired
-    protected DbmsManager dbmsManager;
-
     @Test
     void shouldGenerateRandomValuesOrgUnitCodeAndRandom()
         throws Exception

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.attribute;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.apache.http.HttpStatus;
+import org.hisp.dhis.common.Objects;
+import org.hisp.dhis.dbms.DbmsManager;
+import org.hisp.dhis.schema.descriptors.TrackedEntityAttributeSchemaDescriptor;
+import org.hisp.dhis.textpattern.TextPattern;
+import org.hisp.dhis.textpattern.TextPatternParser;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.webapi.DhisWebSpringTest;
+import org.hisp.dhis.webapi.utils.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.transaction.support.TransactionTemplate;
+
+class TrackedEntityAttributeControllerTest extends DhisWebSpringTest
+{
+    @Autowired
+    protected DbmsManager dbmsManager;
+
+    @Autowired
+    protected TransactionTemplate transactionTemplate;
+
+    @Test
+    void shouldGenerateRandomValuesOrgUnitCodeAndRandom()
+        throws Exception
+    {
+        MockHttpSession session = getSession( "ALL" );
+
+        TrackedEntityAttribute trackedEntityAttribute = createTrackedEntityAttribute( 'A' );
+        trackedEntityAttribute.setGenerated( true );
+
+        String pattern = "ORG_UNIT_CODE() + RANDOM(#######)";
+
+        TextPattern textPattern = TextPatternParser.parse( pattern );
+
+        textPattern.setOwnerObject( Objects.fromClass( trackedEntityAttribute.getClass() ) );
+        textPattern.setOwnerUid( trackedEntityAttribute.getUid() );
+
+        trackedEntityAttribute.setTextPattern( textPattern );
+        trackedEntityAttribute.setPattern( pattern );
+
+        mvc.perform( post( TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT )
+            .session( session )
+            .contentType( TestUtils.APPLICATION_JSON_UTF8 )
+            .content( TestUtils.convertObjectToJsonBytes( trackedEntityAttribute ) ) )
+            .andExpect( status().is( HttpStatus.SC_CREATED ) );
+
+        dbmsManager.clearSession();
+
+        mvc.perform( get( TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT + "/" + trackedEntityAttribute.getUid()
+            + "/generateAndReserve" ).param( "ORG_UNIT_CODE", "A030101" ).session( session ) )
+            .andExpect( status().isOk() );
+    }
+
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/attribute/TrackedEntityAttributeControllerTest.java
@@ -27,31 +27,26 @@
  */
 package org.hisp.dhis.webapi.controller.attribute;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 
-import org.apache.http.HttpStatus;
 import org.hisp.dhis.common.Objects;
 import org.hisp.dhis.schema.descriptors.TrackedEntityAttributeSchemaDescriptor;
 import org.hisp.dhis.textpattern.TextPattern;
 import org.hisp.dhis.textpattern.TextPatternParser;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.hisp.dhis.webapi.DhisWebSpringTest;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.utils.TestUtils;
 import org.junit.jupiter.api.Test;
-import org.springframework.mock.web.MockHttpSession;
 
 /**
  * @author Luca Cambi
  */
-class TrackedEntityAttributeControllerTest extends DhisWebSpringTest
+class TrackedEntityAttributeControllerTest extends DhisControllerConvenienceTest
 {
     @Test
     void shouldGenerateRandomValuesOrgUnitCodeAndRandom()
         throws Exception
     {
-        MockHttpSession session = getSession( "ALL" );
 
         TrackedEntityAttribute trackedEntityAttribute = createTrackedEntityAttribute( 'A' );
         trackedEntityAttribute.setGenerated( true );
@@ -66,15 +61,13 @@ class TrackedEntityAttributeControllerTest extends DhisWebSpringTest
         trackedEntityAttribute.setTextPattern( textPattern );
         trackedEntityAttribute.setPattern( pattern );
 
-        mvc.perform( post( TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT )
-            .session( session )
-            .contentType( TestUtils.APPLICATION_JSON_UTF8 )
-            .content( TestUtils.convertObjectToJsonBytes( trackedEntityAttribute ) ) )
-            .andExpect( status().is( HttpStatus.SC_CREATED ) );
+        String uid = assertStatus( org.springframework.http.HttpStatus.CREATED,
+            POST( TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT,
+                new String( TestUtils.convertObjectToJsonBytes( trackedEntityAttribute ) ) ) );
 
-        mvc.perform( get( TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT + "/" + trackedEntityAttribute.getUid()
-            + "/generateAndReserve" ).param( "ORG_UNIT_CODE", "A030101" ).session( session ) )
-            .andExpect( status().isOk() );
+        assertStatus( org.springframework.http.HttpStatus.OK, GET(
+            TrackedEntityAttributeSchemaDescriptor.API_ENDPOINT + "/" + uid + "/generateAndReserve"
+                + "?ORG_UNIT_CODE=A030101" ) );
     }
 
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.event;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.util.Date;
 import java.util.List;
@@ -38,7 +39,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.reservedvalue.ReserveValueException;
 import org.hisp.dhis.reservedvalue.ReservedValue;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
@@ -119,8 +119,9 @@ public class TrackedEntityAttributeController
     @GetMapping( "/{id}/requiredValues" )
     @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
     public @ResponseBody Map<String, List<String>> getRequiredValues( @PathVariable String id )
+        throws WebMessageException
     {
-        TrackedEntityAttribute trackedEntityAttribute = trackedEntityAttributeService.getTrackedEntityAttribute( id );
+        TrackedEntityAttribute trackedEntityAttribute = getTrackedEntityAttribute( id );
 
         return textPatternService.getRequiredValues( trackedEntityAttribute.getTextPattern() );
     }
@@ -196,12 +197,12 @@ public class TrackedEntityAttributeController
 
         if ( trackedEntityAttribute == null )
         {
-            throw new WebMessageException( WebMessageUtils.notFound( TrackedEntityAttribute.class, id ) );
+            throw new WebMessageException( notFound( TrackedEntityAttribute.class, id ) );
         }
 
         if ( trackedEntityAttribute.getTextPattern() == null )
         {
-            throw new WebMessageException( WebMessageUtils.badRequest( "Attribute does not contain pattern." ) );
+            throw new WebMessageException( badRequest( "Attribute does not contain pattern." ) );
         }
 
         return trackedEntityAttribute;


### PR DESCRIPTION
for segments that do not have a pattern (e.g. ORG_UNIT_CODE), the pattern is serialized as null instead of an empty string
This fix adds a null safe check for those cases