### PR TITLE
feat: job progress tracking for push analysis job [DHIS2-12858]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysisService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/pushanalysis/PushAnalysisService.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.pushanalysis;
 import java.io.IOException;
 import java.util.List;
 
-import org.hisp.dhis.scheduling.JobConfiguration;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.user.User;
 
 /**
@@ -60,11 +60,10 @@ public interface PushAnalysisService
      *
      * @param pushAnalysis PushAnalysis to generate report from
      * @param user User to base data on
-     * @param jobId JobId to track process
      * @return String containing a HTML report
      * @throws IOException if the upload of report content failed.
      */
-    String generateHtmlReport( PushAnalysis pushAnalysis, User user, JobConfiguration jobId )
+    String generateHtmlReport( PushAnalysis pushAnalysis, User user )
         throws IOException;
 
     /**
@@ -72,10 +71,8 @@ public interface PushAnalysisService
      * PushAnalysis, using generateHtmlReport to generate the reports for each
      * individual user in the UserGroups.
      *
-     * @param uid of the PushAnalysis
-     * @param jobId to track process
+     * @param uids UIDs of the PushAnalysis to run
+     * @param progress tracking of the processing
      */
-    void runPushAnalysis( String uid, JobConfiguration jobId );
-
-    void runPushAnalysis( List<String> uids, JobConfiguration jobId );
+    void runPushAnalysis( List<String> uids, JobProgress progress );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -160,7 +160,8 @@ public enum JobType
             || this == EVENT_PROGRAMS_DATA_SYNC
             || this == TRACKER_PROGRAMS_DATA_SYNC
             || this == DATA_SYNC
-            || this == SMS_SEND;
+            || this == SMS_SEND
+            || this == PUSH_ANALYSIS;
     }
 
     public boolean isUsingErrorNotification()

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -66,12 +66,10 @@ import org.hisp.dhis.mapgeneration.MapUtils;
 import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
-import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.grid.GridUtils;
-import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.ChartUtils;
 import org.hisp.dhis.system.velocity.VelocityManager;
@@ -95,10 +93,9 @@ import com.google.common.io.ByteSource;
  * @author Stian Sandvold
  */
 @Slf4j
-@Service( "org.hisp.dhis.pushanalysis.PushAnalysisService" )
+@Service
 @Transactional
-public class DefaultPushAnalysisService
-    implements PushAnalysisService
+public class DefaultPushAnalysisService implements PushAnalysisService
 {
     private static final Encoder encoder = new Encoder();
 
@@ -469,38 +466,6 @@ public class DefaultPushAnalysisService
 
         return dhisConfigurationProvider.getServerBaseUrl() + "/api/externalFileResources/" + accessToken;
 
-    }
-
-    /**
-     * Helper method for logging both for custom logger and for notifier.
-     *
-     * @param jobId associated with the task running (for notifier)
-     * @param notificationLevel The level this message should be logged
-     * @param message message to be logged
-     * @param completed a flag indicating the task is completed (notifier)
-     * @param exception exception if one exists (logger)
-     */
-    private void log( JobConfiguration jobId, NotificationLevel notificationLevel, String message, boolean completed,
-        Throwable exception )
-    {
-        notifier.notify( jobId, notificationLevel, message, completed );
-
-        switch ( notificationLevel )
-        {
-        case DEBUG:
-            log.debug( message );
-        case INFO:
-            log.info( message );
-            break;
-        case WARN:
-            log.warn( message, exception );
-            break;
-        case ERROR:
-            log.error( message, exception );
-            break;
-        default:
-            break;
-        }
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -28,11 +28,13 @@
 package org.hisp.dhis.pushanalysis;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.joining;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -65,7 +67,7 @@ import org.hisp.dhis.mapping.Map;
 import org.hisp.dhis.message.MessageSender;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.grid.GridUtils;
@@ -86,7 +88,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.MimeTypeUtils;
 
-import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
 
@@ -176,130 +177,105 @@ public class DefaultPushAnalysisService
         return pushAnalysisStore.getAll();
     }
 
