### PR TITLE
fix: Event.orgUnit is a MetadataIdentifier DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -119,7 +119,7 @@ public class EventTrackerConverterService
 
             if ( ou != null )
             {
-                event.setOrgUnit( ou.getUid() );
+                event.setOrgUnit( MetadataIdentifier.ofUid( ou.getUid() ) );
                 event.setOrgUnitName( ou.getName() );
             }
 
@@ -206,7 +206,7 @@ public class EventTrackerConverterService
     {
         ProgramStage programStage = preheat.get( ProgramStage.class, event.getProgramStage() );
         Program program = preheat.getProgram( event.getProgram() );
-        OrganisationUnit organisationUnit = preheat.get( OrganisationUnit.class, event.getOrgUnit() );
+        OrganisationUnit organisationUnit = preheat.getOrganisationUnit( event.getOrgUnit() );
 
         Date now = new Date();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -72,7 +72,7 @@ public class Event
     private String enrollment;
 
     @JsonProperty
-    private String orgUnit;
+    private MetadataIdentifier orgUnit;
 
     @JsonProperty
     private String orgUnitName;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -751,6 +751,11 @@ public class TrackerPreheat
             .findAny();
     }
 
+    public OrganisationUnit getOrganisationUnit( MetadataIdentifier id )
+    {
+        return get( OrganisationUnit.class, id );
+    }
+
     public OrganisationUnit getOrganisationUnit( String id )
     {
         return get( OrganisationUnit.class, id );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -71,7 +71,7 @@ public class PreCheckMandatoryFieldsValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, Event event )
     {
-        reporter.addErrorIf( () -> StringUtils.isEmpty( event.getOrgUnit() ), event, E1123, ORG_UNIT );
+        reporter.addErrorIf( () -> event.getOrgUnit().isBlank(), event, E1123, ORG_UNIT );
         reporter.addErrorIf( () -> event.getProgramStage().isBlank(), event, E1123, "programStage" );
 
         // TODO remove if once metadata import is fixed

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -309,7 +309,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         Event event = converter.to( psi );
 
-        assertEquals( event.getEnrollment(), PROGRAM_INSTANCE_UID );
+        assertEquals( PROGRAM_INSTANCE_UID, event.getEnrollment() );
         assertEquals( event.getStoredBy(), user.getUsername() );
         event.getDataValues().forEach( e -> {
             assertEquals( DateUtils.fromInstant( e.getCreatedAt() ), psi.getCreated() );
@@ -324,7 +324,8 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         when( preheat.get( ProgramStage.class, MetadataIdentifier.ofUid( programStage.getUid() ) ) )
             .thenReturn( programStage );
         when( preheat.getProgram( MetadataIdentifier.ofUid( program.getUid() ) ) ).thenReturn( program );
-        when( preheat.get( OrganisationUnit.class, organisationUnit.getUid() ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( organisationUnit.getUid() ) ) )
+            .thenReturn( organisationUnit );
     }
 
     private Event event( DataValue dataValue )
@@ -338,7 +339,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         event.setEvent( uid );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) );
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) );
-        event.setOrgUnit( ORGANISATION_UNIT_UID );
+        event.setOrgUnit( MetadataIdentifier.ofUid( ORGANISATION_UNIT_UID ) );
         event.setDataValues( Sets.newHashSet( dataValue ) );
         return event;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -76,11 +76,16 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         List<Pair<String, TrackerIdSchemeParam>> data = buildDataSet( "PlKwabX2xRW", "COU1", "Country" );
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
-            Event event = new Event();
-            event.setOrgUnit( pair.getLeft() );
-            TrackerImportParams params = buildParams( event, builder().orgUnitIdScheme( pair.getRight() ).build() );
+            String id = pair.getLeft();
+            TrackerIdSchemeParam param = pair.getRight();
+            Event event = Event.builder()
+                .orgUnit( param.toMetadataIdentifier( id ) )
+                .build();
+            TrackerImportParams params = buildParams( event, builder().orgUnitIdScheme( param ).build() );
+
             TrackerPreheat preheat = trackerPreheatService.preheat( params );
