### PR TITLE
fix: TrackerPreheat defaults support idSchemes DHIS2-12563

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/events/EventIdSchemeTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/events/EventIdSchemeTests.java
@@ -27,7 +27,11 @@
  */
 package org.hisp.dhis.tracker.importer.events;
 
-import com.google.gson.JsonObject;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.stream.Stream;
+
 import org.hisp.dhis.Constants;
 import org.hisp.dhis.actions.UserActions;
 import org.hisp.dhis.actions.metadata.AttributeActions;
@@ -40,15 +44,11 @@ import org.hisp.dhis.tracker.TrackerNtiApiTest;
 import org.hisp.dhis.tracker.importer.databuilder.EventDataBuilder;
 import org.hisp.dhis.utils.DataGenerator;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.stream.Stream;
-
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import com.google.gson.JsonObject;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -82,11 +82,11 @@ public class EventIdSchemeTests
     private static Stream<Arguments> provideIdSchemeArguments()
     {
         return Stream.of(
-            Arguments.arguments( "CODE", "code" ),
-            Arguments.arguments( "NAME", "name" ),
-            Arguments.arguments( "UID", "id" ),
-            Arguments.arguments( "AUTO", "id" ),
-            Arguments.arguments( "ATTRIBUTE:" + ATTRIBUTE_ID, "attributeValues.value[0]" ) );
+                Arguments.arguments( "CODE", "code" ),
+                Arguments.arguments( "NAME", "name" ),
+                Arguments.arguments( "UID", "id" ),
+                Arguments.arguments( "AUTO", "id" ),
+                Arguments.arguments( "ATTRIBUTE:" + ATTRIBUTE_ID, "attributeValues.value[0]" ) );
     }
 
     @BeforeAll
@@ -126,9 +126,18 @@ public class EventIdSchemeTests
             .body( "orgUnit", equalTo( ORG_UNIT_ID ) );
     }
 
+    private static Stream<Arguments> provideIdSchemeArgumentsImport()
+    {
+        return Stream.of(
+                Arguments.arguments( "CODE", "code" ),
+                Arguments.arguments( "NAME", "name" ),
+                Arguments.arguments( "UID", "id" ),
+                Arguments.arguments( "AUTO", "id" ));
+                // TODO("DHIS2-12760") fix import using attribute: Exception:Transaction rolled back because it has been marked as rollback-only
+                // Arguments.arguments( "ATTRIBUTE:" + ATTRIBUTE_ID, "attributeValues.value[0]" ) );
+    }
     @ParameterizedTest
