### PR TITLE
feat: Add custom data entry form API endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -67,7 +67,10 @@ public interface IdentifiableObjectManager
 
     <T extends IdentifiableObject> T get( Class<T> type, long id );
 
-    <T extends IdentifiableObject> T get( Class<T> type, String uid );
+    <T extends IdentifiableObject> T get( Class<T> type, String uid )
+        throws IllegalQueryException;
+
+    <T extends IdentifiableObject> T getAndValidate( Class<T> type, String uid );
 
     <T extends IdentifiableObject> boolean exists( Class<T> type, String uid );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataentryform/DataEntryFormService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataentryform/DataEntryFormService.java
@@ -33,7 +33,6 @@ import java.util.regex.Pattern;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.i18n.I18n;
 
 /**
  * @author Bharath Kumar
@@ -107,31 +106,26 @@ public interface DataEntryFormService
      * Prepare DataEntryForm code for save by reversing the effects of
      * prepareDataEntryFormForEdit().
      *
-     * @return htmlCode the HTML code of the data entry form.
+     * @return data entry form content as HTML/CSS.
      */
     String prepareDataEntryFormForSave( String htmlCode );
 
     /**
-     * Prepares the data entry form code by injecting the data element operand
-     * name as value and title for each entry field.
+     * Prepares the data entry form for data entry by injecting required
+     * javascripts and drop down lists. The data set must have form type custom
+     * and have a data entry form associated.
      *
-     * @param dataEntryForm the data entry form.
      * @param dataSet the data set associated with this form.
-     * @param i18n the i18n object.
-     * @return HTML code for the data entry form.
+     * @return data entry form content as HTML/CSS.
      */
-    String prepareDataEntryFormForEdit( DataEntryForm dataEntryForm, DataSet dataSet, I18n i18n );
+    String prepareDataEntryFormForEntry( DataSet dataSet );
 
     /**
-     * Prepares the data entry form for data entry by injecting required
-     * javascripts and drop down lists.
+     * Returns the data elements which are referenced in the custom data entry
+     * form of the given data set.
      *
-     * @param dataEntryForm the data entry form.
-     * @param dataSet the data set associated with this form.
-     * @param i18n the i18n object.
-     * @return HTML code for the form.
+     * @param dataSet the data set.
+     * @return the set of data elements.
      */
-    String prepareDataEntryFormForEntry( DataEntryForm dataEntryForm, DataSet dataSet, I18n i18n );
-
     Set<DataElement> getDataElementsInDataEntryForm( DataSet dataSet );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -50,7 +50,9 @@ public enum ErrorCode
     E1109( "Could not remove item from collection: {0}" ),
     E1110( "Category combo not found or not accessible: `{0}`" ),
     E1111( "Category option not found or not accessible: `{0}`" ),
-    E1112( "Object(s) of type `{0}` not found or not accessible: `{1}`" ),
+    E1112( "Objects of type `{0}` not found or not accessible: `{1}`" ),
+    E1113( "Object of type `{0}` not found or not accessible: `{1}`" ),
+    E1114( "Data set form type must be custom: `{0}`" ),
 
     /* Org unit merge */
     E1500( "At least two source orgs unit must be specified" ),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -292,6 +292,20 @@ public class DefaultIdentifiableObjectManager
     }
 
     @Override
+    public <T extends IdentifiableObject> T getAndValidate( Class<T> type, String uid )
+        throws IllegalQueryException
+    {
+        T object = get( type, uid );
+
+        if ( object == null )
+        {
+            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1112, type.getSimpleName(), uid ) );
+        }
+
+        return object;
+    }
+
+    @Override
     @Transactional( readOnly = true )
     public <T extends IdentifiableObject> boolean exists( Class<T> type, String uid )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -299,7 +299,7 @@ public class DefaultIdentifiableObjectManager
 
         if ( object == null )
         {
-            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1112, type.getSimpleName(), uid ) );
+            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1113, type.getSimpleName(), uid ) );
         }
 
         return object;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.dataentryform;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.text.StringEscapeUtils.escapeHtml3;
 
 import java.util.HashSet;
@@ -37,7 +36,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
-import lombok.extern.slf4j.Slf4j;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdScheme;
@@ -47,11 +46,9 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
-import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.i18n.I18n;
-import org.hisp.dhis.indicator.Indicator;
-import org.hisp.dhis.indicator.IndicatorService;
+import org.hisp.dhis.i18n.I18nManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -60,15 +57,11 @@ import com.google.common.collect.Maps;
 /**
  * @author Bharath Kumar
  */
