### PR TITLE
ci: auto merge dependabot patch PRs

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch metadata on dependabot PR
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.1
+      - name: Approve dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for dependabot PR
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This is a new workflow (based on [the official GitHub docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions\#enable-auto-merge-on-a-pull-request)) to automatically merge patch dependency updates.

The workflow would run a job only if the PR event is caused by the GitHub dependabot!

The workflow would
* use https://github.com/dependabot/fetch-metadata#usage-instructions to get information about the dependencies being updated
* approve the PR if the dependencies updated are only of semver patch
* enable automerge on this specific PR so that if all required checks are successful the PR would automatically be merged

For auto-merge to work a repo admin would need to enable it in the repo settings
https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request#about-auto-merge

We are leveraging this already in the dhis2-sre organization. See an example at https://github.com/dhis2-sre/im-user/actions/runs/2232215226

