### PR TITLE
ci: remove rp_attributes from docker command

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.e2e.yml
@@ -6,4 +6,4 @@ services:
     image: "${IMAGE_NAME}"
     environment:
       RP_UUID: ${RP_UUID}
-    command: ./wait-for-it.sh web:8080 -t 0 -- mvn test --batch-mode --no-transfer-progress -Dinstance.url=http://web:8080/api -Dtest.cleanup=false -Duser.default.username=admin -Duser.default.password=district -Drp.enable=true -Drp.attributes=version:master;
+    command: ./wait-for-it.sh web:8080 -t 0 -- mvn test --batch-mode --no-transfer-progress -Dinstance.url=http://web:8080/api -Dtest.cleanup=false -Duser.default.username=admin -Duser.default.password=district -Drp.enable=true


### PR DESCRIPTION
The property is set on the Jenkins file, so it's not necessary 