### PR TITLE
fix: Disk space utilization for analytics temp tables spiking in 2.37[2.39-DHIS2-13085]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -75,6 +75,7 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.util.Assert;
@@ -346,9 +347,9 @@ public abstract class AbstractJdbcTableManager
         {
             jdbcTemplate.execute( sql );
         }
-        catch ( BadSqlGrammarException ex )
+        catch ( DataAccessException ex )
         {
-            log.debug( ex.getMessage() );
+            log.error( ex.getMessage() );
         }
     }
 


### PR DESCRIPTION
Sometimes the temporary partition table are not dropped and staying in database after the analytics update. Normally the temp partitions are dropped by swapping the old for new ones. If this swap process failed (silently, there is just debug level log), the old data remaining in the partition table and new data are only in temp table. Subsequently new analytics update process will just add the more or less same data into temp table (with reindexing - time and space consuming).
On the beginning of the process we are trying to drop all remaining temp tables. The implementation did not remove (drop) partition temp tables (year handling was incorrect)
This problem was fixed (unintentionally) by Maikel in https://github.com/dhis2/dhis2-core/pull/10014/files and backported down to the 2.37 (PR 9th of March 2022).
2.36 was not backported, we are using another partitioning there, so it is not possible just backport it. It means <=2.36 is still buggy.
Because the reason why the swap process is not able to remove temp table, is not clear to me (probably continuous analytics job process locked the table, maybe forever when hanging), there is no guarantee the problem will gone. Good message is we should have the log indicates there is something wrong.