### PR TITLE
feat: Add data value context API endpoint [DHIS2-13127]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataExportParams.java
@@ -34,6 +34,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryOptionGroup;
@@ -55,6 +59,9 @@ import com.google.common.collect.Sets;
 /**
  * @author Lars Helge Overland
  */
+@Getter
+@Setter
+@Accessors( chain = true )
 public class DataExportParams
 {
     private Set<DataElement> dataElements = new HashSet<>();
@@ -88,6 +95,8 @@ public class DataExportParams
     private boolean orderByPeriod;
 
     private Set<OrganisationUnitGroup> organisationUnitGroups = new HashSet<>();
+
+    private Set<CategoryOptionCombo> categoryOptionCombos = new HashSet<>();
 
     private Set<CategoryOptionCombo> attributeOptionCombos = new HashSet<>();
 
@@ -218,6 +227,11 @@ public class DataExportParams
         return organisationUnitGroups != null && !organisationUnitGroups.isEmpty();
     }
 
+    public boolean hasCategoryOptionCombos()
+    {
+        return categoryOptionCombos != null && !categoryOptionCombos.isEmpty();
+    }
+
     public boolean hasAttributeOptionCombos()
     {
         return attributeOptionCombos != null && !attributeOptionCombos.isEmpty();
@@ -289,284 +303,5 @@ public class DataExportParams
             .add( "output id schemes", outputIdSchemes )
             .add( "blockingQueue", blockingQueue )
             .toString();
-    }
-
-    // -------------------------------------------------------------------------
-    // Get and set methods
-    // -------------------------------------------------------------------------
-
-    public Set<DataElement> getDataElements()
-    {
-        return dataElements;
-    }
-
-    public DataExportParams setDataElements( Set<DataElement> dataElements )
-    {
-        this.dataElements = dataElements;
-        return this;
-    }
-
-    public Set<DataElementOperand> getDataElementOperands()
-    {
-        return dataElementOperands;
-    }
-
-    public DataExportParams setDataElementOperands( Set<DataElementOperand> dataElementOperands )
-    {
-        this.dataElementOperands = dataElementOperands;
-        return this;
-    }
-
-    public Set<DataSet> getDataSets()
-    {
-        return dataSets;
-    }
-
-    public DataExportParams setDataSets( Set<DataSet> dataSets )
-    {
-        this.dataSets = dataSets;
-        return this;
-    }
-
-    public Set<DataElementGroup> getDataElementGroups()
-    {
-        return dataElementGroups;
-    }
-
-    public DataExportParams setDataElementGroups( Set<DataElementGroup> dataElementGroups )
-    {
-        this.dataElementGroups = dataElementGroups;
-        return this;
-    }
-
-    public Set<PeriodType> getPeriodTypes()
-    {
-        return periodTypes;
-    }
-
-    public DataExportParams setPeriodTypes( Set<PeriodType> periodTypes )
-    {
-        this.periodTypes = periodTypes;
-        return this;
-    }
-
-    public Set<Period> getPeriods()
-    {
-        return periods;
-    }
-
-    public DataExportParams setPeriods( Set<Period> periods )
-    {
-        this.periods = periods;
-        return this;
-    }
-
-    public Date getStartDate()
-    {
-        return startDate;
-    }
-
-    public DataExportParams setStartDate( Date startDate )
-    {
-        this.startDate = startDate;
-        return this;
-    }
-
-    public Date getIncludedDate()
-    {
-        return includedDate;
-    }
-
-    public DataExportParams setIncludedDate( Date includedDate )
-    {
-        this.includedDate = includedDate;
-        return this;
-    }
-
-    public Date getEndDate()
-    {
-        return endDate;
-    }
-
-    public DataExportParams setEndDate( Date endDate )
-    {
-        this.endDate = endDate;
-        return this;
-    }
-
-    public Set<OrganisationUnit> getOrganisationUnits()
-    {
-        return organisationUnits;
-    }
-
-    public DataExportParams setOrganisationUnits( Set<OrganisationUnit> organisationUnits )
-    {
-        this.organisationUnits = organisationUnits;
-        return this;
-    }
-
-    public OrganisationUnitSelectionMode getOuMode()
-    {
-        return ouMode;
-    }
-
-    public DataExportParams setOuMode( OrganisationUnitSelectionMode ouMode )
-    {
-        this.ouMode = ouMode;
-        return this;
-    }
-
-    public Integer getOrgUnitLevel()
-    {
-        return orgUnitLevel;
-    }
-
-    public DataExportParams setOrgUnitLevel( Integer orgUnitLevel )
-    {
-        this.orgUnitLevel = orgUnitLevel;
-        return this;
-    }
-
-    public boolean isIncludeDescendants()
-    {
-        return includeDescendants;
-    }
-
-    public DataExportParams setIncludeDescendants( boolean includeDescendants )
-    {
-        this.includeDescendants = includeDescendants;
-        return this;
-    }
-
-    public boolean isOrderByOrgUnitPath()
-    {
-        return orderByOrgUnitPath;
-    }
-
-    public DataExportParams setOrderByOrgUnitPath( boolean orderByOrgUnitPath )
-    {
-        this.orderByOrgUnitPath = orderByOrgUnitPath;
-        return this;
-    }
-
-    public boolean isOrderByPeriod()
-    {
-        return orderByPeriod;
-    }
-
-    public DataExportParams setOrderByPeriod( boolean orderByPeriod )
-    {
-        this.orderByPeriod = orderByPeriod;
-        return this;
-    }
-
-    public Set<OrganisationUnitGroup> getOrganisationUnitGroups()
-    {
-        return organisationUnitGroups;
-    }
-
-    public DataExportParams setOrganisationUnitGroups( Set<OrganisationUnitGroup> organisationUnitGroups )
-    {
-        this.organisationUnitGroups = organisationUnitGroups;
-        return this;
-    }
-
-    public Set<CategoryOptionCombo> getAttributeOptionCombos()
-    {
-        return attributeOptionCombos;
-    }
-
-    public DataExportParams setAttributeOptionCombos( Set<CategoryOptionCombo> attributeOptionCombos )
-    {
-        this.attributeOptionCombos = attributeOptionCombos;
-        return this;
-    }
-
-    public Set<CategoryOption> getCoDimensionConstraints()
-    {
-        return coDimensionConstraints;
-    }
-
-    public DataExportParams setCoDimensionConstraints( Set<CategoryOption> coDimensionConstraints )
-    {
-        this.coDimensionConstraints = coDimensionConstraints;
-        return this;
-    }
-
-    public Set<CategoryOptionGroup> getCogDimensionConstraints()
-    {
-        return cogDimensionConstraints;
-    }
-
-    public DataExportParams setCogDimensionConstraints( Set<CategoryOptionGroup> cogDimensionConstraints )
-    {
-        this.cogDimensionConstraints = cogDimensionConstraints;
-        return this;
-    }
-
-    public boolean isIncludeDeleted()
-    {
-        return includeDeleted;
-    }
-
-    public DataExportParams setIncludeDeleted( boolean includeDeleted )
-    {
-        this.includeDeleted = includeDeleted;
-        return this;
-    }
-
-    public Date getLastUpdated()
-    {
-        return lastUpdated;
-    }
-
-    public DataExportParams setLastUpdated( Date lastUpdated )
-    {
-        this.lastUpdated = lastUpdated;
-        return this;
-    }
-
-    public String getLastUpdatedDuration()
-    {
-        return lastUpdatedDuration;
-    }
-
-    public DataExportParams setLastUpdatedDuration( String lastUpdatedDuration )
-    {
-        this.lastUpdatedDuration = lastUpdatedDuration;
-        return this;
-    }
-
-    public Integer getLimit()
-    {
-        return limit;
-    }
-
-    public DataExportParams setLimit( Integer limit )
-    {
-        this.limit = limit;
-        return this;
-    }
-
-    public IdSchemes getOutputIdSchemes()
-    {
-        return outputIdSchemes;
-    }
-
-    public DataExportParams setOutputIdSchemes( IdSchemes outputIdSchemes )
-    {
-        this.outputIdSchemes = outputIdSchemes;
-        return this;
-    }
-
-    public BlockingQueue<DeflatedDataValue> getBlockingQueue()
-    {
-        return blockingQueue;
-    }
-
-    public DataExportParams setBlockingQueue( BlockingQueue<DeflatedDataValue> blockingQueue )
-    {
-        this.blockingQueue = blockingQueue;
-        return this;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueAuditService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueAuditService.java
@@ -45,7 +45,7 @@ public interface DataValueAuditService
     String ID = DataValueAuditService.class.getName();
 
     /**
-     * Adds a DataValueAudit.
+     * Adds a data value audit.
      *
      * @param dataValueAudit the DataValueAudit to add.
      */
@@ -75,29 +75,61 @@ public interface DataValueAuditService
     List<DataValueAudit> getDataValueAudits( DataValue dataValue );
 
     /**
-     * Returns all DataValueAudits for the given DataElement, Period,
-     * OrganisationUnit and CategoryOptionCombo.
+     * Returns data value audits for the given parameters.
      *
-     * @param dataElements the DataElement of the DataValueAudits.
-     * @param periods the Period of the DataValueAudits.
-     * @param organisationUnits the OrganisationUnit of the DataValueAudits.
-     * @param categoryOptionCombo the CategoryOptionCombo of the
-     *        DataValueAudits.
-     * @param attributeOptionCombo the attribute option combo.
-     * @return a list of DataValueAudits which matches the given DataElement,
-     *         Period, OrganisationUnit and CategoryOptionCombo, or an empty
-     *         collection if there are not matches.
+     * @param dataElement the {@link DataElement}.
+     * @param period the {@link Period}.
+     * @param organisationUnit the {@link OrganisationUnit}.
+     * @param categoryOptionCombo the {@link CategoryOptionCombo}.
+     * @param attributeOptionCombo the {@link CategoryOptionCombo}.
+     * @return a list of {@link DataValueAudit}.
+     */
+    List<DataValueAudit> getDataValueAudits( DataElement dataElement, Period period,
+        OrganisationUnit organisationUnit, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo );
+
+    /**
+     * Returns data value audits for the given parameters.
+     *
+     * @param dataElements the list of {@link DataElement}.
+     * @param periods the list of {@link Period}.
+     * @param organisationUnits the list of {@link OrganisationUnit}.
+     * @param categoryOptionCombo the {@link CategoryOptionCombo}.
+     * @param attributeOptionCombo the {@link CategoryOptionCombo}.
+     * @return a list of {@link DataValueAudit}.
      */
     List<DataValueAudit> getDataValueAudits( List<DataElement> dataElements, List<Period> periods,
-        List<OrganisationUnit> organisationUnits,
-        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo, AuditType auditType );
+        List<OrganisationUnit> organisationUnits, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, AuditType auditType );
 
