### PR TITLE
fix: Event.programStage is a MetadataIdentifier DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
@@ -34,6 +34,7 @@ import lombok.NoArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -134,5 +135,19 @@ public class TrackerIdSchemeParams
     public MetadataIdentifier toMetadataIdentifier( Program program )
     {
         return programIdScheme.toMetadataIdentifier( program );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code programStage} using
+     * {@link #programStageIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param programStage to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         programIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( ProgramStage programStage )
+    {
+        return programStageIdScheme.toMetadataIdentifier( programStage );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -124,8 +124,6 @@ public class EventTrackerConverterService
             }
 
             event.setEnrollment( psi.getProgramInstance().getUid() );
-            // TODO(DHIS2-12563) what are these converters for again?
-            // will/should this always be a uid?
             event.setProgramStage( MetadataIdentifier.ofUid( psi.getProgramStage().getUid() ) );
             event.setAttributeOptionCombo( psi.getAttributeOptionCombo().getUid() );
             event.setAttributeCategoryOptions( psi.getAttributeOptionCombo()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.User;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.util.DateUtils;
@@ -123,7 +124,9 @@ public class EventTrackerConverterService
             }
 
             event.setEnrollment( psi.getProgramInstance().getUid() );
-            event.setProgramStage( psi.getProgramStage().getUid() );
+            // TODO(DHIS2-12563) what are these converters for again?
+            // will/should this always be a uid?
+            event.setProgramStage( MetadataIdentifier.ofUid( psi.getProgramStage().getUid() ) );
             event.setAttributeOptionCombo( psi.getAttributeOptionCombo().getUid() );
             event.setAttributeCategoryOptions( psi.getAttributeOptionCombo()
                 .getCategoryOptions().stream().map( CategoryOption::getUid ).collect( Collectors.joining( ";" ) ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -66,7 +66,7 @@ public class Event
     private MetadataIdentifier program;
 
     @JsonProperty
-    private String programStage;
+    private MetadataIdentifier programStage;
 
     @JsonProperty
     private String enrollment;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -338,12 +338,9 @@ public class TrackerPreheat
     @Setter
     private List<String> programInstanceWithOneOrMoreNonDeletedEvent = Lists.newArrayList();
 
-    // TODO(DHIS2-12563) should this key be a MetadataIdentifier?
     /**
      * A list of Program Stage UID having 1 or more Events
      */
-    @Getter
-    @Setter
     private List<Pair<String, String>> programStageWithEvents = Lists.newArrayList();
 
     /**
@@ -787,6 +784,19 @@ public class TrackerPreheat
     public TrackedEntityAttribute getTrackedEntityAttribute( String id )
     {
         return get( TrackedEntityAttribute.class, id );
+    }
+
+    public TrackerPreheat addProgramStageWithEvents( String programStageUid, String enrollmentUid )
+    {
+        this.programStageWithEvents.add( Pair.of( programStageUid, enrollmentUid ) );
+        return this;
+    }
+
+    public boolean hasProgramStageWithEvents( MetadataIdentifier programStage, String enrollmentUid )
+    {
+        ProgramStage ps = this.getProgramStage( programStage );
+        ProgramInstance pi = this.getEnrollment( enrollmentUid );
+        return this.programStageWithEvents.contains( Pair.of( ps.getUid(), pi.getUid() ) );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -338,6 +338,7 @@ public class TrackerPreheat
     @Setter
     private List<String> programInstanceWithOneOrMoreNonDeletedEvent = Lists.newArrayList();
 
+    // TODO(DHIS2-12563) should this key be a MetadataIdentifier?
     /**
      * A list of Program Stage UID having 1 or more Events
      */
@@ -756,6 +757,11 @@ public class TrackerPreheat
     public OrganisationUnit getOrganisationUnit( String id )
     {
         return get( OrganisationUnit.class, id );
+    }
+
+    public ProgramStage getProgramStage( MetadataIdentifier id )
+    {
+        return get( ProgramStage.class, id );
     }
 
     public ProgramStage getProgramStage( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
@@ -108,7 +108,7 @@ public class EventCategoryOptionComboSupplier extends AbstractPreheatSupplier
             return program;
         }
 
-        if ( StringUtils.isBlank( e.getProgramStage() ) )
+        if ( e.getProgramStage().isBlank() )
         {
             return null;
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramStageInstanceProgramStageMapSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramStageInstanceProgramStageMapSupplier.java
@@ -27,17 +27,16 @@
  */
 package org.hisp.dhis.tracker.preheat.supplier;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.stereotype.Component;
 
@@ -75,7 +74,7 @@ public class ProgramStageInstanceProgramStageMapSupplier
     @Override
     public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
     {
-        if ( params.getEvents().size() == 0 )
+        if ( params.getEvents().isEmpty() )
         {
             return;
         }
@@ -98,18 +97,11 @@ public class ProgramStageInstanceProgramStageMapSupplier
 
         if ( !notRepeatableProgramStageUids.isEmpty() && !programInstanceUids.isEmpty() )
         {
-            List<Pair<String, String>> programStageWithEvents = new ArrayList<>();
-
             MapSqlParameterSource parameters = new MapSqlParameterSource();
             parameters.addValue( "programStageUids", notRepeatableProgramStageUids );
             parameters.addValue( "programInstanceUids", programInstanceUids );
-            jdbcTemplate.query( SQL, parameters, rs -> {
-
-                programStageWithEvents.add( Pair.of( rs.getString( PS_UID ), rs.getString( PI_UID ) ) );
-
-            } );
-
-            preheat.setProgramStageWithEvents( programStageWithEvents );
+            jdbcTemplate.query( SQL, parameters, (RowCallbackHandler) rs -> preheat
+                .addProgramStageWithEvents( rs.getString( PS_UID ), rs.getString( PI_UID ) ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.preprocess;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 import java.util.Objects;
@@ -37,7 +36,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
@@ -59,15 +57,15 @@ public class EventProgramPreProcessor
     {
         List<Event> eventsToPreprocess = bundle.getEvents()
             .stream()
-            .filter( e -> e.getProgram().isBlank() || isBlank( e.getProgramStage() ) )
+            .filter( e -> e.getProgram().isBlank() || e.getProgramStage().isBlank() )
             .collect( Collectors.toList() );
 
         for ( Event event : eventsToPreprocess )
         {
             // Extract program from program stage
-            if ( isNotBlank( event.getProgramStage() ) )
+            if ( !event.getProgramStage().isBlank() )
             {
-                ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
+                ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
                 if ( Objects.nonNull( programStage ) )
                 {
                     // TODO remove if once metadata import is fixed
@@ -104,8 +102,8 @@ public class EventProgramPreProcessor
                     Optional<ProgramStage> programStage = program.getProgramStages().stream().findFirst();
                     if ( programStage.isPresent() )
                     {
-                        TrackerIdSchemeParam idScheme = bundle.getPreheat().getIdSchemes().getProgramStageIdScheme();
-                        event.setProgramStage( idScheme.getIdentifier( programStage.get() ) );
+                        TrackerIdSchemeParams idSchemes = bundle.getPreheat().getIdSchemes();
+                        event.setProgramStage( idSchemes.toMetadataIdentifier( programStage.get() ) );
                         bundle.getPreheat().put( programStage.get() );
                     }
                 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.preprocess;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
@@ -50,7 +49,7 @@ public class EventWithoutRegistrationPreProcessor
     {
         for ( Event event : bundle.getEvents() )
         {
-            if ( StringUtils.isNotEmpty( event.getProgramStage() ) )
+            if ( !event.getProgramStage().isBlank() )
             {
                 ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -148,7 +148,7 @@ abstract public class AbstractRuleActionImplementer<T extends RuleAction>
             .collect( Collectors.toMap( Map.Entry::getKey,
                 e -> {
                     Event event = getEvent( bundle, e.getKey() ).get();
-                    ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
+                    ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
                     Set<DataValue> dataValues = event.getDataValues();
 
                     List<EventActionRule> eventActionRules = e.getValue()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidator.java
@@ -116,7 +116,7 @@ public class SetMandatoryFieldValidator
     private List<ProgramRuleIssue> checkMandatoryDataElement( Event event, List<EventActionRule> actionRules,
         TrackerBundle bundle )
     {
-        ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
 
         Map<String, EventActionRule> mandatoryDataElementsByActionRule = actionRules.stream()
             .filter( eventActionRule -> eventActionRule.getAttributeType() == AttributeType.DATA_ELEMENT )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.program.ProgramStage;
@@ -93,21 +92,23 @@ public class EventDataValuesValidationHook
 
     private void validateMandatoryDataValues( Event event, ValidationErrorReporter reporter )
     {
-        if ( StringUtils.isNotEmpty( event.getProgramStage() ) )
+        if ( event.getProgramStage().isBlank() )
         {
-            TrackerPreheat preheat = reporter.getBundle().getPreheat();
-            ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
-            final List<String> mandatoryDataElements = programStage.getProgramStageDataElements()
-                .stream()
-                .filter( ProgramStageDataElement::isCompulsory )
-                .map( de -> preheat.getIdSchemes().getDataElementIdScheme()
-                    .getIdentifier( de.getDataElement() ) )
-                .collect( Collectors.toList() );
-            List<String> missingDataValue = validateMandatoryDataValue( programStage, event,
-                mandatoryDataElements );
-            missingDataValue
-                .forEach( de -> reporter.addError( event, E1303, de ) );
+            return;
         }
+
+        TrackerPreheat preheat = reporter.getBundle().getPreheat();
+        ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
+        final List<String> mandatoryDataElements = programStage.getProgramStageDataElements()
+            .stream()
+            .filter( ProgramStageDataElement::isCompulsory )
+            .map( de -> preheat.getIdSchemes().getDataElementIdScheme()
+                .getIdentifier( de.getDataElement() ) )
+            .collect( Collectors.toList() );
+        List<String> missingDataValue = validateMandatoryDataValue( programStage, event,
+            mandatoryDataElements );
+        missingDataValue
+            .forEach( de -> reporter.addError( event, E1303, de ) );
     }
 
     private void validateDataElement( ValidationErrorReporter reporter, DataElement dataElement,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -72,7 +72,7 @@ public class PreCheckMandatoryFieldsValidationHook
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
         reporter.addErrorIf( () -> StringUtils.isEmpty( event.getOrgUnit() ), event, E1123, ORG_UNIT );
-        reporter.addErrorIf( () -> StringUtils.isEmpty( event.getProgramStage() ), event, E1123, "programStage" );
+        reporter.addErrorIf( () -> event.getProgramStage().isBlank(), event, E1123, "programStage" );
 
         // TODO remove if once metadata import is fixed
         ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -85,7 +85,7 @@ public class PreCheckUpdatableFieldsValidationHook
         ProgramStage programStage = programStageInstance.getProgramStage();
         ProgramInstance programInstance = programStageInstance.getProgramInstance();
 
-        reporter.addErrorIf( () -> !event.getProgramStage().equals( programStage.getUid() ), event, E1128,
+        reporter.addErrorIf( () -> !event.getProgramStage().isEqualTo( programStage ), event, E1128,
             "programStage" );
         reporter.addErrorIf(
             () -> event.getEnrollment() != null && !event.getEnrollment().equals( programInstance.getUid() ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
-import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -93,8 +92,8 @@ public class RepeatedEventsValidationHook
 
         if ( strategy == TrackerImportStrategy.CREATE && programStage != null && programInstance != null
             && !programStage.getRepeatable()
-            && programStageHasEvents( bundle.getPreheat(), programStage.getUid(),
-                programInstance.getUid() ) )
+            && reporter.getBundle().getPreheat().hasProgramStageWithEvents( event.getProgramStage(),
+                event.getEnrollment() ) )
         {
             reporter.addError( event, TrackerErrorCode.E1039, event.getProgramStage().getIdentifierOrAttributeValue() );
         }
@@ -105,10 +104,4 @@ public class RepeatedEventsValidationHook
     {
         return true;
     }
-
-    private boolean programStageHasEvents( TrackerPreheat preheat, String programStageUid, String enrollmentUid )
-    {
-        return preheat.getProgramStageWithEvents().contains( Pair.of( programStageUid, enrollmentUid ) );
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -321,7 +321,8 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
     private void setUpMocks()
     {
         when( preheat.getUser() ).thenReturn( user );
-        when( preheat.get( ProgramStage.class, programStage.getUid() ) ).thenReturn( programStage );
+        when( preheat.get( ProgramStage.class, MetadataIdentifier.ofUid( programStage.getUid() ) ) )
+            .thenReturn( programStage );
         when( preheat.getProgram( MetadataIdentifier.ofUid( program.getUid() ) ) ).thenReturn( program );
         when( preheat.get( OrganisationUnit.class, organisationUnit.getUid() ) ).thenReturn( organisationUnit );
     }
@@ -335,7 +336,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
     {
         Event event = new Event();
         event.setEvent( uid );
-        event.setProgramStage( PROGRAM_STAGE_UID );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) );
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) );
         event.setOrgUnit( ORGANISATION_UNIT_UID );
         event.setDataValues( Sets.newHashSet( dataValue ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -90,12 +90,16 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         List<Pair<String, TrackerIdSchemeParam>> data = buildDataSet( "NpsdDv6kKSO", "PRGA", "ProgramA" );
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
-            Event event = new Event();
-            event.setProgramStage( MetadataIdentifier.ofUid( pair.getLeft() ) );
-            TrackerImportParams params = buildParams( event,
-                builder().programStageIdScheme( pair.getRight() ).build() );
+            String id = pair.getLeft();
+            TrackerIdSchemeParam param = pair.getRight();
+            Event event = Event.builder()
+                .programStage( param.toMetadataIdentifier( id ) )
+                .build();
+            TrackerImportParams params = buildParams( event, builder().programStageIdScheme( param ).build() );
+
             TrackerPreheat preheat = trackerPreheatService.preheat( params );
-            assertPreheatedObjectExists( preheat, ProgramStage.class, pair.getRight(), pair.getLeft() );
+
+            assertPreheatedObjectExists( preheat, ProgramStage.class, param, id );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -90,7 +91,7 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
             Event event = new Event();
-            event.setProgramStage( pair.getLeft() );
+            event.setProgramStage( MetadataIdentifier.ofUid( pair.getLeft() ) );
             TrackerImportParams params = buildParams( event,
                 builder().programStageIdScheme( pair.getRight() ).build() );
             TrackerPreheat preheat = trackerPreheatService.preheat( params );
@@ -105,7 +106,7 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
             Event event = new Event();
-            event.setProgramStage( "NpsdDv6kKSO" );
+            event.setProgramStage( MetadataIdentifier.ofUid( "NpsdDv6kKSO" ) );
             DataValue dv1 = new DataValue();
             dv1.setDataElement( pair.getLeft() );
             dv1.setValue( "val1" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
@@ -139,7 +139,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Set<CategoryOption> options = aoc.getCategoryOptions();
 
         Event event = Event.builder()
-            .programStage( stage.getCode() )
+            .programStage( identifierParams.toMetadataIdentifier( stage ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
@@ -296,6 +296,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .attributeOptionCombo( identifierParams.getCategoryOptionComboIdScheme().getIdentifier( aoc ) )
+            .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -326,6 +327,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -361,7 +363,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Set<CategoryOption> options = aoc.getCategoryOptions();
 
         Event event = Event.builder()
-            .programStage( stage.getCode() )
+            .programStage( identifierParams.toMetadataIdentifier( stage ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
@@ -87,7 +87,7 @@ class EventProgramPreProcessorTest
     {
         TrackerIdSchemeParams identifierParams = TrackerIdSchemeParams.builder().build();
         when( preheat.getIdSchemes() ).thenReturn( identifierParams );
-        when( preheat.get( ProgramStage.class, PROGRAM_STAGE_WITH_REGISTRATION ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ) ) )
             .thenReturn( programStageWithRegistration() );
 
         TrackerBundle bundle = TrackerBundle.builder()
@@ -105,7 +105,7 @@ class EventProgramPreProcessorTest
     {
         TrackerIdSchemeParams identifierParams = TrackerIdSchemeParams.builder().build();
         when( preheat.getIdSchemes() ).thenReturn( identifierParams );
-        when( preheat.get( ProgramStage.class, PROGRAM_STAGE_WITHOUT_REGISTRATION ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ) ) )
             .thenReturn( programStageWithoutRegistration() );
 
         TrackerBundle bundle = TrackerBundle.builder()
@@ -134,7 +134,8 @@ class EventProgramPreProcessorTest
         verify( preheat, never() ).get( ProgramStage.class, PROGRAM_STAGE_WITH_REGISTRATION );
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ),
             bundle.getEvents().get( 0 ).getProgram() );
-        assertEquals( PROGRAM_STAGE_WITH_REGISTRATION, bundle.getEvents().get( 0 ).getProgramStage() );
+        assertEquals( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ),
+            bundle.getEvents().get( 0 ).getProgramStage() );
     }
 
     @Test
@@ -146,7 +147,7 @@ class EventProgramPreProcessorTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( null ) )
-            .programStage( programStage.getUid() )
+            .programStage( MetadataIdentifier.ofUid( programStage.getUid() ) )
             .build();
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).preheat( preheat )
             .build();
@@ -171,7 +172,8 @@ class EventProgramPreProcessorTest
         preprocessor.process( bundle );
 
         verify( preheat ).put( programStageWithoutRegistration() );
-        assertEquals( PROGRAM_STAGE_WITHOUT_REGISTRATION, bundle.getEvents().get( 0 ).getProgramStage() );
+        assertEquals( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ),
+            bundle.getEvents().get( 0 ).getProgramStage() );
     }
 
     @Test
@@ -189,7 +191,7 @@ class EventProgramPreProcessorTest
 
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ),
             bundle.getEvents().get( 0 ).getProgram() );
-        assertNull( bundle.getEvents().get( 0 ).getProgramStage() );
+        assertEquals( MetadataIdentifier.ofUid( null ), bundle.getEvents().get( 0 ).getProgramStage() );
     }
 
     @Test
@@ -208,7 +210,8 @@ class EventProgramPreProcessorTest
         verify( preheat, never() ).get( ProgramStage.class, PROGRAM_STAGE_WITHOUT_REGISTRATION );
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ),
             bundle.getEvents().get( 0 ).getProgram() );
-        assertEquals( PROGRAM_STAGE_WITHOUT_REGISTRATION, bundle.getEvents().get( 0 ).getProgramStage() );
+        assertEquals( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ),
+            bundle.getEvents().get( 0 ).getProgramStage() );
     }
 
     @Test
@@ -432,23 +435,24 @@ class EventProgramPreProcessorTest
 
     private Event programEventWithProgram()
     {
-        Event event = new Event();
-        event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ) );
-        return event;
+        return Event.builder()
+            .program( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ) )
+            .programStage( MetadataIdentifier.ofUid( null ) )
+            .build();
     }
 
     private Event programEventWithProgramStage()
     {
         return Event.builder()
             .program( MetadataIdentifier.ofUid( null ) )
-            .programStage( PROGRAM_STAGE_WITHOUT_REGISTRATION )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ) )
             .build();
     }
 
     private Event completeProgramEvent()
     {
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITHOUT_REGISTRATION );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ) );
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ) );
         return event;
     }
@@ -457,7 +461,7 @@ class EventProgramPreProcessorTest
     {
         return Event.builder()
             .program( MetadataIdentifier.ofUid( null ) )
-            .programStage( PROGRAM_STAGE_WITH_REGISTRATION )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ) )
             .build();
     }
 
