### PR TITLE
fix: remove unused RollingFileAppenders in log4j2.xml DHIS2-12986

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="warn">
     <Appenders>
-
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout  pattern="* %-5p %d{ABSOLUTE} %m (%F [%t])%n" />
             <Filters>

--- a/dhis-2/dhis-web-embedded-jetty/src/main/resources/log4j2.xml
+++ b/dhis-2/dhis-web-embedded-jetty/src/main/resources/log4j2.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
     <Appenders>
-        <RollingFile name="fileLogger" fileName="dhis.log" filePattern="dhis.log.%i">
-            <PatternLayout>
-                <pattern>* %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId} %X{xRequestID}</pattern>
-            </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="25 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="3"/>
-        </RollingFile>
-
         <Console name="console" target="SYSTEM_OUT" follow="true">
             <PatternLayout
                     pattern="%d{HH:mm:ss.SSS} %highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} [%15.15t] %style{%-40.40C{1.}}{cyan} : %m%n%throwable"/>

--- a/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/dhis-2/dhis-web/dhis-web-commons-resources/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
     <Appenders>
-        <RollingFile name="fileLogger" fileName="dhis.log" filePattern="dhis.log.%i">
-            <PatternLayout>
-                <pattern>* %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId} %X{xRequestID}</pattern>
-            </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="25 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="3"/>
-        </RollingFile>
-
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="* %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId} %X{xRequestID}"/>
         </Console>

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/resources/log4j2-jetty.xml
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/resources/log4j2-jetty.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
     <Appenders>
-        <RollingFile name="fileLogger" fileName="dhis.log" filePattern="dhis.log.%i">
-            <PatternLayout>
-                <pattern>* %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId} %X{xRequestID}</pattern>
-            </PatternLayout>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="25 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="3"/>
-        </RollingFile>
-
         <Console name="console" target="SYSTEM_OUT">
             <PatternLayout pattern="* %-5p %d{ISO8601} %m (%F [%t])%n %X{sessionId} %X{xRequestID}"/>
         </Console>


### PR DESCRIPTION
The "fileLogger" defined in the xml config is never "attached" to a
logger. Not in the config or in code. Its thus unused.
Log4JLogConfigInitializer creates its own RollingFileAppenders unless a
user provides their own logging config.

Just to understand the root cause of the exception on start of DHIS2:
The "fileLogger" in the log4j2.xml config was responsible for it. The
property 'createOnDemand' controls when the RollingFileAppender creates
the log file. Since that is false by default, the "fileLogger" is trying
to create the file once log4j2 initializes. log4j2 does not have
permissions to create the dhis.log specified in "fileLogger".