### PR TITLE
fix: Enrollment.orgUnit is a MetadataIdentifier DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EnrollmentTrackerConverterService.java
@@ -117,17 +117,15 @@ public class EnrollmentTrackerConverterService
 
     private ProgramInstance from( TrackerPreheat preheat, Enrollment enrollment, ProgramInstance programInstance )
     {
-        OrganisationUnit organisationUnit = preheat
-            .get( OrganisationUnit.class, enrollment.getOrgUnit() );
+        OrganisationUnit organisationUnit = preheat.getOrganisationUnit( enrollment.getOrgUnit() );
 
         checkNotNull( organisationUnit, TrackerImporterAssertErrors.ORGANISATION_UNIT_CANT_BE_NULL );
 
-        Program program = preheat.get( Program.class, enrollment.getProgram() );
+        Program program = preheat.getProgram( enrollment.getProgram() );
 
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 
-        TrackedEntityInstance trackedEntityInstance = preheat
-            .getTrackedEntity( enrollment.getTrackedEntity() );
+        TrackedEntityInstance trackedEntityInstance = preheat.getTrackedEntity( enrollment.getTrackedEntity() );
 
         Date now = new Date();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Enrollment.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Enrollment.java
@@ -76,7 +76,7 @@ public class Enrollment
     private EnrollmentStatus status;
 
     @JsonProperty
-    private String orgUnit;
+    private MetadataIdentifier orgUnit;
 
     @JsonProperty
     private String orgUnitName;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -62,7 +62,7 @@ public class PreCheckMandatoryFieldsValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
     {
-        reporter.addErrorIf( () -> StringUtils.isEmpty( enrollment.getOrgUnit() ), enrollment, E1122, ORG_UNIT );
+        reporter.addErrorIf( () -> enrollment.getOrgUnit().isBlank(), enrollment, E1122, ORG_UNIT );
         reporter.addErrorIf( () -> enrollment.getProgram().isBlank(), enrollment, E1122, "program" );
         reporter.addErrorIf( () -> StringUtils.isEmpty( enrollment.getTrackedEntity() ), enrollment, E1122,
             "trackedEntity" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -255,7 +255,7 @@ public class PreCheckSecurityOwnershipValidationHook
         }
         else
         {
-            checkNotNull( enrollment.getOrgUnit(), ORGANISATION_UNIT_CANT_BE_NULL );
+            checkNotNull( enrollment.getOrgUnit().getIdentifierOrAttributeValue(), ORGANISATION_UNIT_CANT_BE_NULL );
             enrollmentOrgUnit = reporter.getBundle().getPreheat().getOrganisationUnit( enrollment.getOrgUnit() );
         }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
@@ -72,7 +72,7 @@ class TrackerIdentifierCollectorTest
             Set.of( new AttributeValue( att, "sunshine" ), attributeValue( "grass" ) ) );
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( orgUnit.getUid() )
+            .orgUnit( MetadataIdentifier.ofUid( orgUnit.getUid() ) )
             .program( MetadataIdentifier.ofAttribute( att.getUid(), "sunshine" ) )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
@@ -98,7 +98,9 @@ class OwnershipTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams enrollmentParams = fromJson( "tracker/ownership_enrollment.json", nonSuperUser.getUid() );
+
         List<TrackedEntityInstance> teis = manager.getAll( TrackedEntityInstance.class );
+
         assertEquals( 1, teis.size() );
         TrackedEntityInstance tei = teis.get( 0 );
         assertNotNull( tei.getProgramOwners() );
@@ -110,7 +112,7 @@ class OwnershipTest extends TrackerTest
         assertNotNull( tepo.getOrganisationUnit() );
         assertTrue(
             enrollmentParams.getEnrollments().get( 0 ).getProgram().isEqualTo( tepo.getProgram() ) );
-        assertEquals( enrollmentParams.getEnrollments().get( 0 ).getOrgUnit(), tepo.getOrganisationUnit().getUid() );
+        assertTrue( enrollmentParams.getEnrollments().get( 0 ).getOrgUnit().isEqualTo( tepo.getOrganisationUnit() ) );
         assertEquals( enrollmentParams.getEnrollments().get( 0 ).getTrackedEntity(),
             tepo.getEntityInstance().getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceIntegrationTest.java
@@ -125,7 +125,7 @@ class TrackerPreheatServiceIntegrationTest extends TransactionalIntegrationTest
             .trackedEntityType( TET_UID )
             .build();
         Enrollment enrollmentA = Enrollment.builder()
-            .orgUnit( "OUA" )
+            .orgUnit( MetadataIdentifier.ofCode( "OUA" ) )
             .program( MetadataIdentifier.ofAttribute( ATTRIBUTE_UID, programAttribute ) )
             .trackedEntity( "TE123456789" )
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -34,6 +34,7 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -104,10 +105,10 @@ class EnrollmentImportValidationTest extends AbstractImportValidationTest
             "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerPreheat preheat = trackerPreheatService.preheat( secondParams );
         secondParams.getEnrollments().forEach( e -> {
-            assertEquals( e.getOrgUnit(),
+            assertTrue( e.getOrgUnit().isEqualTo(
                 preheat.getProgramOwner().get( e.getTrackedEntity() )
                     .get( e.getProgram().getIdentifier() )
-                    .getOrganisationUnit().getUid() );
+                    .getOrganisationUnit() ) );
         } );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -120,7 +120,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void verifyValidationSuccessForEnrollment()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) )
             .thenReturn( orgUnit );
         TrackedEntityType teiType = trackedEntityType( TEI_TYPE_ID );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