-    @Override
-    public void runPushAnalysis( String uid, JobConfiguration jobId )
+    private void runPushAnalysis( String uid, JobProgress progress )
     {
-        // ----------------------------------------------------------------------
-        // Set up
-        // ----------------------------------------------------------------------
-
-        PushAnalysis pushAnalysis = pushAnalysisStore.getByUid( uid );
-        Set<User> receivingUsers = new HashSet<>();
-        notifier.clear( jobId );
-
         // ----------------------------------------------------------------------
         // Pre-check
         // ----------------------------------------------------------------------
-
-        log( jobId, NotificationLevel.INFO, "Starting pre-check on PushAnalysis", false, null );
+        PushAnalysis pushAnalysis = pushAnalysisStore.getByUid( uid );
+        progress.startingStage( "Starting pre-check on PushAnalysis " + uid
+            + ": " + ((pushAnalysis != null) ? pushAnalysis.getName() : "") );
 
         if ( pushAnalysis == null )
         {
-            log( jobId, NotificationLevel.ERROR,
-                "PushAnalysis with uid '" + uid + "' was not found. Terminating PushAnalysis", true, null );
+            progress.failedStage( "PushAnalysis with uid '" + uid + "' was not found. Terminating PushAnalysis" );
             return;
         }
-
-        if ( pushAnalysis.getRecipientUserGroups().size() == 0 )
+        if ( pushAnalysis.getRecipientUserGroups().isEmpty() )
         {
-            log( jobId, NotificationLevel.ERROR,
-                "PushAnalysis with uid '" + uid + "' has no userGroups assigned. Terminating PushAnalysis.", true,
-                null );
+            progress.failedStage(
+                "PushAnalysis with uid '" + uid + "' has no userGroups assigned. Terminating PushAnalysis." );
             return;
         }
 
         if ( pushAnalysis.getDashboard() == null )
         {
-            log( jobId, NotificationLevel.ERROR,
-                "PushAnalysis with uid '" + uid + "' has no dashboard assigned. Terminating PushAnalysis.", true,
-                null );
+            progress.failedStage(
+                "PushAnalysis with uid '" + uid + "' has no dashboard assigned. Terminating PushAnalysis." );
             return;
         }
 
         if ( dhisConfigurationProvider.getServerBaseUrl() == null )
         {
-            log( jobId, NotificationLevel.ERROR,
-                "Missing configuration '" + ConfigurationKey.SERVER_BASE_URL.getKey() + "'. Terminating PushAnalysis.",
-                true, null );
+            progress.failedStage( "Missing configuration '" + ConfigurationKey.SERVER_BASE_URL.getKey()
+                + "'. Terminating PushAnalysis." );
             return;
         }
 
-        log( jobId, NotificationLevel.INFO, "pre-check completed successfully", false, null );
+        progress.completedStage( "pre-check completed successfully" );
 
         // ----------------------------------------------------------------------
         // Compose list of users that can receive PushAnalysis
         // ----------------------------------------------------------------------
 
-        log( jobId, NotificationLevel.INFO, "Composing list of receiving users", false, null );
-
+        progress.startingStage( "Composing list of receiving users" );
+        Set<User> receivingUsers = new HashSet<>();
+        Set<User> skippedUsers = new HashSet<>();
         for ( UserGroup userGroup : pushAnalysis.getRecipientUserGroups() )
         {
             for ( User user : userGroup.getMembers() )
             {
                 if ( !user.hasEmail() )
                 {
-                    log( jobId, NotificationLevel.WARN,
-                        "Skipping user: User '" + user.getUsername() + "' is missing a valid email.", false, null );
-                    continue;
+                    skippedUsers.add( user );
                 }
-
-                receivingUsers.add( user );
+                else
+                {
+                    receivingUsers.add( user );
+                }
             }
         }
-
-        log( jobId, NotificationLevel.INFO, "List composed. " + receivingUsers.size() + " eligible users found.",
-            false, null );
+        progress.completedStage( "List composed. " + receivingUsers.size() + " eligible users found."
+            + "Skipping users without valid email: " + skippedUsers.stream().map( User::getUsername )
+                .collect( joining( "," ) ) );
 
         // ----------------------------------------------------------------------
         // Generating reports
         // ----------------------------------------------------------------------
-
-        log( jobId, NotificationLevel.INFO, "Generating and sending reports", false, null );
-
-        for ( User user : receivingUsers )
-        {
-            try
-            {
+        String name = pushAnalysis.getName();
+        progress.startingStage( "Generating and sending reports for PushAnalysis " + name, receivingUsers.size() );
+        progress.runStage( receivingUsers,
+            user -> "Generating and sending PushAnalysis " + name + " for user '" + user.getUsername() + "'.",
+            user -> {
                 String title = pushAnalysis.getTitle();
-                String html = generateHtmlReport( pushAnalysis, user, jobId );
-
+                String html = "";
+                try
+                {
+                    html = generateHtmlReport( pushAnalysis, user );
+                }
+                catch ( IOException ex )
+                {
+                    throw new UncheckedIOException( ex );
+                }
                 // TODO: Better handling of messageStatus; Might require
                 // refactoring of EmailMessageSender
                 @SuppressWarnings( "unused" )
                 Future<OutboundMessageResponse> status = messageSender
-                    .sendMessageAsync( title, html, "", null, Sets.newHashSet( user ), true );
-
-            }
-            catch ( Exception e )
-            {
-                log( jobId, NotificationLevel.ERROR,
-                    "Could not create or send report for PushAnalysis '" + pushAnalysis.getName() + "' and User '" +
-                        user.getUsername() + "': " + e.getMessage(),
-                    false, e );
-            }
-        }
+                    .sendMessageAsync( title, html, "", null, Set.of( user ), true );
+            } );
     }
 
     @Override