@@ -465,13 +469,14 @@ class EventProgramPreProcessorTest
     {
         return Event.builder()
             .program( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ) )
+            .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
     }
 
     private Event completeTrackerEvent()
     {
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE_WITH_REGISTRATION );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ) );
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ) );
         return event;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventStatusPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventStatusPreProcessorTest.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +62,7 @@ class EventStatusPreProcessorTest
         // Given
         Event event = new Event();
         event.setStatus( EventStatus.VISITED );
-        event.setProgramStage( "programStageUid" );
+        event.setProgramStage( MetadataIdentifier.ofUid( "programStageUid" ) );
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
         ProgramInstance programInstance = new ProgramInstance();
         programInstance.setUid( "programInstanceUid" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessorTest.java
@@ -37,6 +37,7 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +61,7 @@ class EventWithoutRegistrationPreProcessorTest
     {
         // Given
         Event event = new Event();
-        event.setProgramStage( "programStageUid" );
+        event.setProgramStage( MetadataIdentifier.ofUid( "programStageUid" ) );
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
         ProgramInstance programInstance = new ProgramInstance();
         programInstance.setUid( "programInstanceUid" );
@@ -84,7 +85,7 @@ class EventWithoutRegistrationPreProcessorTest
     {
         // Given
         Event event = new Event();
-        event.setProgramStage( "programStageUid" );
+        event.setProgramStage( MetadataIdentifier.ofUid( "programStageUid" ) );
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).build();
         ProgramInstance programInstance = new ProgramInstance();
         programInstance.setUid( "programInstanceUid" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.implementers.AssignValueImplementer;
@@ -150,8 +151,10 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( secondProgramStage,
             dataElementB, 0 );
         secondProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
-        when( preheat.get( ProgramStage.class, firstProgramStage.getUid() ) ).thenReturn( firstProgramStage );
-        when( preheat.get( ProgramStage.class, secondProgramStage.getUid() ) ).thenReturn( secondProgramStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) ) )
+            .thenReturn( firstProgramStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage.getUid() ) ) )
+            .thenReturn( secondProgramStage );
         when( preheat.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( preheat.get( TrackedEntityAttribute.class, attributeA.getUid() ) ).thenReturn( attributeA );
         bundle = TrackerBundle.builder().build();
@@ -377,7 +380,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( FIRST_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( firstProgramStage.getUid() );
+        event.setProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) );
         event.setDataValues( getEventDataValues() );
         return event;
     }