@@ -131,7 +131,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( trackedEntityInstance( TEI_TYPE_ID, teiType, orgUnit ) );
 
         Enrollment enrollment = Enrollment.builder()
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .enrollment( CodeGenerator.generateUid() )
             .trackedEntity( TEI_ID )
@@ -146,7 +146,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void verifyValidationFailsWhenEnrollmentIsNotARegistration()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) )
             .thenReturn( orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( programWithoutRegistration( PROGRAM_UID, orgUnit ) );
@@ -154,7 +154,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
 
         Enrollment enrollment = Enrollment.builder()
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .enrollment( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .build();
@@ -168,7 +168,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void verifyValidationFailsWhenEnrollmentAndProgramOrganisationUnitDontMatch()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) )
             .thenReturn( orgUnit );
         OrganisationUnit anotherOrgUnit = organisationUnit( CodeGenerator.generateUid() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
@@ -180,7 +180,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .build();
 
         hook.validateEnrollment( reporter, enrollment );
@@ -192,7 +192,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void verifyValidationFailsWhenEnrollmentAndProgramTeiTypeDontMatch()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) )
             .thenReturn( orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( programWithRegistration( PROGRAM_UID, orgUnit, trackedEntityType( TEI_TYPE_ID ) ) );
@@ -205,7 +205,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .build();
 
@@ -218,7 +218,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     void verifyValidationFailsWhenEnrollmentAndProgramTeiTypeDontMatchAndTEIIsInPayload()
     {
         OrganisationUnit orgUnit = organisationUnit( ORG_UNIT_ID );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) )
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) )
             .thenReturn( orgUnit );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) )
             .thenReturn( programWithRegistration( PROGRAM_UID, orgUnit, trackedEntityType( TEI_TYPE_ID ) ) );
@@ -235,7 +235,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .build();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -139,7 +139,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
@@ -155,7 +155,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .trackedEntity( null )
             .build();
@@ -171,7 +171,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( CodeGenerator.generateUid() )
+            .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .program( MetadataIdentifier.ofUid( null ) )
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
@@ -187,7 +187,7 @@ class PreCheckMandatoryFieldsValidationHookTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( null )
+            .orgUnit( MetadataIdentifier.ofUid( null ) )
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .trackedEntity( CodeGenerator.generateUid() )
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -165,7 +165,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
@@ -186,7 +187,8 @@ class PreCheckMetaValidationHookTest
         // when
         when( preheat.getReference( TRACKED_ENTITY_UID ) )
             .thenReturn( Optional.of( new ReferenceTrackerEntity( "", "" ) ) );
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
@@ -222,7 +224,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
@@ -240,7 +243,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getOrganisationUnit( ORG_UNIT_UID ) ).thenReturn( new OrganisationUnit() );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
+            .thenReturn( new OrganisationUnit() );
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
 
         validatorToTest.validateEnrollment( reporter, enrollment );
