### PR TITLE
feat: job progress stage specific failure policy [DHIS2-13101]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -121,8 +121,8 @@ public interface JobProgress
     boolean isCancellationRequested();
 
     /**
-     * @return true, if the currently running stage should be skipped.
-     * By default, this is only the case if cancellation was requested.
+     * @return true, if the currently running stage should be skipped. By
+     *         default, this is only the case if cancellation was requested.
      */
     default boolean isSkipCurrentStage()
     {
@@ -173,7 +173,8 @@ public interface JobProgress
     void startingStage( String description, int workItems, FaultTolerance onFailure )
         throws CancellationException;
 
-    default void startingStage( String description, int workItems ) {
+    default void startingStage( String description, int workItems )
+    {
         startingStage( description, workItems, FaultTolerance.PARENT );
     }
 
@@ -196,7 +197,8 @@ public interface JobProgress
         failedStage( getMessage( cause ) );
     }
 
-    default void startingWorkItem( String description ) {
+    default void startingWorkItem( String description )
+    {
         startingWorkItem( description, FaultTolerance.PARENT );
     }
 
@@ -355,7 +357,8 @@ public interface JobProgress
                 failedWorkItem( ex );
                 if ( isSkipCurrentStage() )
                 {
-                    String action = isCancellationRequested() ? "request for cancellation" : "skipping the current stage";
+                    String action = isCancellationRequested() ? "request for cancellation"
+                        : "skipping the current stage";
                     failedStage( new CancellationException( "skipped as failing item caused " + action ) );
                     return false;
                 }
@@ -537,18 +540,19 @@ public interface JobProgress
     enum FaultTolerance
     {
         /**
-         * Default used to "inherit" the behaviour from the node level above.
-         * If the root is not specified the behaviour is {@link #FAIL}.
+         * Default used to "inherit" the behaviour from the node level above. If
+         * the root is not specified the behaviour is {@link #FAIL}.
          */
         PARENT,
         /**
-         * Fail and abort processing as soon as possible.
-         * This is the effective default.
+         * Fail and abort processing as soon as possible. This is the effective
+         * default.
          */
         FAIL,
         /**
-         * When an item or stage fails the entire stage is skipped/ignored unconditionally.
-         * This means no further items are processed in the stage.
+         * When an item or stage fails the entire stage is skipped/ignored
+         * unconditionally. This means no further items are processed in the
+         * stage.
          */
         SKIP_STAGE,
         /**
@@ -556,10 +560,11 @@ public interface JobProgress
          */
         SKIP_ITEM,
         /**
-         * Same as {@link #SKIP_ITEM} but only if there has been a successfully completed item before.
-         * Otherwise, behaves like {@link #FAIL}.
+         * Same as {@link #SKIP_ITEM} but only if there has been a successfully
+         * completed item before. Otherwise, behaves like {@link #FAIL}.
          *
-         * This option is useful to only skip when it has been proven that the processing in general works but some items just have issues.
+         * This option is useful to only skip when it has been proven that the
+         * processing in general works but some items just have issues.
          */
         SKIP_ITEM_OUTLIER
     }
@@ -625,6 +630,7 @@ public interface JobProgress
         {
             return job.isEmpty() ? defaultValue : job.iterator().next().getStartedTime();
         }
+
         private final Date startedTime = new Date();
 
         @JsonProperty

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/scheduling/JobProgressTest.java
@@ -242,7 +242,8 @@ class JobProgressTest
         };
         JobProgress progress = newMockJobProgress();
         List<Integer> items = IntStream.range( 1, parallelism * 2 ).boxed().collect( toList() );
-        assertTrue( progress.runStageInParallel( parallelism, items, String::valueOf, work ) );
+        progress.runStageInParallel( parallelism, items, String::valueOf, work );
+        assertFalse( progress.isSkipCurrentStage() );
         int itemCount = items.size();
         assertEquals( new HashSet<>( items ), new HashSet<>( worked ) );
         assertEquals( itemCount, enterCount.get() );
@@ -280,7 +281,8 @@ class JobProgressTest
         };
         JobProgress progress = newMockJobProgress();
         List<Integer> items = IntStream.range( 1, parallelism * 2 ).boxed().collect( toList() );