-@Slf4j
+@AllArgsConstructor
 @Service( "org.hisp.dhis.dataentryform.DataEntryFormService" )
 public class DefaultDataEntryFormService
     implements DataEntryFormService
 {
-    private static final String EMPTY_VALUE_TAG = "value=\"\"";
-
-    private static final String EMPTY_TITLE_TAG = "title=\"\"";
-
     private static final String TAG_CLOSE = "/>";
 
     private static final String EMPTY = "";
@@ -81,24 +74,7 @@ public class DefaultDataEntryFormService
 
     private final IdentifiableObjectManager idObjectManager;
 
-    private final DataElementService dataElementService;
-
-    private final IndicatorService indicatorService;
-
-    public DefaultDataEntryFormService( DataEntryFormStore dataEntryFormStore,
-        IdentifiableObjectManager idObjectManager, DataElementService dataElementService,
-        IndicatorService indicatorService )
-    {
-        checkNotNull( dataEntryFormStore );
-        checkNotNull( idObjectManager );
-        checkNotNull( dataElementService );
-        checkNotNull( indicatorService );
-
-        this.dataEntryFormStore = dataEntryFormStore;
-        this.idObjectManager = idObjectManager;
-        this.dataElementService = dataElementService;
-        this.indicatorService = indicatorService;
-    }
+    private final I18nManager i18nManager;
 
     // ------------------------------------------------------------------------
     // Implemented Methods
@@ -192,111 +168,13 @@ public class DefaultDataEntryFormService
 
     @Override
     @Transactional( readOnly = true )
-    public String prepareDataEntryFormForEdit( DataEntryForm dataEntryForm, DataSet dataSet, I18n i18n )
-    {
-        // ------------------------------------------------------------------------
-        // Only called for creation of CustomDataForm
-        // ------------------------------------------------------------------------
-
-        // TODO HTML encode names
-
-        if ( dataEntryForm == null || !dataEntryForm.hasForm() || dataSet == null )
-        {
-            return null;
-        }
-
-        CachingMap<String, CategoryOptionCombo> optionComboMap = new CachingMap<>();
-
-        optionComboMap.putAll( IdentifiableObjectUtils.getUidObjectMap( dataSet.getDataElementOptionCombos() ) );
-
-        StringBuffer sb = new StringBuffer();
-
-        Matcher inputMatcher = INPUT_PATTERN.matcher( dataEntryForm.getHtmlCode() );
-
-        while ( inputMatcher.find() )
-        {
-            String inputHtml = inputMatcher.group();
-
-            Matcher identifierMatcher = IDENTIFIER_PATTERN.matcher( inputHtml );
-            Matcher dataElementTotalMatcher = DATAELEMENT_TOTAL_PATTERN.matcher( inputHtml );
-            Matcher indicatorMatcher = INDICATOR_PATTERN.matcher( inputHtml );
-
-            String displayValue = null;
-            String displayTitle = null;
-
-            if ( identifierMatcher.find() && identifierMatcher.groupCount() > 0 )
-            {
-                String dataElementId = identifierMatcher.group( 1 );
-                DataElement dataElement = dataElementService.getDataElement( dataElementId );
-
-                String optionComboId = identifierMatcher.group( 2 );
-
-                CategoryOptionCombo categoryOptionCombo = optionComboMap.get( optionComboId,
-                    () -> idObjectManager.getObject( CategoryOptionCombo.class, IdScheme.UID, optionComboId ) );
-
-                String optionComboName = categoryOptionCombo != null ? escapeHtml3( categoryOptionCombo.getName() )
-                    : "[ " + i18n.getString( "cat_option_combo_not_exist" ) + " ]";
-
-                StringBuilder title = dataElement != null ? new StringBuilder( "title=\"" ).append( dataElementId )
-                    .append( " - " ).append( escapeHtml3( dataElement.getDisplayName() ) ).append( " - " )
-                    .append( optionComboId ).append( " - " ).append( optionComboName ).append( " - " )
-                    .append( dataElement.getValueType() ).append( "\"" ) : new StringBuilder();
-
-                displayValue = dataElement != null
-                    ? "value=\"[ " + escapeHtml3( dataElement.getDisplayName() ) + " " + optionComboName + " ]\""
-                    : "[ " + i18n.getString( "data_element_not_exist" ) + " ]";
-                displayTitle = dataElement != null ? title.toString()
-                    : "[ " + i18n.getString( "dataelement_not_exist" ) + " ]";
-            }
-            else if ( dataElementTotalMatcher.find() && dataElementTotalMatcher.groupCount() > 0 )
-            {
-                String dataElementId = dataElementTotalMatcher.group( 1 );
-                DataElement dataElement = dataElementService.getDataElement( dataElementId );
-
-                displayValue = dataElement != null ? "value=\"[ " + escapeHtml3( dataElement.getDisplayName() ) + " ]\""
-                    : "[ " + i18n.getString( "data_element_not_exist" ) + " ]";
-                displayTitle = dataElement != null ? "title=\"" + escapeHtml3( dataElement.getDisplayName() ) + "\""
-                    : "[ " + i18n.getString( "data_element_not_exist" ) + " ]";
-            }
-            else if ( indicatorMatcher.find() && indicatorMatcher.groupCount() > 0 )
-            {
-                String indicatorId = indicatorMatcher.group( 1 );
-                Indicator indicator = indicatorService.getIndicator( indicatorId );
-
-                displayValue = indicator != null ? "value=\"[ " + escapeHtml3( indicator.getDisplayName() ) + " ]\""
-                    : "[ " + i18n.getString( "indicator_not_exist" ) + " ]";
-                displayTitle = indicator != null ? "title=\"" + escapeHtml3( indicator.getDisplayName() ) + "\""
-                    : "[ " + i18n.getString( "indicator_not_exist" ) + " ]";
-            }
-
-            // -----------------------------------------------------------------
-            // Insert name of data element operand as value and title
-            // -----------------------------------------------------------------
-
-            if ( displayValue == null || displayTitle == null )
-            {
-                log.warn( "Ignoring invalid form markup: '" + inputHtml + "'" );
-                continue;
-            }
-
-            inputHtml = inputHtml.contains( EMPTY_VALUE_TAG ) ? inputHtml.replace( EMPTY_VALUE_TAG, displayValue )
-                : inputHtml.replace( TAG_CLOSE, (displayValue + TAG_CLOSE) );
-            inputHtml = inputHtml.contains( EMPTY_TITLE_TAG ) ? inputHtml.replace( EMPTY_TITLE_TAG, displayTitle )
-                : inputHtml.replace( TAG_CLOSE, (displayTitle + TAG_CLOSE) );
-
-            inputMatcher.appendReplacement( sb, inputHtml );
-        }
-
-        inputMatcher.appendTail( sb );
-
-        return sb.toString();
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public String prepareDataEntryFormForEntry( DataEntryForm dataEntryForm, DataSet dataSet, I18n i18n )
+    public String prepareDataEntryFormForEntry( DataSet dataSet )
     {
         // TODO HTML encode names
+
+        DataEntryForm dataEntryForm = dataSet.getDataEntryForm();
+
+        I18n i18n = i18nManager.getI18n();
 
         if ( dataEntryForm == null || !dataEntryForm.hasForm() || dataSet == null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
@@ -176,7 +176,7 @@ public class DefaultDataEntryFormService
     {
         // TODO HTML encode names
 
-        if ( dataSet == null || dataSet.getFormType() != FormType.CUSTOM || !dataSet.hasDataEntryForm() )
+        if ( dataSet.getFormType() != FormType.CUSTOM || !dataSet.hasDataEntryForm() )
         {
             throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1114, dataSet.getUid() ) );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataentryform/DefaultDataEntryFormService.java
@@ -42,11 +42,15 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.FormType;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
 import org.springframework.stereotype.Service;
@@ -172,14 +176,14 @@ public class DefaultDataEntryFormService
     {
         // TODO HTML encode names
 
+        if ( dataSet == null || dataSet.getFormType() != FormType.CUSTOM || !dataSet.hasDataEntryForm() )
+        {
+            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1114, dataSet.getUid() ) );
+        }
+
         DataEntryForm dataEntryForm = dataSet.getDataEntryForm();
 
         I18n i18n = i18nManager.getI18n();
-
-        if ( dataEntryForm == null || !dataEntryForm.hasForm() || dataSet == null )
-        {
-            return null;
-        }
 
         // ---------------------------------------------------------------------
         // Inline javascript/html to add to HTML before output

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -137,7 +137,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
 
         IllegalQueryException ex = assertThrows( IllegalQueryException.class,
             () -> idObjectManager.getAndValidate( DataElement.class, "nonExisting" ) );
-        assertEquals( ErrorCode.E1114, ex.getErrorCode() );
+        assertEquals( ErrorCode.E1113, ex.getErrorCode() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -79,7 +79,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     private DataElementService dataElementService;
 
     @Autowired
-    private IdentifiableObjectManager identifiableObjectManager;
+    private IdentifiableObjectManager idObjectManager;
 
     @Autowired
     private UserService _userService;
@@ -96,9 +96,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         DataElement dataElementA = createDataElement( 'A' );
         dataElementService.addDataElement( dataElementA );
-        assertEquals( dataElementA, identifiableObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
+        assertEquals( dataElementA, idObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
             IdScheme.CODE, dataElementA.getCode() ) );
-        assertEquals( dataElementA, identifiableObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
+        assertEquals( dataElementA, idObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
             IdScheme.UID, dataElementA.getUid() ) );
     }
 
@@ -118,13 +118,26 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementService.addDataElementGroup( dataElementGroupB );
         long dataElementGroupIdB = dataElementGroupB.getId();
         assertEquals( dataElementA,
-            identifiableObjectManager.getObject( dataElementIdA, DataElement.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementIdA, DataElement.class.getSimpleName() ) );
         assertEquals( dataElementB,
-            identifiableObjectManager.getObject( dataElementIdB, DataElement.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementIdB, DataElement.class.getSimpleName() ) );
         assertEquals( dataElementGroupA,
-            identifiableObjectManager.getObject( dataElementGroupIdA, DataElementGroup.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementGroupIdA, DataElementGroup.class.getSimpleName() ) );
         assertEquals( dataElementGroupB,
-            identifiableObjectManager.getObject( dataElementGroupIdB, DataElementGroup.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementGroupIdB, DataElementGroup.class.getSimpleName() ) );
+    }
+
+    @Test
+    void testGetAndValidate()
+    {
+        DataElement dataElementA = createDataElement( 'A' );
+        dataElementService.addDataElement( dataElementA );
+
+        assertEquals( dataElementA, idObjectManager.getAndValidate( DataElement.class, dataElementA.getUid() ) );
+
+        IllegalQueryException ex = assertThrows( IllegalQueryException.class,
+            () -> idObjectManager.getAndValidate( DataElement.class, "nonExisting" ) );
+        assertEquals( ErrorCode.E1114, ex.getErrorCode() );
     }
 
     @Test
@@ -136,8 +149,8 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementService.addDataElement( dataElementB );
         Set<Class<? extends IdentifiableObject>> classes = ImmutableSet.<Class<? extends IdentifiableObject>> builder()
             .add( Indicator.class ).add( DataElement.class ).add( DataElementOperand.class ).build();
-        assertEquals( dataElementA, identifiableObjectManager.get( classes, dataElementA.getUid() ) );
-        assertEquals( dataElementB, identifiableObjectManager.get( classes, dataElementB.getUid() ) );
+        assertEquals( dataElementA, idObjectManager.get( classes, dataElementA.getUid() ) );
+        assertEquals( dataElementB, idObjectManager.get( classes, dataElementB.getUid() ) );
     }
 
     @Test
@@ -149,23 +162,23 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementService.addDataElement( dataElementB );
         OrganisationUnit unitA = createOrganisationUnit( 'A' );
         OrganisationUnit unitB = createOrganisationUnit( 'B' );
-        identifiableObjectManager.save( unitA );
-        identifiableObjectManager.save( unitB );
+        idObjectManager.save( unitA );
+        idObjectManager.save( unitB );
         Set<Class<? extends IdentifiableObject>> classes = ImmutableSet.<Class<? extends IdentifiableObject>> builder()
             .add( DataElement.class ).add( OrganisationUnit.class ).build();
         Set<String> uids = ImmutableSet.of( dataElementA.getUid(), unitB.getUid() );
-        assertEquals( 2, identifiableObjectManager.getByUid( classes, uids ).size() );
-        assertTrue( identifiableObjectManager.getByUid( classes, uids ).contains( dataElementA ) );
-        assertTrue( identifiableObjectManager.getByUid( classes, uids ).contains( unitB ) );
-        assertFalse( identifiableObjectManager.getByUid( classes, uids ).contains( dataElementB ) );
-        assertFalse( identifiableObjectManager.getByUid( classes, uids ).contains( unitA ) );
+        assertEquals( 2, idObjectManager.getByUid( classes, uids ).size() );
+        assertTrue( idObjectManager.getByUid( classes, uids ).contains( dataElementA ) );
+        assertTrue( idObjectManager.getByUid( classes, uids ).contains( unitB ) );
+        assertFalse( idObjectManager.getByUid( classes, uids ).contains( dataElementB ) );
+        assertFalse( idObjectManager.getByUid( classes, uids ).contains( unitA ) );
     }
 
     @Test
     void publicAccessSetIfNoUser()
     {
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getPublicAccess() );
         assertFalse( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertFalse( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
@@ -174,31 +187,31 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     @Test
     void getCount()
     {
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
     }
 
     @Test
     void getEqualToName()
     {
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
-        assertNotNull( identifiableObjectManager.getByName( DataElement.class, "DataElementA" ) );
-        assertNull( identifiableObjectManager.getByName( DataElement.class, "DataElementB" ) );
-        assertEquals( dataElement, identifiableObjectManager.getByName( DataElement.class, "DataElementA" ) );
+        idObjectManager.save( dataElement );
+        assertNotNull( idObjectManager.getByName( DataElement.class, "DataElementA" ) );
+        assertNull( idObjectManager.getByName( DataElement.class, "DataElementB" ) );
+        assertEquals( dataElement, idObjectManager.getByName( DataElement.class, "DataElementA" ) );
     }
 
     @Test
     void getAllOrderedName()
     {
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        List<DataElement> dataElements = new ArrayList<>( identifiableObjectManager.getAllSorted( DataElement.class ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'A' ) );
+        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAllSorted( DataElement.class ) );
         assertEquals( 4, dataElements.size() );
         assertEquals( "DataElementA", dataElements.get( 0 ).getName() );
         assertEquals( "DataElementB", dataElements.get( 1 ).getName() );
@@ -211,7 +224,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         User user = createUserAndInjectSecurityContext( true );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getCreatedBy() );
         assertEquals( user, dataElement.getCreatedBy() );
     }