-            assertPreheatedObjectExists( preheat, OrganisationUnit.class, pair.getRight(), pair.getLeft() );
+
+            assertPreheatedObjectExists( preheat, OrganisationUnit.class, param, id );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -248,8 +248,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void eventValidationSucceedsWhenAOCAndCOsAreNotSetAndProgramHasDefaultCC()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
-            .thenReturn( orgUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( orgUnit );
         Program program = programWithRegistration( PROGRAM_UID, orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( program );
@@ -269,7 +268,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .enrollment( ENROLLMENT_ID )
             .build();
 
@@ -282,8 +281,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void eventValidationFailsWhenEventAndProgramStageProgramDontMatch()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
-            .thenReturn( orgUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( orgUnit );
         Program program = programWithRegistration( PROGRAM_UID, orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( program );
@@ -302,7 +300,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -314,8 +312,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void eventValidationFailsWhenProgramIsRegistrationAndEnrollmentIsMissing()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
-            .thenReturn( orgUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( orgUnit );
         Program program = programWithRegistration( PROGRAM_UID, orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( program );
@@ -333,7 +330,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -346,8 +343,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void eventValidationFailsWhenEventAndEnrollmentProgramDontMatch()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
-            .thenReturn( orgUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( orgUnit );
         Program program = programWithRegistration( PROGRAM_UID, orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( program );
@@ -368,7 +364,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .enrollment( ENROLLMENT_ID )
             .build();
 
@@ -382,8 +378,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void eventValidationFailsWhenEventAndProgramOrganisationUnitDontMatch()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
-            .thenReturn( orgUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( orgUnit );
         OrganisationUnit anotherOrgUnit = organisationUnit( CodeGenerator.generateUid() );
         Program program = programWithRegistration( PROGRAM_UID, anotherOrgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
@@ -405,7 +400,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .enrollment( ENROLLMENT_ID )
             .build();
 
@@ -1051,7 +1046,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     private OrganisationUnit setupOrgUnit()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) )
             .thenReturn( orgUnit );
         return orgUnit;
     }
@@ -1118,7 +1113,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .event( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .enrollment( ENROLLMENT_ID );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -203,7 +203,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
@@ -219,7 +219,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( null ) )
             .build();
@@ -235,7 +235,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
         ProgramStage programStage = new ProgramStage();
@@ -256,7 +256,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
@@ -272,7 +272,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
-            .orgUnit( null )
+            .orgUnit( MetadataIdentifier.ofUid( null ) )
             .programStage( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -258,7 +258,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
             .thenReturn( new ProgramStage() );
@@ -278,7 +279,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
             .thenReturn( new ProgramStage() );
 
@@ -297,7 +299,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
         validatorToTest.validateEvent( reporter, event );
@@ -381,7 +384,7 @@ class PreCheckMetaValidationHookTest
         return Event.builder()
             .event( CodeGenerator.generateUid() )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) )
-            .orgUnit( ORG_UNIT_UID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -713,7 +713,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Event event = Event.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -746,7 +746,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Event event = Event.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -758,7 +758,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -775,7 +775,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -785,7 +785,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -803,7 +803,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Event event = Event.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -813,7 +813,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -832,7 +832,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Event event = Event.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.COMPLETED )
@@ -865,7 +865,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( eventUid )
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.COMPLETED )
@@ -904,7 +904,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Event event = Event.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -936,7 +936,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -947,7 +947,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -966,7 +966,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.SCHEDULE )
@@ -978,7 +978,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -998,7 +998,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -1029,7 +1029,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         Event event = Event.builder()
             .event( CodeGenerator.generateUid() )
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .programStage( MetadataIdentifier.ofUid( PS_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .status( EventStatus.COMPLETED )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
@@ -125,7 +125,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -153,7 +156,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8z",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "TvctPPhpD8v",
-      "orgUnit": "QfUVllTs6cZ",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cZ"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
@@ -44,7 +44,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -80,7 +83,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -116,7 +122,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -152,7 +161,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -188,7 +200,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -224,7 +239,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -292,7 +310,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -360,7 +381,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -125,7 +125,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -162,7 +165,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -199,7 +205,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -236,7 +245,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -273,7 +285,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -310,7 +325,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -379,7 +397,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -448,7 +469,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_event.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -71,7 +74,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -97,7 +103,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_event_and_one_new_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_event_and_one_new_event.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -71,7 +74,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "uoNW0E3xXUy",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
@@ -44,7 +44,10 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSe"
       },
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_event.json
@@ -45,7 +45,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
@@ -86,7 +86,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
@@ -254,7 +254,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",
@@ -281,7 +284,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "TvctPPhpD8v",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
@@ -44,7 +44,10 @@
         "idScheme": "UID",
         "identifier": "o68AuhbJDSz"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
@@ -44,7 +44,10 @@
         "idScheme": "UID",
         "identifier": "o68AuhbJDSz"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-cat-write-access.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-cat-write-access.json
@@ -45,7 +45,10 @@
         "identifier": "OilWH8Cj6QU"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2020-07-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2020-07-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-registration.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-registration.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
@@ -44,7 +44,10 @@
         "identifier": "NpsdDv6kKSO"
       },
       "enrollment": "TvctPPhpD8u",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "relationships": [],
       "occurredAt": "2019-01-28T00:00:00.000",
       "scheduledAt": "2019-01-28T12:10:38.100",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
@@ -43,7 +43,10 @@
         "idScheme": "UID",
         "identifier": "o68AuhbJDSz"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
@@ -44,7 +44,10 @@
         "idScheme": "UID",
         "identifier": "A9dLfii5MEu"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-opt-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-opt-combo.json
@@ -45,7 +45,10 @@
         "identifier": "Pmqxq907VNz"
       },
       "enrollment": "KNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
@@ -45,7 +45,10 @@
         "identifier": "Pmqxq907VNz"
       },
       "enrollment": "KNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
@@ -45,7 +45,10 @@
         "identifier": "Pmqxq907VNz"
       },
       "enrollment": "KNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_combo-date-wrong.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_combo-date-wrong.json
@@ -44,7 +44,10 @@
         "idScheme": "UID",
         "identifier": "o68AuhbJDSz"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2018-12-31T06:13:07.000",
       "followup": false,
@@ -63,7 +66,10 @@
         "idScheme": "UID",
         "identifier": "o68AuhbJDSz"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2020-08-01T00:00:00.000",
       "scheduledAt": "2020-08-19T13:59:13.688",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-programStage-access.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-programStage-access.json
@@ -45,7 +45,10 @@
         "identifier": "pgabcdefghA"
       },
       "enrollment": "MNWZ6hnuhSX",