@@ -387,7 +390,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( FIRST_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( firstProgramStage.getUid() );
+        event.setProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) );
         event.setDataValues( getEventDataValuesSameValue() );
         return event;
     }
@@ -397,17 +400,17 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( firstProgramStage.getUid() );
+        event.setProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) );
         return event;
     }
 
     private Event getEventWithDataValueNOTSetInDifferentProgramStage()
     {
-        Event event = new Event();
-        event.setEvent( SECOND_EVENT_ID );
-        event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( secondProgramStage.getUid() );
-        return event;
+        return Event.builder()
+            .event( SECOND_EVENT_ID )
+            .status( EventStatus.ACTIVE )
+            .programStage( MetadataIdentifier.ofUid( secondProgramStage.getUid() ) )
+            .build();
     }
 
     private Set<DataValue> getEventDataValues()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.implementers.SetMandatoryFieldValidator;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
@@ -126,8 +127,10 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( secondProgramStage,
             dataElementB, 0 );
         secondProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
-        when( preheat.get( ProgramStage.class, firstProgramStage.getUid() ) ).thenReturn( firstProgramStage );
-        when( preheat.get( ProgramStage.class, secondProgramStage.getUid() ) ).thenReturn( secondProgramStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) ) )
+            .thenReturn( firstProgramStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage.getUid() ) ) )
+            .thenReturn( secondProgramStage );
         bundle = TrackerBundle.builder().build();
         bundle.setRuleEffects( getRuleEventAndEnrollmentEffects() );
         bundle.setPreheat( preheat );