@@ -221,7 +234,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD" );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getPublicAccess() );
         assertTrue( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertTrue( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
@@ -232,7 +245,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getPublicAccess() );
         assertFalse( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertFalse( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
@@ -243,7 +256,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false );
         assertThrows( CreateAccessDeniedException.class,
-            () -> identifiableObjectManager.save( createDataElement( 'A' ) ) );
+            () -> idObjectManager.save( createDataElement( 'A' ) ) );
     }
 
     @Test
@@ -252,7 +265,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
         assertFalse( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertFalse( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
     }
@@ -263,7 +276,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
     }
 
     @Test
@@ -272,7 +285,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        assertThrows( CreateAccessDeniedException.class, () -> identifiableObjectManager.save( dataElement, false ) );
+        assertThrows( CreateAccessDeniedException.class, () -> idObjectManager.save( dataElement, false ) );
     }
 
     @Test
@@ -281,7 +294,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
     }
 
     @Test
@@ -290,9 +303,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        assertThrows( UpdateAccessDeniedException.class, () -> identifiableObjectManager.update( dataElement ) );
+        assertThrows( UpdateAccessDeniedException.class, () -> idObjectManager.update( dataElement ) );
     }
 
     @Test
@@ -301,7 +314,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        assertThrows( CreateAccessDeniedException.class, () -> identifiableObjectManager.save( dataElement, false ) );
+        assertThrows( CreateAccessDeniedException.class, () -> idObjectManager.save( dataElement, false ) );
     }
 
     @Test