@@ -374,7 +378,7 @@ class PreCheckMetaValidationHookTest
         return Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
             .trackedEntity( TRACKED_ENTITY_UID )
-            .orgUnit( ORG_UNIT_UID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) )
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -415,7 +415,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -450,7 +450,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -472,7 +472,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -480,7 +480,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -498,7 +498,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Enrollment enrollment = Enrollment.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -525,7 +525,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Enrollment enrollment = Enrollment.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -533,7 +533,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
-        when( preheat.getOrganisationUnit( ORG_UNIT_ID ) ).thenReturn( organisationUnit );
+        when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -549,7 +549,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -575,7 +575,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -603,7 +603,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -630,7 +630,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     {
         Enrollment enrollment = Enrollment.builder()
             .enrollment( CodeGenerator.generateUid() )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -659,7 +659,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Enrollment enrollment = Enrollment.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();
@@ -686,7 +686,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         String enrollmentUid = CodeGenerator.generateUid();
         Enrollment enrollment = Enrollment.builder()
             .enrollment( enrollmentUid )
-            .orgUnit( ORG_UNIT_ID )
+            .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .trackedEntity( TEI_ID )
             .program( MetadataIdentifier.ofUid( PROGRAM_ID ) )
             .build();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/enrollment_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/enrollment_basic_data_for_deletion.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
@@ -80,7 +80,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",
@@ -100,7 +103,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -80,7 +80,10 @@
         "identifier": "BFcipDERJwr"
       },
       "status": "ACTIVE",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",
@@ -100,7 +103,10 @@
         "identifier": "BFcipDERJwr"
       },
       "status": "COMPLETED",
-      "orgUnit": "PlKwabX2xRW",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "PlKwabX2xRW"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/non_existent_enrollment_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/non_existent_enrollment_basic_data_for_deletion.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_enrollment.json
@@ -41,7 +41,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "COMPLETED",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",
@@ -61,7 +64,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",
@@ -81,7 +87,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_enrollment_and_one_new_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_enrollment_and_one_new_enrollment.json
@@ -41,7 +41,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "COMPLETED",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",
@@ -61,7 +64,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_enrollment.json
@@ -44,7 +44,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "uoNW0E3xXUy",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "uoNW0E3xXUy"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_metadata.json
@@ -73,8 +73,7 @@
         "program": {
           "id": "BFcipDERJnf"
         },
-        "programStage" :
-        {
+        "programStage": {
           "id": "NpsdDv6kKSO"
         }
       },

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/simple_metadata.json
@@ -76,7 +76,6 @@
         "programStage": {
           "id": "NpsdDv6kKSO"
         }
-
       },
       "userGroupAccesses": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_enrollment.json
@@ -44,7 +44,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_data.json
@@ -82,7 +82,10 @@
         "identifier": "hJUBNVQWl4e"
       },
       "status": "ACTIVE",
-      "orgUnit": "cNEZTkdAvmg",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "cNEZTkdAvmg"
+      },
       "orgUnitName": "Country",
       "enrolledAt": "2020-02-20T00:00:00.000",
       "occurredAt": "2020-02-20T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_delete_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_delete_data.json
@@ -67,7 +67,10 @@
         "identifier": "hJUBNVQWl4e"
       },
       "status": "ACTIVE",
-      "orgUnit": "cNEZTkdAvmg",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "cNEZTkdAvmg"
+      },
       "orgUnitName": "Country",
       "enrolledAt": "2020-02-20T00:00:00.000",
       "occurredAt": "2020-02-20T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_encryption_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_encryption_data.json
@@ -89,7 +89,10 @@
         "identifier": "hJUBNVQWl4e"
       },
       "status": "ACTIVE",
-      "orgUnit": "cNEZTkdAvmg",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "cNEZTkdAvmg"
+      },
       "orgUnitName": "Country",
       "enrolledAt": "2020-02-20T00:00:00.000",
       "occurredAt": "2020-02-20T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_fileresource_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_fileresource_data.json
@@ -89,7 +89,10 @@
         "identifier": "hJUBNVQWl4e"
       },
       "status": "ACTIVE",