@@ -198,7 +201,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( FIRST_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( firstProgramStage.getUid() );
+        event.setProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) );
         event.setDataValues( getActiveEventDataValues() );
         return event;
     }
@@ -208,7 +211,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( firstProgramStage.getUid() );
+        event.setProgramStage( MetadataIdentifier.ofUid( firstProgramStage.getUid() ) );
         return event;
     }
 
@@ -217,7 +220,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( SECOND_EVENT_ID );
         event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( secondProgramStage.getUid() );
+        event.setProgramStage( MetadataIdentifier.ofUid( secondProgramStage.getUid() ) );
         return event;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.implementers.ShowErrorOnCompleteValidator;
 import org.hisp.dhis.tracker.programrule.implementers.ShowErrorValidator;
@@ -138,7 +139,7 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
         ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( anotherProgramStage,
             dataElementB, 0 );
         anotherProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
-        when( preheat.get( ProgramStage.class, PROGRAM_STAGE_ID ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) ).thenReturn( programStage );
     }
 
     @Test
@@ -255,11 +256,11 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
         Event activeEvent = new Event();
         activeEvent.setEvent( ACTIVE_EVENT_ID );
         activeEvent.setStatus( EventStatus.ACTIVE );
-        activeEvent.setProgramStage( PROGRAM_STAGE_ID );
+        activeEvent.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) );
         Event completedEvent = new Event();
         completedEvent.setEvent( COMPLETED_EVENT_ID );
         completedEvent.setStatus( EventStatus.COMPLETED );
-        completedEvent.setProgramStage( PROGRAM_STAGE_ID );
+        completedEvent.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) );
         return Lists.newArrayList( activeEvent, completedEvent );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.User;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -96,7 +97,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         // given
         Event event = new Event();
         event.setAssignedUser( VALID_USER );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -113,7 +114,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         // given
         Event event = new Event();
         event.setAssignedUser( null );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -130,7 +131,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         // given
         Event event = new Event();
         event.setAssignedUser( User.builder().build() );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -148,7 +149,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( INVALID_USER );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -166,7 +167,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( VALID_USER );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         // when
         TrackerPreheat preheat = new TrackerPreheat();
@@ -187,7 +188,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( VALID_USER );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -211,7 +212,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( VALID_USER );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -52,6 +52,7 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -92,18 +93,19 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenDataElementIsValid()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -115,20 +117,21 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenCreatedAtIsNull()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setCreatedAt( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) ).build();
 
@@ -140,20 +143,21 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenUpdatedAtIsNull()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setUpdatedAt( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) ).build();
 
@@ -165,18 +169,19 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsInvalid()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( null );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -189,12 +194,13 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenAMandatoryDataElementIsMissing()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
+        programStage.setAutoFields();
         ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
         DataElement mandatoryElement1 = new DataElement();
         mandatoryElement1.setUid( "MANDATORY_DE" );
@@ -206,12 +212,13 @@ class EventDataValuesValidationHookTest
         mandatoryStageElement2.setDataElement( mandatoryElement2 );
         mandatoryStageElement2.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
-        when( preheat.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage.getUid() ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( "PROGRAM_STAGE" )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -224,12 +231,13 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
+        programStage.setAutoFields();
         ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
         DataElement mandatoryElement1 = new DataElement();
         mandatoryElement1.setUid( "MANDATORY_DE" );
@@ -241,12 +249,13 @@ class EventDataValuesValidationHookTest
         mandatoryStageElement2.setDataElement( mandatoryElement2 );
         mandatoryStageElement2.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
-        when( preheat.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage.getUid() ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( "PROGRAM_STAGE" )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -271,14 +280,15 @@ class EventDataValuesValidationHookTest
         when( preheat.get( DataElement.class, dataElement.getCode() ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement, true );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue dataValue = dataValue();
         dataValue.setDataElement( "DE_424050" );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( dataValue ) ).build();
 
@@ -290,7 +300,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsNotPresentInProgramStage()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
@@ -300,20 +310,22 @@ class EventDataValuesValidationHookTest
         when( preheat.get( DataElement.class, "de_not_present_in_program_stage" ) ).thenReturn( notPresentDataElement );
 
         ProgramStage programStage = new ProgramStage();
+        programStage.setAutoFields();
         ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
         DataElement mandatoryElement1 = new DataElement();
         mandatoryElement1.setUid( dataValue().getDataElement() );
         mandatoryStageElement1.setDataElement( mandatoryElement1 );
         mandatoryStageElement1.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1 ) );
