### PR TITLE
fix: app hub returns 503 when internal app hub request fails [DHIS2-13107]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/DefaultAppHubService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/apphub/DefaultAppHubService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.apphub;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.apphub.AppHubUtils.getJsonRequestEntity;
 import static org.hisp.dhis.apphub.AppHubUtils.sanitizeQuery;
 import static org.hisp.dhis.apphub.AppHubUtils.validateApiVersion;
@@ -45,6 +44,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.io.IOUtils;
@@ -53,7 +53,6 @@ import org.hisp.dhis.appmanager.AppStatus;
 import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -62,26 +61,15 @@ import org.springframework.web.client.RestTemplate;
  * @author Lars Helge Overland
  */
 @Slf4j
-@Service( "org.hisp.dhis.apphub.AppHubService" )
-public class DefaultAppHubService
-    implements AppHubService
+@Service
+@AllArgsConstructor
+public class DefaultAppHubService implements AppHubService
 {
     private final RestTemplate restTemplate;
 
     private final AppManager appManager;
 
     private final DhisConfigurationProvider dhisConfigurationProvider;
-
-    public DefaultAppHubService( RestTemplate restTemplate, AppManager appManager,
-        DhisConfigurationProvider dhisConfigurationProvider )
-    {
-        checkNotNull( restTemplate );
-        checkNotNull( appManager );
-        checkNotNull( dhisConfigurationProvider );
-        this.restTemplate = restTemplate;
-        this.appManager = appManager;
-        this.dhisConfigurationProvider = dhisConfigurationProvider;
-    }
 
     @Override
     public String getAppHubApiResponse( String apiVersion, String query )
@@ -102,10 +90,7 @@ public class DefaultAppHubService
 
         log.info( "App Hub proxy request URL: '{}'", url );
 
-        ResponseEntity<String> response = restTemplate.exchange( new URI( url ), HttpMethod.GET, getJsonRequestEntity(),
-            String.class );
-
-        return response.getBody();
+        return restTemplate.exchange( new URI( url ), HttpMethod.GET, getJsonRequestEntity(), String.class ).getBody();
     }
 
     @Override

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AppHubControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AppHubControllerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.hisp.dhis.external.conf.ConfigurationKey;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the {@link AppHubController} using (mocked) REST requests.
+ *
+ * @author Jan Bernitt
+ */
+class AppHubControllerTest extends DhisControllerConvenienceTest
+{
+    @Autowired
+    private DhisConfigurationProvider configuration;
+
+    @AfterEach
+    void cleanUp()
+    {
+        // back to default
+        configuration.getProperties().remove( ConfigurationKey.APPHUB_API_URL.getKey() );
+    }
+
+    @Test
+    void testListAppHub()
+    {
+        JsonArray apps = GET( "/appHub" ).content();
+        assertTrue( apps.isArray() );
+        assertTrue( apps.size() > 0, "There should be apps registered" );
+    }
+
+    @Test
+    void testListAppHub_ClientError()
+    {
+        configuration.getProperties().setProperty( ConfigurationKey.APPHUB_API_URL.getKey(),
+            "http://localhost/doesnotwork" );
+        assertWebMessage( "Service Unavailable", 503, "ERROR",
+            "I/O error on GET request for \"http://localhost/doesnotwork/apps\": Connection refused (Connection refused); nested exception is java.net.ConnectException: Connection refused (Connection refused)",
+            GET( "/appHub" ).content( HttpStatus.SERVICE_UNAVAILABLE ) );
+    }
+
+    @Test
+    void testGetAppHubApiResponse()
+    {
+        assertWebMessage( "Not Found", 404, "ERROR",
+            "404 Not Found: \"{\"statusCode\":404,\"error\":\"Not Found\",\"message\":\"Not Found\"}\"",
+            GET( "/appHub/v37/test" ).content( HttpStatus.NOT_FOUND ) );
+    }
+
+    @Test
+    void testGetAppHubApiResponse_ClientError()
+    {
+        configuration.getProperties().setProperty( ConfigurationKey.APPHUB_API_URL.getKey(),
+            "http://localhost/doesnotwork" );
+        assertWebMessage( "Service Unavailable", 503, "ERROR",
+            "I/O error on GET request for \"http://localhost/doesnotwork/v37/test\": Connection refused (Connection refused); nested exception is java.net.ConnectException: Connection refused (Connection refused)",
+            GET( "/appHub/v37/test" ).content( HttpStatus.SERVICE_UNAVAILABLE ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppHubController.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
 
@@ -75,7 +74,6 @@ public class AppHubController
      */
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     public List<WebApp> listAppHub()
-        throws IOException
     {
         return appHubService.getAppHub();
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -93,6 +93,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
 
 import com.fasterxml.jackson.core.JsonParseException;
 
@@ -113,6 +114,13 @@ public class CrudControllerAdvice
     {
         binder.registerCustomEditor( Date.class, new FromTextPropertyEditor( DateUtils::parseDate ) );
         binder.registerCustomEditor( IdentifiableProperty.class, new FromTextPropertyEditor( String::toUpperCase ) );
+    }
+
+    @ExceptionHandler( RestClientException.class )
+    @ResponseBody
+    public WebMessage restClientExceptionHandler( RestClientException ex )
+    {
+        return createWebMessage( ex.getMessage(), Status.ERROR, HttpStatus.SERVICE_UNAVAILABLE );
     }
 
     @ExceptionHandler( IllegalQueryException.class )


### PR DESCRIPTION
### Summary
The best fix here seemed to me to map the `RestClientException` to a `WebMessage` with `503` HTTP response code.
This exception was previously not mapped resulting in a HTTP 500.
Mapping all "client" (requests done by the server internally to other web services) to a 503 might be a bit broad but it surely is better than a 500 and doing very detailed error handling just seems overkill for this and similar problems.

### Automatic Testing
Added some controller tests that verify the 503 by changing the configuration for the app hub API URL to some non-existing URL. This is not a timeout as encountered in the original ticket but should be a similar type of scenario.

I also added two "success" path scenarios which work with the default URL which means the test do a request to the https://apps.dhis2.org/api URL. We have to see if this works without issues on CI.