-    public void runPushAnalysis( List<String> uids, JobConfiguration jobId )
+    public void runPushAnalysis( List<String> uids, JobProgress progress )
     {
-        uids.forEach( uid -> runPushAnalysis( uid, jobId ) );
+        uids.forEach( uid -> runPushAnalysis( uid, progress ) );
     }
 
     @Override
-    public String generateHtmlReport( PushAnalysis pushAnalysis, User user, JobConfiguration jobId )
+    public String generateHtmlReport( PushAnalysis pushAnalysis, User user )
         throws IOException
     {
-        if ( jobId == null )
-        {
-            jobId = new JobConfiguration( "inMemoryGenerateHtmlReport", JobType.PUSH_ANALYSIS,
-                currentUserService.getCurrentUser().getUid(), true );
-            notifier.clear( jobId );
-        }
-
         user = user == null ? currentUserService.getCurrentUser() : user;
-        log( jobId, NotificationLevel.INFO, "Generating PushAnalysis for user '" + user.getUsername() + "'.", false,
-            null );
 
         // ----------------------------------------------------------------------
         // Pre-process the dashboardItem and store them as Strings
@@ -314,7 +290,7 @@ public class DefaultPushAnalysisService
             // In normal conditions all DashboardItem has a type.
             if ( item.getType() != null )
             {
-                itemHtml.put( item.getUid(), getItemHtml( item, user, jobId ) );
+                itemHtml.put( item.getUid(), getItemHtml( item, user ) );
                 itemLink.put( item.getUid(), getItemLink( item ) );
             }
         }
@@ -344,11 +320,7 @@ public class DefaultPushAnalysisService
 
         new VelocityManager().getEngine().getTemplate( "push-analysis-main-html.vm" ).merge( context, stringWriter );
 
-        log( jobId, NotificationLevel.INFO, "Finished generating PushAnalysis for user '" + user.getUsername() + "'.",
-            false, null );
-
         return stringWriter.toString().replaceAll( "\\R", "" );
-
     }
 
     // --------------------------------------------------------------------------
@@ -361,9 +333,8 @@ public class DefaultPushAnalysisService
      *
      * @param item to generate resource
      * @param user to generate for
-     * @param jobId for logging
      */