@@ -309,24 +322,24 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD", "F_USER_ADD" );
         User user = createUser( 'B' );
-        identifiableObjectManager.save( user );
+        idObjectManager.save( user );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         dataElement.setOwner( user.getUid() );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
         sessionFactory.getCurrentSession().update( dataElement );
-        assertThrows( DeleteAccessDeniedException.class, () -> identifiableObjectManager.delete( dataElement ) );
+        assertThrows( DeleteAccessDeniedException.class, () -> idObjectManager.delete( dataElement ) );
     }
 
     @Test
     void objectsWithNoUser()
     {
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
     }
 
     @Test
@@ -334,21 +347,21 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD", "F_USER_ADD" );
         User user = createUser( 'B' );
-        identifiableObjectManager.save( user );
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
-        List<DataElement> dataElements = new ArrayList<>( identifiableObjectManager.getAll( DataElement.class ) );
+        idObjectManager.save( user );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
+        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAll( DataElement.class ) );
         for ( DataElement dataElement : dataElements )
         {
             dataElement.setOwner( user.getUid() );
             dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
             sessionFactory.getCurrentSession().update( dataElement );
         }
-        assertEquals( 0, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 0, identifiableObjectManager.getAll( DataElement.class ).size() );
+        assertEquals( 0, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 0, idObjectManager.getAll( DataElement.class ).size() );
     }
 
     @Test