-        when( preheat.getProgramStage( "PROGRAM_STAGE" ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage.getUid() ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue notPresentDataValue = dataValue();
         notPresentDataValue.setDataElement( "de_not_present_in_program_stage" );
         Event event = Event.builder()
-            .programStage( "PROGRAM_STAGE" )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue(), notPresentDataValue ) ).build();
 
@@ -339,14 +351,15 @@ class EventDataValuesValidationHookTest
         when( preheat.get( DataElement.class, dataElement.getCode() ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue dataValue = dataValue();
         dataValue.setDataElement( "DE_424050" );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue ) ).build();
 
@@ -358,19 +371,20 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementValueTypeIsNull()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
         DataElement invalidDataElement = dataElement( null );
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( invalidDataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) )
             .build();
@@ -384,7 +398,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsNull()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
@@ -393,12 +407,13 @@ class EventDataValuesValidationHookTest
         when( preheat.get( FileResource.class, validDataValue.getValue() ) ).thenReturn( null );
 
         ProgramStage programStage = programStage( validDataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -414,20 +429,21 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenFileResourceValueIsNullAndDataElementIsNotCompulsory()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, false );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -440,20 +456,21 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceValueIsNullAndDataElementIsCompulsory()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -467,21 +484,22 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnActiveEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -495,21 +513,22 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -523,21 +542,22 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnActiveEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -550,21 +570,22 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -578,20 +599,21 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnScheduledEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SCHEDULE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -604,20 +626,21 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnSkippedEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -630,20 +653,21 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenDataElementIsNullAndDataElementIsNotCompulsory()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, false );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -656,13 +680,14 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsAlreadyAssigned()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -671,7 +696,7 @@ class EventDataValuesValidationHookTest
         DataValue validDataValue = dataValue( "QX4LpiTZmUH" );
         when( preheat.get( FileResource.class, validDataValue.getValue() ) ).thenReturn( fileResource );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -714,7 +739,7 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationDataElementOptionValueIsValid()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataValue validDataValue = dataValue( "code" );
         DataValue nullDataValue = dataValue( null );
@@ -731,12 +756,13 @@ class EventDataValuesValidationHookTest
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue, nullDataValue ) )
             .build();
@@ -749,7 +775,7 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationDataElementOptionValueIsInValid()
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataValue validDataValue = dataValue( "value" );
         validDataValue.setDataElement( dataElementUid );
@@ -766,12 +792,13 @@ class EventDataValuesValidationHookTest
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -786,13 +813,14 @@ class EventDataValuesValidationHookTest
 
     private void runAndAssertValidationForDataValue( ValueType valueType, String value )
     {
-        setUpIdentifiers();
+        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement invalidDataElement = dataElement( valueType );
         when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( invalidDataElement );
 
         ProgramStage programStage = programStage( dataElement() );
-        when( preheat.getProgramStage( programStageUid ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
@@ -800,7 +828,7 @@ class EventDataValuesValidationHookTest
         validDataValue.setDataElement( dataElementUid );
         validDataValue.setValue( value );
         Event event = Event.builder()
-            .programStage( programStage.getUid() )
+            .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -811,7 +839,7 @@ class EventDataValuesValidationHookTest
         assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
     }
 
-    private void setUpIdentifiers()
+    private TrackerIdSchemeParams setUpIdentifiers()
     {
         TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
             .idScheme( TrackerIdSchemeParam.UID )
@@ -820,6 +848,7 @@ class EventDataValuesValidationHookTest
             .dataElementIdScheme( TrackerIdSchemeParam.UID )
             .build();
         when( preheat.getIdSchemes() ).thenReturn( params );
+        return params;
     }
 
     private DataElement dataElement( ValueType type )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,7 +82,8 @@ class EventGeoValidationHookTest
 
         ProgramStage programStage = new ProgramStage();
         programStage.setFeatureType( FeatureType.POINT );
-        when( preheat.getProgramStage( PROGRAM_STAGE ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) ) )
+            .thenReturn( programStage );
     }
 
     @Test