-    private String getItemHtml( DashboardItem item, User user, JobConfiguration jobId )
+    private String getItemHtml( DashboardItem item, User user )
         throws IOException
     {
         switch ( item.getType() )
@@ -372,15 +343,10 @@ public class DefaultPushAnalysisService
             return generateMapHtml( item.getMap(), user );
         case VISUALIZATION:
             return generateVisualizationHtml( item.getVisualization(), user );
-        case EVENT_CHART:
-            // TODO: Add support for EventCharts
-            return "";
-        case EVENT_REPORT:
-            // TODO: Add support for EventReports
-            return "";
         default:
-            log( jobId, NotificationLevel.WARN,
-                "Dashboard item of type '" + item.getType() + "' not supported. Skipping.", false, null );
+            // TODO: Add support for EventCharts
+            // TODO: Add support for EventReports
+            log.warn( "Dashboard item of type '" + item.getType() + "' not supported. Skipping." );
             return "";
         }
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -70,7 +70,6 @@ import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.grid.GridUtils;
-import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.system.util.ChartUtils;
 import org.hisp.dhis.system.velocity.VelocityManager;
 import org.hisp.dhis.user.CurrentUserService;
@@ -99,8 +98,6 @@ public class DefaultPushAnalysisService implements PushAnalysisService
 {
     private static final Encoder encoder = new Encoder();
 
-    private final Notifier notifier;
-
     private final SystemSettingManager systemSettingManager;
 
     private final DhisConfigurationProvider dhisConfigurationProvider;
@@ -123,7 +120,7 @@ public class DefaultPushAnalysisService implements PushAnalysisService
 
     private final IdentifiableObjectStore<PushAnalysis> pushAnalysisStore;
 
-    public DefaultPushAnalysisService( Notifier notifier, SystemSettingManager systemSettingManager,
+    public DefaultPushAnalysisService( SystemSettingManager systemSettingManager,
         DhisConfigurationProvider dhisConfigurationProvider, ExternalFileResourceService externalFileResourceService,
         FileResourceService fileResourceService, CurrentUserService currentUserService,
         MapGenerationService mapGenerationService, VisualizationGridService visualizationGridService,
@@ -131,7 +128,6 @@ public class DefaultPushAnalysisService implements PushAnalysisService
         @Qualifier( "emailMessageSender" ) MessageSender messageSender,
         @Qualifier( "org.hisp.dhis.pushanalysis.PushAnalysisStore" ) IdentifiableObjectStore<PushAnalysis> pushAnalysisStore )
     {
-        checkNotNull( notifier );
         checkNotNull( systemSettingManager );
         checkNotNull( dhisConfigurationProvider );
         checkNotNull( externalFileResourceService );
@@ -144,7 +140,6 @@ public class DefaultPushAnalysisService implements PushAnalysisService
         checkNotNull( messageSender );
         checkNotNull( pushAnalysisStore );
 
-        this.notifier = notifier;
         this.systemSettingManager = systemSettingManager;
         this.dhisConfigurationProvider = dhisConfigurationProvider;
         this.externalFileResourceService = externalFileResourceService;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/PushAnalysisJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/scheduling/PushAnalysisJob.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.pushanalysis.scheduling;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.pushanalysis.PushAnalysisService;
 import org.hisp.dhis.scheduling.Job;
@@ -40,20 +42,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Stian Sandvold
  */
-@Component( "pushAnalysisJob" )
+@Component
+@AllArgsConstructor
 public class PushAnalysisJob implements Job
 {
     private final PushAnalysisService pushAnalysisService;
-
-    public PushAnalysisJob( PushAnalysisService pushAnalysisService )
-    {
-        checkNotNull( pushAnalysisService );
-        this.pushAnalysisService = pushAnalysisService;
-    }
-
-    // -------------------------------------------------------------------------
-    // Implementation
-    // -------------------------------------------------------------------------
 
     @Override
     public JobType getJobType()
@@ -62,11 +55,14 @@ public class PushAnalysisJob implements Job
     }
 
     @Override
-    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
+    public void execute( JobConfiguration config, JobProgress progress )
     {
-        PushAnalysisJobParameters parameters = (PushAnalysisJobParameters) jobConfiguration.getJobParameters();
+        PushAnalysisJobParameters params = (PushAnalysisJobParameters) config.getJobParameters();
 
-        pushAnalysisService.runPushAnalysis( parameters.getPushAnalysis(), jobConfiguration );
+        List<String> pushAnalysis = params.getPushAnalysis();
+        progress.startingProcess( "Push analysis for " + pushAnalysis );
+        pushAnalysisService.runPushAnalysis( pushAnalysis, progress );
+        progress.completedProcess( null );
     }
 
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/PushAnalysisController.java
@@ -97,8 +97,7 @@ public class PushAnalysisController
         log.info(
             "User '" + currentUserService.getCurrentUser().getUsername() + "' started PushAnalysis for 'rendering'" );
 
-        String result = pushAnalysisService.generateHtmlReport( pushAnalysis, currentUserService.getCurrentUser(),
-            null );
+        String result = pushAnalysisService.generateHtmlReport( pushAnalysis, currentUserService.getCurrentUser() );
         response.getWriter().write( result );
         response.getWriter().close();
     }
@@ -106,8 +105,7 @@ public class PushAnalysisController
     @ResponseStatus( HttpStatus.NO_CONTENT )
     @PostMapping( "/{uid}/run" )
     public void sendPushAnalysis( @PathVariable( ) String uid )
-        throws WebMessageException,
-        IOException
+        throws WebMessageException
     {
         PushAnalysis pushAnalysis = pushAnalysisService.getByUid( uid );
 
@@ -117,8 +115,8 @@ public class PushAnalysisController
                 notFound( "Push analysis with uid " + uid + " was not found" ) );
         }
 
-        JobConfiguration pushAnalysisJobConfiguration = new JobConfiguration( "pushAnalysisJob from controller",
+        JobConfiguration config = new JobConfiguration( "pushAnalysisJob from controller",
             JobType.PUSH_ANALYSIS, "", new PushAnalysisJobParameters( uid ), true, true );
-        schedulingManager.executeNow( pushAnalysisJobConfiguration );
+        schedulingManager.executeNow( config );
     }
 }


