### PR TITLE
fix: V{value_count} in PI filter DHIS2-13099

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -382,7 +382,9 @@ public class DefaultProgramIndicatorService
     private String _getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate,
         String tableAlias )
     {
-        Set<String> uids = getDataElementAndAttributeIdentifiers( expression, programIndicator.getAnalyticsType() );
+        // Get the uids from the expression even if this is the filter
+        Set<String> uids = getDataElementAndAttributeIdentifiers( programIndicator.getExpression(),
+            programIndicator.getAnalyticsType() );
 
         ProgramExpressionParams params = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vValueCount.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.program.variable;
 
+import java.util.Set;
+
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
@@ -41,9 +43,16 @@ public class vValueCount
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
+        Set<String> uids = visitor.getProgParams().getDataElementAndAttributeIdentifiers();
+
+        if ( uids.isEmpty() )
+        {
+            return "0";
+        }
+
         String sql = "nullif(cast((";
 
-        for ( String uid : visitor.getProgParams().getDataElementAndAttributeIdentifiers() )
+        for ( String uid : uids )
         {
             sql += "case when " + visitor.getStatementBuilder().columnQuote( uid )
                 + " is not null then 1 else 0 end + ";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/vZeroPosValueCount.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.program.variable;
 
+import java.util.Set;
+
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 
@@ -41,9 +43,16 @@ public class vZeroPosValueCount
     @Override
     public Object getSql( CommonExpressionVisitor visitor )
     {
+        Set<String> uids = visitor.getProgParams().getDataElementAndAttributeIdentifiers();
+
+        if ( uids.isEmpty() )
+        {
+            return "0";
+        }
+
         String sql = "nullif(cast((";
 
-        for ( String uid : visitor.getProgParams().getDataElementAndAttributeIdentifiers() )
+        for ( String uid : uids )
         {
             sql += "case when " + visitor.getStatementBuilder().columnQuote( uid ) + " >= 0 then 1 else 0 end + ";
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -478,11 +478,13 @@ class ProgramIndicatorServiceTest extends DhisSpringTest
     @Test
     void testValueCount()
     {
-        String expected = "coalesce(\"DataElmentA\"::numeric,0)" + " + coalesce(\"Attribute0A\"::numeric,0)"
-            + " + nullif(cast((case when \"DataElmentA\" is not null then 1 else 0 end + case when \"Attribute0A\" is not null then 1 else 0 end) as double),0)";
-        String expression = "#{ProgrmStagA.DataElmentA} + A{Attribute0A} + V{value_count}";
+        String expected = "nullif(cast((" +
+            "case when \"DataElmentA\" is not null then 1 else 0 end + " +
+            "case when \"Attribute0A\" is not null then 1 else 0 end + " +
+            "case when \"Attribute0B\" is not null then 1 else 0 end) as double),0)";
+        String expression = "V{value_count}";
         assertEquals( expected,
-            programIndicatorService.getAnalyticsSql( expression, indicatorA, new Date(), new Date() ) );
+            programIndicatorService.getAnalyticsSql( expression, indicatorE, new Date(), new Date() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -39,6 +39,8 @@ import java.util.HashSet;
 import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,6 +60,9 @@ class ProgramIndicatorServiceVariableTest extends DhisSpringTest
     @Autowired
     private ProgramService programService;
 
+    @Autowired
+    private TrackedEntityAttributeService attributeService;
+
     private Program programA;
 
     private ProgramIndicator piA;
@@ -73,23 +78,33 @@ class ProgramIndicatorServiceVariableTest extends DhisSpringTest
     {
         OrganisationUnit organisationUnit = createOrganisationUnit( 'A' );
         organisationUnitService.addOrganisationUnit( organisationUnit );
+
         programA = createProgram( 'A', new HashSet<>(), organisationUnit );
         programA.setUid( "Program000A" );
         programService.addProgram( programA );
+
         piA = createProgramIndicator( 'A', programA, "20", null );
         programA.getProgramIndicators().add( piA );
         piB = createProgramIndicator( 'B', programA, "70", null );
         piB.setAnalyticsType( AnalyticsType.ENROLLMENT );
         programA.getProgramIndicators().add( piB );
+
+        TrackedEntityAttribute teaA = createTrackedEntityAttribute( 'A' );
+        teaA.setUid( "TEAttribute" );
+        attributeService.addTrackedEntityAttribute( teaA );
     }
 
     private String getSql( String expression )
     {
+        piA.setExpression( expression );
+
         return programIndicatorService.getAnalyticsSql( expression, piA, startDate, endDate );
     }
 
     private String getSqlEnrollment( String expression )
     {
+        piB.setExpression( expression );
+
         return programIndicatorService.getAnalyticsSql( expression, piB, startDate, endDate );
     }
 
@@ -236,14 +251,28 @@ class ProgramIndicatorServiceVariableTest extends DhisSpringTest
     @Test
     void testValueCount()
     {
-        assertEquals( "nullif(cast(() as double),0)", getSql( "V{value_count}" ) );
-        assertEquals( "nullif(cast(() as double),0)", getSqlEnrollment( "V{value_count}" ) );
+        assertEquals( "0", getSql( "V{value_count}" ) );
+        assertEquals( "0", getSqlEnrollment( "V{value_count}" ) );
+
+        assertEquals(
+            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" is not null then 1 else 0 end) as double),0)",
+            getSql( "A{TEAttribute} + V{value_count}" ) );
+        assertEquals(
+            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" is not null then 1 else 0 end) as double),0)",
+            getSqlEnrollment( "A{TEAttribute} + V{value_count}" ) );
     }
 
     @Test
     void testZeroPosValueCount()
     {
-        assertEquals( "nullif(cast(() as double),0)", getSql( "V{zero_pos_value_count}" ) );
-        assertEquals( "nullif(cast(() as double),0)", getSqlEnrollment( "V{zero_pos_value_count}" ) );
+        assertEquals( "0", getSql( "V{zero_pos_value_count}" ) );
+        assertEquals( "0", getSqlEnrollment( "V{zero_pos_value_count}" ) );
+
+        assertEquals(
+            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
+            getSql( "A{TEAttribute} + V{zero_pos_value_count}" ) );
+        assertEquals(
+            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
+            getSqlEnrollment( "A{TEAttribute} + V{zero_pos_value_count}" ) );
     }
 }


### PR DESCRIPTION
See [DHIS2-13099](https://jira.dhis2.org/browse/DHIS2-13099). The Program Indicator variables `V{value_count}` and `V{zero_pos_value_count}` were not working properly when used in a program indicator filter. This is because they were counting the values of data elements or attributes specified in the filter, instead of counting the values of those items specified in the program indicator main expression. This has been fixed.

(The User Manual clearly says that these functions should return the number of values "in the expression part of the event." See [here](https://docs.dhis2.org/en/full/use/user-guides/dhis-core-version-master/dhis2-user-manual.html#configure_program_indicator), under the table _Variables to use in a program indicator expression or filter_.)

A secondary problem is that if no data elements or attributes are present in the expression, the `V{value_count}` and `V{zero_pos_value_count}` functions were generating invalid SQL. This has been fixed so they now generate a "0" in the SQL query, because there are no values that could be found.

The unit tests for these functions have been adjusted accordingly.