@@ -357,20 +370,20 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         User loginUser = createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD", "F_USER_ADD",
             "F_USERGROUP_PUBLIC_ADD" );
         User user = createUser( 'B' );
-        identifiableObjectManager.save( user );
+        idObjectManager.save( user );
         UserGroup userGroup = createUserGroup( 'A', Sets.newHashSet( loginUser ) );
-        identifiableObjectManager.save( userGroup );
+        idObjectManager.save( userGroup );
         user.getGroups().add( userGroup );
         loginUser.getGroups().add( userGroup );
-        identifiableObjectManager.save( loginUser );
-        identifiableObjectManager.save( user );
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
-        List<DataElement> dataElements = new ArrayList<>( identifiableObjectManager.getAll( DataElement.class ) );
+        idObjectManager.save( loginUser );
+        idObjectManager.save( user );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
+        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAll( DataElement.class ) );
         for ( DataElement dataElement : dataElements )
         {
             dataElement.getSharing().setOwner( user );
@@ -378,9 +391,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
             dataElement.getSharing().addUserGroupAccess( new UserGroupAccess( userGroup, AccessStringHelper.READ ) );
             sessionFactory.getCurrentSession().update( dataElement );
         }
-        identifiableObjectManager.flush();
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
+        idObjectManager.flush();
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
     }
 
     @Test
@@ -390,13 +403,13 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<DataElement> ab = identifiableObjectManager.getByUid( DataElement.class,
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<DataElement> ab = idObjectManager.getByUid( DataElement.class,
             Arrays.asList( dataElementA.getUid(), dataElementB.getUid() ) );
-        List<DataElement> cd = identifiableObjectManager.getByUid( DataElement.class,
+        List<DataElement> cd = idObjectManager.getByUid( DataElement.class,
             Arrays.asList( dataElementC.getUid(), dataElementD.getUid() ) );
         assertTrue( ab.contains( dataElementA ) );
         assertTrue( ab.contains( dataElementB ) );
@@ -414,10 +427,10 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementA = createDataElement( 'A' );
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        List<DataElement> ab = identifiableObjectManager.getAndValidateByUid( DataElement.class,
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        List<DataElement> ab = idObjectManager.getAndValidateByUid( DataElement.class,
             Arrays.asList( dataElementA.getUid(), dataElementB.getUid() ) );
         assertTrue( ab.contains( dataElementA ) );
         assertTrue( ab.contains( dataElementB ) );
@@ -428,8 +441,8 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     void getAndValidateByUidExceptionTest()
     {
         DataElement dataElementA = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElementA );
-        IllegalQueryException ex = assertThrows( IllegalQueryException.class, () -> identifiableObjectManager
+        idObjectManager.save( dataElementA );
+        IllegalQueryException ex = assertThrows( IllegalQueryException.class, () -> idObjectManager
             .getAndValidateByUid( DataElement.class, Arrays.asList( dataElementA.getUid(), "xhjG82jHaky" ) ) );
         assertEquals( ErrorCode.E1112, ex.getErrorCode() );
     }
@@ -441,16 +454,16 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
         List<String> uids = Arrays.asList( dataElementA.getUid(), dataElementC.getUid(), dataElementB.getUid(),
             dataElementD.getUid() );
         List<DataElement> expected = new ArrayList<>(
             Arrays.asList( dataElementA, dataElementC, dataElementB, dataElementD ) );
         List<DataElement> actual = new ArrayList<>(
-            identifiableObjectManager.getOrdered( DataElement.class, IdScheme.UID, uids ) );
+            idObjectManager.getOrdered( DataElement.class, IdScheme.UID, uids ) );
         assertEquals( expected, actual );
     }
 
@@ -461,16 +474,16 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
         List<String> codes = Arrays.asList( dataElementA.getCode(), dataElementC.getCode(), dataElementB.getCode(),
             dataElementD.getCode() );
         List<DataElement> expected = new ArrayList<>(
             Arrays.asList( dataElementA, dataElementC, dataElementB, dataElementD ) );
         List<DataElement> actual = new ArrayList<>(
-            identifiableObjectManager.getOrdered( DataElement.class, IdScheme.CODE, codes ) );
+            idObjectManager.getOrdered( DataElement.class, IdScheme.CODE, codes ) );
         assertEquals( expected, actual );
     }
 
