### PR TITLE
fix: collection api error with additions and deletions in one payload 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/CollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/CollectionService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dxf2.metadata.collection;
 import java.util.Collection;
 
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.feedback.TypeReport;
 
 /**
@@ -47,5 +48,19 @@ public interface CollectionService
 
     TypeReport replaceCollectionItems( IdentifiableObject object, String propertyName,
         Collection<? extends IdentifiableObject> objects )
+        throws Exception;
+
+    /**
+     * Perform addition and deletion of given {@link IdentifiableObjects} to
+     * given {@link IdentifiableObject} in one transaction.
+     *
+     * @param object {@link IdentifiableObject} to be updated
+     * @param propertyName property name of the given {@link IdentifiableObject}
+     *        which will be updated.
+     * @param items {@link IdentifiableObjects} contains additions and deletions
+     *        items.
+     * @return {@link TypeReport}
+     */
+    TypeReport mergeCollectionItems( IdentifiableObject object, String propertyName, IdentifiableObjects items )
         throws Exception;
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/collection/DefaultCollectionService.java
@@ -39,6 +39,7 @@ import lombok.AllArgsConstructor;
 import org.hisp.dhis.cache.HibernateCacheManager;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IdentifiableObjects;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
@@ -107,7 +108,6 @@ public class DefaultCollectionService implements CollectionService
         }
 
         dbmsManager.clearSession();
-        cacheManager.clearCache();
         return report;
     }
 
@@ -191,7 +191,6 @@ public class DefaultCollectionService implements CollectionService
         manager.update( object );
 
         dbmsManager.clearSession();
-        cacheManager.clearCache();
         return report;
     }
 
@@ -252,6 +251,16 @@ public class DefaultCollectionService implements CollectionService
         TypeReport deletions = delCollectionItems( object, propertyName, getCollection( object, property ) );
         TypeReport additions = addCollectionItems( object, propertyName, objects );
         return deletions.mergeAllowEmpty( additions );
+    }
+
+    @Override
+    @Transactional
+    public TypeReport mergeCollectionItems( IdentifiableObject object, String propertyName, IdentifiableObjects items )
+        throws Exception
+    {
+        TypeReport delReport = delCollectionItems( object, propertyName, items.getDeletions() );
+        TypeReport addReport = addCollectionItems( object, propertyName, items.getAdditions() );
+        return delReport.mergeAllowEmpty( addReport );
     }
 
     private Property validateUpdate( IdentifiableObject object, String propertyName, String message )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -535,6 +535,30 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testMergeCollectionItemsJson()
+    {
+        String userId = getCurrentUser().getUid();
+        // first create an object which has a collection
+        String groupId = assertStatus( HttpStatus.CREATED, POST( "/userGroups/", "{'name':'testers'}" ) );
+        assertStatus( HttpStatus.OK,
+            POST( "/userGroups/" + groupId + "/users", "{'additions': [{'id':'" + userId + "'}]}" ) );
+        assertUserGroupHasOnlyUser( groupId, userId );
+
+        User testUser1 = createUser( "test1" );
+        User testUser2 = createUser( "test2" );
+
+        // Add 2 new users and remove existing user from the created group
+        assertStatus( HttpStatus.OK,
+            POST( "/userGroups/" + groupId + "/users",
+                "{'additions': [{'id':'" + testUser1.getUid() + "'},{'id':'" + testUser2.getUid() + "'}]" +
+                    ",'deletions':[{'id':'" + userId + "'}]}" ) );
+
+        JsonList<JsonUser> usersInGroup = GET( "/userGroups/{uid}/", groupId ).content()
+            .getList( "users", JsonUser.class );
+        assertEquals( 2, usersInGroup.size() );
+    }
+
+    @Test
     void testReplaceCollectionItemsJson()
     {
         String userId = getCurrentUser().getUid();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -758,10 +758,10 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         throws Exception
     {
         preUpdateItems( object, items );
-        TypeReport deletions = collectionService.delCollectionItems( object, pvProperty, items.getDeletions() );
-        TypeReport additions = collectionService.addCollectionItems( object, pvProperty, items.getAdditions() );
+        TypeReport report = collectionService.mergeCollectionItems( object, pvProperty, items );
         postUpdateItems( object, items );
-        return typeReport( deletions.mergeAllowEmpty( additions ) );
+        hibernateCacheManager.clearCache();
+        return typeReport( report );
     }
 
     @PutMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
@@ -797,6 +797,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         TypeReport report = collectionService.replaceCollectionItems( object, pvProperty,
             items.getIdentifiableObjects() );
         postUpdateItems( object, items );
+        hibernateCacheManager.clearCache();
         return typeReport( report );
     }
 
@@ -823,6 +824,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         preUpdateItems( object, items );
         TypeReport report = collectionService.addCollectionItems( object, pvProperty, items.getIdentifiableObjects() );
         postUpdateItems( object, items );
+        hibernateCacheManager.clearCache();
         return typeReport( report );
     }
 
@@ -858,6 +860,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         preUpdateItems( object, items );
         TypeReport report = collectionService.delCollectionItems( object, pvProperty, items.getIdentifiableObjects() );
         postUpdateItems( object, items );
+        hibernateCacheManager.clearCache();
         return typeReport( report );
     }
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12958
### Issue
- User sends a `POST` request to `/api/userGroups/{groupId}/users` with payload contains both deletions and additions.
- Server returns `500` error with message `A different object with the same identifier value was already associated with the session : [org.hisp.dhis.user.UserGroup#224024`

### Fix
-  Move the service calls of `collectionService.delCollectionItems()` and `collectionService.addCollectionItems()`  from the controller to service layer. By this the `@Transactional` should be able to handle the clearing session and refreshing entity correctly.
- Move the `session.clearCache()` function to controller layer. This fixes the issue of duplicate objects in session. We should only call cache clear after all changes have been flushed to database ( both additions and deletions ) not in the middle of a transaction.  

### Test
- Added a controller test.