-      "orgUnit": "ouabcdefghA",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "ouabcdefghA"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-uncomplete.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-uncomplete.json
@@ -45,7 +45,10 @@
         "identifier": "pgabcdefghA"
       },
       "enrollment": "MNWZ6hnuhSX",
-      "orgUnit": "ouabcdefghA",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "ouabcdefghA"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-default-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-default-combo.json
@@ -45,7 +45,10 @@
         "identifier": "Pmqxq907VNz"
       },
       "enrollment": "KNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part2.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part2.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/program_and_tracker_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/program_and_tracker_events.json
@@ -45,7 +45,10 @@
         "identifier": "Qmqxq907VNz"
       },
       "enrollment": "MNWZ6hnuhSw",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "TA org_unit lvl2",
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
@@ -68,7 +71,10 @@
       "programStage": {
         "idScheme": "UID"
       },
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "relationships": [],
       "occurredAt": "2019-08-01T00:00:00.000",
       "scheduledAt": "2019-08-19T13:59:13.688",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
@@ -45,5 +45,6 @@ interface EventMapper extends DomainMapper<Event, org.hisp.dhis.tracker.domain.E
 {
     @Mapping( target = "program", source = "program", qualifiedByName = "programToMetadataIdentifier" )
     @Mapping( target = "programStage", source = "programStage", qualifiedByName = "programStageToMetadataIdentifier" )
+    @Mapping( target = "orgUnit", source = "orgUnit", qualifiedByName = "orgUnitToMetadataIdentifier" )
     org.hisp.dhis.tracker.domain.Event from( Event event, @Context TrackerIdSchemeParams idSchemeParams );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
@@ -49,4 +49,11 @@ interface MetadataIdentifierMapper
     {
         return idSchemeParams.getProgramStageIdScheme().toMetadataIdentifier( identifier );
     }
+
+    @Named( "orgUnitToMetadataIdentifier" )
+    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromOrgUnit( String identifier,
+        @Context TrackerIdSchemeParams idSchemeParams )
+    {
+        return idSchemeParams.getOrgUnitIdScheme().toMetadataIdentifier( identifier );
+    }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -129,4 +129,48 @@ class MetadataIdentifierMapperTest
         assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
         assertNull( id.getIdentifier() );
     }
+
+    @Test
+    void orgUnitIdentifierFromUID()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromOrgUnit( "RiNIt1yJoge", params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+    }
+
+    @Test
+    void orgUnitIdentifierFromAttribute()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .orgUnitIdScheme( TrackerIdSchemeParam.ofAttribute( "RiNIt1yJoge" ) )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromOrgUnit( "clouds", params );
+
+        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( "clouds", id.getAttributeValue() );
+    }
+
+    @Test
+    void orgUnitIdentifierFromUIDIfNull()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromOrgUnit( null, params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertNull( id.getIdentifier() );
+    }
 }


### PR DESCRIPTION
draft PR, next in line after https://github.com/dhis2/dhis2-core/pull/10509 is merged

## Overview of changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in the query parameters (not in the body) and only on import. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute
* DataValue.dataElement
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo
* Event.attributeCategoryOptions
* TrackedEntity.trackedEntityType
* Relationship.relationshipType
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,ProgramOwner}.program
* {Enrollment,Event :heavy_check_mark:,TrackedEntity,ProgramOwner}.orgUnit

will become idScheme aware.

## This PR

* migrate Event.orgUnit to MetadataIdentifier