@@ -481,16 +494,16 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
         List<String> uids = Arrays.asList( dataElementA.getUid(), dataElementC.getUid(), dataElementB.getUid(),
             dataElementD.getUid() );
         List<DataElement> expected = new ArrayList<>(
             Arrays.asList( dataElementA, dataElementC, dataElementB, dataElementD ) );
         List<DataElement> actual = new ArrayList<>(
-            identifiableObjectManager.getByUidOrdered( DataElement.class, uids ) );
+            idObjectManager.getByUidOrdered( DataElement.class, uids ) );
         assertEquals( expected, actual );
     }
 
@@ -505,13 +518,13 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementB.setCode( "DE_B" );
         dataElementC.setCode( "DE_C" );
         dataElementD.setCode( "DE_D" );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<DataElement> ab = identifiableObjectManager.getByCode( DataElement.class,
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<DataElement> ab = idObjectManager.getByCode( DataElement.class,
             Arrays.asList( dataElementA.getCode(), dataElementB.getCode() ) );
-        List<DataElement> cd = identifiableObjectManager.getByCode( DataElement.class,
+        List<DataElement> cd = idObjectManager.getByCode( DataElement.class,
             Arrays.asList( dataElementC.getCode(), dataElementD.getCode() ) );
         assertTrue( ab.contains( dataElementA ) );
         assertTrue( ab.contains( dataElementB ) );
@@ -533,12 +546,12 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementB.setCode( "DE_B" );
         dataElementC.setCode( "DE_C" );
         OrganisationUnit unit1 = createOrganisationUnit( 'A' );
-        identifiableObjectManager.save( unit1 );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
+        idObjectManager.save( unit1 );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
         List<String> uids = Lists.newArrayList( dataElementA.getUid(), dataElementB.getUid(), dataElementC.getUid() );
-        List<DataElement> dataElements = identifiableObjectManager.getNoAcl( DataElement.class, uids );
+        List<DataElement> dataElements = idObjectManager.getNoAcl( DataElement.class, uids );
         assertEquals( 3, dataElements.size() );
         assertTrue( dataElements.contains( dataElementA ) );
         assertTrue( dataElements.contains( dataElementB ) );
@@ -551,11 +564,11 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         OrganisationUnit unit1 = createOrganisationUnit( 'A' );
         OrganisationUnit unit2 = createOrganisationUnit( 'B' );
         OrganisationUnit unit3 = createOrganisationUnit( 'C' );
-        identifiableObjectManager.save( unit1 );
-        identifiableObjectManager.save( unit2 );
-        identifiableObjectManager.save( unit3 );
+        idObjectManager.save( unit1 );
+        idObjectManager.save( unit2 );
+        idObjectManager.save( unit3 );
         Set<String> codes = Sets.newHashSet( unit2.getCode(), unit3.getCode() );
-        List<OrganisationUnit> units = identifiableObjectManager.getObjects( OrganisationUnit.class,
+        List<OrganisationUnit> units = idObjectManager.getObjects( OrganisationUnit.class,
             IdentifiableProperty.CODE, codes );
         assertEquals( 2, units.size() );
         assertTrue( units.contains( unit2 ) );
@@ -569,7 +582,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         dataElementService.addDataElement( dataElementA );
         dataElementService.addDataElement( dataElementB );
-        Map<String, DataElement> map = identifiableObjectManager.getIdMap( DataElement.class, IdScheme.CODE );
+        Map<String, DataElement> map = idObjectManager.getIdMap( DataElement.class, IdScheme.CODE );
         assertEquals( dataElementA, map.get( "DataElementCodeA" ) );
         assertEquals( dataElementB, map.get( "DataElementCodeB" ) );
         assertNull( map.get( "DataElementCodeX" ) );
@@ -581,19 +594,19 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         User userA = createUser( 'A' );
         userService.addUser( userA );
         UserGroup userGroupA = createUserGroup( 'A', Sets.newHashSet( userA ) );
-        identifiableObjectManager.save( userGroupA );
+        idObjectManager.save( userGroupA );
         String userGroupUid = userGroupA.getUid();
         DataElement de = createDataElement( 'A' );
         Sharing sharing = new Sharing();
         sharing.setUserGroupAccess( singleton( new UserGroupAccess( "rw------", userGroupA.getUid() ) ) );
         de.setSharing( sharing );
-        identifiableObjectManager.save( de, false );
-        de = identifiableObjectManager.get( de.getUid() );
+        idObjectManager.save( de, false );
+        de = idObjectManager.get( de.getUid() );
         assertEquals( 1, de.getSharing().getUserGroups().size() );
-        identifiableObjectManager.delete( userGroupA );
-        identifiableObjectManager.removeUserGroupFromSharing( userGroupUid );
+        idObjectManager.delete( userGroupA );
+        idObjectManager.removeUserGroupFromSharing( userGroupUid );
         dbmsManager.clearSession();
-        de = identifiableObjectManager.get( de.getUid() );
+        de = idObjectManager.get( de.getUid() );
         assertEquals( 0, de.getSharing().getUserGroups().size() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataentryform/DataEntryFormServiceTest.java
@@ -35,14 +35,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 
 import org.hisp.dhis.DhisSpringTest;
-import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetService;
-import org.hisp.dhis.i18n.I18n;
-import org.hisp.dhis.mock.MockI18n;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.PeriodType;
 import org.junit.jupiter.api.Test;
@@ -63,20 +59,9 @@ class DataEntryFormServiceTest extends DhisSpringTest
     @Autowired
     private DataElementService dataElementService;
 
-    @Autowired
-    private CategoryService categoryService;
-
     private PeriodType periodType;
 
     private DataElement dataElement;
-
-    private CategoryOptionCombo categoryOptionCombo;
-
-    private I18n i18n;
-
-    private String dataElementUid;
-
-    private String categoryOptionComboUid;
 
     // -------------------------------------------------------------------------
     // Fixture
@@ -88,10 +73,6 @@ class DataEntryFormServiceTest extends DhisSpringTest
         periodType = new MonthlyPeriodType();
         dataElement = createDataElement( 'A' );
         dataElementService.addDataElement( dataElement );
-        categoryOptionCombo = categoryService.getDefaultCategoryOptionCombo();
-        dataElementUid = dataElement.getUid();
-        categoryOptionComboUid = categoryOptionCombo.getUid();
-        i18n = new MockI18n();
     }
 
     // -------------------------------------------------------------------------
@@ -173,22 +154,5 @@ class DataEntryFormServiceTest extends DhisSpringTest
         String expected = "<table><tr><td><input id=\"1434-11-val\" style=\"width:4em;text-align:center\" title=\"\" value=\"\" /></td></tr></table>";
         String actual = dataEntryFormService.prepareDataEntryFormForSave( html );
         assertEquals( expected, actual );
-    }
-
-    @Test
-    void testPrepareForEdit()
-    {
-        String html = "<table><tr><td><input id=\"" + dataElementUid + "-" + categoryOptionComboUid
-            + "-val\" style=\"width:4em;text-align:center\" title=\"\" value=\"\" /></td></tr></table>";
-        String title = "" + dataElementUid + " - " + dataElement.getName() + " - " + categoryOptionComboUid + " - "
-            + categoryOptionCombo.getName() + " - " + dataElement.getValueType();
-        String value = "[ " + dataElement.getName() + " " + categoryOptionCombo.getName() + " ]";
-        String expected = "<table><tr><td><input id=\"" + dataElementUid + "-" + categoryOptionComboUid
-            + "-val\" style=\"width:4em;text-align:center\" title=\"" + title + "\" value=\"" + value
-            + "\" /></td></tr></table>";
-        DataSet dsA = createDataSet( 'A', null );
-        DataEntryForm dfA = createDataEntryForm( 'A', html );
-        String actual = dataEntryFormService.prepareDataEntryFormForEdit( dfA, dsA, i18n );
-        assertEquals( expected.length(), actual.length() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -51,7 +51,7 @@ public class CustomDataEntryFormController
 {
     private final IdentifiableObjectManager idObjectManager;
 
-    @GetMapping( "/customDataEntryForms/{uid}" )
+    @GetMapping( "/customForms/{uid}" )
     public CustomDataEntryFormDto getForm( @PathVariable String uid )
     {
         DataSet dataSet = idObjectManager.getAndValidate( DataSet.class, uid );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -31,12 +31,8 @@ import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataentryform.DataEntryFormService;
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.dataset.FormType;
-import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.webdomain.dataentry.CustomDataEntryFormDto;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -58,11 +54,6 @@ public class CustomDataEntryFormController
     public CustomDataEntryFormDto getForm( @PathVariable String uid )
     {
         DataSet dataSet = idObjectManager.getAndValidate( DataSet.class, uid );
-
-        if ( dataSet.getFormType() != FormType.CUSTOM || !dataSet.hasDataEntryForm() )
-        {
-            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1114, uid ) );
-        }
 
         String form = dataEntryFormService.prepareDataEntryFormForEntry( dataSet );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -61,7 +61,7 @@ public class CustomDataEntryFormController
             .setId( dataSet.getDataEntryForm().getUid() )
             .setDataSetId( dataSet.getUid() )
             .setVersion( dataSet.getVersion() )
-            .setForm( form )
-            .setDisplayDensity( dataSet.getDataEntryForm().getStyle() );
+            .setDisplayDensity( dataSet.getDataEntryForm().getStyle() )
+            .setForm( form );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -63,6 +63,7 @@ public class CustomDataEntryFormController
 
         return new CustomDataEntryFormDto()
             .setId( dataSet.getDataEntryForm().getUid() )
+            .setDataSetId( dataSet.getUid() )
             .setVersion( dataSet.getVersion() )
             .setForm( dataSet.getDataEntryForm().getHtmlCode() )
             .setDisplayDensity( dataSet.getDataEntryForm().getStyle() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.dataentry;
+
+import lombok.AllArgsConstructor;
+
+import org.hisp.dhis.common.DhisApiVersion;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.FormType;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
+import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
+import org.hisp.dhis.webapi.webdomain.dataentry.CustomDataEntryFormDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping( "/dataEntry" )
+@AllArgsConstructor
+@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+public class CustomDataEntryFormController
+{
+    private final IdentifiableObjectManager idObjectManager;
+
+    @GetMapping( "/customDataEntryForms/{uid}" )
+    public CustomDataEntryFormDto getForm( @PathVariable String uid )
+    {
+        DataSet dataSet = idObjectManager.getAndValidate( DataSet.class, uid );
+
+        if ( dataSet.getFormType() != FormType.CUSTOM || !dataSet.hasDataEntryForm() )
+        {
+            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1114, uid ) );
+        }
+
+        return new CustomDataEntryFormDto()
+            .setId( dataSet.getDataEntryForm().getUid() )
+            .setVersion( dataSet.getVersion() )
+            .setForm( dataSet.getDataEntryForm().getHtmlCode() )
+            .setDisplayDensity( dataSet.getDataEntryForm().getStyle() );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/CustomDataEntryFormController.java
@@ -32,6 +32,7 @@ import lombok.AllArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.dataentryform.DataEntryFormService;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.FormType;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -49,6 +50,8 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class CustomDataEntryFormController
 {
+    private final DataEntryFormService dataEntryFormService;
+
     private final IdentifiableObjectManager idObjectManager;
 
     @GetMapping( "/customForms/{uid}" )
@@ -61,11 +64,13 @@ public class CustomDataEntryFormController
             throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1114, uid ) );
         }
 
+        String form = dataEntryFormService.prepareDataEntryFormForEntry( dataSet );
+
         return new CustomDataEntryFormDto()
             .setId( dataSet.getDataEntryForm().getUid() )
             .setDataSetId( dataSet.getUid() )
             .setVersion( dataSet.getVersion() )
-            .setForm( dataSet.getDataEntryForm().getHtmlCode() )
+            .setForm( form )
             .setDisplayDensity( dataSet.getDataEntryForm().getStyle() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetMetadataExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/dataentry/DataSetMetadataExportController.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.metadata;
+package org.hisp.dhis.webapi.controller.dataentry;
 
 import lombok.AllArgsConstructor;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/dataentry/CustomDataEntryFormDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/dataentry/CustomDataEntryFormDto.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.webdomain.dataentry;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+import org.hisp.dhis.common.DisplayDensity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO which represents a custom data entry form.
+ *
+ * @author Lars Helge Overland
+ */
+@Getter
+@Setter
+@Accessors( chain = true )
+@NoArgsConstructor
+public class CustomDataEntryFormDto
+{
+    /**
+     * Form identifier.
+     */
+    @JsonProperty
+    private String id;
+
+    /**
+     * Form version.
+     */
+    @JsonProperty
+    private Integer version;
+
+    /**
+     * Form content, may contain CSS, HTML and Javascript.
+     */
+    @JsonProperty
+    private String form;
+
+    /**
+     * Form display density.
+     */
+    @JsonProperty
+    private DisplayDensity displayDensity;
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/dataentry/CustomDataEntryFormDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/dataentry/CustomDataEntryFormDto.java
@@ -66,14 +66,14 @@ public class CustomDataEntryFormDto
     private Integer version;
 
     /**
-     * Form content, may contain CSS, HTML and Javascript.
-     */
-    @JsonProperty
-    private String form;
-
-    /**
      * Form display density.
      */
     @JsonProperty
     private DisplayDensity displayDensity;
+
+    /**
+     * Form content, may contain CSS, HTML and Javascript.
+     */
+    @JsonProperty
+    private String form;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/dataentry/CustomDataEntryFormDto.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/dataentry/CustomDataEntryFormDto.java
@@ -54,6 +54,12 @@ public class CustomDataEntryFormDto
     private String id;
 
     /**
+     * Data set identifier.
+     */
+    @JsonProperty
+    private String dataSetId;
+
+    /**
      * Form version.
      */
     @JsonProperty

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/LoadFormAction.java
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/LoadFormAction.java
@@ -59,7 +59,6 @@ import org.hisp.dhis.dataset.comparator.SectionOrderComparator;
 import org.hisp.dhis.datavalue.AggregateAccessManager;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.util.SectionUtils;
-import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.user.CurrentUserService;
@@ -115,13 +114,6 @@ public class LoadFormAction
     public void setCurrentUserService( CurrentUserService currentUserService )
     {
         this.currentUserService = currentUserService;
-    }
-
-    private I18n i18n;
-
-    public void setI18n( I18n i18n )
-    {
-        this.i18n = i18n;
     }
 
     @Autowired
@@ -301,7 +293,7 @@ public class LoadFormAction
         if ( formType.isCustom() && dataSet.hasDataEntryForm() )
         {
             dataEntryForm = dataSet.getDataEntryForm();
-            customDataEntryFormCode = dataEntryFormService.prepareDataEntryFormForEntry( dataEntryForm, dataSet, i18n );
+            customDataEntryFormCode = dataEntryFormService.prepareDataEntryFormForEntry( dataSet );
             return formType.toString();
         }
 


### PR DESCRIPTION
### Overview

Adds a custom data entry form API endpoint at the following API path, where the `id` refers to the data set UID. The response type is JSON.

```
GET /api/dataEntry/customForms/{id}
```

Removes unused method from `DataEntryFormService`.

### Testing

* Unit tests added.
* Test URL for valid form: `/api/dataEntry/customForms/lyLU2wR22tC`
* Test URL for non-custom form: `/api/dataEntry/customForms/BfMAe6Itzgt`
* Test URL for non-existing data set: `/api/dataEntry/customForms/lyLU2wR22tX`