@@ -89,7 +91,7 @@ class EventGeoValidationHookTest
     {
         // given
         Event event = new Event();
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -121,7 +123,7 @@ class EventGeoValidationHookTest
         // given
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -141,7 +143,7 @@ class EventGeoValidationHookTest
         // given
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -163,7 +165,7 @@ class EventGeoValidationHookTest
         // given
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
-        event.setProgramStage( PROGRAM_STAGE );
+        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -255,7 +255,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( program );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( preheat.getProgramStage( PROGRAM_STAGE_ID ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( bundle.getProgramInstance( ENROLLMENT_ID ) )
             .thenReturn( programInstance( ENROLLMENT_ID, program ) );
@@ -268,7 +268,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( ORG_UNIT_ID )
             .enrollment( ENROLLMENT_ID )
             .build();
@@ -289,7 +289,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( program );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( preheat.getProgramStage( PROGRAM_STAGE_ID ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn(
                 programStage( PROGRAM_STAGE_ID, programWithRegistration( CodeGenerator.generateUid(), orgUnit ) ) );
 
@@ -301,7 +301,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( ORG_UNIT_ID )
             .build();
 
@@ -321,7 +321,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( program );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( preheat.getProgramStage( PROGRAM_STAGE_ID ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
 
         CategoryCombo defaultCC = defaultCategoryCombo();
@@ -332,7 +332,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( ORG_UNIT_ID )
             .build();
 
@@ -353,7 +353,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( program );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( preheat.getProgramStage( PROGRAM_STAGE_ID ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( bundle.getProgramInstance( ENROLLMENT_ID ) )
             .thenReturn(
@@ -367,7 +367,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( ORG_UNIT_ID )
             .enrollment( ENROLLMENT_ID )
             .build();
@@ -391,7 +391,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn(
                 Collections.singletonMap( PROGRAM_UID, Collections.singletonList( anotherOrgUnit.getUid() ) ) );
-        when( preheat.getProgramStage( PROGRAM_STAGE_ID ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( bundle.getProgramInstance( ENROLLMENT_ID ) )
             .thenReturn( programInstance( ENROLLMENT_ID, program ) );
@@ -404,7 +404,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( ORG_UNIT_ID )
             .enrollment( ENROLLMENT_ID )
             .build();
@@ -1041,7 +1041,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( program );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( preheat.getProgramStage( PROGRAM_STAGE_ID ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
         when( bundle.getProgramInstance( ENROLLMENT_ID ) )
             .thenReturn( programInstance( ENROLLMENT_ID, program ) );
@@ -1117,7 +1117,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         return Event.builder()
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( ORG_UNIT_ID )
             .enrollment( ENROLLMENT_ID );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -38,7 +38,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1008;
 import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReporter.hasTrackerError;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.CodeGenerator;
@@ -205,7 +204,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
-            .programStage( CodeGenerator.generateUid() )
+            .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
@@ -221,7 +220,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
-            .programStage( CodeGenerator.generateUid() )
+            .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( null ) )
             .build();
 
@@ -237,11 +236,12 @@ class PreCheckMandatoryFieldsValidationHookTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
-            .programStage( CodeGenerator.generateUid() )
+            .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
         ProgramStage programStage = new ProgramStage();
-        programStage.setUid( event.getProgramStage() );
-        when( preheat.getProgramStage( anyString() ) ).thenReturn( programStage );
+        programStage.setUid( event.getProgramStage().getIdentifier() );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage.getUid() ) ) )
+            .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, event );
@@ -257,7 +257,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .orgUnit( CodeGenerator.generateUid() )
-            .programStage( null )
+            .programStage( MetadataIdentifier.ofUid( null ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
@@ -273,7 +273,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .orgUnit( null )
-            .programStage( CodeGenerator.generateUid() )
+            .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -260,7 +260,8 @@ class PreCheckMetaValidationHookTest
         // when
         when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
-        when( preheat.getProgramStage( PROGRAM_STAGE_UID ) ).thenReturn( new ProgramStage() );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
+            .thenReturn( new ProgramStage() );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -278,7 +279,8 @@ class PreCheckMetaValidationHookTest
 
         // when
         when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
-        when( preheat.getProgramStage( PROGRAM_STAGE_UID ) ).thenReturn( new ProgramStage() );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
+            .thenReturn( new ProgramStage() );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -314,7 +316,8 @@ class PreCheckMetaValidationHookTest
 
         // when
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
-        when( preheat.getProgramStage( PROGRAM_STAGE_UID ) ).thenReturn( new ProgramStage() );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
+            .thenReturn( new ProgramStage() );
 
         validatorToTest.validateEvent( reporter, event );
 
@@ -377,7 +380,7 @@ class PreCheckMetaValidationHookTest
     {
         return Event.builder()
             .event( CodeGenerator.generateUid() )
-            .programStage( PROGRAM_STAGE_UID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) )
             .orgUnit( ORG_UNIT_UID )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -714,7 +714,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -747,7 +747,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -776,7 +776,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -804,7 +804,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -833,7 +833,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.COMPLETED )
             .build();
@@ -866,7 +866,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .event( eventUid )
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.COMPLETED )
             .build();
@@ -905,7 +905,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -937,7 +937,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .enrollment( CodeGenerator.generateUid() )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -967,7 +967,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .enrollment( CodeGenerator.generateUid() )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.SCHEDULE )
             .build();
@@ -999,7 +999,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
 
@@ -1030,7 +1030,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .enrollment( enrollmentUid )
             .orgUnit( ORG_UNIT_ID )
-            .programStage( PS_ID )
+            .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.COMPLETED )
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -195,7 +195,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     {
         // given
         Event event = validEvent();
-        event.setProgramStage( "NewProgramStageId" );
+        event.setProgramStage( MetadataIdentifier.ofUid( "NewProgramStageId" ) );
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
@@ -248,7 +248,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     {
         return Event.builder()
             .event( EVENT_ID )
-            .programStage( PROGRAM_STAGE_ID )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .enrollment( ENROLLMENT_ID )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
@@ -121,9 +120,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         bundle.setStrategy( event, TrackerImportStrategy.CREATE );
 
         when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
-        when( preheat.getProgramStageWithEvents() )
-            .thenReturn(
-                Lists.newArrayList( Pair.of( event.getProgramStage().getIdentifier(), event.getEnrollment() ) ) );
+        when( preheat.hasProgramStageWithEvents( event.getProgramStage(), event.getEnrollment() ) ).thenReturn( true );
         bundle.setEvents( Lists.newArrayList( event ) );
         ValidationErrorReporter errorReporter = new ValidationErrorReporter( bundle );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
@@ -120,7 +120,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],
@@ -145,7 +148,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8z",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "TvctPPhpD8v",
       "orgUnit": "QfUVllTs6cZ",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -73,7 +76,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -106,7 +112,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -139,7 +148,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -172,7 +184,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -205,7 +220,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -270,7 +288,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
@@ -335,7 +356,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -120,7 +120,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -154,7 +157,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -188,7 +194,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -222,7 +231,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -256,7 +268,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -290,7 +305,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -356,7 +374,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],
@@ -422,7 +443,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJwr"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "PlKwabX2xRW",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
@@ -1,41 +1,82 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
   "events": [
     {
       "event": "EVENT123456",
-      "enrollment": "TvctPPhpD8u",
-      "trackedEntity": "IOR1AXXl24H",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
-      "completedAt": "2019-01-28T00:00:00.000",
+      "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
         {
+          "createdAt": "2019-01-28T12:10:38.113",
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
-          "createdAt": "2019-01-28T12:10:38.113",
-          "dataElement": "DATAEL00001",
-          "value": "NEWTEXT",
-          "providedElsewhere": false
+          "providedElsewhere": false,
+          "dataElement": "DATAEL00002",
+          "value": "NEWTEXT"
         },
         {
+          "createdAt": "2019-01-28T12:10:38.113",
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
-          "createdAt": "2019-01-28T12:10:38.113",
-          "dataElement": "DATAEL00002",
-          "value": "NEWTEXT",
-          "providedElsewhere": false
+          "providedElsewhere": false,
+          "dataElement": "DATAEL00001",
+          "value": "NEWTEXT"
         }
-      ]
+      ],
+      "notes": []
     }
-  ]
+  ],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
@@ -1,33 +1,74 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
   "events": [
     {
       "event": "EVENT123456",
-      "enrollment": "TvctPPhpD8u",
-      "trackedEntity": "IOR1AXXl24H",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
-      "completedAt": "2019-01-28T00:00:00.000",
+      "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
         {
+          "createdAt": "2019-01-28T12:10:38.113",
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
-          "createdAt": "2019-01-28T12:10:38.113",
+          "providedElsewhere": false,
           "dataElement": "DATAEL00002",
-          "value": "NEWTEXT",
-          "providedElsewhere": false
+          "value": "NEWTEXT"
         }
-      ]
+      ],
+      "notes": []
     }
-  ]
+  ],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_event.json
@@ -1,58 +1,117 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
   "events": [
     {
       "event": "D9PbzJY8bJO",
-      "enrollment": "TvctPPhpD8u",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "completedBy": "admin"
+      "dataValues": [],
+      "notes": []
     },
     {
       "event": "NEWEVENT001",
-      "enrollment": "TvctPPhpD8u",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "completedBy": "admin"
+      "dataValues": [],
+      "notes": []
     },
     {
       "event": "EVENTUID-TOOLONG",
-      "enrollment": "TvctPPhpD8u",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "completedBy": "admin"
+      "dataValues": [],
+      "notes": []
     }
-  ]
+  ],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_event_and_one_new_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_event_and_one_new_event.json
@@ -1,40 +1,91 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
   "events": [
     {
       "event": "D9PbzJY8bJO",
-      "enrollment": "TvctPPhpD8u",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "completedBy": "admin"
+      "dataValues": [],
+      "notes": []
     },
     {
       "event": "NEWEVENT001",
-      "enrollment": "TvctPPhpD8u",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "completedBy": "admin"
+      "dataValues": [],
+      "notes": []
     }
-  ]
+  ],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_tei_and_one_new_tei.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_tei_and_one_new_tei.json
@@ -1,42 +1,77 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
   "trackedEntities": [
     {
-      "trackedEntityType": "ja8NY4PW7Xm",
       "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": "ja8NY4PW7Xm",
       "createdAt": "2020-02-20T12:09:21.844",
       "updatedAt": "2020-08-31T12:09:21.844",
-      "clientCreatedAt": "2020-02-20T12:09:21.844",
-      "clientUpdatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": "h4w96yEMlzO",
       "inactive": false,
       "deleted": false,
-      "featureType": "NONE",
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": [],
       "programOwners": [
         {
-          "ownerOrgUnit": "cNEZTkdAvmg",
-          "program": "hJUBNVQWl4e",
-          "trackedEntity": "EEFkxTWB55Y"
+          "trackedEntity": "EEFkxTWB55Y",
+          "program": "hJUBNVQWl4e"
         }
       ]
     },
     {
-      "trackedEntityType": "ja8NY4PW7Xm",
       "trackedEntity": "CREATEDTEI1",
+      "trackedEntityType": "ja8NY4PW7Xm",
       "createdAt": "2020-02-20T12:09:21.844",
       "updatedAt": "2020-02-20T12:09:21.844",
-      "clientCreatedAt": "2020-02-20T12:09:21.844",
-      "clientUpdatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": "h4w96yEMlzO",
       "inactive": false,
       "deleted": false,
-      "featureType": "NONE",
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": [],
       "programOwners": [
         {
-          "ownerOrgUnit": "cNEZTkdAvmg",
-          "program": "hJUBNVQWl4e",
-          "trackedEntity": "EEFkxTWB55Y"
+          "trackedEntity": "EEFkxTWB55Y",
+          "program": "hJUBNVQWl4e"
         }
       ]
     }
-  ]
+  ],
+  "enrollments": [],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_tei_and_one_new_tei_and_one_invalid_tei.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_tei_and_one_new_tei_and_one_invalid_tei.json
@@ -1,61 +1,96 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
   "trackedEntities": [
     {
-      "trackedEntityType": "ja8NY4PW7Xm",
       "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": "ja8NY4PW7Xm",
       "createdAt": "2020-02-20T12:09:21.844",
       "updatedAt": "2020-08-31T12:09:21.844",
-      "clientCreatedAt": "2020-02-20T12:09:21.844",
-      "clientUpdatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": "h4w96yEMlzO",
       "inactive": false,
       "deleted": false,
-      "featureType": "NONE",
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": [],
       "programOwners": [
         {
-          "ownerOrgUnit": "cNEZTkdAvmg",
-          "program": "hJUBNVQWl4e",
-          "trackedEntity": "EEFkxTWB55Y"
+          "trackedEntity": "EEFkxTWB55Y",
+          "program": "hJUBNVQWl4e"
         }
       ]
     },
     {
-      "trackedEntityType": "ja8NY4PW7Xm",
       "trackedEntity": "CREATEDTEI1",
+      "trackedEntityType": "ja8NY4PW7Xm",
       "createdAt": "2020-02-20T12:09:21.844",
       "updatedAt": "2020-02-20T12:09:21.844",
-      "clientCreatedAt": "2020-02-20T12:09:21.844",
-      "clientUpdatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": "h4w96yEMlzO",
       "inactive": false,
       "deleted": false,
-      "featureType": "NONE",
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": [],
       "programOwners": [
         {
-          "ownerOrgUnit": "cNEZTkdAvmg",
-          "program": "hJUBNVQWl4e",
-          "trackedEntity": "EEFkxTWB55Y"
+          "trackedEntity": "EEFkxTWB55Y",
+          "program": "hJUBNVQWl4e"
         }
       ]
     },
     {
-      "trackedEntityType": "ja8NY4PW7Xm",
       "trackedEntity": "INVALIDTEI-UIDTOOLONG",
+      "trackedEntityType": "ja8NY4PW7Xm",
       "createdAt": "2020-02-20T12:09:21.844",
       "updatedAt": "2020-02-20T12:09:21.844",
-      "clientCreatedAt": "2020-02-20T12:09:21.844",
-      "clientUpdatedAt": "2020-02-20T12:09:21.844",
       "orgUnit": "h4w96yEMlzO",
       "inactive": false,
       "deleted": false,
-      "featureType": "NONE",
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": [],
       "programOwners": [
         {
-          "ownerOrgUnit": "cNEZTkdAvmg",
-          "program": "hJUBNVQWl4e",
-          "trackedEntity": "EEFkxTWB55Y"
+          "trackedEntity": "EEFkxTWB55Y",
+          "program": "hJUBNVQWl4e"
         }
       ]
     }
-  ]
+  ],
+  "enrollments": [],
+  "events": [],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "uoNW0E3xXUy",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
@@ -1,23 +1,66 @@
 {
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [],
+  "enrollments": [],
   "events": [
     {
       "event": "EVENT123456",
-      "storedBy": "admin",
-      "scheduledAt": "2019-01-28T12:10:38.100",
+      "status": "COMPLETED",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJne"
       },
-      "programStage": "NpsdDv6kKSe",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSe"
+      },
       "orgUnit": "h4w96yEMlzO",
-      "status": "COMPLETED",
+      "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
-      "attributeCategoryOptions": "xYerKDKCefk",
-      "updatedAt": "2019-01-28T12:10:38.109",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
-      "completedAt": "2019-01-28T00:00:00.000",
+      "updatedAt": "2019-01-28T12:10:38.109",
       "attributeOptionCombo": "HllvX50cXC0",
-      "completedBy": "admin"
+      "attributeCategoryOptions": "xYerKDKCefk",
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "dataValues": [],
+      "notes": []
     }