-        assertFalse( progress.runStageInParallel( parallelism, items, String::valueOf, work ) );
+        progress.runStageInParallel( parallelism, items, String::valueOf, work );
+        assertTrue( progress.isSkipCurrentStage() );
         int itemCount = items.size();
         int successCount = itemCount / 2;
         int errorCount = itemCount - successCount;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -40,6 +40,7 @@ import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssu
 import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -880,7 +881,7 @@ public class DefaultDataIntegrityService
         BiFunction<DataIntegrityCheck, RuntimeException, T> createErrorReport )
     {
         progress.startingProcess( "Data Integrity check" );
-        progress.startingStage( stageDesc, checks.size() );
+        progress.startingStage( stageDesc, checks.size(), SKIP_ITEM );
         progress.runStage( checks.stream().map( checksByName::get ).filter( Objects::nonNull ),
             DataIntegrityCheck::getDescription,
             check -> {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -40,7 +40,7 @@ import static org.hisp.dhis.dataintegrity.DataIntegrityDetails.DataIntegrityIssu
 import static org.hisp.dhis.dataintegrity.DataIntegrityYamlReader.readDataIntegrityYaml;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.resourcetable;
 
 import static java.util.Comparator.reverseOrder;
 import static java.util.stream.Collectors.toList;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.resourcetable;
 
 import static java.util.Comparator.reverseOrder;
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -215,7 +216,7 @@ public class DefaultResourceTableService
             .filter( view -> !view.isQuery() )
             .collect( toList() );
 
-        progress.startingStage( "Create SQL views", nonQueryViews.size() );
+        progress.startingStage( "Create SQL views", nonQueryViews.size(), SKIP_ITEM );
         progress.runStage( nonQueryViews, SqlView::getViewName, view -> {
             try
             {
@@ -236,7 +237,7 @@ public class DefaultResourceTableService
             .filter( view -> !view.isQuery() )
             .sorted( reverseOrder() )
             .collect( toList() );
-        progress.startingStage( "Drop SQL views", nonQueryViews.size() );
+        progress.startingStage( "Drop SQL views", nonQueryViews.size(), SKIP_ITEM );
         progress.runStage( nonQueryViews, SqlView::getViewName, sqlViewService::deleteSqlView );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.sms.scheduling;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.Date;
 import java.util.List;

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sms/scheduling/SendScheduledMessageJob.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.sms.scheduling;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.Date;
 import java.util.List;
@@ -106,7 +107,7 @@ public class SendScheduledMessageJob implements Job
 
         if ( outboundSmsList != null && !outboundSmsList.isEmpty() )
         {
-            progress.startingStage( "Sending SMS messages", outboundSmsList.size() );
+            progress.startingStage( "Sending SMS messages", outboundSmsList.size(), SKIP_ITEM_OUTLIER );
             progress.runStage( outboundSmsList,
                 outboundSms -> format( "Sending message `%1.20s...` to %d recipients",
                     outboundSms.getMessage(), outboundSms.getRecipients().size() ),

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.table;
 
 import static org.hisp.dhis.commons.collection.CollectionUtils.emptyIfNull;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.util.Date;
@@ -114,7 +115,7 @@ public class DefaultAnalyticsTableGenerator
         progress.startingStage( "Updating settings" );
         progress.runStage( () -> updateLastSuccessfulSystemSettings( params, clock ) );
 
-        progress.startingStage( "Invalidate analytics caches" );
+        progress.startingStage( "Invalidate analytics caches", SKIP_STAGE );
         progress.runStage( analyticsCache::invalidateAll );
         progress.completedProcess( "Analytics tables updated" );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.analytics.table;
 
 import static org.hisp.dhis.commons.collection.CollectionUtils.emptyIfNull;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.analytics.table;
 
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexName;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexes;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.util.Collection;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.table;
 
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexName;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexes;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.util.Collection;
@@ -150,7 +151,7 @@ public class DefaultAnalyticsTableService
         }
 
         List<AnalyticsIndex> indexes = getIndexes( partitions );
-        progress.startingStage( "Creating indexes " + tableType, indexes.size() );
+        progress.startingStage( "Creating indexes " + tableType, indexes.size(), SKIP_ITEM_OUTLIER );
         createIndexes( indexes, progress );
         clock.logTime( "Created indexes" );
 
@@ -294,7 +295,6 @@ public class DefaultAnalyticsTableService
     private void createIndexes( List<AnalyticsIndex> indexes, JobProgress progress )
     {
         AnalyticsTableType type = getAnalyticsTableType();
-        log.info( "No of analytics table indexes: " + indexes.size() );
         progress.runStageInParallel( getProcessNo(), indexes,
             index -> getIndexName( index, type ).replace( "\"", "" ),
             tableManager::createIndex );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dataset.notifications;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.*;
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_DUE_DATE;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.*;
 import java.util.Map.Entry;
@@ -56,7 +57,6 @@ import org.hisp.dhis.notification.NotificationMessageRenderer;
 import org.hisp.dhis.notification.SendStrategy;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.outboundmessage.BatchResponseStatus;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.program.message.ProgramMessage;
@@ -447,7 +447,8 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
 
     private void sendInternalDhisMessages( String type, List<DhisMessage> messages, JobProgress progress )
     {
-        progress.startingStage( "Dispatching DHIS " + type + " notification messages", messages.size() );
+        progress.startingStage( "Dispatching DHIS " + type + " notification messages", messages.size(),
+            SKIP_ITEM_OUTLIER );
         progress.runStage( messages, msg -> msg.message.getSubject(),
             msg -> internalMessageService.sendMessage(
                 new MessageConversationParams.Builder( msg.recipients, null, msg.message.getSubject(),
@@ -458,9 +459,11 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
 
     private void sendProgramMessages( String type, List<ProgramMessage> messages, JobProgress progress )
     {
-        progress.startingStage( "Dispatching DHIS " + type + " notification messages", messages.size() );
-        BatchResponseStatus status = externalMessageService.sendMessages( messages );
-        progress.completedStage( "Resulting status from ProgramMessageService:\n " + status.toString() );
+        progress.startingStage( "Dispatching DHIS " + type + " notification messages", messages.size(),
+            SKIP_ITEM_OUTLIER );
+        progress.runStage( null,
+            status -> "Resulting status from ProgramMessageService:\n " + status.toString(),
+            () ->externalMessageService.sendMessages( messages ));
     }
 
     private void sendBatch( String type, MessageBatch batch, JobProgress progress )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -463,7 +463,7 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
             SKIP_ITEM_OUTLIER );
         progress.runStage( null,
             status -> "Resulting status from ProgramMessageService:\n " + status.toString(),
-            () ->externalMessageService.sendMessages( messages ));
+            () -> externalMessageService.sendMessages( messages ) );
     }
 
     private void sendBatch( String type, MessageBatch batch, JobProgress progress )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.dataset.notifications;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.*;
 import static org.hisp.dhis.program.notification.NotificationTrigger.SCHEDULED_DAYS_DUE_DATE;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.*;
 import java.util.Map.Entry;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.fileresource;
 
 import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -83,7 +84,7 @@ public class FileResourceCleanUpJob implements Job
         if ( !FileResourceRetentionStrategy.FOREVER.equals( retentionStrategy ) )
         {
             List<FileResource> expired = fileResourceService.getExpiredFileResources( retentionStrategy );
-            progress.startingStage( "Deleting expired file resources", expired.size() );
+            progress.startingStage( "Deleting expired file resources", expired.size(), SKIP_ITEM_OUTLIER );
             progress.runStage( expired, FileResourceCleanUpJob::toIdentifier, fr -> {
                 if ( safeDelete( fr ) )
                 {
@@ -95,7 +96,7 @@ public class FileResourceCleanUpJob implements Job
         // Delete failed uploads
         List<FileResource> orphanedFileResources = fileResourceService.getOrphanedFileResources().stream()
             .filter( fr -> !isFileStored( fr ) ).collect( toList() );
-        progress.startingStage( "Deleting failed uploads", orphanedFileResources.size() );
+        progress.startingStage( "Deleting failed uploads", orphanedFileResources.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( orphanedFileResources, FileResourceCleanUpJob::toIdentifier, fr -> {
             if ( safeDelete( fr ) )
             {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/FileResourceCleanUpJob.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.fileresource;
 
 import static java.util.stream.Collectors.toList;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.fileresource;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ImageResizingJob.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.fileresource;
 
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -76,7 +77,7 @@ public class ImageResizingJob implements Job
         progress.startingProcess( "Resizing image resources" );
 
         List<FileResource> images = fileResourceService.getAllUnProcessedImagesFiles();
-        progress.startingStage( "Creating and storing images", images.size() );
+        progress.startingStage( "Creating and storing images", images.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( images, FileResource::getStorageKey, this::storeImageFiles );
 
         progress.completedProcess( format( "Number of FileResources processed: %d", images.size() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.program.notification;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.program.notification.NotificationTrigger.PROGRAM_RULE;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.Collections;
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.program.notification;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.program.notification.NotificationTrigger.PROGRAM_RULE;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.Collections;
 import java.util.Date;
@@ -140,7 +141,8 @@ public class DefaultProgramNotificationService
         List<ProgramNotificationTemplate> scheduledTemplates = progress.runStage( List.of(),
             this::getScheduledTemplates );
 
-        progress.startingStage( "Processing ProgramStageNotification messages", scheduledTemplates.size() );
+        progress.startingStage( "Processing ProgramStageNotification messages", scheduledTemplates.size(),
+            SKIP_ITEM_OUTLIER );
         AtomicInteger totalMessageCount = new AtomicInteger();
         progress.runStage( scheduledTemplates.stream(),
             template -> "Processing template " + template.getName(),
@@ -165,7 +167,7 @@ public class DefaultProgramNotificationService
                 .collect( toList() ) );
 
         progress.startingStage( "Processing ProgramStageNotification messages scheduled by program rules",
-            instancesWithTemplates.size() );
+            instancesWithTemplates.size(), SKIP_ITEM_OUTLIER );
         if ( instancesWithTemplates.isEmpty() )
         {
             progress.completedStage( "No instances with templates found." );
@@ -188,7 +190,7 @@ public class DefaultProgramNotificationService
             return Stream.concat( programInstanceBatches, programStageInstanceBatches ).collect( toList() );
         } );
 
-        progress.startingStage( "Sending message batches", batches.size() );
+        progress.startingStage( "Sending message batches", batches.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( batches.stream(),
             batch -> format( "Sending batch with %d DHIS messages and %d program messages",
                 batch.dhisMessages.size(), batch.programMessages.size() ),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
@@ -67,6 +67,8 @@ public class ControlledJobProgress implements JobProgress
 
     private final AtomicBoolean abortAfterFailure = new AtomicBoolean();
 
+    private final AtomicBoolean skipCurrentStage = new AtomicBoolean();
+
     private final Deque<Process> processes = new ConcurrentLinkedDeque<>();
 
     private final AtomicReference<Process> incompleteProcess = new AtomicReference<>();
@@ -112,6 +114,12 @@ public class ControlledJobProgress implements JobProgress
     public boolean isCancellationRequested()
     {
         return cancellationRequested.get();
+    }
+
+    @Override
+    public boolean isSkipCurrentStage()
+    {
+        return skipCurrentStage.get() || isCancellationRequested();
     }
 
     @Override
@@ -168,14 +176,15 @@ public class ControlledJobProgress implements JobProgress
     }
 
     @Override
-    public void startingStage( String description, int workItems )
+    public void startingStage( String description, int workItems, FaultTolerance onFailure )
     {
         if ( isCancellationRequested() )
         {
             throw new CancellationException();
         }
+        skipCurrentStage.set( false );
         tracker.startingStage( description, workItems );
-        Stage stage = addStageRecord( getOrAddLastIncompleteProcess(), description, workItems );
+        Stage stage = addStageRecord( getOrAddLastIncompleteProcess(), description, workItems, onFailure );
         logInfo( stage, "started", description );
     }
 
@@ -192,9 +201,12 @@ public class ControlledJobProgress implements JobProgress
     public void failedStage( String error )
     {
         tracker.failedStage( error );
-        automaticAbort( error, null );
         Stage stage = getOrAddLastIncompleteStage();
         stage.completeExceptionally( error, null );
+        if (stage.getOnFailure() != FaultTolerance.SKIP_STAGE)
+        {
+            automaticAbort( error, null );
+        }
         logError( stage, null, error );
     }
 
@@ -204,18 +216,21 @@ public class ControlledJobProgress implements JobProgress
         cause = cancellationAsAbort( cause );
         tracker.failedStage( cause );
         String message = getMessage( cause );
-        automaticAbort( message, cause );
         Stage stage = getOrAddLastIncompleteStage();
         stage.completeExceptionally( message, cause );
-        sendErrorNotification( stage, cause );
+        if (stage.getOnFailure() != FaultTolerance.SKIP_STAGE)
+        {
+            automaticAbort( message, cause );
+            sendErrorNotification( stage, cause );
+        }
         logError( stage, cause, message );
     }
 
     @Override
-    public void startingWorkItem( String description )
+    public void startingWorkItem( String description, FaultTolerance onFailure )
     {
-        tracker.startingWorkItem( description );
-        Item item = addItemRecord( getOrAddLastIncompleteStage(), description );
+        tracker.startingWorkItem( description, onFailure );
+        Item item = addItemRecord( getOrAddLastIncompleteStage(), description, onFailure );
         logDebug( item, "started", description );
     }
 
@@ -232,9 +247,12 @@ public class ControlledJobProgress implements JobProgress
     public void failedWorkItem( String error )
     {
         tracker.failedWorkItem( error );
-        automaticAbort( error, null );
         Item item = getOrAddLastIncompleteItem();
         item.completeExceptionally( error, null );
+        if (!isSkipped( item ))
+        {
+            automaticAbort( error, null );
+        }
         logError( item, null, error );
     }
 
@@ -243,11 +261,26 @@ public class ControlledJobProgress implements JobProgress
     {
         tracker.failedWorkItem( cause );
         String message = getMessage( cause );
-        automaticAbort( message, cause );
         Item item = getOrAddLastIncompleteItem();
         item.completeExceptionally( message, cause );
-        sendErrorNotification( item, cause );
+        if (!isSkipped( item ) )
+        {
+            automaticAbort( message, cause );
+            sendErrorNotification( item, cause );
+        }
         logError( item, cause, message );
+    }
+
+    private boolean isSkipped( Item item )
+    {
+        FaultTolerance onFailure = item.getOnFailure();
+        if (onFailure == FaultTolerance.SKIP_STAGE) {
+            skipCurrentStage.set( true );
+            return true;
+        }
+        return onFailure == FaultTolerance.SKIP_ITEM
+            || onFailure == FaultTolerance.SKIP_ITEM_OUTLIER
+                && incompleteStage.get().getItems().stream().anyMatch( i -> i.status == Status.SUCCESS );
     }
 
     private void automaticAbort( String error, Exception cause )
@@ -299,13 +332,14 @@ public class ControlledJobProgress implements JobProgress
         Stage stage = incompleteStage.get();
         return stage != null && !stage.isComplete()
             ? stage
-            : addStageRecord( getOrAddLastIncompleteProcess(), null, -1 );
+            : addStageRecord( getOrAddLastIncompleteProcess(), null, -1, FaultTolerance.PARENT );
     }
 
-    private Stage addStageRecord( Process process, String description, int totalItems )
+    private Stage addStageRecord( Process process, String description, int totalItems, FaultTolerance onFailure )
     {
         Deque<Stage> stages = process.getStages();
-        Stage stage = new Stage( description, totalItems );
+        Stage stage = new Stage(description, totalItems,
+            onFailure == FaultTolerance.PARENT ? FaultTolerance.FAIL : onFailure );
         stages.addLast( stage );
         incompleteStage.set( stage );
         return stage;
@@ -316,13 +350,14 @@ public class ControlledJobProgress implements JobProgress
         Item item = incompleteItem.get();
         return item != null && !item.isComplete()
             ? item
-            : addItemRecord( getOrAddLastIncompleteStage(), null );
+            : addItemRecord( getOrAddLastIncompleteStage(), null, FaultTolerance.PARENT );
     }
 
-    private Item addItemRecord( Stage stage, String description )
+    private Item addItemRecord( Stage stage, String description, FaultTolerance onFailure )
     {
         Deque<Item> items = stage.getItems();
-        Item item = new Item( description );
+        Item item = new Item( description,
+            onFailure == FaultTolerance.PARENT ? stage.getOnFailure() : onFailure );
         items.addLast( item );
         incompleteItem.set( item );
         return item;
@@ -330,7 +365,8 @@ public class ControlledJobProgress implements JobProgress
 
     private Exception cancellationAsAbort( Exception cause )
     {
-        return cause instanceof CancellationException && abortAfterFailure.get()
+        return cause instanceof CancellationException
+            && (abortAfterFailure.get() || skipCurrentStage.get())
             ? new RuntimeException( "processing aborted: " + getMessage( cause ) )
             : cause;
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
@@ -203,7 +203,7 @@ public class ControlledJobProgress implements JobProgress
         tracker.failedStage( error );
         Stage stage = getOrAddLastIncompleteStage();
         stage.completeExceptionally( error, null );
-        if (stage.getOnFailure() != FaultTolerance.SKIP_STAGE)
+        if ( stage.getOnFailure() != FaultTolerance.SKIP_STAGE )
         {
             automaticAbort( error, null );
         }
@@ -218,7 +218,7 @@ public class ControlledJobProgress implements JobProgress
         String message = getMessage( cause );
         Stage stage = getOrAddLastIncompleteStage();
         stage.completeExceptionally( message, cause );
-        if (stage.getOnFailure() != FaultTolerance.SKIP_STAGE)
+        if ( stage.getOnFailure() != FaultTolerance.SKIP_STAGE )
         {
             automaticAbort( message, cause );
             sendErrorNotification( stage, cause );
@@ -249,7 +249,7 @@ public class ControlledJobProgress implements JobProgress
         tracker.failedWorkItem( error );
         Item item = getOrAddLastIncompleteItem();
         item.completeExceptionally( error, null );
-        if (!isSkipped( item ))
+        if ( !isSkipped( item ) )
         {
             automaticAbort( error, null );
         }
@@ -263,7 +263,7 @@ public class ControlledJobProgress implements JobProgress
         String message = getMessage( cause );
         Item item = getOrAddLastIncompleteItem();
         item.completeExceptionally( message, cause );
-        if (!isSkipped( item ) )
+        if ( !isSkipped( item ) )
         {
             automaticAbort( message, cause );
             sendErrorNotification( item, cause );
@@ -274,7 +274,8 @@ public class ControlledJobProgress implements JobProgress
     private boolean isSkipped( Item item )
     {
         FaultTolerance onFailure = item.getOnFailure();
-        if (onFailure == FaultTolerance.SKIP_STAGE) {
+        if ( onFailure == FaultTolerance.SKIP_STAGE )
+        {
             skipCurrentStage.set( true );
             return true;
         }
@@ -338,7 +339,7 @@ public class ControlledJobProgress implements JobProgress
     private Stage addStageRecord( Process process, String description, int totalItems, FaultTolerance onFailure )
     {
         Deque<Stage> stages = process.getStages();
-        Stage stage = new Stage(description, totalItems,
+        Stage stage = new Stage( description, totalItems,
             onFailure == FaultTolerance.PARENT ? FaultTolerance.FAIL : onFailure );
         stages.addLast( stage );
         incompleteStage.set( stage );
@@ -367,8 +368,8 @@ public class ControlledJobProgress implements JobProgress
     {
         return cause instanceof CancellationException
             && (abortAfterFailure.get() || skipCurrentStage.get())
-            ? new RuntimeException( "processing aborted: " + getMessage( cause ) )
-            : cause;
+                ? new RuntimeException( "processing aborted: " + getMessage( cause ) )
+                : cause;
     }
 
     private void sendErrorNotification( Node node, Exception cause )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -69,7 +69,7 @@ public class NoopJobProgress implements JobProgress
     }
 
     @Override
-    public void startingStage( String description, int workItems, FaultTolerance onFailure )
+    public void startingStage( String description, int workItems, FailurePolicy onFailure )
     {
         // as the name said we do nothing
     }
@@ -87,7 +87,7 @@ public class NoopJobProgress implements JobProgress
     }
 
     @Override
-    public void startingWorkItem( String description, FaultTolerance onFailure )
+    public void startingWorkItem( String description, FailurePolicy onFailure )
     {
         // as the name said we do nothing
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.scheduling;
 
+import java.util.concurrent.CancellationException;
+
 /**
  * The {@link NoopJobProgress} can be used as a {@link JobProgress} instance
  * when no actual flow control and tracking is wanted. For example in test
@@ -69,7 +71,7 @@ public class NoopJobProgress implements JobProgress
     }
 
     @Override
-    public void startingStage( String description, int workItems )
+    public void startingStage( String description, int workItems, FaultTolerance onFailure )
     {
         // as the name said we do nothing
     }
@@ -87,7 +89,7 @@ public class NoopJobProgress implements JobProgress
     }
 
     @Override
-    public void startingWorkItem( String description )
+    public void startingWorkItem( String description, FaultTolerance onFailure )
     {
         // as the name said we do nothing
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NoopJobProgress.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.scheduling;
 
-import java.util.concurrent.CancellationException;
-
 /**
  * The {@link NoopJobProgress} can be used as a {@link JobProgress} instance
  * when no actual flow control and tracking is wanted. For example in test

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -88,7 +88,7 @@ public class NotifierJobProgress implements JobProgress
     }
 
     @Override
-    public void startingStage( String description, int workItems, FaultTolerance onFailure )
+    public void startingStage( String description, int workItems, FailurePolicy onFailure )
     {
         stageItems = workItems;
         stageItem = 0;
@@ -117,7 +117,7 @@ public class NotifierJobProgress implements JobProgress
     }
 
     @Override
-    public void startingWorkItem( String description, FaultTolerance onFailure )
+    public void startingWorkItem( String description, FailurePolicy onFailure )
     {
         if ( isNotEmpty( description ) )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.scheduling;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.RequiredArgsConstructor;
@@ -88,7 +89,7 @@ public class NotifierJobProgress implements JobProgress
     }
 
     @Override
-    public void startingStage( String description, int workItems )
+    public void startingStage( String description, int workItems, FaultTolerance onFailure )
     {
         stageItems = workItems;
         stageItem = 0;
@@ -117,7 +118,7 @@ public class NotifierJobProgress implements JobProgress
     }
 
     @Override
-    public void startingWorkItem( String description )
+    public void startingWorkItem( String description, FaultTolerance onFailure )
     {
         if ( isNotEmpty( description ) )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.scheduling;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lombok.RequiredArgsConstructor;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.system;
 
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
@@ -59,6 +59,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.vdurmont.semver4j.Semver;
 
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+
 /**
  * @author Morten Svanaes
  */
@@ -233,7 +235,7 @@ public class SystemUpdateService
 
         if ( existingMessages.isEmpty() )
         {
-            progress.startingStage( "Sending notifications to recipients", recipients.size() );
+            progress.startingStage( "Sending notifications to recipients", recipients.size(), SKIP_ITEM_OUTLIER );
             progress.runStage( recipients, recipient -> "to: " + recipient.getUsername(),
                 recipient -> messageService.sendMessage( new MessageConversationParams.Builder()
                     .withRecipients( Set.of( recipient ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemUpdateService.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.system;
 
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,8 +60,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.vdurmont.semver4j.Semver;
-
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 /**
  * @author Morten Svanaes

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.trackedentityattributevalue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.HashSet;
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -168,7 +170,7 @@ public class TrackerTrigramIndexingJob implements Job
         Set<Long> teaIds = new HashSet<>( teaIdList );
 
         // Collect tea ids of all indexable attributets
-        Set<Long> allIndexableAttributeIds = allIndexableAttributes.stream().map( tea -> tea.getId() ).collect(
+        Set<Long> allIndexableAttributeIds = allIndexableAttributes.stream().map( BaseIdentifiableObject::getId ).collect(
             Collectors.toSet() );
 
         log.debug( "Found total {} trigram indexes in db", teaIds.size() );
@@ -182,12 +184,10 @@ public class TrackerTrigramIndexingJob implements Job
 
         log.debug( "Found total {} obsolete trigram indexes in db", teaIds.size() );
 
-        progress.startingStage( "Deleting obsolete trigram indexes", teaIds.size() );
+        progress.startingStage( "Deleting obsolete trigram indexes", teaIds.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( teaIds.stream(), Object::toString,
-            teaId -> trackedEntityAttributeTableManager.dropTrigramIndex( teaId ),
+            trackedEntityAttributeTableManager::dropTrigramIndex,
             TrackerTrigramIndexingJob::computeTrigramIndexingDropSummary );
-        progress.completedStage( "Obsolete trigram indexes dropped" );
-        log.debug( "Dropped {} obsolete trigram indexes", teaIds.size() );
     }
 
     private void createTrigramIndexes( JobProgress progress, Set<TrackedEntityAttribute> indexableAttributes )
@@ -195,7 +195,7 @@ public class TrackerTrigramIndexingJob implements Job
         log.debug( "Creating {} trigram indexes", indexableAttributes.size() );
         progress.startingStage( "Creating trigram indexes for attributes", indexableAttributes.size() );
         progress.runStage( indexableAttributes.stream(), TrackedEntityAttribute::getName,
-            tea -> trackedEntityAttributeTableManager.createTrigramIndex( tea ),
+            trackedEntityAttributeTableManager::createTrigramIndex,
             TrackerTrigramIndexingJob::computeTrigramIndexingCreationSummary );
         progress.completedStage( "Trigram indexes created" );
         log.debug( "Created {} trigram indexes", indexableAttributes.size() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.trackedentityattributevalue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.HashSet;
 import java.util.List;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackerTrigramIndexingJob.java
@@ -170,8 +170,9 @@ public class TrackerTrigramIndexingJob implements Job
         Set<Long> teaIds = new HashSet<>( teaIdList );
 
         // Collect tea ids of all indexable attributets
-        Set<Long> allIndexableAttributeIds = allIndexableAttributes.stream().map( BaseIdentifiableObject::getId ).collect(
-            Collectors.toSet() );
+        Set<Long> allIndexableAttributeIds = allIndexableAttributes.stream().map( BaseIdentifiableObject::getId )
+            .collect(
+                Collectors.toSet() );
 
         log.debug( "Found total {} trigram indexes in db", teaIds.size() );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.user.job;
 
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.List;
 
@@ -105,7 +106,7 @@ public class AccountExpiryAlertJob implements Job
         }
 
         progress.startingStage( "Notify user accounts that expire within next " + inDays + " days",
-            soonExpiring.size() );
+            soonExpiring.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( soonExpiring.stream(), UserAccountExpiryInfo::getUsername,
             user -> emailMessageSender.sendMessage( "Account Expiry Alert", computeEmailMessage( user ),
                 user.getEmail() ),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/AccountExpiryAlertJob.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.user.job;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.List;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.user.job;
 
 import static java.lang.String.format;
 import static java.time.ZoneId.systemDefault;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -77,7 +78,7 @@ public class DisableInactiveUsersJob implements Job
         LocalDate since = today.minusMonths( parameters.getInactiveMonths() );
         Date nMonthsAgo = Date.from( since.atStartOfDay( systemDefault() ).toInstant() );
 
-        progress.startingStage( "Disabling inactive users" );
+        progress.startingStage( "Disabling inactive users", SKIP_STAGE );
         progress.runStage( 0,
             count -> format( "Disabled %d users with %d months of inactivity", count, parameters.getInactiveMonths() ),
             () -> userService.disableUsersInactiveSince( nMonthsAgo ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.user.job;
 
 import static java.lang.String.format;
 import static java.time.ZoneId.systemDefault;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/ControlledJobProgressTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/ControlledJobProgressTest.java
@@ -1,40 +1,140 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package org.hisp.dhis.scheduling;
+
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Consumer;
-import java.util.stream.Stream;
-
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+/**
+ * Tests the processing (in particular the fault tolerance logic) of the
+ * {@link ControlledJobProgress} implementation.
+ *
+ * @author Jan Bernitt
+ */
 class ControlledJobProgressTest
 {
     private final JobConfiguration config = createJobConfig();
 
     private final JobProgress progress = new ControlledJobProgress( config );
 
-    private final Consumer<Integer> alwaysFail =  item -> {
-        throw new IllegalArgumentException("failing");
-    };
+    @Test
+    void testSkipItem_FirstItemFails()
+    {
+        progress.startingStage( "test", 3, SKIP_ITEM );
+        boolean stageSuccessful = progress.runStage( Stream.of( 1, 2, 3 ), String::valueOf, alwaysFail,
+            assertSummary( 0, 3 ) );
+
+        assertTrue( stageSuccessful, "the stage should be considered successful as failing items are skipped" );
+        assertProcessCanContinue();
+    }
 
     @Test
-    void testSkipItem_FirstItemFails() {
-        progress.startingStage( "test", 3, SKIP_ITEM );
-        boolean stageSuccessful = progress.runStage( Stream.of(1,2,3), String::valueOf, alwaysFail,
-            (successes, failures) -> {
-                assertEquals( 0, successes );
-                assertEquals( 3, failures );
-                return null;
-            });
+    void testSkipItemOutlier_FirstItemFailsStageFails()
+    {
+        progress.startingStage( "test", 3, SKIP_ITEM_OUTLIER );
+        boolean stageSuccessful = progress.runStage( Stream.of( 1, 2, 3 ), String::valueOf, alwaysFail,
+            assertSummary( 0, 1 ) );
 
-        assertTrue( stageSuccessful, "the stage should be considered successful as we skip failing items" );
+        assertFalse( stageSuccessful, "the stage should be considered failed as first item failed" );
+        assertProcessCanNotContinue();
+    }
+
+    @Test
+    void testSkipItemOutlier_SecondItemFailsStageContinues()
+    {
+        progress.startingStage( "test", 3, SKIP_ITEM_OUTLIER );
+        boolean stageSuccessful = progress.runStage( Stream.of( 1, 2, 3 ), String::valueOf, failsAfter( 1 ),
+            assertSummary( 1, 2 ) );
+
+        assertTrue( stageSuccessful, "the stage should be considered successful as first item was successful" );
+        assertProcessCanContinue();
+    }
+
+    @Test
+    void testSkipStage_ItemFails()
+    {
+        progress.startingStage( "test", 5, SKIP_STAGE );
+        boolean stageSuccessful = progress.runStage( Stream.of( 1, 2, 3, 4, 5 ), String::valueOf, failsAfter( 2 ),
+            assertSummary( 2, 1 ) );
+
+        assertFalse( stageSuccessful, "the stage should be considered failed when an item fails" );
+        assertProcessCanContinue();
+    }
+
+    private void assertProcessCanContinue()
+    {
+        assertFalse( progress.isCancellationRequested() );
         assertDoesNotThrow( () -> progress.startingStage( "another" ),
-            "execution should be possible to continue with next stage");
+            "execution should be possible to continue with next stage" );
+    }
+
+    private void assertProcessCanNotContinue()
+    {
+        assertTrue( progress.isCancellationRequested() );
+        assertThrows( CancellationException.class, () -> progress.startingStage( "another" ),
+            "execution should not be possible to continue with next stage" );
+    }
+
+    private BiFunction<Integer, Integer, String> assertSummary( int successes, int failures )
+    {
+        return ( actualSuccesses, actualFailures ) -> {
+            assertEquals( successes, actualSuccesses, "successes" );
+            assertEquals( failures, actualFailures, "failures" );
+            return null;
+        };
+    }
+
+    private final Consumer<Integer> alwaysFail = item -> {
+        throw new IllegalArgumentException( "failing" );
+    };
+
+    private static Consumer<Integer> failsAfter( int n )
+    {
+        AtomicInteger callCount = new AtomicInteger();
+        return item -> {
+            if ( callCount.incrementAndGet() > n )
+                throw new IllegalStateException( "now failing" );
+        };
     }
 
     private static JobConfiguration createJobConfig()

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/ControlledJobProgressTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/ControlledJobProgressTest.java
@@ -1,0 +1,47 @@
+package org.hisp.dhis.scheduling;
+
+import org.hisp.dhis.common.CodeGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControlledJobProgressTest
+{
+    private final JobConfiguration config = createJobConfig();
+
+    private final JobProgress progress = new ControlledJobProgress( config );
+
+    private final Consumer<Integer> alwaysFail =  item -> {
+        throw new IllegalArgumentException("failing");
+    };
+
+    @Test
+    void testSkipItem_FirstItemFails() {
+        progress.startingStage( "test", 3, SKIP_ITEM );
+        boolean stageSuccessful = progress.runStage( Stream.of(1,2,3), String::valueOf, alwaysFail,
+            (successes, failures) -> {
+                assertEquals( 0, successes );
+                assertEquals( 3, failures );
+                return null;
+            });
+
+        assertTrue( stageSuccessful, "the stage should be considered successful as we skip failing items" );
+        assertDoesNotThrow( () -> progress.startingStage( "another" ),
+            "execution should be possible to continue with next stage");
+    }
+
+    private static JobConfiguration createJobConfig()
+    {
+        JobConfiguration config = new JobConfiguration();
+        config.setJobType( JobType.PREDICTOR );
+        config.setUid( CodeGenerator.generateUid() );
+        return config;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
@@ -150,9 +150,10 @@ public class DataValueSynchronization implements DataSynchronizationWithPaging
             + context.getPageSize();
 
         progress.startingStage( msg, context.getPages(), SKIP_ITEM_OUTLIER );
-        return progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
+        progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> synchronizePage( page, context ) );
+        return !progress.isSkipCurrentStage();
     }
 
     protected void synchronizePage( int page, DataValueSynchronisationContext context )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.Date;
 import java.util.stream.IntStream;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.Date;
 import java.util.stream.IntStream;
@@ -148,7 +149,7 @@ public class DataValueSynchronization implements DataSynchronizationWithPaging
         msg += "DataValueSynchronization job has " + context.getPages() + " pages to sync. With page size: "
             + context.getPageSize();
 
-        progress.startingStage( msg, context.getPages() );
+        progress.startingStage( msg, context.getPages(), SKIP_ITEM_OUTLIER );
         return progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> synchronizePage( page, context ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventSynchronization.java
@@ -150,9 +150,10 @@ public class EventSynchronization implements DataSynchronizationWithPaging
         msg += "Event programs data synchronization job has " + context.getPages()
             + " pages to synchronize. With page size: " + context.getPageSize();
         progress.startingStage( msg, context.getPages() );
-        return progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
+        progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> synchronizePage( page, context ) );
+        return !progress.isSkipCurrentStage();
     }
 
     protected void synchronizePage( int page, EventSynchronisationContext context )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 import static org.hisp.dhis.setting.SettingKey.SKIP_SYNCHRONIZATION_FOR_DATA_CHANGED_BEFORE;
 
 import java.util.Date;
@@ -144,7 +145,7 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging
         msg += "Tracker programs data synchronization job has " + context.getPages()
             + " pages to synchronize. With page size: " + context.getPageSize();
 
-        progress.startingStage( msg, context.getPages() );
+        progress.startingStage( msg, context.getPages(), SKIP_ITEM_OUTLIER );
         return progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -146,12 +146,13 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging
             + " pages to synchronize. With page size: " + context.getPageSize();
 
         progress.startingStage( msg, context.getPages(), SKIP_ITEM_OUTLIER );
-        return progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
+        progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> {
                 queryParams.setPage( page );
                 synchronizePage( queryParams, context );
             } );
+        return !progress.isSkipCurrentStage();
     }
 
     private void synchronizePage( TrackedEntityInstanceQueryParams queryParams,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 import static org.hisp.dhis.setting.SettingKey.SKIP_SYNCHRONIZATION_FOR_DATA_CHANGED_BEFORE;
 
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.credentials;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.Date;
 import java.util.List;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.credentials;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.Date;
 import java.util.List;
@@ -121,7 +122,7 @@ public class CredentialsExpiryAlertJob implements Job
 
     private void sendExpiryAlert( List<User> users, JobProgress progress )
     {
-        progress.startingStage( "sending expiry alert emails", users.size() );
+        progress.startingStage( "sending expiry alert emails", users.size(), SKIP_ITEM_OUTLIER );
         if ( emailMessageSender.isConfigured() )
         {
             progress.runStage( users,

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.datastatistics;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -137,37 +138,37 @@ public class DefaultDataStatisticsService
         // when counting fails we use null so the count does not appear in the
         // stats
         Integer errorValue = null;
-        progress.startingStage( "Counting maps" );
+        progress.startingStage( "Counting maps", SKIP_STAGE );
         Integer savedMaps = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( org.hisp.dhis.mapping.Map.class, startDate ) );
-        progress.startingStage( "Counting visualisations" );
+        progress.startingStage( "Counting visualisations", SKIP_STAGE );
         Integer savedVisualizations = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( Visualization.class, startDate ) );
-        progress.startingStage( "Counting event reports" );
+        progress.startingStage( "Counting event reports", SKIP_STAGE );
         Integer savedEventReports = progress.runStage( errorValue,
             () -> eventVisualizationStore.countReportsCreated( startDate ) );
-        progress.startingStage( "Counting event charts" );
+        progress.startingStage( "Counting event charts", SKIP_STAGE );
         Integer savedEventCharts = progress.runStage( errorValue,
             () -> eventVisualizationStore.countChartsCreated( startDate ) );
-        progress.startingStage( "Counting event visualisations" );
+        progress.startingStage( "Counting event visualisations", SKIP_STAGE );
         Integer savedEventVisualizations = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( EventVisualization.class, startDate ) );
-        progress.startingStage( "Counting dashboards" );
+        progress.startingStage( "Counting dashboards", SKIP_STAGE );
         Integer savedDashboards = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( Dashboard.class, startDate ) );
-        progress.startingStage( "Counting indicators" );
+        progress.startingStage( "Counting indicators", SKIP_STAGE );
         Integer savedIndicators = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( Indicator.class, startDate ) );
-        progress.startingStage( "Counting data values" );
+        progress.startingStage( "Counting data values", SKIP_STAGE );
         Integer savedDataValues = progress.runStage( errorValue,
             () -> dataValueService.getDataValueCount( days ) );
-        progress.startingStage( "Counting active users" );
+        progress.startingStage( "Counting active users", SKIP_STAGE );
         Integer activeUsers = progress.runStage( errorValue,
             () -> userService.getActiveUsersCount( 1 ) );
-        progress.startingStage( "Counting users" );
+        progress.startingStage( "Counting users", SKIP_STAGE );
         Integer users = progress.runStage( errorValue,
             () -> idObjectManager.getCount( User.class ) );
-        progress.startingStage( "Counting views" );
+        progress.startingStage( "Counting views", SKIP_STAGE );
         Map<DataStatisticsEventType, Double> eventCountMap = progress.runStage( Map.of(),
             () -> dataStatisticsEventStore.getDataStatisticsEventCount( startDate, day ) );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.datastatistics;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 
 import java.util.Calendar;
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
 import static org.hisp.dhis.predictor.PredictionFormatter.formatPrediction;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.ArrayList;
 import java.util.Date;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
 import static org.hisp.dhis.predictor.PredictionFormatter.formatPrediction;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -167,7 +168,7 @@ public class DefaultPredictionService
 
         PredictionSummary summary = new PredictionSummary();
         progress.startingStage( format( "Running predictors from %s to %s", startDate, endDate ),
-            predictorList.size() );
+            predictorList.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( predictorList.stream(),
             predictor -> format( "Running predictor %s from %s to %s", predictor.getName(), startDate, endDate ),
             predictor -> predict( predictor, startDate, endDate, summary ),

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.pushanalysis;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.joining;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -235,7 +236,8 @@ public class DefaultPushAnalysisService implements PushAnalysisService
         // Generating reports
         // ----------------------------------------------------------------------
         String name = pushAnalysis.getName();
-        progress.startingStage( "Generating and sending reports for PushAnalysis " + name, receivingUsers.size() );
+        progress.startingStage( "Generating and sending reports for PushAnalysis " + name,
+            receivingUsers.size(), SKIP_ITEM_OUTLIER );
         progress.runStage( receivingUsers,
             user -> "Generating and sending PushAnalysis " + name + " for user '" + user.getUsername() + "'.",
             user -> {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/pushanalysis/DefaultPushAnalysisService.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.pushanalysis;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.joining;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.validation;
 
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/DefaultValidationService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.validation;
 
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_STAGE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -145,7 +146,7 @@ public class DefaultValidationService implements ValidationService, CurrentUserS
 
         if ( context.isPersistResults() )
         {
-            progress.startingStage( "Persisting Results" );
+            progress.startingStage( "Persisting Results", SKIP_STAGE );
             progress.runStage( () -> validationResultService.saveValidationResults( context.getValidationResults() ) );
         }
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
@@ -76,7 +76,8 @@ public class Validator
         int chunkSize = ValidationRunContext.ORG_UNITS_PER_TASK;
         List<ValidationChunk> orgUnitLists = splitIntoChunks( context, chunkSize );
 
-        progress.startingStage( "Evaluating validation rules in chunks of " + chunkSize, orgUnitLists.size(), SKIP_ITEM_OUTLIER );
+        progress.startingStage( "Evaluating validation rules in chunks of " + chunkSize, orgUnitLists.size(),
+            SKIP_ITEM_OUTLIER );
         progress.runStageInParallel( threadPoolSize, orgUnitLists, ValidationChunk::toString,
             chunk -> runner.run( chunk.getOrgUnits(), context ) );
 

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.validation;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/Validator.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.validation;
 
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,7 +76,7 @@ public class Validator
         int chunkSize = ValidationRunContext.ORG_UNITS_PER_TASK;
         List<ValidationChunk> orgUnitLists = splitIntoChunks( context, chunkSize );
 
-        progress.startingStage( "Evaluating validation rules in chunks of " + chunkSize, orgUnitLists.size() );
+        progress.startingStage( "Evaluating validation rules in chunks of " + chunkSize, orgUnitLists.size(), SKIP_ITEM_OUTLIER );
         progress.runStageInParallel( threadPoolSize, orgUnitLists, ValidationChunk::toString,
             chunk -> runner.run( chunk.getOrgUnits(), context ) );
 

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.validation.notification;
 
 import static java.lang.String.format;
 import static org.hisp.dhis.commons.util.TextUtils.LN;
-import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
 import static org.hisp.dhis.validation.Importance.HIGH;
 import static org.hisp.dhis.validation.Importance.LOW;
 import static org.hisp.dhis.validation.Importance.MEDIUM;

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.validation.notification;
 
 import static java.lang.String.format;
 import static org.hisp.dhis.commons.util.TextUtils.LN;
+import static org.hisp.dhis.scheduling.JobProgress.FaultTolerance.SKIP_ITEM_OUTLIER;
 import static org.hisp.dhis.validation.Importance.HIGH;
 import static org.hisp.dhis.validation.Importance.LOW;
 import static org.hisp.dhis.validation.Importance.MEDIUM;
@@ -113,8 +114,8 @@ public class DefaultValidationNotificationService implements ValidationNotificat
                 .filter( IS_APPLICABLE_RESULT )
                 .collect( Collectors.toCollection( TreeSet::new ) ) );
 
-        progress
-            .startingStage( format( "Creating notifications for %d validation results", applicableResults.size() ) );
+        progress.startingStage(
+            format( "Creating notifications for %d validation results", applicableResults.size() ) );
         Map<SendStrategy, Map<Set<User>, NotificationMessage>> notifications = progress.runStage( Map.of(),
             () -> createNotifications( applicableResults ) );
 
@@ -122,7 +123,7 @@ public class DefaultValidationNotificationService implements ValidationNotificat
             .getOrDefault( SendStrategy.SINGLE_NOTIFICATION, Map.of() ).entrySet();
         if ( !singleNotifications.isEmpty() )
         {
-            progress.startingStage( "Sending single notification(s)", singleNotifications.size() );
+            progress.startingStage( "Sending single notification(s)", singleNotifications.size(), SKIP_ITEM_OUTLIER );
             progress.runStage( singleNotifications,
                 entry -> format( "Sending notification %s to %d users", entry.getValue().getSubject(),
                     entry.getKey().size() ),
@@ -133,7 +134,7 @@ public class DefaultValidationNotificationService implements ValidationNotificat
             .getOrDefault( SendStrategy.COLLECTIVE_SUMMARY, Map.of() ).entrySet();
         if ( !summaryNotifications.isEmpty() )
         {
-            progress.startingStage( "Sending summary notification(s)", summaryNotifications.size() );
+            progress.startingStage( "Sending summary notification(s)", summaryNotifications.size(), SKIP_ITEM_OUTLIER );
             progress.runStage( summaryNotifications,
                 entry -> format( "Sending notification %s to %d users", entry.getValue().getSubject(),
                     entry.getKey().size() ),


### PR DESCRIPTION
### Summary
This PR adds per stage or item failure policy.
This allows to not fail the entire job process when an item or stage is failing but based on the policy chosen evaluate if the run should continue and eventually skip items in the failing stage.

The policy can be set when calling the `startingStage` or `startingWorkItem` method.
By default, the policy is to fail as before.
A policy is set on stage level is "inherited" by the item level unless it is explicitly set on that level.
The effective policy for each stage and item will be visible in the tracked information as `onFailure`.

Besides adding the general concept of custom failure policies the policies got used in the different jobs where it seemed suiting.

Possible failure policies are:
* `FAIL`: just fail (as before) by (eventually) throwing an exception and effectively abort/end the job run
* `SKIP_STAGE`: if stage or item fails skip the entire stage (skips further items) and continue the process
* `SKIP_ITEM`: if item fails effectively ignore it (just consider it failed) but continue the process with next item
* `SKIP_ITEM_OUTLIER`: same as `SKIP_ITEM` except that it acts like `FAIL` in case there is no successful item in the same stage already tracked before. This is to only skip items when they are outliers but fail if all items apparently fail.

### Note for Reviewers
Please pay special attention to the usages of any of the skip policies. If you are familiar with the job think about if that policy is what you would want to happen in case of a failure for the step performed.

### Automatic Testing
Existing tests got adjusted.
New tests were added to verify the failure policies work as expected.

### Manual Testing
Manually ran analytics table and resource table generation just to generally check.
As this affects all modified jobs only way to fully test this would be to test all types of jobs.

### Example Output
```json
[
  {
    "summary":"Resource tables generated: 00:00:12.123",
    "status":"SUCCESS",
    "completedTime":"2022-04-26T13:11:56.048",
    "startedTime":"2022-04-26T13:11:43.925",
    "description":"Generating resource tables",
    "stages":[
      {
        "summary":"0 successful and 0 failed items",
        "status":"SUCCESS",
        "completedTime":"2022-04-26T13:11:43.930",
        "startedTime":"2022-04-26T13:11:43.929",
        "description":"Drop SQL views",
        "totalItems":0,
        "onFailure":"SKIP_ITEM",
        "items":[
          
        ],
        "duration":1,
        "complete":true
      },
      {
        "summary":"11 successful and 0 failed items",
        "status":"SUCCESS",
        "completedTime":"2022-04-26T13:11:56.040",
        "startedTime":"2022-04-26T13:11:43.931",
        "description":"Generating resource tables",
        "totalItems":11,
        "onFailure":"FAIL",
        "items":[
          {
            "status":"SUCCESS",
            "completedTime":"2022-04-26T13:11:44.416",
            "startedTime":"2022-04-26T13:11:43.931",
            "description":"generating OrganisationUnit structures",
            "onFailure":"FAIL",
            "duration":485,
            "complete":true
          },
          //...
        ],
        "duration":12109,
        "complete":true
      },
      {
        "summary":"0 successful and 0 failed items",
        "status":"SUCCESS",
        "completedTime":"2022-04-26T13:11:56.048",
        "startedTime":"2022-04-26T13:11:56.047",
        "description":"Create SQL views",
        "totalItems":0,
        "onFailure":"SKIP_ITEM",
        "items":[
          
        ],
        "duration":1,
        "complete":true
      }
    ],
    "jobId":"QQe3BCOBSi5",
    "duration":12123,
    "complete":true
  }
]
```
Note the different values for the `onFailure` property of stages and items.