+    /**
+     * Returns data value audits for the given parameters.
+     *
+     * @param dataElements the list of {@link DataElement}.
+     * @param periods the list of {@link Period}.
+     * @param organisationUnits the list of {@link OrganisationUnit}.
+     * @param categoryOptionCombo the {@link CategoryOptionCombo}.
+     * @param attributeOptionCombo the {@link CategoryOptionCombo}.
+     * @param offset the item offset.
+     * @param limit the item limit.
+     * @return a list of {@link DataValueAudit}.
+     */
     List<DataValueAudit> getDataValueAudits( List<DataElement> dataElements, List<Period> periods,
-        List<OrganisationUnit> organisationUnits,
-        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo, AuditType auditType,
-        int first, int max );
+        List<OrganisationUnit> organisationUnits, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, AuditType auditType,
+        int offset, int limit );
 
+    /**
+     * Returns the count of data value audits for the given parameters.
+     *
+     * @param dataElements the list of {@link DataElement}.
+     * @param periods the list of {@link Period}.
+     * @param organisationUnits the list of {@link OrganisationUnit}.
+     * @param categoryOptionCombo the {@link CategoryOptionCombo}.
+     * @param attributeOptionCombo the {@link CategoryOptionCombo}.
+     * @return the count of data value audits.
+     */
     int countDataValueAudits( List<DataElement> dataElements, List<Period> periods,
-        List<OrganisationUnit> organisationUnits,
-        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo, AuditType auditType );
+        List<OrganisationUnit> organisationUnits, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, AuditType auditType );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
@@ -122,9 +123,25 @@ public interface DataValueService
      * @param categoryOptionCombo the category option combo.
      * @param attributeOptionCombo the attribute option combo.
      * @return the DataValue which corresponds to the given parameters, or null
-     *         if no match.
+     *         if not found or not accessible.
      */
     DataValue getDataValue( DataElement dataElement, Period period, OrganisationUnit source,
+        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo );
+
+    /**
+     * Returns a DataValue. Throws {@link IllegalQueryException} if the data
+     * value was not found or is not accessible.
+     *
+     * @param dataElement the DataElement of the DataValue.
+     * @param period the Period of the DataValue.
+     * @param source the Source of the DataValue.
+     * @param categoryOptionCombo the category option combo.
+     * @param attributeOptionCombo the attribute option combo.
+     * @return the DataValue which corresponds to the given parameters.
+     * @throws IllegalQueryException if the data value was not found or not
+     *         accessible.
+     */
+    DataValue getAndValidateDataValue( DataElement dataElement, Period period, OrganisationUnit source,
         CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo );
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -107,7 +107,7 @@ public enum ErrorCode
     E2029( "Data value is not a valid option of the data element option set: `{0}`" ),
     E2030( "Data value must match data element value type: `{0}`" ),
     E2031( "User does not have write access to category option combo: `{0}`" ),
