### PR TITLE
fix: tracker page sync [DHIS2-13030]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -171,6 +171,7 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging
                 .collect( Collectors.toList() );
             log.info( "The lastSynchronized flag of these TEIs will be updated: " + teiUIDs );
             teiService.updateTrackedEntityInstancesSyncTimestamp( teiUIDs, context.getStartTime() );
+            return;
         }
         throw new MetadataSyncServiceException( format( "Page %d synchronisation failed.", queryParams.getPage() ) );
     }


### PR DESCRIPTION
By mistake I changed the branching logic while I introduced the job progress tracking. Here a `return` was needed so we do not always run into the `throw` below for the success path. 