### PR TITLE
 fix: Align OptionSet with the outputIdScheme param [DHIS2-13098]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EnrollmentAnalyticsQueryCriteria.java
@@ -97,6 +97,12 @@ public class EnrollmentAnalyticsQueryCriteria extends AnalyticsPagingCriteria
 
     private IdScheme dataIdScheme;
 
+    /**
+     * Identifier scheme to use for metadata items the query response, can be
+     * identifier, code or attributes. ( options: UID | CODE | ATTRIBUTE:<ID> )
+     */
+    private IdScheme outputIdScheme;
+
     private Set<ProgramStatus> programStatus;
 
     private DisplayProperty displayProperty;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/EventDataQueryRequest.java
@@ -192,6 +192,7 @@ public class EventDataQueryRequest
         queryRequest.paging = this.paging;
         queryRequest.totalPages = this.totalPages;
         queryRequest.endpointItem = this.endpointItem;
+        queryRequest.outputIdScheme = outputIdScheme;
         return request;
     }
 
@@ -330,6 +331,7 @@ public class EventDataQueryRequest
                 .coordinatesOnly( criteria.isCoordinatesOnly() )
                 .includeMetadataDetails( criteria.isIncludeMetadataDetails() )
                 .dataIdScheme( criteria.getDataIdScheme() )
+                .outputIdScheme( criteria.getOutputIdScheme() )
                 .programStatus( criteria.getProgramStatus() )
                 .page( criteria.getPage() )
                 .pageSize( criteria.getPageSize() )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/SchemaIdResponseMapper.java
@@ -33,8 +33,12 @@ import static org.hisp.dhis.common.DimensionalObjectUtils.getDataElementOperandI
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionItemIdSchemeMap;
 
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.option.Option;
 import org.springframework.stereotype.Component;
 
 /**
@@ -70,8 +74,7 @@ public class SchemaIdResponseMapper
         if ( params.isGeneralOutputIdSchemeSet() )
         {
             // Apply a schema to all data element operands using the general
-            // output schema
-            // defined.
+            // output schema defined.
             applyGeneralIdSchemaMapping( params, responseMap );
         }
 
@@ -120,6 +123,17 @@ public class SchemaIdResponseMapper
         if ( params.getProgram() != null )
         {
             map.put( params.getProgram().getUid(), params.getProgram().getPropertyValue( params.getOutputIdScheme() ) );
+        }
+
+        if ( params instanceof EventQueryParams
+            && CollectionUtils.isNotEmpty( ((EventQueryParams) params).getItemOptions() ) )
+        {
+            final Set<Option> options = ((EventQueryParams) params).getItemOptions();
+
+            for ( final Option option : options )
+            {
+                map.put( option.getCode(), option.getPropertyValue( params.getOutputIdScheme() ) );
+            }
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.common.ValueType.TEXT;
 
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
+import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsService;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -86,16 +87,21 @@ public class DefaultEnrollmentAnalyticsService
 
     private final EventQueryPlanner queryPlanner;
 
+    private final SchemaIdResponseMapper schemaIdResponseMapper;
+
     public DefaultEnrollmentAnalyticsService( EnrollmentAnalyticsManager enrollmentAnalyticsManager,
-        AnalyticsSecurityManager securityManager, EventQueryPlanner queryPlanner, EventQueryValidator queryValidator )
+        AnalyticsSecurityManager securityManager, EventQueryPlanner queryPlanner, EventQueryValidator queryValidator,
+        SchemaIdResponseMapper schemaIdResponseMapper )
     {
-        super( securityManager, queryValidator );
+        super( securityManager, queryValidator, schemaIdResponseMapper );
 
         checkNotNull( enrollmentAnalyticsManager );
         checkNotNull( queryPlanner );
+        checkNotNull( schemaIdResponseMapper );
 
         this.enrollmentAnalyticsManager = enrollmentAnalyticsManager;
         this.queryPlanner = queryPlanner;
+        this.schemaIdResponseMapper = schemaIdResponseMapper;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -193,7 +193,7 @@ public class DefaultEventAnalyticsService
         AnalyticsCache analyticsCache, EnrollmentAnalyticsManager enrollmentAnalyticsManager,
         SchemaIdResponseMapper schemaIdResponseMapper )
     {
-        super( securityManager, queryValidator );
+        super( securityManager, queryValidator, schemaIdResponseMapper );
 
         checkNotNull( dataElementService );
         checkNotNull( trackedEntityAttributeService );
@@ -633,26 +633,6 @@ public class DefaultEventAnalyticsService
         return grid;
     }
 
-    /**
-     * Substitutes the meta data of the grid with the identifier scheme meta
-     * data property indicated in the query. This happens only when a custom ID
-     * Schema is set.
-     *
-     * @param params the {@link EventQueryParams}.
-     * @param grid the grid.
-     */
-    private void maybeApplyIdScheme( EventQueryParams params, Grid grid )
-    {
-        if ( !params.isSkipMeta() )
-        {
-            if ( params.hasCustomIdSchemaSet() )
-            {
-                // Apply all schemas set/mapped to the grid.
-                grid.substituteMetaData( schemaIdResponseMapper.getSchemeIdResponseMap( params ) );
-            }
-        }
-    }
-
     // -------------------------------------------------------------------------
     // Query
     // -------------------------------------------------------------------------