-  ]
+  ],
+  "relationships": [],
+  "username": "system-process"
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_event.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
@@ -81,7 +81,10 @@
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
@@ -249,7 +249,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
@@ -273,7 +276,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "TvctPPhpD8v",
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/event-data-delete.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/event-data-delete.json
@@ -35,9 +35,18 @@
   "events": [
     {
       "event": "ZwwuwNp6gVd",
+      "status": "ACTIVE",
       "program": {
         "idScheme": "UID"
-      }
+      },
+      "programStage": {
+        "idScheme": "UID"
+      },
+      "relationships": [],
+      "followup": false,
+      "deleted": false,
+      "dataValues": [],
+      "notes": []
     }
   ],
   "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "rT3rvcn2vid"
       },
-      "programStage": "o68AuhbJDSz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "o68AuhbJDSz"
+      },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "rT3rvcn2vid"
       },
-      "programStage": "o68AuhbJDSz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "o68AuhbJDSz"
+      },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-cat-write-access.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-cat-write-access.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "OilWH8Cj6QU",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "OilWH8Cj6QU"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-registration.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-registration.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
@@ -39,7 +39,10 @@
       "program": {
         "idScheme": "UID"
       },
-      "programStage": "NpsdDv6kKSO",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
       "enrollment": "TvctPPhpD8u",
       "orgUnit": "h4w96yEMlzO",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
