### PR TITLE
fix: Disable builtin logging customization when given logging config by user DHIS2-13163

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
@@ -93,7 +93,7 @@ public class Log4JLogConfigInitializer
 
     private static final String AUDIT_LOGGER_FILENAME = "dhis-audit.log";
 
-    private static final String LOG4J_CONF_PROP = "log4j.configuration";
+    private static final String LOG4J_CONF_PROP = "log4j2.configurationFile";
 
     private static final String LOGGING_LEVEL_PREFIX = "logging.level.";
 
@@ -113,16 +113,16 @@ public class Log4JLogConfigInitializer
     @Override
     public void initConfig()
     {
-        if ( !locationManager.externalDirectorySet() )
-        {
-            log.warn( "Could not initialize additional log configuration, external home directory not set" );
-            return;
-        }
-
         if ( isNotBlank( System.getProperty( LOG4J_CONF_PROP ) ) )
         {
             log.info( "Aborting default log config, external config set through system prop " + LOG4J_CONF_PROP + ": "
                 + System.getProperty( LOG4J_CONF_PROP ) );
+            return;
+        }
+
+        if ( !locationManager.externalDirectorySet() )
+        {
+            log.warn( "Could not initialize additional log configuration, external home directory not set" );
             return;
         }
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -152,7 +152,7 @@
         <jetty.version>10.0.9</jetty.version>
 
         <!-- Div. utils -->
-        <version.debezium>1.8.1.Final</version.debezium>
+        <version.debezium>1.9.1.Final</version.debezium>
         <guava.version>31.0.1-jre</guava.version>
         <jsr305.version>3.0.2</jsr305.version>
         <imgscalr-lib.version>4.2</imgscalr-lib.version>
@@ -817,6 +817,7 @@
                             <rules>
                                 <bannedDependencies>
                                     <excludes>
+                                        <exclude>log4j:log4j</exclude>
                                         <exclude>org.slf4j:slf4j-simple</exclude>
                                     </excludes>
                                 </bannedDependencies>


### PR DESCRIPTION
* check log4j version 2 property `log4j2.configurationFile` https://logging.apache.org/log4j/2.x/manual/configuration.html to see if a user brings their own logging configuration
* ban log4j version 1 so we do not accidentally log using log4j version 1, parse any log4j version 2 config using version 1, remove any log4j version 1 log errors like

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
--
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```
* only check `locationManager.externalDirectorySet()` in case the user has not provided their own config. Only then will we need to create the directory/files for logging. 