-    E2032( "Data value does not exist" ),
+    E2032( "Data value not found or not accessible" ),
     E2033( "Follow-up must be specified" ),
     E2034( "Filter not supported: `{0}`" ),
     E2035( "Operator not supported: `{0}`" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodService.java
@@ -38,8 +38,6 @@ import org.hisp.dhis.i18n.I18nFormat;
  */
 public interface PeriodService
 {
-    String ID = PeriodService.class.getName();
-
     // -------------------------------------------------------------------------
     // Period
     // -------------------------------------------------------------------------
@@ -142,19 +140,6 @@ public interface PeriodService
     List<Period> getPeriodsBetweenOrSpanningDates( Date startDate, Date endDate );
 
     /**
-     * Returns all Intersecting Periods between the startDate and endDate based
-     * on PeriodType For example if the startDate is 2007-05-01 and endDate is
-     * 2007-08-01 and periodType is Quarterly then it returns the periods for
-     * Q2,Q3
-     *
-     * @param periodType is the ultimate period type
-     * @param startDate is intercepting startDate
-     * @param endDate is intercepting endDate
-     * @return a list of Periods.
-     */
-    List<Period> getIntersectingPeriodsByPeriodType( PeriodType periodType, Date startDate, Date endDate );
-
-    /**
      * Returns Periods where at least one its days are between the given start
      * date and end date.
      *
@@ -173,17 +158,6 @@ public interface PeriodService
      * @return a list of Periods.
      */
     List<Period> getIntersectionPeriods( Collection<Period> periods );
-
-    /**
-     * Returns all Periods from the given collection of Periods which span the
-     * border of either the start date OR end date of the given Period.
-     *
-     * @param period the base Period.
-     * @param periods the collection of Periods.
-     * @return all Periods from the given list of Periods which span the border
-     *         of either the start date or end date of the given Period.
-     */
-    List<Period> getBoundaryPeriods( Period period, Collection<Period> periods );
 
     /**
      * Returns all Periods from the given collection of Periods which are
@@ -215,14 +189,14 @@ public interface PeriodService
     List<Period> reloadPeriods( List<Period> periods );
 
     /**
-     * Returns historyLength number of Periods chronologically ending with
-     * lastPeriod.
+     * Returns a list of the given number of previous periods in ascending
+     * order. The given last period appears last in the returned list.
      *
-     * @param lastPeriod the last Period in the provided collection.
-     * @param historyLength the number of Periods in the provided collection.
-     * @return a collection of Periods.
+     * @param lastPeriod the last period.
+     * @param previousPeriods the number of previous periods.
+     * @return a list of {@link Period}.
      */
-    List<Period> getPeriods( Period lastPeriod, int historyLength );
+    List<Period> getPeriods( Period lastPeriod, int previousPeriods );
 
     /**
      * Populates the name property of Period with the formatted name for the

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodStore.java
@@ -103,19 +103,6 @@ public interface PeriodStore
     List<Period> getPeriodsBetweenOrSpanningDates( Date startDate, Date endDate );
 
     /**
-     * Returns all intersecting Periods between the startDate and endDate based
-     * on PeriodType For example if the startDate is 2007-05-01 and endDate is
-     * 2007-08-01 and periodType is Quarterly then it returns the periods for
-     * Q2,Q3
-     *
-     * @param periodType is the ultimate period type
-     * @param startDate is intercepting startDate
-     * @param endDate is intercepting endDate
-     * @return a list of periods.
-     */
-    List<Period> getIntersectingPeriodsByPeriodType( PeriodType periodType, Date startDate, Date endDate );
-
-    /**
      * Returns Periods where at least one its days is between the given start
      * date and end date.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueAuditService.java
@@ -94,9 +94,19 @@ public class DefaultDataValueAuditService
 
     @Override
     @Transactional( readOnly = true )
+    public List<DataValueAudit> getDataValueAudits( DataElement dataElement, Period period,
+        OrganisationUnit organisationUnit, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo )
+    {
+        return dataValueAuditStore.getDataValueAudits( List.of( dataElement ), List.of( period ),
+            List.of( organisationUnit ), categoryOptionCombo, attributeOptionCombo, null );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
     public List<DataValueAudit> getDataValueAudits( List<DataElement> dataElements, List<Period> periods,
-        List<OrganisationUnit> organisationUnits,
-        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo, AuditType auditType )
+        List<OrganisationUnit> organisationUnits, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, AuditType auditType )
     {
         return dataValueAuditStore.getDataValueAudits( dataElements, periods, organisationUnits, categoryOptionCombo,
             attributeOptionCombo, auditType );
@@ -105,9 +115,8 @@ public class DefaultDataValueAuditService
     @Override
     @Transactional( readOnly = true )
     public List<DataValueAudit> getDataValueAudits( List<DataElement> dataElements, List<Period> periods,
-        List<OrganisationUnit> organisationUnits,
-        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo, AuditType auditType,
-        int first, int max )
+        List<OrganisationUnit> organisationUnits, CategoryOptionCombo categoryOptionCombo,
+        CategoryOptionCombo attributeOptionCombo, AuditType auditType, int first, int max )
     {
         return dataValueAuditStore.getDataValueAudits( dataElements, periods, organisationUnits, categoryOptionCombo,
             attributeOptionCombo, auditType, first, max );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -256,6 +256,22 @@ public class DefaultDataValueService
         return dataValueStore.getDataValue( dataElement, period, source, categoryOptionCombo, attributeOptionCombo );
     }
 
+    @Override
+    @Transactional( readOnly = true )
+    public DataValue getAndValidateDataValue( DataElement dataElement, Period period, OrganisationUnit source,
+        CategoryOptionCombo categoryOptionCombo, CategoryOptionCombo attributeOptionCombo )
+    {
+        DataValue dataValue = dataValueStore.getDataValue(
+            dataElement, period, source, categoryOptionCombo, attributeOptionCombo );
+
+        if ( dataValue == null )
+        {
+            throw new IllegalQueryException( ErrorCode.E2032 );
+        }
+
+        return dataValue;
+    }
+
     // -------------------------------------------------------------------------
     // Collections of DataValues
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -219,6 +219,11 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
             hql += "and ou.id in (:orgUnits) ";
         }
 
+        if ( params.hasCategoryOptionCombos() )
+        {
+            hql += "and co.id in (:categoryOptionCombos) ";
+        }
+
         if ( params.hasAttributeOptionCombos() )
         {
             hql += "and ao.id in (:attributeOptionCombos) ";
@@ -270,6 +275,11 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
         if ( !params.isIncludeDescendantsForOrganisationUnits() && !organisationUnits.isEmpty() )
         {
             query.setParameterList( "orgUnits", getIdentifiers( organisationUnits ) );
+        }
+
+        if ( params.hasCategoryOptionCombos() )
+        {
+            query.setParameterList( "categoryOptionCombos", getIdentifiers( params.getCategoryOptionCombos() ) );
         }
 
         if ( params.hasAttributeOptionCombos() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/DefaultPeriodService.java
@@ -149,13 +149,6 @@ public class DefaultPeriodService
 
     @Override
     @Transactional( readOnly = true )
-    public List<Period> getIntersectingPeriodsByPeriodType( PeriodType periodType, Date startDate, Date endDate )
-    {
-        return periodStore.getIntersectingPeriodsByPeriodType( periodType, startDate, endDate );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
     public List<Period> getIntersectingPeriods( Date startDate, Date endDate )
     {
         return periodStore.getIntersectingPeriods( startDate, endDate );
@@ -173,28 +166,6 @@ public class DefaultPeriodService
         }
 
         return new ArrayList<>( intersecting );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public List<Period> getBoundaryPeriods( Period period, Collection<Period> periods )
-    {
-        List<Period> immutablePeriods = new ArrayList<>( periods );
-
-        Iterator<Period> iterator = immutablePeriods.iterator();
-
-        while ( iterator.hasNext() )
-        {
-            Period iterated = iterator.next();
-
-            if ( !DateUtils.strictlyBetween( period.getStartDate(), iterated.getStartDate(), iterated.getEndDate() )
-                && !DateUtils.strictlyBetween( period.getEndDate(), iterated.getStartDate(), iterated.getEndDate() ) )
-            {
-                iterator.remove();
-            }
-        }
-
-        return immutablePeriods;
     }
 
     @Override
@@ -234,16 +205,16 @@ public class DefaultPeriodService
     }
 
     @Override
-    @Transactional( readOnly = true )
-    public List<Period> getPeriods( Period lastPeriod, int historyLength )
+    @Transactional
+    public List<Period> getPeriods( Period lastPeriod, int previousPeriods )
     {
-        List<Period> periods = new ArrayList<>( historyLength );
+        List<Period> periods = new ArrayList<>( previousPeriods );
 
         lastPeriod = periodStore.reloadForceAddPeriod( lastPeriod );
 
         PeriodType periodType = lastPeriod.getPeriodType();
 
-        for ( int i = 0; i < historyLength; ++i )
+        for ( int i = 0; i < previousPeriods; ++i )
         {
             Period pe = getPeriodFromDates( lastPeriod.getStartDate(), lastPeriod.getEndDate(), periodType );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/period/hibernate/HibernatePeriodStore.java
@@ -136,18 +136,6 @@ public class HibernatePeriodStore
     }
 
     @Override
-    public List<Period> getIntersectingPeriodsByPeriodType( PeriodType periodType, Date startDate, Date endDate )
-    {
-        String query = "from Period p where p.startDate <=:endDate and p.endDate >=:startDate and p.periodType.id =:periodType";
-
-        Query<Period> typedQuery = getQuery( query )
-            .setParameter( "startDate", startDate )
-            .setParameter( "endDate", endDate )
-            .setParameter( "periodType", reloadPeriodType( periodType ).getId() );
-        return getList( typedQuery );
-    }
-
-    @Override
     public List<Period> getIntersectingPeriods( Date startDate, Date endDate )
     {
         String query = "from Period p where p.startDate <=:endDate and p.endDate >=:startDate";

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
@@ -348,7 +348,9 @@ class DataValueServiceTest
         assertEquals( 2, dataValueService
             .getDataValues( new DataExportParams()
                 .setDataElements( Sets.newHashSet( dataElementA ) )
-                .setCategoryOptionCombos( Sets.newHashSet( optionCombo ) ) )
+                .setCategoryOptionCombos( Sets.newHashSet( optionCombo ) )
+                .setPeriods( Sets.newHashSet( periodA ) )
+                .setOrganisationUnits( Sets.newHashSet( sourceA, sourceB ) ) )
             .size() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/datavalue/DataValueServiceTest.java
@@ -53,9 +53,9 @@ import com.google.common.collect.Sets;
 /**
  * @author Kristian Nordal
  */
-class DataValueServiceTest extends DhisSpringTest
+class DataValueServiceTest
+    extends DhisSpringTest
 {
-
     @Autowired
     private CategoryService categoryService;
 
@@ -71,6 +71,7 @@ class DataValueServiceTest extends DhisSpringTest
     // -------------------------------------------------------------------------
     // Supporting data
     // -------------------------------------------------------------------------
+
     private DataElement dataElementA;
 
     private DataElement dataElementB;
@@ -98,6 +99,7 @@ class DataValueServiceTest extends DhisSpringTest
     // -------------------------------------------------------------------------
     // Set up/tear down
     // -------------------------------------------------------------------------
+
     @Override
     public void setUpTest()
         throws Exception
@@ -221,6 +223,7 @@ class DataValueServiceTest extends DhisSpringTest
     // -------------------------------------------------------------------------
     // Collections of DataValues
     // -------------------------------------------------------------------------
+
     @Test
     void testGetDataValuesDataExportParamsA()
     {
@@ -283,39 +286,70 @@ class DataValueServiceTest extends DhisSpringTest
         dataValueService.addDataValue( dataValueH );
         dataValueService.addDataValue( dataValueI );
         dataValueService.addDataValue( dataValueJ );
+
         assertEquals( 4, dataValueService
-            .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
-                .setPeriods( Sets.newHashSet( periodB ) ).setOrganisationUnits( Sets.newHashSet( sourceA, sourceB ) ) )
+            .getDataValues( new DataExportParams()
+                .setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
+                .setPeriods( Sets.newHashSet( periodB ) )
+                .setOrganisationUnits( Sets.newHashSet( sourceA, sourceB ) ) )
             .size() );
         assertEquals( 2,
             dataValueService
-                .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
-                    .setPeriods( Sets.newHashSet( periodA ) ).setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
+                .getDataValues( new DataExportParams()
+                    .setDataElements( Sets.newHashSet( dataElementA, dataElementB ) )
+                    .setPeriods( Sets.newHashSet( periodA ) )
+                    .setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
                 .size() );
         assertEquals( 4,
-            dataValueService.getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA ) )
+            dataValueService.getDataValues( new DataExportParams()
+                .setDataElements( Sets.newHashSet( dataElementA ) )
                 .setPeriods( Sets.newHashSet( periodA, periodC ) )
                 .setOrganisationUnits( Sets.newHashSet( sourceA, sourceB ) ) ).size() );
         assertEquals( 4,
-            dataValueService.getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementB ) )
+            dataValueService.getDataValues( new DataExportParams()
+                .setDataElements( Sets.newHashSet( dataElementB ) )
                 .setPeriods( Sets.newHashSet( periodA, periodB ) )
                 .setOrganisationUnits( Sets.newHashSet( sourceA, sourceB ) ) ).size() );
         assertEquals( 1,
             dataValueService
-                .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementB ) )
-                    .setPeriods( Sets.newHashSet( periodB ) ).setOrganisationUnits( Sets.newHashSet( sourceA ) ) )
+                .getDataValues( new DataExportParams()
+                    .setDataElements( Sets.newHashSet( dataElementB ) )
+                    .setPeriods( Sets.newHashSet( periodB ) )
+                    .setOrganisationUnits( Sets.newHashSet( sourceA ) ) )
                 .size() );
         assertEquals( 1,
             dataValueService
-                .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA ) )
-                    .setPeriods( Sets.newHashSet( periodA ) ).setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
+                .getDataValues( new DataExportParams()
+                    .setDataElements( Sets.newHashSet( dataElementA ) )
+                    .setPeriods( Sets.newHashSet( periodA ) )
+                    .setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
                 .size() );
         assertEquals( 1,
             dataValueService
-                .getDataValues( new DataExportParams().setDataElements( Sets.newHashSet( dataElementA ) )
+                .getDataValues( new DataExportParams()
+                    .setDataElements( Sets.newHashSet( dataElementA ) )
                     .setStartDate( periodA.getStartDate() ).setEndDate( periodA.getEndDate() )
                     .setOrganisationUnits( Sets.newHashSet( sourceB ) ) )
                 .size() );
+    }
+
+    @Test
+    void testGetDataValuesExportParamsC()
+    {
+        DataValue dataValueA = new DataValue( dataElementA, periodA, sourceA, optionCombo, optionCombo, "1" );
+        DataValue dataValueB = new DataValue( dataElementA, periodA, sourceB, optionCombo, optionCombo, "2" );
+        DataValue dataValueC = new DataValue( dataElementB, periodA, sourceA, optionCombo, optionCombo, "3" );
+        DataValue dataValueD = new DataValue( dataElementB, periodA, sourceB, optionCombo, optionCombo, "4" );
+        dataValueService.addDataValue( dataValueA );
+        dataValueService.addDataValue( dataValueB );
+        dataValueService.addDataValue( dataValueC );
+        dataValueService.addDataValue( dataValueD );
+
+        assertEquals( 2, dataValueService
+            .getDataValues( new DataExportParams()
+                .setDataElements( Sets.newHashSet( dataElementA ) )
+                .setCategoryOptionCombos( Sets.newHashSet( optionCombo ) ) )
+            .size() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodServiceTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -243,77 +242,6 @@ class PeriodServiceTest extends DhisSpringTest
     }
 
     @Test
-    void testGetIntersectingPeriodsByPeriodType()
-    {
-        PeriodType ypt = PeriodType.getPeriodTypeByName( YearlyPeriodType.NAME );
-        Date jan2006 = getDate( 2006, 1, 1 );
-        Date dec2006 = getDate( 2006, 12, 31 );
-        Date jan2007 = getDate( 2007, 1, 1 );
-        Date dec2007 = getDate( 2007, 12, 31 );
-        Period periodA = new Period( ypt, jan2006, dec2006 );
-        Period periodB = new Period( ypt, jan2007, dec2007 );
-        periodService.addPeriod( periodA );
-        periodService.addPeriod( periodB );
-        PeriodType mpt = PeriodType.getPeriodTypeByName( MonthlyPeriodType.NAME );
-        Date janstart = getDate( 2006, 1, 1 );
-        Date janend = getDate( 2006, 1, 31 );
-        Date febstart = getDate( 2006, 2, 1 );
-        Date febend = getDate( 2006, 2, 28 );
-        Date marstart = getDate( 2006, 3, 1 );
-        Date marend = getDate( 2006, 3, 31 );
-        Date aprstart = getDate( 2006, 4, 1 );
-        Date aprend = getDate( 2006, 4, 30 );
-        Date maystart = getDate( 2006, 5, 1 );
-        Date mayend = getDate( 2006, 5, 31 );
-        Date junstart = getDate( 2006, 6, 1 );
-        Date junend = getDate( 2006, 6, 30 );
-        Date julstart = getDate( 2006, 7, 1 );
-        Date julend = getDate( 2006, 7, 31 );
-        Date augstart = getDate( 2006, 8, 1 );
-        Date augend = getDate( 2006, 8, 31 );
-        Date sepstart = getDate( 2006, 9, 1 );
-        Date sepend = getDate( 2006, 9, 30 );
-        Date octstart = getDate( 2006, 10, 1 );
-        Date octend = getDate( 2006, 10, 31 );
-        Date novstart = getDate( 2006, 11, 1 );
-        Date novend = getDate( 2006, 11, 30 );
-        Date decstart = getDate( 2006, 12, 1 );
-        Date decend = getDate( 2006, 12, 31 );
-        Period periodC = new Period( mpt, janstart, janend );
-        Period periodD = new Period( mpt, febstart, febend );
-        Period periodE = new Period( mpt, marstart, marend );
-        Period periodF = new Period( mpt, aprstart, aprend );
-        Period periodG = new Period( mpt, maystart, mayend );
-        Period periodH = new Period( mpt, junstart, junend );
-        Period periodI = new Period( mpt, julstart, julend );
-        Period periodJ = new Period( mpt, augstart, augend );
-        Period periodK = new Period( mpt, sepstart, sepend );
-        Period periodL = new Period( mpt, octstart, octend );
-        Period periodM = new Period( mpt, novstart, novend );
-        Period periodN = new Period( mpt, decstart, decend );
-        periodService.addPeriod( periodC );
-        periodService.addPeriod( periodD );
-        periodService.addPeriod( periodE );
-        periodService.addPeriod( periodF );
-        periodService.addPeriod( periodG );
-        periodService.addPeriod( periodH );
-        periodService.addPeriod( periodI );
-        periodService.addPeriod( periodJ );
-        periodService.addPeriod( periodK );
-        periodService.addPeriod( periodL );
-        periodService.addPeriod( periodM );
-        periodService.addPeriod( periodN );
-        List<Period> periodsA = periodService.getIntersectingPeriodsByPeriodType( ypt, getDate( 2006, 6, 1 ),
-            getDate( 2006, 11, 30 ) );
-        assertNotNull( periodsA );
-        assertEquals( 1, periodsA.size() );
-        List<Period> periodsB = periodService.getIntersectingPeriodsByPeriodType( mpt, getDate( 2006, 6, 1 ),
-            getDate( 2006, 11, 30 ) );
-        assertNotNull( periodsB );
-        assertEquals( 6, periodsB.size() );
-    }
-
-    @Test
     void testGetIntersectingPeriods()
     {
         PeriodType type = periodService.getAllPeriodTypes().iterator().next();
@@ -380,38 +308,6 @@ class PeriodServiceTest extends DhisSpringTest
         List<Period> periodsC = periodService.getPeriodsByPeriodType( periodTypeC );
         assertNotNull( periodsC );
         assertEquals( 0, periodsC.size() );
-    }
-
-    @Test
-    void testGetBoundaryPeriods()
-    {
-        PeriodType periodType = periodService.getAllPeriodTypes().iterator().next();
-        Period periodA = new Period( periodType, getDay( 5 ), getDay( 8 ) );
-        Period periodB = new Period( periodType, getDay( 8 ), getDay( 11 ) );
-        Period periodC = new Period( periodType, getDay( 11 ), getDay( 14 ) );
-        Period periodD = new Period( periodType, getDay( 14 ), getDay( 17 ) );
-        Period periodE = new Period( periodType, getDay( 17 ), getDay( 20 ) );
-        Period periodF = new Period( periodType, getDay( 5 ), getDay( 20 ) );
-        List<Period> periods = new ArrayList<>();
-        periods.add( periodA );
-        periods.add( periodB );
-        periods.add( periodC );
-        periods.add( periodD );
-        periods.add( periodE );
-        periods.add( periodF );
-        Period basePeriod = new Period( periodType, getDay( 9 ), getDay( 15 ) );
-        List<Period> boundaryPeriods = periodService.getBoundaryPeriods( basePeriod, periods );
-        assertTrue( boundaryPeriods.size() == 3 );
-        assertTrue( boundaryPeriods.contains( periodB ) );
-        assertTrue( boundaryPeriods.contains( periodD ) );
-        assertTrue( boundaryPeriods.contains( periodF ) );
-        basePeriod = new Period( periodType, getDay( 11 ), getDay( 14 ) );
-        boundaryPeriods = periodService.getBoundaryPeriods( basePeriod, periods );
-        assertTrue( boundaryPeriods.size() == 1 );
-        assertTrue( boundaryPeriods.contains( periodF ) );
-        basePeriod = new Period( periodType, getDay( 2 ), getDay( 5 ) );
-        boundaryPeriods = periodService.getBoundaryPeriods( basePeriod, periods );
-        assertTrue( boundaryPeriods.size() == 0 );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/period/PeriodStoreTest.java
@@ -33,7 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -289,77 +288,6 @@ class PeriodStoreTest extends DhisSpringTest
         assertTrue( periods.contains( periodC ) );
         assertTrue( periods.contains( periodD ) );
         assertTrue( periods.contains( periodE ) );
-    }
-
-    @Test
-    void testGetIntersectingPeriodsByPeriodType()
-    {
-        PeriodType ypt = PeriodType.getPeriodTypeByName( YearlyPeriodType.NAME );
-        Date jan2006 = getDate( 2006, 1, 1 );
-        Date dec2006 = getDate( 2006, 12, 31 );
-        Date jan2007 = getDate( 2007, 1, 1 );
-        Date dec2007 = getDate( 2007, 12, 31 );
-        Period periodA = new Period( ypt, jan2006, dec2006 );
-        Period periodB = new Period( ypt, jan2007, dec2007 );
-        periodStore.addPeriod( periodA );
-        periodStore.addPeriod( periodB );
-        PeriodType mpt = PeriodType.getPeriodTypeByName( MonthlyPeriodType.NAME );
-        Date janstart = getDate( 2006, 1, 1 );
-        Date janend = getDate( 2006, 1, 31 );
-        Date febstart = getDate( 2006, 2, 1 );
-        Date febend = getDate( 2006, 2, 28 );
-        Date marstart = getDate( 2006, 3, 1 );
-        Date marend = getDate( 2006, 3, 31 );
-        Date aprstart = getDate( 2006, 4, 1 );
-        Date aprend = getDate( 2006, 4, 30 );
-        Date maystart = getDate( 2006, 5, 1 );
-        Date mayend = getDate( 2006, 5, 31 );
-        Date junstart = getDate( 2006, 6, 1 );
-        Date junend = getDate( 2006, 6, 30 );
-        Date julstart = getDate( 2006, 7, 1 );
-        Date julend = getDate( 2006, 7, 31 );
-        Date augstart = getDate( 2006, 8, 1 );
-        Date augend = getDate( 2006, 8, 31 );
-        Date sepstart = getDate( 2006, 9, 1 );
-        Date sepend = getDate( 2006, 9, 30 );
-        Date octstart = getDate( 2006, 10, 1 );
-        Date octend = getDate( 2006, 10, 31 );
-        Date novstart = getDate( 2006, 11, 1 );
-        Date novend = getDate( 2006, 11, 30 );
-        Date decstart = getDate( 2006, 12, 1 );
-        Date decend = getDate( 2006, 12, 31 );
-        Period periodC = new Period( mpt, janstart, janend );
-        Period periodD = new Period( mpt, febstart, febend );
-        Period periodE = new Period( mpt, marstart, marend );
-        Period periodF = new Period( mpt, aprstart, aprend );
-        Period periodG = new Period( mpt, maystart, mayend );
-        Period periodH = new Period( mpt, junstart, junend );
-        Period periodI = new Period( mpt, julstart, julend );
-        Period periodJ = new Period( mpt, augstart, augend );
-        Period periodK = new Period( mpt, sepstart, sepend );
-        Period periodL = new Period( mpt, octstart, octend );
-        Period periodM = new Period( mpt, novstart, novend );
-        Period periodN = new Period( mpt, decstart, decend );
-        periodStore.addPeriod( periodC );
-        periodStore.addPeriod( periodD );
-        periodStore.addPeriod( periodE );
-        periodStore.addPeriod( periodF );
-        periodStore.addPeriod( periodG );
-        periodStore.addPeriod( periodH );
-        periodStore.addPeriod( periodI );
-        periodStore.addPeriod( periodJ );
-        periodStore.addPeriod( periodK );
-        periodStore.addPeriod( periodL );
-        periodStore.addPeriod( periodM );
-        periodStore.addPeriod( periodN );
-        List<Period> periodsA = periodStore.getIntersectingPeriodsByPeriodType( ypt, getDate( 2006, 6, 1 ),
-            getDate( 2006, 11, 30 ) );
-        assertNotNull( periodsA );
-        assertEquals( 1, periodsA.size() );
-        List<Period> periodsB = periodStore.getIntersectingPeriodsByPeriodType( mpt, getDate( 2006, 6, 1 ),
-            getDate( 2006, 11, 30 ) );
-        assertNotNull( periodsB );
-        assertEquals( 6, periodsB.size() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dataelementhistory/DataElementHistory.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dataelementhistory/DataElementHistory.java
@@ -36,7 +36,6 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
  * @author Torgeir Lorange Ostby
- * @version $Id: DataElementHistory.java 4438 2008-01-26 16:35:24Z abyot $
  */
 public class DataElementHistory
 {

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
@@ -85,6 +85,23 @@ public class CollectionUtils
     }
 
     /**
+     * Performs a mapping of the given collection using the given mapping
+     * function.
+     *
+     * @param <A>
+     * @param <B>
+     * @param collection collection the collection of objects to map.
+     * @param mapper the mapping function.
+     * @return a list of mapped objects.
+     */
+    public static <A, B> List<B> mapToList( Collection<A> collection, Function<? super A, ? extends B> mapper )
+    {
+        return collection.stream()
+            .map( mapper )
+            .collect( Collectors.toList() );
+    }
+
+    /**
      * Returns the intersection of the given Collections.
      *
      * @param <A>

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/CollectionUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/CollectionUtilsTest.java
@@ -44,7 +44,7 @@ import com.google.common.collect.Lists;
 class CollectionUtilsTest
 {
     @Test
-    public void testFlatMapToSet()
+    void testFlatMapToSet()
     {
         DataElement deA = new DataElement();
         DataElement deB = new DataElement();
@@ -71,7 +71,7 @@ class CollectionUtilsTest
     }
 
     @Test
-    public void testDifference()
+    void testDifference()
     {
         List<String> collection1 = Lists.newArrayList( "One", "Two", "Three" );
         List<String> collection2 = Lists.newArrayList( "One", "Two", "Four" );
@@ -82,7 +82,7 @@ class CollectionUtilsTest
     }
 
     @Test
-    public void testMapToList()
+    void testMapToList()
     {
         List<String> collection = Lists.newArrayList( "1", "2", "3" );
 

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/CollectionUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/CollectionUtilsTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.commons.util;
 
 import static org.hisp.dhis.commons.collection.CollectionUtils.flatMapToSet;
+import static org.hisp.dhis.commons.collection.CollectionUtils.mapToList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -78,5 +79,14 @@ class CollectionUtilsTest
 
         assertEquals( 1, difference.size() );
         assertEquals( "Three", difference.get( 0 ) );
+    }
+
+    @Test
+    public void testMapToList()
+    {
+        List<String> collection = Lists.newArrayList( "1", "2", "3" );
+
+        assertEquals( 3, mapToList( collection, Integer::parseInt ).size() );
+        assertEquals( 1, mapToList( collection, Integer::parseInt ).get( 0 ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataValueControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataValueControllerTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
@@ -58,22 +59,22 @@ class DataValueControllerTest extends AbstractDataValueControllerTest
     @Test
     void testSetDataValuesFollowUp_Empty()
     {
-        assertEquals( "Follow-up must be specified",
-            PUT( "/dataValues/followups", Body( "{}" ) ).error( HttpStatus.CONFLICT ).getMessage() );
-        assertEquals( "Follow-up must be specified",
-            PUT( "/dataValues/followups", Body( "{'values':null}" ) ).error( HttpStatus.CONFLICT ).getMessage() );
-        assertEquals( "Follow-up must be specified",
-            PUT( "/dataValues/followups", Body( "{'values':[]}" ) ).error( HttpStatus.CONFLICT ).getMessage() );
+        assertEquals( ErrorCode.E2033,
+            PUT( "/dataValues/followups", Body( "{}" ) ).error( HttpStatus.CONFLICT ).getErrorCode() );
+        assertEquals( ErrorCode.E2033,
+            PUT( "/dataValues/followups", Body( "{'values':null}" ) ).error( HttpStatus.CONFLICT ).getErrorCode() );
+        assertEquals( ErrorCode.E2033,
+            PUT( "/dataValues/followups", Body( "{'values':[]}" ) ).error( HttpStatus.CONFLICT ).getErrorCode() );
     }
 
     @Test
     void testSetDataValuesFollowUp_NonExisting()
     {
         addDataValue( "2021-01", "2", null, false );
-        assertEquals( "Data value does not exist",
+        assertEquals( ErrorCode.E2032,
             PUT( "/dataValues/followups",
                 Body( String.format( "{'values':[%s]}", dataValueKeyJSON( "2021-02", true ) ) ) )
-                    .error( HttpStatus.CONFLICT ).getMessage() );
+                    .error( HttpStatus.CONFLICT ).getErrorCode() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataValueSetController.java
@@ -58,8 +58,6 @@ import java.util.zip.ZipOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.SessionFactory;
@@ -96,7 +94,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping( value = "/dataValueSets" )
-@Slf4j
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class DataValueSetController
 {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/ChangeLogController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/ChangeLogController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataentry;
+
+import lombok.AllArgsConstructor;
+
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.datavalue.DataValueAuditService;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.datavalue.DataValueQueryParams;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping( value = "/dataEntry" )
+@AllArgsConstructor
+@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+public class ChangeLogController
+{
+    private final DataValueAuditService dataValueAuditService;
+
+    @GetMapping( value = "/changeLog" )
+    public void getChangeLog( DataValueQueryParams params )
+    {
+        dataValueAuditService.getDataValueAudits( null, null, null, null, null, null );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/ChangeLogController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/ChangeLogController.java
@@ -27,10 +27,14 @@
  */
 package org.hisp.dhis.webapi.controller.dataentry;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.datavalue.DataValueAudit;
 import org.hisp.dhis.datavalue.DataValueAuditService;
+import org.hisp.dhis.webapi.controller.datavalue.DataValidator;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.webdomain.datavalue.DataValueQueryParams;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -45,9 +49,16 @@ public class ChangeLogController
 {
     private final DataValueAuditService dataValueAuditService;
 
+    private final DataValidator dataValidator;
+
     @GetMapping( value = "/changeLog" )
     public void getChangeLog( DataValueQueryParams params )
     {
-        dataValueAuditService.getDataValueAudits( null, null, null, null, null, null );
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
+            dataValidator.getAndValidateDataElement( params.getDe() ),
+            dataValidator.getAndValidatePeriod( params.getPe() ),
+            dataValidator.getAndValidateOrganisationUnit( params.getOu() ),
+            null, null );
+
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
@@ -55,7 +55,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping( value = "/dataEntry" )
+@RequestMapping( "/dataEntry" )
 @AllArgsConstructor
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class DataValueContextController
@@ -68,7 +68,7 @@ public class DataValueContextController
 
     private final DataValidator dataValidator;
 
-    @GetMapping( value = "/dataValueContext" )
+    @GetMapping( "/dataValueContext" )
     public DataValueContextDto getChangeLog( DataValueQueryParams params )
     {
         DataElement de = dataValidator.getAndValidateDataElement( params.getDe() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
@@ -77,7 +77,7 @@ public class DataValueContextController
         CategoryOptionCombo co = dataValidator.getAndValidateCategoryOptionCombo( params.getCo() );
         CategoryOptionCombo ao = dataValidator.getAndValidateAttributeOptionCombo( params.getCc(), params.getCp() );
 
-        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( de, pe, ou, null, null );
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( de, pe, ou, co, ao );
 
         List<Period> periods = periodService.getPeriods( pe, 13 );
 
@@ -89,9 +89,8 @@ public class DataValueContextController
             .setAttributeOptionCombos( Set.of( ao ) )
             .setOrderByPeriod( true ) );
 
-        DataValueContextDto context = new DataValueContextDto();
-        context.setAudits( mapToList( audits, DataValueDtoMapper::toDto ) );
-        context.setHistory( mapToList( dataValues, DataValueDtoMapper::toDto ) );
-        return context;
+        return new DataValueContextDto()
+            .setAudits( mapToList( audits, DataValueDtoMapper::toDto ) )
+            .setHistory( mapToList( dataValues, DataValueDtoMapper::toDto ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataentry;
+
+import static org.hisp.dhis.commons.collection.CollectionUtils.mapToList;
+
+import java.util.List;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.datavalue.DataExportParams;
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueAudit;
+import org.hisp.dhis.datavalue.DataValueAuditService;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.webapi.controller.datavalue.DataValidator;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.datavalue.DataValueContextDto;
+import org.hisp.dhis.webapi.webdomain.datavalue.DataValueDtoMapper;
+import org.hisp.dhis.webapi.webdomain.datavalue.DataValueQueryParams;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping( value = "/dataEntry" )
+@AllArgsConstructor
+@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+public class DataValueContextController
+{
+    private final DataValueAuditService dataValueAuditService;
+
+    private final DataValueService dataValueService;
+
+    private final PeriodService periodService;
+
+    private final DataValidator dataValidator;
+
+    @GetMapping( value = "/dataValueContext" )
+    public DataValueContextDto getChangeLog( DataValueQueryParams params )
+    {
+        DataElement de = dataValidator.getAndValidateDataElement( params.getDe() );
+        Period pe = dataValidator.getAndValidatePeriod( params.getPe() );
+        OrganisationUnit ou = dataValidator.getAndValidateOrganisationUnit( params.getOu() );
+        CategoryOptionCombo co = dataValidator.getAndValidateCategoryOptionCombo( params.getCo() );
+        CategoryOptionCombo ao = dataValidator.getAndValidateAttributeOptionCombo( params.getCc(), params.getCp() );
+
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( de, pe, ou, null, null );
+
+        List<Period> periods = periodService.getPeriods( pe, 13 );
+
+        List<DataValue> dataValues = dataValueService.getDataValues( new DataExportParams()
+            .setDataElements( Set.of( de ) )
+            .setPeriods( Set.copyOf( periods ) )
+            .setOrganisationUnits( Set.of( ou ) )
+            .setCategoryOptionCombos( Set.of( co ) )
+            .setAttributeOptionCombos( Set.of( ao ) )
+            .setOrderByPeriod( true ) );
+
+        DataValueContextDto context = new DataValueContextDto();
+        context.setAudits( mapToList( audits, DataValueDtoMapper::toDto ) );
+        context.setHistory( mapToList( dataValues, DataValueDtoMapper::toDto ) );
+        return context;
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataValueContextController.java
@@ -77,6 +77,8 @@ public class DataValueContextController
         CategoryOptionCombo co = dataValidator.getAndValidateCategoryOptionCombo( params.getCo() );
         CategoryOptionCombo ao = dataValidator.getAndValidateAttributeOptionCombo( params.getCc(), params.getCp() );
 
+        DataValue dataValue = dataValueService.getAndValidateDataValue( de, pe, ou, co, ao );
+
         List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( de, pe, ou, co, ao );
 
         List<Period> periods = periodService.getPeriods( pe, 13 );
@@ -90,6 +92,7 @@ public class DataValueContextController
             .setOrderByPeriod( true ) );
 
         return new DataValueContextDto()
+            .setDataValue( DataValueDtoMapper.toDto( dataValue ) )
             .setAudits( mapToList( audits, DataValueDtoMapper::toDto ) )
             .setHistory( mapToList( dataValues, DataValueDtoMapper::toDto ) );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValidator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValidator.java
@@ -148,10 +148,32 @@ public class DataValidator
     }
 
     /**
-     * Retrieves and verifies a category option combo.
+     * Retrieves and verifies a category option combination.
+     *
+     * @param uid the category option combination identifier.
+     * @return the {@link CategoryOptionCombo}.
+     * @throws IllegalQueryException if the validation fails.
+     */
+    public CategoryOptionCombo getAndValidateCategoryOptionCombo( String uid )
+    {
+        CategoryOptionCombo categoryOptionCombo = categoryService.getCategoryOptionCombo( uid );
+
+        if ( categoryOptionCombo == null )
+        {
+            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1103, uid ) );
+        }
+
+        return categoryOptionCombo;
+    }
+
+    /**
+     * Retrieves and verifies a category option combo. If not required, and if
+     * the given identifier is null, the default category option combo will be
+     * returned if an object with the given identifier does not exist.
      *
      * @param uid the category option combo identifier.
-     * @param requireCategoryOptionCombo flag used as part of the validation.
+     * @param requireCategoryOptionCombo whether an exception should be thrown
+     *        if the category option combo does not exist.
      * @return the {@link CategoryOptionCombo}.
      * @throws IllegalQueryException if the validation fails.
      */
@@ -239,7 +261,7 @@ public class DataValidator
      * @return the {@link Period}.
      * @throws IllegalQueryException if the validation fails.
      */
-    public Period getAndValidatePeriod( final String pe )
+    public Period getAndValidatePeriod( String pe )
     {
         final Period period = PeriodType.getPeriodFromIsoString( pe );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -74,6 +74,7 @@ import org.hisp.dhis.webapi.webdomain.DataValueFollowUpRequest;
 import org.hisp.dhis.webapi.webdomain.DataValuesFollowUpRequest;
 import org.hisp.dhis.webapi.webdomain.datavalue.DataValueCategoryDto;
 import org.hisp.dhis.webapi.webdomain.datavalue.DataValueDto;
+import org.hisp.dhis.webapi.webdomain.datavalue.DataValueQueryParams;
 import org.jclouds.rest.AuthorizationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -414,12 +415,7 @@ public class DataValueController
     @DeleteMapping
     @ResponseStatus( HttpStatus.NO_CONTENT )
     public void deleteDataValue(
-        @RequestParam String de,
-        @RequestParam( required = false ) String co,
-        @RequestParam( required = false ) String cc,
-        @RequestParam( required = false ) String cp,
-        @RequestParam String pe,
-        @RequestParam String ou,
+        DataValueQueryParams params,
         @RequestParam( required = false ) String ds,
         @RequestParam( required = false ) boolean force,
         @CurrentUser User currentUser,
@@ -433,15 +429,17 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( de );
+        DataElement dataElement = dataValueValidation.getAndValidateDataElement( params.getDe() );
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo( co, false );
+        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo( params.getCo(),
+            false );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo( cc, cp );
+        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo(
+            params.getCc(), params.getCp() );
 
-        Period period = dataValueValidation.getAndValidatePeriod( pe );
+        Period period = dataValueValidation.getAndValidatePeriod( params.getPe() );
 
-        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( ou );
+        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( params.getOu() );
 
         DataSet dataSet = dataValueValidation.getAndValidateOptionalDataSet( ds, dataElement );
 
@@ -488,12 +486,7 @@ public class DataValueController
 
     @GetMapping
     public List<String> getDataValue(
-        @RequestParam String de,
-        @RequestParam( required = false ) String co,
-        @RequestParam( required = false ) String cc,
-        @RequestParam( required = false ) String cp,
-        @RequestParam String pe,
-        @RequestParam String ou,
+        DataValueQueryParams params,
         @CurrentUser User currentUser,
         Model model, HttpServletResponse response )
         throws WebMessageException
@@ -502,15 +495,17 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( de );
+        DataElement dataElement = dataValueValidation.getAndValidateDataElement( params.getDe() );
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo( co, false );
+        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo(
+            params.getCo(), false );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo( cc, cp );
+        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo(
+            params.getCc(), params.getCp() );
 
-        Period period = dataValueValidation.getAndValidatePeriod( pe );
+        Period period = dataValueValidation.getAndValidatePeriod( params.getPe() );
 
-        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( ou );
+        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( params.getOu() );
 
         // ---------------------------------------------------------------------
         // Get data value
@@ -580,12 +575,7 @@ public class DataValueController
 
     @GetMapping( "/files" )
     public void getDataValueFile(
-        @RequestParam String de,
-        @RequestParam( required = false ) String co,
-        @RequestParam( required = false ) String cc,
-        @RequestParam( required = false ) String cp,
-        @RequestParam String pe,
-        @RequestParam String ou,
+        DataValueQueryParams params,
         @RequestParam( defaultValue = "original" ) String dimension,
         HttpServletResponse response, HttpServletRequest request )
         throws WebMessageException
@@ -594,20 +584,22 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( de );
+        DataElement dataElement = dataValueValidation.getAndValidateDataElement( params.getDe() );
 
         if ( !dataElement.isFileType() )
         {
             throw new WebMessageException( conflict( "DataElement must be of type file" ) );
         }
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo( co, false );
+        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo(
+            params.getCo(), false );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo( cc, cp );
+        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo(
+            params.getCc(), params.getCp() );
 
-        Period period = dataValueValidation.getAndValidatePeriod( pe );
+        Period period = dataValueValidation.getAndValidatePeriod( params.getPe() );
 
-        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( ou );
+        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( params.getOu() );
 
         dataValueValidation.validateOrganisationUnitPeriod( organisationUnit, period );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/datavalue/DataValueController.java
@@ -116,7 +116,7 @@ public class DataValueController
 
     private final FileResourceService fileResourceService;
 
-    private final DataValidator dataValueValidation;
+    private final DataValidator dataValidator;
 
     private final FileResourceUtils fileResourceUtils;
 
@@ -142,7 +142,7 @@ public class DataValueController
         @CurrentUser User currentUser, HttpServletResponse response )
         throws WebMessageException
     {
-        DataValueCategoryDto attribute = dataValueValidation.getDataValueCategoryDto( cc, cp );
+        DataValueCategoryDto attribute = dataValidator.getDataValueCategoryDto( cc, cp );
 
         DataValueDto dataValue = new DataValueDto()
             .setDataElement( de )
@@ -187,7 +187,7 @@ public class DataValueController
         throws WebMessageException,
         IOException
     {
-        DataValueCategoryDto attribute = dataValueValidation.getDataValueCategoryDto( cc, cp );
+        DataValueCategoryDto attribute = dataValidator.getDataValueCategoryDto( cc, cp );
 
         FileResource fileResource = fileResourceUtils.saveFileResource( file, FileResourceDomain.DATA_VALUE );
 
@@ -237,35 +237,35 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( dataValue.getDataElement() );
+        DataElement dataElement = dataValidator.getAndValidateDataElement( dataValue.getDataElement() );
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo(
+        CategoryOptionCombo categoryOptionCombo = dataValidator.getAndValidateCategoryOptionCombo(
             dataValue.getCategoryOptionCombo(), requireCategoryOptionCombo );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo( attribute );
+        CategoryOptionCombo attributeOptionCombo = dataValidator.getAndValidateAttributeOptionCombo( attribute );
 
-        Period period = dataValueValidation.getAndValidatePeriod( dataValue.getPeriod() );
+        Period period = dataValidator.getAndValidatePeriod( dataValue.getPeriod() );
 
-        OrganisationUnit organisationUnit = dataValueValidation
+        OrganisationUnit organisationUnit = dataValidator
             .getAndValidateOrganisationUnit( dataValue.getOrgUnit() );
 
-        dataValueValidation.validateOrganisationUnitPeriod( organisationUnit, period );
+        dataValidator.validateOrganisationUnitPeriod( organisationUnit, period );
 
-        DataSet dataSet = dataValueValidation.getAndValidateOptionalDataSet( dataValue.getDataSet(), dataElement );
+        DataSet dataSet = dataValidator.getAndValidateOptionalDataSet( dataValue.getDataSet(), dataElement );
 
-        dataValueValidation.validateInvalidFuturePeriod( period, dataElement );
+        dataValidator.validateInvalidFuturePeriod( period, dataElement );
 
-        dataValueValidation.validateAttributeOptionCombo( attributeOptionCombo, period, dataSet, dataElement );
+        dataValidator.validateAttributeOptionCombo( attributeOptionCombo, period, dataSet, dataElement );
 
-        value = dataValueValidation.validateAndNormalizeDataValue( dataValue.getValue(), dataElement );
+        value = dataValidator.validateAndNormalizeDataValue( dataValue.getValue(), dataElement );
 
-        dataValueValidation.validateComment( dataValue.getComment() );
+        dataValidator.validateComment( dataValue.getComment() );
 
-        dataValueValidation.validateOptionSet( value, dataElement.getOptionSet(), dataElement );
+        dataValidator.validateOptionSet( value, dataElement.getOptionSet(), dataElement );
 
-        dataValueValidation.checkCategoryOptionComboAccess( currentUser, categoryOptionCombo );
+        dataValidator.checkCategoryOptionComboAccess( currentUser, categoryOptionCombo );
 
-        dataValueValidation.checkCategoryOptionComboAccess( currentUser, attributeOptionCombo );
+        dataValidator.checkCategoryOptionComboAccess( currentUser, attributeOptionCombo );
 
         // ---------------------------------------------------------------------
         // Optional constraints
@@ -298,7 +298,7 @@ public class DataValueController
 
         if ( !inputUtils.canForceDataInput( currentUser, dataValue.isForce() ) )
         {
-            dataValueValidation.validateDataSetNotLocked( currentUser, dataElement, period, dataSet, organisationUnit,
+            dataValidator.validateDataSetNotLocked( currentUser, dataElement, period, dataSet, organisationUnit,
                 attributeOptionCombo );
         }
 
@@ -306,7 +306,7 @@ public class DataValueController
         // Period validation
         // ---------------------------------------------------------------------
 
-        dataValueValidation.validateDataInputPeriodForDataElementAndPeriod( dataElement, dataSet, period );
+        dataValidator.validateDataInputPeriodForDataElementAndPeriod( dataElement, dataSet, period );
 
         // ---------------------------------------------------------------------
         // Assemble and save data value
@@ -329,7 +329,7 @@ public class DataValueController
 
             if ( dataElement.getValueType().isFile() )
             {
-                fileResource = dataValueValidation.validateAndSetAssigned( value, dataElement.getValueType(),
+                fileResource = dataValidator.validateAndSetAssigned( value, dataElement.getValueType(),
                     dataElement.getValueTypeOptions() );
             }
 
@@ -355,7 +355,7 @@ public class DataValueController
 
             if ( dataElement.getValueType().isFile() )
             {
-                fileResource = dataValueValidation.validateAndSetAssigned( value, dataElement.getValueType(),
+                fileResource = dataValidator.validateAndSetAssigned( value, dataElement.getValueType(),
                     dataElement.getValueTypeOptions() );
             }
 
@@ -429,19 +429,19 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( params.getDe() );
+        DataElement dataElement = dataValidator.getAndValidateDataElement( params.getDe() );
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo( params.getCo(),
+        CategoryOptionCombo categoryOptionCombo = dataValidator.getAndValidateCategoryOptionCombo( params.getCo(),
             false );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo(
+        CategoryOptionCombo attributeOptionCombo = dataValidator.getAndValidateAttributeOptionCombo(
             params.getCc(), params.getCp() );
 
-        Period period = dataValueValidation.getAndValidatePeriod( params.getPe() );
+        Period period = dataValidator.getAndValidatePeriod( params.getPe() );
 
-        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( params.getOu() );
+        OrganisationUnit organisationUnit = dataValidator.getAndValidateOrganisationUnit( params.getOu() );
 
-        DataSet dataSet = dataValueValidation.getAndValidateOptionalDataSet( ds, dataElement );
+        DataSet dataSet = dataValidator.getAndValidateOptionalDataSet( ds, dataElement );
 
         // ---------------------------------------------------------------------
         // Locking validation
@@ -449,7 +449,7 @@ public class DataValueController
 
         if ( !inputUtils.canForceDataInput( currentUser, force ) )
         {
-            dataValueValidation.validateDataSetNotLocked( currentUser, dataElement, period, dataSet, organisationUnit,
+            dataValidator.validateDataSetNotLocked( currentUser, dataElement, period, dataSet, organisationUnit,
                 attributeOptionCombo );
         }
 
@@ -457,7 +457,7 @@ public class DataValueController
         // Period validation
         // ---------------------------------------------------------------------
 
-        dataValueValidation.validateDataInputPeriodForDataElementAndPeriod( dataElement, dataSet, period );
+        dataValidator.validateDataInputPeriodForDataElementAndPeriod( dataElement, dataSet, period );
 
         // ---------------------------------------------------------------------
         // Delete data value
@@ -495,17 +495,17 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( params.getDe() );
+        DataElement dataElement = dataValidator.getAndValidateDataElement( params.getDe() );
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo(
+        CategoryOptionCombo categoryOptionCombo = dataValidator.getAndValidateCategoryOptionCombo(
             params.getCo(), false );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo(
+        CategoryOptionCombo attributeOptionCombo = dataValidator.getAndValidateAttributeOptionCombo(
             params.getCc(), params.getCp() );
 
-        Period period = dataValueValidation.getAndValidatePeriod( params.getPe() );
+        Period period = dataValidator.getAndValidatePeriod( params.getPe() );
 
-        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( params.getOu() );
+        OrganisationUnit organisationUnit = dataValidator.getAndValidateOrganisationUnit( params.getOu() );
 
         // ---------------------------------------------------------------------
         // Get data value
@@ -523,7 +523,7 @@ public class DataValueController
         // Data Sharing check
         // ---------------------------------------------------------------------
 
-        dataValueValidation.checkDataValueSharing( currentUser, dataValue );
+        dataValidator.checkDataValueSharing( currentUser, dataValue );
 
         List<String> value = new ArrayList<>();
         value.add( dataValue.getValue() );
@@ -545,7 +545,7 @@ public class DataValueController
             throw new IllegalQueryException( ErrorCode.E2033 );
         }
 
-        DataValue dataValue = dataValueValidation.getAndValidateDataValue( request );
+        DataValue dataValue = dataValidator.getAndValidateDataValue( request );
         dataValue.setFollowup( request.getFollowup() );
         dataValueService.updateDataValue( dataValue );
     }
@@ -563,7 +563,7 @@ public class DataValueController
         List<DataValue> dataValues = new ArrayList<>();
         for ( DataValueFollowUpRequest e : values )
         {
-            DataValue dataValue = dataValueValidation.getAndValidateDataValue( e );
+            DataValue dataValue = dataValidator.getAndValidateDataValue( e );
             dataValue.setFollowup( e.getFollowup() );
         }
         dataValueService.updateDataValues( dataValues );
@@ -584,24 +584,24 @@ public class DataValueController
         // Input validation
         // ---------------------------------------------------------------------
 
-        DataElement dataElement = dataValueValidation.getAndValidateDataElement( params.getDe() );
+        DataElement dataElement = dataValidator.getAndValidateDataElement( params.getDe() );
 
         if ( !dataElement.isFileType() )
         {
             throw new WebMessageException( conflict( "DataElement must be of type file" ) );
         }
 
-        CategoryOptionCombo categoryOptionCombo = dataValueValidation.getAndValidateCategoryOptionCombo(
+        CategoryOptionCombo categoryOptionCombo = dataValidator.getAndValidateCategoryOptionCombo(
             params.getCo(), false );
 
-        CategoryOptionCombo attributeOptionCombo = dataValueValidation.getAndValidateAttributeOptionCombo(
+        CategoryOptionCombo attributeOptionCombo = dataValidator.getAndValidateAttributeOptionCombo(
             params.getCc(), params.getCp() );
 
-        Period period = dataValueValidation.getAndValidatePeriod( params.getPe() );
+        Period period = dataValidator.getAndValidatePeriod( params.getPe() );
 
-        OrganisationUnit organisationUnit = dataValueValidation.getAndValidateOrganisationUnit( params.getOu() );
+        OrganisationUnit organisationUnit = dataValidator.getAndValidateOrganisationUnit( params.getOu() );
 
-        dataValueValidation.validateOrganisationUnitPeriod( organisationUnit, period );
+        dataValidator.validateOrganisationUnitPeriod( organisationUnit, period );
 
         // ---------------------------------------------------------------------
         // Get data value

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/DataSetMetadataExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/metadata/DataSetMetadataExportController.java
@@ -44,13 +44,13 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 @Controller
 @AllArgsConstructor
-@RequestMapping( "/dataSetMetadata" )
+@RequestMapping( "/dataEntry" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class DataSetMetadataExportController
 {
     private final DataSetMetadataExportService exportService;
 
-    @GetMapping
+    @GetMapping( "/metadata" )
     public ResponseEntity<JsonNode> getMetadata()
     {
         return ResponseEntity.ok( exportService.getDataSetMetadata() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueAuditDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueAuditDto.java
@@ -39,6 +39,8 @@ import org.hisp.dhis.common.AuditType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
+ * DTO which represents a data value audit record.
+ *
  * @author Lars Helge Overland
  */
 @Getter

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueAuditDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueAuditDto.java
@@ -25,52 +25,52 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.dataelementhistory;
+package org.hisp.dhis.webapi.webdomain.datavalue;
 
-import org.hisp.dhis.period.Period;
+import java.util.Date;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.hisp.dhis.common.AuditType;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * @author Torgeir Lorange Ostby
+ * @author Lars Helge Overland
  */
-public class DataElementHistoryPoint
+@Getter
+@Setter
+@Accessors( chain = true )
+@NoArgsConstructor
+public class DataValueAuditDto
 {
-    private Period period;
+    @JsonProperty
+    private String dataElement;
 
-    private Double value;
+    @JsonProperty
+    private String period;
 
-    private double average;
+    @JsonProperty
+    private String orgUnit;
 
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
+    @JsonProperty
+    private String categoryOptionCombo;
 
-    public double getAverage()
-    {
-        return average;
-    }
+    @JsonProperty
+    private String attributeOptionCombo;
 
-    public void setAverage( double average )
-    {
-        this.average = average;
-    }
+    @JsonProperty
+    private String value;
 
-    public Period getPeriod()
-    {
-        return period;
-    }
+    @JsonProperty
+    private String modifiedBy;
 
-    public void setPeriod( Period period )
-    {
-        this.period = period;
-    }
+    @JsonProperty
+    private Date created;
 
-    public Double getValue()
-    {
-        return value;
-    }
-
-    public void setValue( Double value )
-    {
-        this.value = value;
-    }
+    @JsonProperty
+    private AuditType auditType;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueCategoryDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueCategoryDto.java
@@ -38,6 +38,9 @@ import lombok.experimental.Accessors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
+ * DTO which represents a data value category option combination represented as
+ * a category combination and a set of category options.
+ *
  * @author Lars Helge Overland
  */
 @Getter

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueContextDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueContextDto.java
@@ -25,40 +25,33 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.dataentry;
+package org.hisp.dhis.webapi.webdomain.datavalue;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
-import org.hisp.dhis.common.DhisApiVersion;
-import org.hisp.dhis.datavalue.DataValueAudit;
-import org.hisp.dhis.datavalue.DataValueAuditService;
-import org.hisp.dhis.webapi.controller.datavalue.DataValidator;
-import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.webdomain.datavalue.DataValueQueryParams;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-@RestController
-@RequestMapping( value = "/dataEntry" )
-@AllArgsConstructor
-@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-public class ChangeLogController
+/**
+ * DTO which represents the context, such as data value audit records and data
+ * value history, for a single data value.
+ *
+ * @author Lars Helge Overland
+ */
+@Getter
+@Setter
+@Accessors( chain = true )
+@NoArgsConstructor
+public class DataValueContextDto
 {
-    private final DataValueAuditService dataValueAuditService;
+    @JsonProperty
+    private List<DataValueAuditDto> audits = new ArrayList<>();
 
-    private final DataValidator dataValidator;
-
-    @GetMapping( value = "/changeLog" )
-    public void getChangeLog( DataValueQueryParams params )
-    {
-        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
-            dataValidator.getAndValidateDataElement( params.getDe() ),
-            dataValidator.getAndValidatePeriod( params.getPe() ),
-            dataValidator.getAndValidateOrganisationUnit( params.getOu() ),
-            null, null );
-
-    }
+    @JsonProperty
+    private List<DataValueDto> history = new ArrayList<>();
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueContextDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueContextDto.java
@@ -50,6 +50,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class DataValueContextDto
 {
     @JsonProperty
+    private DataValueDto dataValue;
+
+    @JsonProperty
     private List<DataValueAuditDto> audits = new ArrayList<>();
 
     @JsonProperty

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDto.java
@@ -35,6 +35,8 @@ import lombok.experimental.Accessors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
+ * DTO which represents a data value.
+ *
  * @author Lars Helge Overland
  */
 @Getter

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.webdomain.datavalue;
+
+import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.datavalue.DataValueAudit;
+
+public class DataValueDtoMapper
+{
+    /**
+     * Converts a {@link DataValueAudit} object to a {@link DataValueAuditDto}
+     * object.
+     *
+     * @param audit the {@link DataValueAudit}.
+     * @return a {@link DataValueAuditDto}.
+     */
+    public static DataValueAuditDto toDto( DataValueAudit audit )
+    {
+        DataValueAuditDto dto = new DataValueAuditDto();
+        dto.setDataElement( audit.getDataElement().getUid() );
+        dto.setPeriod( audit.getPeriod().getIsoDate() );
+        dto.setOrgUnit( audit.getOrganisationUnit().getUid() );
+        dto.setCategoryOptionCombo( audit.getCategoryOptionCombo().getUid() );
+        dto.setAttributeOptionCombo( audit.getAttributeOptionCombo().getUid() );
+        dto.setValue( audit.getValue() );
+        dto.setModifiedBy( audit.getModifiedBy() );
+        dto.setCreated( audit.getCreated() );
+        dto.setAuditType( audit.getAuditType() );
+        return dto;
+    }
+
+    /**
+     * Converts a {@link DataValue} object to a {@link DataValueDto} object.
+     *
+     * @param audit the {@link DataValue}.
+     * @return a {@link DataValueDto}.
+     */
+    public static DataValueDto toDto( DataValue value )
+    {
+        DataValueDto dto = new DataValueDto();
+        dto.setDataElement( value.getDataElement().getUid() );
+        dto.setPeriod( value.getPeriod().getIsoDate() );
+        dto.setOrgUnit( value.getSource().getUid() );
+        dto.setCategoryOptionCombo( value.getCategoryOptionCombo().getUid() );
+        dto.setAttribute( null );
+        dto.setValue( value.getValue() );
+        dto.setComment( value.getComment() );
+        dto.setFollowUp( value.isFollowup() );
+        return dto;
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.webapi.webdomain.datavalue;
 
+import static org.hisp.dhis.commons.collection.CollectionUtils.mapToSet;
+
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueAudit;
 
@@ -46,17 +50,16 @@ public class DataValueDtoMapper
      */
     public static DataValueAuditDto toDto( DataValueAudit audit )
     {
-        DataValueAuditDto dto = new DataValueAuditDto();
-        dto.setDataElement( audit.getDataElement().getUid() );
-        dto.setPeriod( audit.getPeriod().getIsoDate() );
-        dto.setOrgUnit( audit.getOrganisationUnit().getUid() );
-        dto.setCategoryOptionCombo( audit.getCategoryOptionCombo().getUid() );
-        dto.setAttributeOptionCombo( audit.getAttributeOptionCombo().getUid() );
-        dto.setValue( audit.getValue() );
-        dto.setModifiedBy( audit.getModifiedBy() );
-        dto.setCreated( audit.getCreated() );
-        dto.setAuditType( audit.getAuditType() );
-        return dto;
+        return new DataValueAuditDto()
+            .setDataElement( audit.getDataElement().getUid() )
+            .setPeriod( audit.getPeriod().getIsoDate() )
+            .setOrgUnit( audit.getOrganisationUnit().getUid() )
+            .setCategoryOptionCombo( audit.getCategoryOptionCombo().getUid() )
+            .setAttributeOptionCombo( audit.getAttributeOptionCombo().getUid() )
+            .setValue( audit.getValue() )
+            .setModifiedBy( audit.getModifiedBy() )
+            .setCreated( audit.getCreated() )
+            .setAuditType( audit.getAuditType() );
     }
 
     /**
@@ -67,15 +70,28 @@ public class DataValueDtoMapper
      */
     public static DataValueDto toDto( DataValue value )
     {
-        DataValueDto dto = new DataValueDto();
-        dto.setDataElement( value.getDataElement().getUid() );
-        dto.setPeriod( value.getPeriod().getIsoDate() );
-        dto.setOrgUnit( value.getSource().getUid() );
-        dto.setCategoryOptionCombo( value.getCategoryOptionCombo().getUid() );
-        dto.setAttribute( null );
-        dto.setValue( value.getValue() );
-        dto.setComment( value.getComment() );
-        dto.setFollowUp( value.isFollowup() );
-        return dto;
+        return new DataValueDto()
+            .setDataElement( value.getDataElement().getUid() )
+            .setPeriod( value.getPeriod().getIsoDate() )
+            .setOrgUnit( value.getSource().getUid() )
+            .setCategoryOptionCombo( value.getCategoryOptionCombo().getUid() )
+            .setAttribute( toDto( value.getAttributeOptionCombo() ) )
+            .setValue( value.getValue() )
+            .setComment( value.getComment() )
+            .setFollowUp( value.isFollowup() );
+    }
+
+    /**
+     * Converts an attribute {@link CategoryOptionCombo} object to a
+     * {@link DataValueCategoryDto} object.
+     *
+     * @param attribute the attribute {@link CategoryOptionCombo}.
+     * @return a {@link DataValueCategoryDto}.
+     */
+    public static DataValueCategoryDto toDto( CategoryOptionCombo attribute )
+    {
+        return new DataValueCategoryDto()
+            .setCombo( attribute.getCategoryCombo().getUid() )
+            .setOptions( mapToSet( attribute.getCategoryOptions(), CategoryOption::getUid ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
@@ -65,7 +65,7 @@ public class DataValueDtoMapper
     /**
      * Converts a {@link DataValue} object to a {@link DataValueDto} object.
      *
-     * @param audit the {@link DataValue}.
+     * @param value the {@link DataValue}.
      * @return a {@link DataValueDto}.
      */
     public static DataValueDto toDto( DataValue value )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
@@ -30,6 +30,12 @@ package org.hisp.dhis.webapi.webdomain.datavalue;
 import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueAudit;
 
+/**
+ * Class which provides methods for mapping between domain objcets and DTO
+ * objects.
+ *
+ * @author Lars Helge Overland
+ */
 public class DataValueDtoMapper
 {
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueDtoMapper.java
@@ -31,8 +31,7 @@ import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.datavalue.DataValueAudit;
 
 /**
- * Class which provides methods for mapping between domain objcets and DTO
- * objects.
+ * Class which provides methods for mapping between domain objcets and DTOs.
  *
  * @author Lars Helge Overland
  */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueQueryParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueQueryParams.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.webdomain.datavalue;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor( access = AccessLevel.PRIVATE )
+public class DataValueQueryParams
+{
+    @NotBlank
+    private String de;
+
+    private String co;
+
+    private String cc;
+
+    private String cp;
+
+    @NotBlank
+    private String pe;
+
+    @NotBlank
+    private String ou;
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueQueryParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueQueryParams.java
@@ -36,6 +36,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+/**
+ * Object which encapsulates parameters for a data value query.
+ *
+ * @author Lars Helge Overland
+ */
 @Getter
 @Setter
 @Builder

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/datavalue/DataValidatorTest.java
@@ -236,12 +236,22 @@ class DataValidatorTest
     }
 
     @Test
+    void testMissingCategoryOptionCombo()
+    {
+        final String uid = CodeGenerator.generateUid();
+
+        when( categoryService.getCategoryOptionCombo( uid ) ).thenReturn( null );
+
+        IllegalQueryException ex = assertThrows( IllegalQueryException.class,
+            () -> dataValidator.getAndValidateCategoryOptionCombo( uid ) );
+
+        assertEquals( ErrorCode.E1103, ex.getErrorCode() );
+    }
+
+    @Test
     void testValidateAttributeOptionComboWithEarlyData()
     {
-        // Given
         categoryOptionA.setStartDate( feb15 );
-
-        // Then
 
         assertThrows( IllegalQueryException.class,
             () -> dataValidator.validateAttributeOptionCombo( optionComboA, periodJan, dataSetA, dataElementA ) );
@@ -250,10 +260,7 @@ class DataValidatorTest
     @Test
     void testValidateAttributeOptionComboWithLateData()
     {
-        // Given
         categoryOptionA.setEndDate( jan15 );
-
-        // Then
 
         assertThrows( IllegalQueryException.class,
             () -> dataValidator.validateAttributeOptionCombo( optionComboA, periodFeb, null, dataElementA ) );
@@ -262,11 +269,8 @@ class DataValidatorTest
     @Test
     void testValidateAttributeOptionComboWithLateAdjustedData()
     {
-        // Given
         categoryOptionA.setEndDate( jan15 );
         dataSetA.setOpenPeriodsAfterCoEndDate( 1 );
-
-        // Then
 
         assertThrows( IllegalQueryException.class,
             () -> dataValidator.validateAttributeOptionCombo( optionComboA, periodMar, dataSetA, dataElementA ) );
@@ -275,12 +279,10 @@ class DataValidatorTest
     @Test
     void validateBooleanDataValueWhenValuesAreAcceptableTrue()
     {
-        // Given
         final DataElement aBooleanTypeDataElement = new DataElement();
         final String normalizedBooleanValue = "true";
         aBooleanTypeDataElement.setValueType( BOOLEAN );
 
-        // Then
         String aBooleanDataValue = "true";
         aBooleanDataValue = dataValidator.validateAndNormalizeDataValue( aBooleanDataValue, aBooleanTypeDataElement );
         assertThat( aBooleanDataValue, is( normalizedBooleanValue ) );
@@ -305,12 +307,10 @@ class DataValidatorTest
     @Test
     void validateBooleanDataValueWhenValuesAreAcceptableFalse()
     {
-        // Given
         final DataElement aBooleanTypeDataElement = new DataElement();
         final String normalizedBooleanValue = "false";
         aBooleanTypeDataElement.setValueType( BOOLEAN );
 
-        // Then
         String aBooleanDataValue = "false";
         aBooleanDataValue = dataValidator.validateAndNormalizeDataValue( aBooleanDataValue, aBooleanTypeDataElement );
         assertThat( aBooleanDataValue, is( normalizedBooleanValue ) );
@@ -335,7 +335,6 @@ class DataValidatorTest
     @Test
     void validateBooleanDataValueWhenValueIsNotValid()
     {
-        // Given
         String anInvalidBooleanValue = "InvalidValue";
         final DataElement aBooleanTypeDataElement = new DataElement();
         aBooleanTypeDataElement.setValueType( BOOLEAN );


### PR DESCRIPTION
### Overview

* Adds new endpoint at `/api/dataEntry/dataValueContext` which provides context for a single data value, including the data value, audit records and data value history. The `/dataEntry` path will be a common path for all endpoints designed specifically for the data entry app.
* Moves the data set metadata endpoint to `/api/dataEntry/metadata`. 
* Adds new DTO classes `DataValueContextDto` and `DataValueAuditDto`.
* Introduces `DataValueQueryParams` to encapsulate query parameters for a single data value.
* Removes various unused methods.

### Testing

* Affects the `/api/dataValues` endpoint, which should be regression tested.
* Introduces `/api/dataEntry/dataValueContext` endpoint, sample GET URL: `/api/dataEntry/dataValueContext?de=BOSZApCrBni&pe=202201&&ou=DiszpKrYNg8&co=TkDhg29x18A&cc=O4VaNks6tta&cp=C6nZpLKjEJr%3Bi4Nbp8S2G6A`.