### PR TITLE
feat: persistent unique shortNames for predictors [DHIS2-10688]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/predictor/hibernate/Predictor.hbm.xml
@@ -15,6 +15,8 @@
 
     <property name="name" column="name" not-null="true" unique="true" length="230" />
 
+    <property name="shortName" column="shortname" not-null="true" unique="true" length="50" />
+
     <property name="description" type="text" />
 
     <many-to-one name="generator" column="generatorexpressionid" class="org.hisp.dhis.expression.Expression"

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v39/V2_39_6__Add_unique_shortName_to_predictors.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v39/V2_39_6__Add_unique_shortName_to_predictors.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.db.migration.v39;
 
+import static org.hisp.dhis.db.migration.helper.UniqueValueUtils.copyUniqueValue;
+
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
-
-import static org.hisp.dhis.db.migration.helper.UniqueValueUtils.copyUniqueValue;
 
 /**
  * Initialises the {@code shortname} column with a unique name based on the

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v39/V2_39_6__Add_unique_shortName_to_predictors.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/v39/V2_39_6__Add_unique_shortName_to_predictors.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.db.migration.v39;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import static org.hisp.dhis.db.migration.helper.UniqueValueUtils.copyUniqueValue;
+
+/**
+ * Initialises the {@code shortname} column with a unique name based on the
+ * {@code name} column for {@link org.hisp.dhis.predictor.Predictor}s.
+ *
+ * @author Jan Bernitt
+ */
+public class V2_39_6__Add_unique_shortName_to_predictors extends BaseJavaMigration
+{
+    @Override
+    public void migrate( Context context )
+        throws Exception
+    {
+        copyUniqueValue( context, "predictor", "predictorid", "name", "shortname", 50 );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_5__Add_column_shortName_to_predictor_table.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_5__Add_column_shortName_to_predictor_table.sql
@@ -1,0 +1,2 @@
+alter table predictor
+    add column if not exists shortname character varying(50);

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_7__Add_unique_and_not_null_to_predictor_shortName.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_7__Add_unique_and_not_null_to_predictor_shortName.sql
@@ -1,0 +1,2 @@
+alter table predictor alter column shortname set not null;
+alter table predictor add constraint predictor_unique_shortname unique (shortname);

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -1273,6 +1273,7 @@ public abstract class DhisConvenienceTest
         predictor.setOutput( output );
         predictor.setOutputCombo( combo );
         predictor.setName( "Predictor" + uniqueCharacter );
+        predictor.setShortName( "Predictor" + uniqueCharacter );
         predictor.setDescription( "Description" + uniqueCharacter );
         predictor.setGenerator( generator );
         predictor.setSampleSkipTest( skipTest );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/PredictorControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/PredictorControllerTest.java
@@ -105,7 +105,8 @@ class PredictorControllerTest extends DhisControllerConvenienceTest
                     + "'categoryCombo': {'id': '" + ccId + "'}}" ) );
         return assertStatus( HttpStatus.CREATED,
             POST( "/predictors/",
-                "{'name':'Pred1'," + "'output': {'id':'" + deId + "'}, " + "'generator': {'expression': '1 != 1'},"
+                "{'name':'Pred1','shortName':'Pred1'," + "'output': {'id':'" + deId + "'}, "
+                    + "'generator': {'expression': '1 != 1'},"
                     + "'periodType': 'Monthly'," + "'sequentialSampleCount':4," + "'annualSampleCount':3,"
                     + "'organisationUnitLevels': []," + "'organisationUnitDescendants': 'SELECTED'" + " }" ) );
     }


### PR DESCRIPTION
### Summary
Predictors got a short name that is persistet.
DB update scripts make sure short name derived from name column is unique.

### Automatic Testing
Existing tests were updated to set the short name.

### Manual Testing
* open maintenance app
* navigate to predictors list
* pick a predictor, change its short name and save the change
* check the change is persistent, e.g. return to edit after navigating to different page, check `api/predictors` or similar