### PR TITLE
fix: Disk space utilization for analytics temp tables spiking in [2.36-DHIS2-13085]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsTableManager.java
@@ -145,6 +145,13 @@ public interface AnalyticsTableManager
     void dropTempTable( AnalyticsTable table );
 
     /**
+     * Drops the given {@link AnalyticsTable}.
+     *
+     * @param tablePartition the analytics partition table.
+     */
+    public void dropTempTablePartition( AnalyticsTablePartition tablePartition );
+
+    /**
      * Drops the given table.
      *
      * @param tableName the table name.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -74,6 +74,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
@@ -391,7 +392,7 @@ public abstract class AbstractJdbcTableManager
         {
             jdbcTemplate.execute( sql );
         }
-        catch ( BadSqlGrammarException ex )
+        catch ( DataAccessException ex )
         {
             log.error( ex.getMessage() );
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -263,6 +263,12 @@ public abstract class AbstractJdbcTableManager
     }
 
     @Override
+    public void dropTempTablePartition( AnalyticsTablePartition tablePartition )
+    {
+        dropTableCascade( tablePartition.getTempTableName() );
+    }
+
+    @Override
     public void dropTable( String tableName )
     {
         executeSilently( "drop table if exists " + tableName );
@@ -387,7 +393,7 @@ public abstract class AbstractJdbcTableManager
         }
         catch ( BadSqlGrammarException ex )
         {
-            log.debug( ex.getMessage() );
+            log.error( ex.getMessage() );
         }
     }
 
@@ -678,4 +684,5 @@ public abstract class AbstractJdbcTableManager
 
         executeSilently( sql );
     }
+
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -154,7 +154,7 @@ public class DefaultAnalyticsTableService
         clock.logTime( "Performed pre-create table work" );
         notifier.notify( jobId, "Dropping temp tables" );
 
-        dropTempTables( tables );
+        dropAllTempTables( tables );
 
         clock.logTime( "Dropped temp tables" );
         notifier.notify( jobId, "Creating analytics tables" );
@@ -233,6 +233,17 @@ public class DefaultAnalyticsTableService
     // -------------------------------------------------------------------------
 
     /**
+     * Drops the given temporary analytics tables including partition tables.
+     *
+     * @param tables the list of {@link AnalyticsTable}.
+     */
+    private void dropAllTempTables( final List<AnalyticsTable> tables )
+    {
+        dropTempTablesPartitions( tables );
+        dropTempTables( tables );
+    }
+
+    /**
      * Drops the given temporary analytics tables.
      *
      * @param tables the list of {@link AnalyticsTable}.
@@ -240,6 +251,12 @@ public class DefaultAnalyticsTableService
     private void dropTempTables( List<AnalyticsTable> tables )
     {
         tables.forEach( table -> tableManager.dropTempTable( table ) );
+    }
+
+    private void dropTempTablesPartitions( List<AnalyticsTable> tables )
+    {
+        tables.forEach( table -> table.getTablePartitions()
+            .forEach( partitionTable -> tableManager.dropTempTablePartition( partitionTable ) ) );
     }
 
     /**


### PR DESCRIPTION
Sometimes the temporary partition table are not dropped and staying in database after the analytics update. Normally the temp partitions are dropped by swapping the old for new ones. If this swap process failed (silently, there is just debug level log), the old data remaining in the partition table. Subsequently new analytics update process will just add the more or less same data into temp table (with reindexing - time and space consuming).
On the beginning of the process we are trying to drop  all remaining temp tables. The implementation did not remove (drop) partition temp tables (year handling was incorrect)
This problem was fixed (unintentionally) by Maikel in https://github.com/dhis2/dhis2-core/pull/10014/files and backported down to the 2.37 (PR 9th of March 2022).
2.36 was not backported, we are using another partitioning there, so it is not possible just backport it. It means <=2.36 is still buggy.
Because the reason why the swap process is not able to remove temp table, is not clear to me (probably continuous analytics job process  locked the table, maybe forever when hanging), there is no guarantee the problem will gone. Good message is we should have the log indicates there is something wrong.