### PR TITLE
fix: datastore - keys in namespace lastUpdated can be empty [DHIS2-12602]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
@@ -39,6 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.LocalDate;
+
 import org.hisp.dhis.datastore.DatastoreEntry;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionType;
@@ -110,6 +112,15 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest
     {
         assertEquals( "Namespace not found: 'missing'",
             GET( "/dataStore/missing" ).error( HttpStatus.NOT_FOUND ).getMessage() );
+    }
+
+    @Test
+    void testGetKeysInNamespace_LastUpdatedFilter()
+    {
+        assertStatus( HttpStatus.CREATED, POST( "/dataStore/pets/cat", "{'answer': 42}" ) );
+        assertStatus( HttpStatus.CREATED, POST( "/dataStore/pets/dog", "{'answer': true}" ) );
+        assertTrue( GET( "/dataStore/pets?lastUpdated=" + (LocalDate.now().getYear() + 1) ).content().stringValues()
+            .isEmpty() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
@@ -106,7 +106,7 @@ public class DatastoreController
 
         List<String> keys = service.getKeysInNamespace( namespace, lastUpdated );
 
-        if ( keys.isEmpty() )
+        if ( keys.isEmpty() && !service.isUsedNamespace( namespace ) )
         {
             throw new NotFoundException( String.format( "Namespace not found: '%s'", namespace ) );
         }


### PR DESCRIPTION
### Summary
Problem was that empty `keys` collection could be due to the `lastUpdated` filtering and not because the namespace was generally empty (non existent). 

So in case the found `keys` are empty we also need to check that `!service.isUsedNamespace( namespace )`.
This was simply added.

### Automatic Testing
I added a new test scenario testing that an empty list after `lastUpdated` filtering on non empty namespace does return an empty list and does not throw the exception causing the error web message.