@@ -39,7 +39,10 @@
       "program": {
         "idScheme": "UID"
       },
-      "programStage": "o68AuhbJDSz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "o68AuhbJDSz"
+      },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "o4dcWCsO6p9"
       },
-      "programStage": "A9dLfii5MEu",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "A9dLfii5MEu"
+      },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-opt-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-opt-combo.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "YYY1E9tAppy"
       },
-      "programStage": "Pmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Pmqxq907VNz"
+      },
       "enrollment": "KNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "YYY1E9tAppy"
       },
-      "programStage": "Pmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Pmqxq907VNz"
+      },
       "enrollment": "KNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "YYY1E9tAppy"
       },
-      "programStage": "Pmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Pmqxq907VNz"
+      },
       "enrollment": "KNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_combo-date-wrong.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_combo-date-wrong.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "rT3rvcn2vid"
       },
-      "programStage": "o68AuhbJDSz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "o68AuhbJDSz"
+      },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
       "occurredAt": "2018-12-31T06:13:07.000",
@@ -56,7 +59,10 @@
       "program": {
         "idScheme": "UID"
       },
-      "programStage": "o68AuhbJDSz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "o68AuhbJDSz"
+      },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],
       "occurredAt": "2020-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-programStage-access.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-programStage-access.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "prabcdefghA"
       },
-      "programStage": "pgabcdefghA",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "pgabcdefghA"
+      },
       "enrollment": "MNWZ6hnuhSX",
       "orgUnit": "ouabcdefghA",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-uncomplete.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-uncomplete.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "prabcdefghA"
       },
-      "programStage": "pgabcdefghA",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "pgabcdefghA"
+      },
       "enrollment": "MNWZ6hnuhSX",
       "orgUnit": "ouabcdefghA",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-default-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-default-combo.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "YYY1E9tAppy"
       },
-      "programStage": "Pmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Pmqxq907VNz"
+      },
       "enrollment": "KNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part2.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part2.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/program_and_tracker_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/program_and_tracker_events.json
@@ -40,7 +40,10 @@
         "idScheme": "UID",
         "identifier": "E8o1E9tAppy"
       },
-      "programStage": "Qmqxq907VNz",
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "Qmqxq907VNz"
+      },
       "enrollment": "MNWZ6hnuhSw",
       "orgUnit": "QfUVllTs6cS",
       "orgUnitName": "TA org_unit lvl2",
@@ -61,6 +64,9 @@
       "program": {
         "idScheme": "UID",
         "identifier": "VVV1E9tAppy"
+      },
+      "programStage": {
+        "idScheme": "UID"
       },
       "orgUnit": "QfUVllTs6cS",
       "relationships": [],

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventMapper.java
@@ -39,7 +39,8 @@ import org.mapstruct.Named;
     NoteMapper.class,
     DataValueMapper.class,
     InstantMapper.class,
-    UserMapper.class } )
+    UserMapper.class,
+} )
 interface EventMapper extends ViewMapper<org.hisp.dhis.dxf2.events.event.Event, Event>
 {
     @Mapping( target = "occurredAt", source = "eventDate" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventMapper.java
@@ -39,8 +39,7 @@ import org.mapstruct.Named;
     NoteMapper.class,
     DataValueMapper.class,
     InstantMapper.class,
-    UserMapper.class,
-} )
+    UserMapper.class } )
 interface EventMapper extends ViewMapper<org.hisp.dhis.dxf2.events.event.Event, Event>
 {
     @Mapping( target = "occurredAt", source = "eventDate" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
@@ -44,5 +44,6 @@ import org.mapstruct.Mapping;
 interface EventMapper extends DomainMapper<Event, org.hisp.dhis.tracker.domain.Event>
 {
     @Mapping( target = "program", source = "program", qualifiedByName = "programToMetadataIdentifier" )
+    @Mapping( target = "programStage", source = "programStage", qualifiedByName = "programStageToMetadataIdentifier" )
     org.hisp.dhis.tracker.domain.Event from( Event event, @Context TrackerIdSchemeParams idSchemeParams );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
@@ -37,9 +37,16 @@ interface MetadataIdentifierMapper
 {
 
     @Named( "programToMetadataIdentifier" )
-    default org.hisp.dhis.tracker.domain.MetadataIdentifier from( String identifier,
+    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromProgram( String identifier,
         @Context TrackerIdSchemeParams idSchemeParams )
     {
         return idSchemeParams.getProgramIdScheme().toMetadataIdentifier( identifier );
+    }
+
+    @Named( "programStageToMetadataIdentifier" )
+    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromProgramStage( String identifier,
+        @Context TrackerIdSchemeParams idSchemeParams )
+    {
+        return idSchemeParams.getProgramStageIdScheme().toMetadataIdentifier( identifier );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -50,7 +50,7 @@ class MetadataIdentifierMapperTest
             .idScheme( TrackerIdSchemeParam.CODE )
             .build();
 
-        MetadataIdentifier id = MAPPER.from( "RiNIt1yJoge", params );
+        MetadataIdentifier id = MAPPER.fromProgram( "RiNIt1yJoge", params );
 
         assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
         assertEquals( "RiNIt1yJoge", id.getIdentifier() );
@@ -65,7 +65,7 @@ class MetadataIdentifierMapperTest
             .programIdScheme( TrackerIdSchemeParam.ofAttribute( "RiNIt1yJoge" ) )
             .build();
 
-        MetadataIdentifier id = MAPPER.from( "clouds", params );
+        MetadataIdentifier id = MAPPER.fromProgram( "clouds", params );
 
         assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
         assertEquals( "RiNIt1yJoge", id.getIdentifier() );
@@ -80,7 +80,51 @@ class MetadataIdentifierMapperTest
             .idScheme( TrackerIdSchemeParam.CODE )
             .build();
 
-        MetadataIdentifier id = MAPPER.from( null, params );
+        MetadataIdentifier id = MAPPER.fromProgram( null, params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertNull( id.getIdentifier() );
+    }
+
+    @Test
+    void programStageIdentifierFromUID()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromProgramStage( "RiNIt1yJoge", params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+    }
+
+    @Test
+    void programStageIdentifierFromAttribute()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .programStageIdScheme( TrackerIdSchemeParam.ofAttribute( "RiNIt1yJoge" ) )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromProgramStage( "clouds", params );
+
+        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( "clouds", id.getAttributeValue() );
+    }
+
+    @Test
+    void programStageIdentifierFromUIDIfNull()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromProgramStage( null, params );
 
         assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
         assertNull( id.getIdentifier() );


### PR DESCRIPTION
draft PR, next in line after https://github.com/dhis2/dhis2-core/pull/10508 is merged

## Overview of changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in query parameters. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute
* DataValue.dataElement
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo
* Event.attributeCategoryOptions
* TrackedEntity.trackedEntityType
* Relationship.relationshipType
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,ProgramOwner}.program
* {Enrollment,Event,TrackedEntity,ProgramOwner}.orgUnit

will become idScheme aware.

## This PR

* migrate Event.programStage to MetadataIdentifier