@@ -660,11 +640,7 @@ public class DefaultEventAnalyticsService
     @Override
     public Grid getEvents( EventQueryParams params )
     {
-        final Grid grid = getGrid( params );
-
-        maybeApplyIdScheme( params, grid );
-
-        return grid;
+        return getGrid( params );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsServiceTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
+import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.common.BaseDimensionalObject;
@@ -92,10 +93,14 @@ class AbstractAnalyticsServiceTest
     @Mock
     private EventQueryValidator eventQueryValidator;
 
+    @Mock
+    private SchemaIdResponseMapper schemaIdResponseMapper;
+
     @BeforeEach
     public void setUp()
     {
-        dummyAnalyticsService = new DummyAnalyticsService( securityManager, eventQueryValidator );
+        dummyAnalyticsService = new DummyAnalyticsService( securityManager, eventQueryValidator,
+            schemaIdResponseMapper );
 
         peA = MonthlyPeriodType.getPeriodFromIsoString( "201701" );
         ouA = createOrganisationUnit( 'A' );
@@ -156,9 +161,10 @@ class AbstractAnalyticsServiceTest
 
 class DummyAnalyticsService extends AbstractAnalyticsService
 {
-    public DummyAnalyticsService( AnalyticsSecurityManager securityManager, EventQueryValidator queryValidator )
+    public DummyAnalyticsService( AnalyticsSecurityManager securityManager, EventQueryValidator queryValidator,
+        SchemaIdResponseMapper schemaIdResponseMapper )
     {
-        super( securityManager, queryValidator );
+        super( securityManager, queryValidator, schemaIdResponseMapper );
     }
 
     @Override


### PR DESCRIPTION
**[Backport from master (2.39)]**

This fix enables the usage of `outputIdScheme` in `/enrollments/query` endpoint. It will also take into consideration OptionSet types.

For example, the GET call (which generates an Excel file) below:
```
https://play.dhis2.org/2.37.4/api/29/analytics/enrollments/query/IpHINAT79UW.xls?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&dimension=A03MvHHogjR.cejWyOfXge6&stage=A03MvHHogjR&displayProperty=NAME&outputType=ENROLLMENT&desc=enrollmentdate&pageSize=100&page=1&outputIdScheme=NAME
```
Before the fix, it would always output the code of the OptionSet.

After this fix, if the `outputIdScheme`is specified and set to `NAME`, the Excel file will be exported using the OptionSet name instead of its code.