-    @Disabled("DHIS2-12759, DHIS2-12760")
-    @MethodSource( "provideIdSchemeArguments" )
+    @MethodSource( "provideIdSchemeArgumentsImport" )
     public void eventsShouldBeImportedWithIdScheme( String scheme, String property )
     {
         String ouPropertyValue = orgUnitActions.get( ORG_UNIT_ID ).extractString( property );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -41,7 +41,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -85,8 +84,7 @@ public class TrackerIdentifierCollector
 
     private final ProgramRuleService programRuleService;
 
-    public Map<Class<?>, Set<String>> collect( TrackerImportParams params,
-        Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults )
+    public Map<Class<?>, Set<String>> collect( TrackerImportParams params )
     {
         final Map<Class<?>, Set<String>> identifiers = new HashMap<>();
 
@@ -98,7 +96,6 @@ public class TrackerIdentifierCollector
         // preloaded in the Preheat
         identifiers.put( TrackedEntityType.class, ImmutableSet.of( ID_WILDCARD ) );
         identifiers.put( RelationshipType.class, ImmutableSet.of( ID_WILDCARD ) );
-        collectDefaults( identifiers, defaults );
 
         collectProgramRulesFields( identifiers );
         return identifiers;
@@ -122,13 +119,6 @@ public class TrackerIdentifierCollector
             .collect( Collectors.toSet() );
 
         attributes.forEach( attribute -> addIdentifier( map, TrackedEntityAttribute.class, attribute ) );
-    }
-
-    private void collectDefaults( Map<Class<?>, Set<String>> map,
-        Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults )
-    {
-        defaults.forEach(
-            ( defaultClass, defaultMetadata ) -> addIdentifier( map, defaultClass, defaultMetadata.getUid() ) );
     }
 
     private void collectTrackedEntities( Map<Class<?>, Set<String>> identifiers, List<TrackedEntity> trackedEntities )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -240,8 +240,7 @@ public class EventTrackerConverterService
         }
         else
         {
-            programStageInstance.setAttributeOptionCombo(
-                (CategoryOptionCombo) preheat.getDefaults().get( CategoryOptionCombo.class ) );
+            programStageInstance.setAttributeOptionCombo( preheat.getDefault( CategoryOptionCombo.class ) );
         }
 
         programStageInstance.setGeometry( event.getGeometry() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
@@ -80,7 +80,6 @@ public class DefaultTrackerPreheatService implements TrackerPreheatService, Appl
         TrackerPreheat preheat = new TrackerPreheat();
         preheat.setIdSchemes( params.getIdSchemes() );
         preheat.setUser( params.getUser() );
-        preheat.setDefaults( manager.getDefaults() );
 
         checkNotNull( preheat.getUser(), "TrackerPreheat is missing the user object." );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -124,9 +124,7 @@ public class TrackerPreheat
     /**
      * Internal map of all default object (like category option combo, etc).
      */
-    @Getter
-    @Setter
-    private Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults = new HashMap<>();
+    private final Map<Class<? extends IdentifiableObject>, IdentifiableObject> defaults = new HashMap<>();
 
     /**
      * All periods available.
@@ -369,6 +367,26 @@ public class TrackerPreheat
     }
 
     /**
+     * Put a default metadata value (i.e. CategoryOption "default") into the
+     * preheat.
+     *
+     * @param defaultClass class of the default metadata
+     * @param metadata the default metadata
+     * @return the tracker preheat
+     */
+    public <T extends IdentifiableObject> TrackerPreheat putDefault( Class<T> defaultClass, T metadata )
+    {
+        if ( metadata == null )
+        {
+            return this;
+        }
+
+        defaults.put( defaultClass, metadata );
+
+        return this;
+    }
+
+    /**
      * Get a default value from the preheat
      *
      * @param defaultClass The type of object to retrieve
@@ -376,8 +394,7 @@ public class TrackerPreheat
      */
     public <T extends IdentifiableObject> T getDefault( Class<T> defaultClass )
     {
-        String uid = this.defaults.get( defaultClass ).getUid();
-        return this.get( defaultClass, uid );
+        return (T) this.defaults.get( defaultClass );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/DefaultPreheatCacheService.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 
 import lombok.RequiredArgsConstructor;
 
@@ -82,6 +83,30 @@ public class DefaultPreheatCacheService implements PreheatCacheService
         }
 
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<IdentifiableObject> get( String cacheKey, String id,
+        BiFunction<String, String, Optional<IdentifiableObject>> mappingFunction, int cacheTTL, long capacity )
+    {
+        if ( mappingFunction == null )
+        {
+            throw new IllegalArgumentException( "MappingFunction cannot be null" );
+        }
+
+        Optional<IdentifiableObject> value = get( cacheKey, id );
+        if ( value.isPresent() )
+        {
+            return value;
+        }
+
+        value = mappingFunction.apply( cacheKey, id );
+        if ( value.isPresent() )
+        {
+            put( cacheKey, id, value.get(), cacheTTL, capacity );
+        }
+
+        return value;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/PreheatCacheService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/cache/PreheatCacheService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.preheat.cache;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.event.ApplicationCacheClearedEvent;
@@ -48,6 +49,24 @@ public interface PreheatCacheService
      *
      */
     Optional<IdentifiableObject> get( String cacheKey, String id );
+
+    /**
+     * Returns the metadata value cached in {@code cacheKey} mapped to
+     * {@code id}, obtaining that value from the {@code mappingFunction} if
+     * necessary. This method provides a simple substitute for the conventional
+     * "if cached, return; otherwise create, cache and return" pattern. If
+     * metadata value is null, the given mapping function is evaluated and
+     * inserted into this cache unless {@code null}.
+     *
+     * @param cacheKey the cacheKey for retrieving the cache
+     * @param id the identifier for retrieving the metadata value from the cache
+     * @param mappingFunction the function to compute a value.
+     * @return an optional containing current (existing or computed) value, or
+     *         Optional.empty() if the computed value is null
+     * @throws IllegalArgumentException if the specified mappingFunction is null
+     */
+    Optional<IdentifiableObject> get( String cacheKey, String id,
+        BiFunction<String, String, Optional<IdentifiableObject>> mappingFunction, int cacheTTL, long capacity );
 
     /**
      * Check whether a class type is part of the cache

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryMapper.java
@@ -44,5 +44,6 @@ public interface CategoryMapper
     @Mapping( target = "uid" )
     @Mapping( target = "name" )
     @Mapping( target = "code" )
+    @Mapping( target = "sharing" )
     Category map( Category category );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryMapper.java
@@ -25,47 +25,24 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.config;
+package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import org.hisp.dhis.category.Category;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
 
-import org.hisp.dhis.tracker.preheat.supplier.*;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import com.google.common.collect.ImmutableList;
-
-@Configuration( "trackerPreheatConfig" )
-public class TrackerPreheatConfig
+@Mapper( uses = DebugMapper.class )
+public interface CategoryMapper
+    extends PreheatMapper<Category>
 {
-    private final List<Class<? extends PreheatSupplier>> preheatOrder = ImmutableList.of(
-        ClassBasedSupplier.class,
-        DefaultsSupplier.class,
-        TrackedEntityProgramInstanceSupplier.class,
-        ProgramInstanceSupplier.class,
-        ProgramInstancesWithAtLeastOneEventSupplier.class,
-        ProgramStageInstanceProgramStageMapSupplier.class,
-        ProgramOrgUnitsSupplier.class,
-        ProgramOwnerSupplier.class,
-        PeriodTypeSupplier.class,
-        UniqueAttributesSupplier.class,
-        UserSupplier.class,
-        UsernameValueTypeSupplier.class,
-        FileResourceSupplier.class,
-        EventCategoryOptionComboSupplier.class );
+    CategoryMapper INSTANCE = Mappers.getMapper( CategoryMapper.class );
 
-    @Bean( "preheatOrder" )
-    public List<String> getPreheatOrder()
-    {
-        return preheatOrder.stream().map( Class::getSimpleName )
-            .collect( Collectors.toList() );
-    }
-
-    @Bean( "preheatStrategies" )
-    public Map<String, String> getPreheatStrategies()
-    {
-        return new PreheatStrategyScanner().scanSupplierStrategies();
-    }
+    @BeanMapping( ignoreByDefault = true )
+    @Mapping( target = "id" )
+    @Mapping( target = "uid" )
+    @Mapping( target = "name" )
+    @Mapping( target = "code" )
+    Category map( Category category );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
@@ -28,7 +28,9 @@
 package org.hisp.dhis.tracker.preheat.mappers;
 
 import org.hisp.dhis.category.CategoryOption;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper( uses = DebugMapper.class )
@@ -36,5 +38,10 @@ public interface CategoryOptionMapper extends PreheatMapper<CategoryOption>
 {
     CategoryOptionMapper INSTANCE = Mappers.getMapper( CategoryOptionMapper.class );
 
+    @BeanMapping( ignoreByDefault = true )
+    @Mapping( target = "id" )
+    @Mapping( target = "uid" )
+    @Mapping( target = "name" )
+    @Mapping( target = "code" )
     CategoryOption map( CategoryOption categoryOption );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
@@ -43,5 +43,10 @@ public interface CategoryOptionMapper extends PreheatMapper<CategoryOption>
     @Mapping( target = "uid" )
     @Mapping( target = "name" )
     @Mapping( target = "code" )
+    @Mapping( target = "startDate" )
+    @Mapping( target = "endDate" )
+    @Mapping( target = "formName" )
+    @Mapping( target = "style" )
+    @Mapping( target = "sharing" )
     CategoryOption map( CategoryOption categoryOption );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
@@ -28,9 +28,7 @@
 package org.hisp.dhis.tracker.preheat.mappers;
 
 import org.hisp.dhis.category.CategoryOption;
-import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper( uses = DebugMapper.class )
@@ -38,15 +36,5 @@ public interface CategoryOptionMapper extends PreheatMapper<CategoryOption>
 {
     CategoryOptionMapper INSTANCE = Mappers.getMapper( CategoryOptionMapper.class );
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "startDate" )
-    @Mapping( target = "endDate" )
-    @Mapping( target = "formName" )
-    @Mapping( target = "style" )
-    @Mapping( target = "sharing" )
     CategoryOption map( CategoryOption categoryOption );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplier.java
@@ -81,7 +81,7 @@ public class ClassBasedSupplier
          * is the reference type (e.g. Enrollment) and the value is a Set of
          * identifiers (e.g. a list of all Enrollment UIDs found in the payload)
          */
-        Map<Class<?>, Set<String>> identifierMap = identifierCollector.collect( params, preheat.getDefaults() );
+        Map<Class<?>, Set<String>> identifierMap = identifierCollector.collect( params );
 
         identifierMap.forEach( ( key, identifiers ) -> {
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
@@ -53,9 +53,9 @@ import org.springframework.stereotype.Component;
 public class DefaultsSupplier extends AbstractPreheatSupplier
 {
 
-    private static final int CACHE_TTL = 60;
+    private static final int CACHE_TTL = 720; // 12h
 
-    private static final long CACHE_CAPACITY = 1000;
+    private static final long CACHE_CAPACITY = 10;
 
     @NonNull
     private final IdentifiableObjectManager manager;
@@ -85,8 +85,8 @@ public class DefaultsSupplier extends AbstractPreheatSupplier
     private <T extends IdentifiableObject> void preheatDefault( TrackerPreheat preheat, Class<T> klass,
         PreheatMapper<T> mapper, String name )
     {
-        Optional<T> metadata = (Optional<T>) cache.get( klass.getName(), name,
-            ( k, n ) -> Optional.ofNullable( mapper.map( manager.getByName( klass, n ) ) ),
+        Optional<T> metadata = (Optional<T>) cache.get( this.getClass().getName(), klass.getName(),
+            ( k, n ) -> Optional.ofNullable( mapper.map( manager.getByName( klass, name ) ) ),
             CACHE_TTL, CACHE_CAPACITY );
         if ( metadata.isPresent() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.preheat.supplier;
+
+import java.util.Optional;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
+import org.hisp.dhis.tracker.preheat.mappers.CategoryComboMapper;
+import org.hisp.dhis.tracker.preheat.mappers.CategoryMapper;
+import org.hisp.dhis.tracker.preheat.mappers.CategoryOptionComboMapper;
+import org.hisp.dhis.tracker.preheat.mappers.CategoryOptionMapper;
+import org.hisp.dhis.tracker.preheat.mappers.PreheatMapper;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class DefaultsSupplier extends AbstractPreheatSupplier
+{
+
+    private static final int CACHE_TTL = 60;
+
+    private static final long CACHE_CAPACITY = 1000;
+
+    @NonNull
+    private final IdentifiableObjectManager manager;
+
+    @NonNull
+    private final PreheatCacheService cache;
+
+    @Override
+    public void preheatAdd( TrackerImportParams params, TrackerPreheat preheat )
+    {
+        // not using manager.getDefaults() as the collections of the entities
+        // are still hibernate proxies
+        // this leads to lazy init exceptions with - no session. reason is the
+        // defaults are cached in another thread
+        // and the session is closed. using manager.getDefaults() and
+        // session.merge(entity) works, but we would not
+        // benefit from caching.
+
+        preheatDefault( preheat, Category.class, CategoryMapper.INSTANCE, Category.DEFAULT_NAME );
+        preheatDefault( preheat, CategoryCombo.class, CategoryComboMapper.INSTANCE,
+            CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME );
+        preheatDefault( preheat, CategoryOption.class, CategoryOptionMapper.INSTANCE, CategoryOption.DEFAULT_NAME );
+        preheatDefault( preheat, CategoryOptionCombo.class, CategoryOptionComboMapper.INSTANCE,
+            CategoryOptionCombo.DEFAULT_NAME );
+    }
+
+    private <T extends IdentifiableObject> void preheatDefault( TrackerPreheat preheat, Class<T> klass,
+        PreheatMapper<T> mapper, String name )
+    {
+        Optional<T> metadata = (Optional<T>) cache.get( klass.getName(), name,
+            ( k, n ) -> Optional.ofNullable( mapper.map( manager.getByName( klass, n ) ) ),
+            CACHE_TTL, CACHE_CAPACITY );
+        if ( metadata.isPresent() )
+        {
+            preheat.putDefault( klass, metadata.get() );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
@@ -88,9 +88,6 @@ public class DefaultsSupplier extends AbstractPreheatSupplier
         Optional<T> metadata = (Optional<T>) cache.get( this.getClass().getName(), klass.getName(),
             ( k, n ) -> Optional.ofNullable( mapper.map( manager.getByName( klass, name ) ) ),
             CACHE_TTL, CACHE_CAPACITY );
-        if ( metadata.isPresent() )
-        {
-            preheat.putDefault( klass, metadata.get() );
-        }
+        metadata.ifPresent( t -> preheat.putDefault( klass, t ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
@@ -85,7 +85,7 @@ public class DefaultsSupplier extends AbstractPreheatSupplier
     private <T extends IdentifiableObject> void preheatDefault( TrackerPreheat preheat, Class<T> klass,
         PreheatMapper<T> mapper, String name )
     {
-        Optional<T> metadata = (Optional<T>) cache.get( this.getClass().getName(), klass.getName(),
+        Optional<T> metadata = (Optional<T>) cache.get( DefaultsSupplier.class.getName(), klass.getName(),
             ( k, n ) -> Optional.ofNullable( mapper.map( manager.getByName( klass, name ) ) ),
             CACHE_TTL, CACHE_CAPACITY );
         metadata.ifPresent( t -> preheat.putDefault( klass, t ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.preheat.mappers.CategoryOptionComboMapper;
 import org.springframework.stereotype.Component;
 
 /**
@@ -88,7 +89,8 @@ public class EventCategoryOptionComboSupplier extends AbstractPreheatSupplier
                 continue;
             }
 
-            CategoryOptionCombo aoc = categoryService.getCategoryOptionCombo( p.getLeft(), p.getRight() );
+            CategoryOptionCombo aoc = CategoryOptionComboMapper.INSTANCE
+                .map( categoryService.getCategoryOptionCombo( p.getLeft(), p.getRight() ) );
             preheat.putCategoryOptionCombo( p.getLeft(), p.getRight(), aoc );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -85,7 +84,7 @@ class TrackerIdentifierCollectorTest
             .enrollments( Collections.singletonList( enrollment ) )
             .build();
 
-        Map<Class<?>, Set<String>> ids = collector.collect( params, new HashMap<>() );
+        Map<Class<?>, Set<String>> ids = collector.collect( params );
 
         assertNotNull( ids );
         assertContainsOnly( ids.get( Enrollment.class ), enrollment.getUid() );
@@ -108,7 +107,7 @@ class TrackerIdentifierCollectorTest
             .enrollments( Collections.singletonList( enrollment ) )
             .build();
 
-        Map<Class<?>, Set<String>> ids = collector.collect( params, new HashMap<>() );
+        Map<Class<?>, Set<String>> ids = collector.collect( params );
 
         assertNotNull( ids );
         assertContainsOnly( ids.get( Enrollment.class ), enrollment.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.tracker.TrackerIdSchemeParams.builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,8 +41,13 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStage;
@@ -62,6 +69,9 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
 
     @Autowired
     private TrackerPreheatService trackerPreheatService;
+
+    @Autowired
+    private IdentifiableObjectManager manager;
 
     @Override
     protected void initTest()
@@ -156,6 +166,43 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         }
     }
 
+    @Test
+    void testDefaultsWithIdSchemeUID()
+    {
+
+        TrackerImportParams params = TrackerImportParams.builder()
+            .user( currentUserService.getCurrentUser() )
+            .build();
+
+        TrackerPreheat preheat = trackerPreheatService.preheat( params );
+
+        assertPreheatHasDefault( preheat, Category.class );
+        assertPreheatHasDefault( preheat, CategoryCombo.class );
+        assertPreheatHasDefault( preheat, CategoryOption.class );
+        assertPreheatHasDefault( preheat, CategoryOptionCombo.class );
+    }
+
+    @Test
+    void testDefaultsWithIdSchemesOtherThanUID()
+    {
+
+        Event event = new Event();
+
+        TrackerImportParams params = buildParams( event,
+            builder()
+                .idScheme( TrackerIdSchemeParam.NAME )
+                .categoryOptionIdScheme( TrackerIdSchemeParam.ofAttribute( CodeGenerator.generateUid() ) )
+                .categoryOptionComboIdScheme( TrackerIdSchemeParam.CODE )
+                .build() );
+
+        TrackerPreheat preheat = trackerPreheatService.preheat( params );
+
+        assertPreheatHasDefault( preheat, Category.class );
+        assertPreheatHasDefault( preheat, CategoryCombo.class );
+        assertPreheatHasDefault( preheat, CategoryOption.class );
+        assertPreheatHasDefault( preheat, CategoryOptionCombo.class );
+    }
+
     private TrackerImportParams buildParams( Event event, TrackerIdSchemeParams idParams )
     {
         TrackerImportParams params = TrackerImportParams.builder()
@@ -182,5 +229,19 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
             "Expecting a preheated object for idSchemeParam: " + idSchemeParam.getIdScheme().name() + " with value: "
                 + id,
             preheat.get( klazz, id ), is( notNullValue() ) );
+    }
+
+    private <T extends IdentifiableObject> void assertPreheatHasDefault( TrackerPreheat preheat, Class<T> klass )
+    {
+        T actual = preheat.getDefault( klass );
+        T expected = manager.getByName( klass, "default" );
+        assertNotNull( actual );
+        assertNotNull( expected );
+        // since these are mapped entities, not all fields are mapped
+        // we should at least get the identifiers
+        assertEquals( expected.getId(), actual.getId() );
+        assertEquals( expected.getUid(), actual.getUid() );
+        assertEquals( expected.getCode(), actual.getCode() );
+        assertEquals( expected.getName(), actual.getName() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -77,7 +76,7 @@ class TrackerPreheatServiceTest extends TrackerTest
     void testCollectIdentifiersSimple()
     {
         TrackerImportParams params = new TrackerImportParams();
-        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
+        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params );
         assertEquals( 2, collectedMap.keySet().size() );
         assertTrue( collectedMap.containsKey( TrackedEntityType.class ) );
         assertTrue( collectedMap.containsKey( RelationshipType.class ) );
@@ -91,7 +90,7 @@ class TrackerPreheatServiceTest extends TrackerTest
         assertTrue( params.getTrackedEntities().isEmpty() );
         assertTrue( params.getEnrollments().isEmpty() );
         assertFalse( params.getEvents().isEmpty() );
-        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
+        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params );
         assertTrue( collectedMap.containsKey( DataElement.class ) );
         assertTrue( collectedMap.containsKey( ProgramStage.class ) );
         assertTrue( collectedMap.containsKey( OrganisationUnit.class ) );
@@ -138,7 +137,7 @@ class TrackerPreheatServiceTest extends TrackerTest
         assertFalse( params.getTrackedEntities().isEmpty() );
         assertTrue( params.getEnrollments().isEmpty() );
         assertTrue( params.getEvents().isEmpty() );
-        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params, Maps.newHashMap() );
+        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params );
         assertTrue( collectedMap.containsKey( TrackedEntity.class ) );
         Set<String> trackedEntities = collectedMap.get( TrackedEntity.class );
         assertTrue( collectedMap.containsKey( OrganisationUnit.class ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/ClassBasedSupplierTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.hisp.dhis.tracker.TrackerIdentifierCollector;
 import org.hisp.dhis.tracker.TrackerImportParams;
@@ -86,8 +85,8 @@ class ClassBasedSupplierTest
 
         TrackerPreheat trackerPreheat = new TrackerPreheat();
 
-        when( identifierCollector.collect( trackerImportParams, trackerPreheat.getDefaults() ) )
-            .thenReturn( new HashMap<Class<?>, Set<String>>()
+        when( identifierCollector.collect( trackerImportParams ) )
+            .thenReturn( new HashMap<>()
             {
                 {
                     put( TrackedEntity.class, new HashSet<>( Collections.singletonList( "trackedEntity" ) ) );


### PR DESCRIPTION
Relates to both https://jira.dhis2.org/browse/DHIS2-12563 and https://jira.dhis2.org/browse/DHIS2-12759

defaults for metadata like Category, CategoryOptionCombo, ... where not returned by

https://github.com/dhis2/dhis2-core/pull/10546/files#diff-8bcab5fc74e034ebd337f7c3a069adb167a1451414163c9b7938aafaab26dc11L379-L380

since imports using idScheme other than UID failed to insert the metadata into the TrackerPreheat.map. So even though `TrackerPreheat.defaults` contained the defaults `return this.get( defaultClass, uid );` (which accesses `TrackerPreheat.map`) did not.

Add default metadata into the preheat using a dedicated supplier. The logic is irrespective of the idScheme chosen during the import. Defaults can be retrieved using their name (`default`). Its important to map the metadata to avoid lazy initialization exceptions we get from relying on hibernate proxies. Note: the manager.getDefaults() still returns proxies (parents are not, but children collections are)!