### PR DESCRIPTION
### Summary
Adds `JobProgress` tracking for push analysis job.

Because of the way tracking loops works I had to reduce the level of detail of logging done previously for the generation itself. The  `generateHtmlReport` could also be called directly from the controller in which case it now only logs errors to log files. The task scheduling that was sort of abused earlier so messages would end up in the `Notifier` is now only part of an actual job run when called via `runPushAnalysis`. I think the intention here never was to have `generateHtmlReport` also push to the `Notifier` but to make the code work for both entry points.

### Manual Testing
* open scheduler app
* create new job of type _Push Analysis_ (select available _Push analysis_ parameter)
* eventually setup the `server.base.url` (see documentation?)
* manually run the created job
* check http://localhost:8080/api/scheduling/running/PUSH_ANALYSIS
* check http://localhost:8080/api/scheduling/completed/PUSH_ANALYSIS
* check http://localhost:8080/api/system/tasks/PUSH_ANALYSIS.json

### Example Output
Here for a failed run as I did not setup the base URL. Not fully sure how to test this.

```json
[
  {
    "error":"Missing configuration 'server.base.url'. Terminating PushAnalysis.",
    "status":"ERROR",
    "completedTime":"2022-04-11T15:47:34.634",
    "startedTime":"2022-04-11T15:47:34.618",
    "description":"Push analysis for [jtcMAKhWwnc]",
    "stages":[
      {
        "error":"Missing configuration 'server.base.url'. Terminating PushAnalysis.",
        "status":"ERROR",
        "completedTime":"2022-04-11T15:47:34.634",
        "startedTime":"2022-04-11T15:47:34.626",
        "description":"Starting pre-check on PushAnalysis jtcMAKhWwnc: Immunization Key Indicators Monthly Report",
        "totalItems":0,
        "items":[
          
        ],
        "duration":8,
        "complete":true
      }
    ],
    "jobId":"oO5rNnFyCcI",
    "duration":16,
    "complete":true
  },
  {
    "status":"SUCCESS",
    "completedTime":"2022-04-11T15:47:34.636",
    "startedTime":"2022-04-11T15:47:34.636",
    "stages":[
      
    ],
    "jobId":"oO5rNnFyCcI",
    "duration":0,
    "complete":true
  }
]
```