### PR TITLE
build: increase heap size during tests

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -54,7 +54,7 @@
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
         <sonar.organization>dhis2</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <surefireArgLine>-Xmx1024m --illegal-access=permit</surefireArgLine>
+        <surefireArgLine>-Xmx2024m --illegal-access=permit</surefireArgLine>
 
         <!-- Needed so we can disable running tests when the default profile is used (activated by default). It does not
           honor -DskipTests otherwise https://maven.apache.org/surefire/maven-surefire-plugin/examples/skipping-tests.html -->


### PR DESCRIPTION
2.38.0-rc builds are failing on jenkins wth out-of-memory errors. It doesn't fail on master where the heap size is larger or github actions. Not sure if this setting will help, but it's worth trying. Setting maven_opts or java_opts on jenkins agent doesn't seem to increase the heap. 