-      "orgUnit": "cNEZTkdAvmg",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "cNEZTkdAvmg"
+      },
       "orgUnitName": "Country",
       "enrolledAt": "2020-02-20T00:00:00.000",
       "occurredAt": "2020-02-20T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_update_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_update_data.json
@@ -82,7 +82,10 @@
         "identifier": "hJUBNVQWl4e"
       },
       "status": "ACTIVE",
-      "orgUnit": "cNEZTkdAvmg",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "cNEZTkdAvmg"
+      },
       "orgUnitName": "Country",
       "enrolledAt": "2020-02-20T00:00:00.000",
       "occurredAt": "2020-02-20T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
@@ -61,7 +61,10 @@
         "identifier": "BFcipDERJnf"
       },
       "status": "ACTIVE",
-      "orgUnit": "h4w96yEMlzO",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2019-03-28T12:05:00.000",
       "occurredAt": "2019-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
@@ -209,7 +209,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",
@@ -229,7 +232,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2020-03-28T12:05:00.000",
       "occurredAt": "2020-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_data_for_deletion.json
@@ -65,7 +65,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-03-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_bad-note-no-value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_bad-note-no-value.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_double-tei-enrollment_part1.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_double-tei-enrollment_part1.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_double-tei-enrollment_part2.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_double-tei-enrollment_part2.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_error_non_program_attr.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_error_non_program_attr.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_no-access-program.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_no-access-program.json
@@ -41,7 +41,10 @@
         "identifier": "prabcdefghA"
       },
       "status": "ACTIVE",
-      "orgUnit": "ouabcdefghA",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "ouabcdefghA"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_no-access-tei.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_no-access-tei.json
@@ -41,7 +41,10 @@
         "identifier": "prabcdefghA"
       },
       "status": "ACTIVE",
-      "orgUnit": "ouabcdefghA",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "ouabcdefghA"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_program-teitype-missmatch.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_program-teitype-missmatch.json
@@ -41,7 +41,10 @@
         "identifier": "prabcdefghA"
       },
       "status": "ACTIVE",
-      "orgUnit": "ouabcdefghA",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "ouabcdefghA"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-data.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-missing-mandatory.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-missing-mandatory.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-missing-uuid.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-missing-uuid.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-missing-value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-missing-value.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-only-program-attr.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_attr-only-program-attr.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_enrollments-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_enrollments-data.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,
@@ -61,7 +64,10 @@
         "identifier": "YYY1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,
@@ -81,7 +87,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,
@@ -101,7 +110,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_unique_attr.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_unique_attr.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,
@@ -76,7 +79,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_unique_attr_in_db.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_unique_attr_in_db.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_unique_attr_same_tei.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_unique_attr_same_tei.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,
@@ -76,7 +79,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "COMPLETED",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_with_invalid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_with_invalid_option_value.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_with_valid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/enrollments_te_with_valid_option_value.json
@@ -41,7 +41,10 @@
         "identifier": "E8o1E9tAppy"
       },
       "status": "ACTIVE",
-      "orgUnit": "QfUVllTs6cS",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "QfUVllTs6cS"
+      },
       "enrolledAt": "2019-08-19T00:00:00.000",
       "occurredAt": "2019-08-19T00:00:00.000",
       "followUp": false,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EnrollmentMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EnrollmentMapper.java
@@ -46,6 +46,7 @@ import org.mapstruct.Mapping;
 interface EnrollmentMapper extends DomainMapper<Enrollment, org.hisp.dhis.tracker.domain.Enrollment>
 {
     @Mapping( target = "program", source = "program", qualifiedByName = "programToMetadataIdentifier" )
+    @Mapping( target = "orgUnit", source = "orgUnit", qualifiedByName = "orgUnitToMetadataIdentifier" )
     org.hisp.dhis.tracker.domain.Enrollment from( Enrollment enrollment,
         @Context TrackerIdSchemeParams idSchemeParams );
 


### PR DESCRIPTION
## This PR

* migrate Enrollment.orgUnit to MetadataIdentifier

## Background on changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in the query parameters (not in the body) and only on import. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute
* DataValue.dataElement
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo
* Event.attributeCategoryOptions
* TrackedEntity.trackedEntityType
* Relationship.relationshipType
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,ProgramOwner}.program
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,TrackedEntity,ProgramOwner}.orgUnit

will become idScheme aware.