### PR TITLE
fix: Event.attributeOptionCombo is a MetadataIdentifier DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java
@@ -113,6 +113,10 @@ public class TrackerIdSchemeParam
      */
     public MetadataIdentifier toMetadataIdentifier( IdentifiableObject metadata )
     {
+        if ( metadata == null )
+        {
+            return toMetadataIdentifier( (String) null );
+        }
         return toMetadataIdentifier( getIdentifier( metadata ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
@@ -32,6 +32,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -122,6 +123,20 @@ public class TrackerIdSchemeParams
             return idScheme;
         }
 
+    }
+
+    /**
+     * Creates metadata identifier for given {@code categoryOptionCombo} using
+     * {@link #categoryOptionComboIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param categoryOptionCombo to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         categoryOptionComboIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( CategoryOptionCombo categoryOptionCombo )
+    {
+        return categoryOptionComboIdScheme.toMetadataIdentifier( categoryOptionCombo );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -125,7 +125,7 @@ public class EventTrackerConverterService
 
             event.setEnrollment( psi.getProgramInstance().getUid() );
             event.setProgramStage( MetadataIdentifier.ofUid( psi.getProgramStage().getUid() ) );
-            event.setAttributeOptionCombo( psi.getAttributeOptionCombo().getUid() );
+            event.setAttributeOptionCombo( MetadataIdentifier.ofUid( psi.getAttributeOptionCombo().getUid() ) );
             event.setAttributeCategoryOptions( psi.getAttributeOptionCombo()
                 .getCategoryOptions().stream().map( CategoryOption::getUid ).collect( Collectors.joining( ";" ) ) );
 
@@ -231,12 +231,10 @@ public class EventTrackerConverterService
         programStageInstance.setExecutionDate( DateUtils.fromInstant( event.getOccurredAt() ) );
         programStageInstance.setDueDate( DateUtils.fromInstant( event.getScheduledAt() ) );
 
-        String attributeOptionCombo = event.getAttributeOptionCombo();
-
-        if ( attributeOptionCombo != null )
+        if ( !event.getAttributeOptionCombo().isBlank() )
         {
             programStageInstance.setAttributeOptionCombo(
-                preheat.get( CategoryOptionCombo.class, event.getAttributeOptionCombo() ) );
+                preheat.getCategoryOptionCombo( event.getAttributeOptionCombo() ) );
         }
         else
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -109,7 +109,7 @@ public class Event
     private Instant updatedAtClient;
 
     @JsonProperty
-    private String attributeOptionCombo;
+    private MetadataIdentifier attributeOptionCombo;
 
     @JsonProperty
     private String attributeCategoryOptions;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -219,22 +219,22 @@ public class TrackerPreheat
      *
      * Category option identifiers needs to match the idScheme used when storing
      * the category option combo using {@link #putCategoryOptionCombo}. Category
-     * option combo identifiers will be in the idScheme defined by the user on
+     * option combo identifier will be in the idScheme defined by the user on
      * import.
      *
      * @param categoryCombo category combo
      * @param categoryOptions semicolon separated list of category options
      * @return category option combo identifier
      */
-    public String getCategoryOptionComboIdentifier( CategoryCombo categoryCombo, String categoryOptions )
+    public MetadataIdentifier getCategoryOptionComboIdentifier( CategoryCombo categoryCombo, String categoryOptions )
     {
         CategoryOptionCombo categoryOptionCombo = this.getCategoryOptionCombo(
             this.cosToCOC.get( categoryOptionComboCacheKey( categoryCombo, categoryOptions ) ) );
         if ( categoryOptionCombo == null )
         {
-            return null;
+            return idSchemes.toMetadataIdentifier( (CategoryOptionCombo) null );
         }
-        return idSchemes.getCategoryOptionComboIdScheme().getIdentifier( categoryOptionCombo );
+        return idSchemes.toMetadataIdentifier( categoryOptionCombo );
     }
 
     private Pair<String, Set<String>> categoryOptionComboCacheKey( CategoryCombo categoryCombo,
@@ -437,6 +437,11 @@ public class TrackerPreheat
     public CategoryOption getCategoryOption( String id )
     {
         return get( CategoryOption.class, id );
+    }
+
+    public CategoryOptionCombo getCategoryOptionCombo( MetadataIdentifier id )
+    {
+        return get( CategoryOptionCombo.class, id );
     }
 
     public CategoryOptionCombo getCategoryOptionCombo( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
@@ -74,7 +74,7 @@ public class EventCategoryOptionComboSupplier extends AbstractPreheatSupplier
     {
 
         List<Pair<CategoryCombo, Set<CategoryOption>>> events = params.getEvents().stream()
-            .filter( e -> StringUtils.isBlank( e.getAttributeOptionCombo() )
+            .filter( e -> e.getAttributeOptionCombo().isBlank()
                 && !StringUtils.isBlank( e.getAttributeCategoryOptions() ) )
             .map( e -> Pair.of( resolveProgram( preheat, e ), parseCategoryOptionIds( e ) ) )
             .filter( p -> p.getLeft() != null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -117,7 +117,7 @@ public class EventProgramPreProcessor
 
         TrackerPreheat preheat = bundle.getPreheat();
         List<Event> events = bundle.getEvents().stream()
-            .filter( e -> isBlank( e.getAttributeOptionCombo() )
+            .filter( e -> e.getAttributeOptionCombo().isBlank()
                 && !isBlank( e.getAttributeCategoryOptions() ) )
             .filter( e -> preheat.getProgram( e.getProgram() ) != null )
             .collect( Collectors.toList() );
@@ -125,9 +125,8 @@ public class EventProgramPreProcessor
         for ( Event e : events )
         {
             Program program = preheat.getProgram( e.getProgram() );
-            String aoc = preheat.getCategoryOptionComboIdentifier( program.getCategoryCombo(),
-                e.getAttributeCategoryOptions() );
-            e.setAttributeOptionCombo( aoc );
+            e.setAttributeOptionCombo( preheat.getCategoryOptionComboIdentifier( program.getCategoryCombo(),
+                e.getAttributeCategoryOptions() ) );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -218,7 +218,7 @@ public class PreCheckDataRelationsValidationHook
 
     private boolean hasNoAttributeOptionComboSet( Event event )
     {
-        return StringUtils.isBlank( event.getAttributeOptionCombo() );
+        return event.getAttributeOptionCombo().isBlank();
     }
 
     private boolean validateCategoryOptionsExist( ValidationErrorReporter reporter, Event event )
@@ -311,7 +311,7 @@ public class PreCheckDataRelationsValidationHook
         if ( !program.getCategoryCombo().equals( aoc.getCategoryCombo() ) )
         {
             reporter.addError( event, TrackerErrorCode.E1054,
-                event.getAttributeOptionCombo(), program.getCategoryCombo() );
+                event.getAttributeOptionCombo().getIdentifierOrAttributeValue(), program.getCategoryCombo() );
             return false;
         }
 
@@ -392,7 +392,8 @@ public class PreCheckDataRelationsValidationHook
         }
         else
         {
-            reporter.addError( event, TrackerErrorCode.E1117, event.getAttributeOptionCombo(),
+            reporter.addError( event, TrackerErrorCode.E1117,
+                event.getAttributeOptionCombo().getIdentifierOrAttributeValue(),
                 event.getAttributeCategoryOptions() );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdSchemeParamTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdSchemeParamTest.java
@@ -32,12 +32,14 @@ import static org.hisp.dhis.tracker.TrackerIdScheme.CODE;
 import static org.hisp.dhis.tracker.TrackerIdScheme.NAME;
 import static org.hisp.dhis.tracker.TrackerIdScheme.UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Set;
 
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.junit.jupiter.api.Test;
@@ -79,6 +81,19 @@ class TrackerIdSchemeParamTest
     }
 
     @Test
+    void toMetadataIdentifierAttributeFromStringNull()
+    {
+
+        TrackerIdSchemeParam param = TrackerIdSchemeParam.ofAttribute( "z3Z4TD3oBCP" );
+
+        MetadataIdentifier id = param.toMetadataIdentifier( (String) null );
+
+        assertEquals( ATTRIBUTE, id.getIdScheme() );
+        assertEquals( "z3Z4TD3oBCP", id.getIdentifier() );
+        assertNull( id.getAttributeValue() );
+    }
+
+    @Test
     void toMetadataIdentifierUIDFromIdentifiableObject()
     {
 
@@ -88,6 +103,16 @@ class TrackerIdSchemeParamTest
 
         assertEquals( UID, id.getIdScheme() );
         assertEquals( "z3Z4TD3oBCP", id.getIdentifier() );
+    }
+
+    @Test
+    void toMetadataIdentifierUIDFromIdentifiableObjectNull()
+    {
+
+        MetadataIdentifier id = TrackerIdSchemeParam.UID.toMetadataIdentifier( (IdentifiableObject) null );
+
+        assertEquals( UID, id.getIdScheme() );
+        assertNull( id.getIdentifier() );
     }
 
     @Test
@@ -116,6 +141,19 @@ class TrackerIdSchemeParamTest
         assertEquals( ATTRIBUTE, id.getIdScheme() );
         assertEquals( "z3Z4TD3oBCP", id.getIdentifier() );
         assertEquals( "sunshine", id.getAttributeValue() );
+    }
+
+    @Test
+    void toMetadataIdentifierAttributeFromIdentifiableObjectNull()
+    {
+
+        TrackerIdSchemeParam param = TrackerIdSchemeParam.ofAttribute( "z3Z4TD3oBCP" );
+
+        MetadataIdentifier id = param.toMetadataIdentifier( (IdentifiableObject) null );
+
+        assertEquals( ATTRIBUTE, id.getIdScheme() );
+        assertEquals( "z3Z4TD3oBCP", id.getIdentifier() );
+        assertNull( id.getAttributeValue() );
     }
 
     private AttributeValue attributeValue( String value )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -335,13 +335,14 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
     private Event event( String uid, DataValue dataValue )
     {
-        Event event = new Event();
-        event.setEvent( uid );
-        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) );
-        event.setProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) );
-        event.setOrgUnit( MetadataIdentifier.ofUid( ORGANISATION_UNIT_UID ) );
-        event.setDataValues( Sets.newHashSet( dataValue ) );
-        return event;
+        return Event.builder()
+            .event( uid )
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) )
+            .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
+            .orgUnit( MetadataIdentifier.ofUid( ORGANISATION_UNIT_UID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
+            .dataValues( Sets.newHashSet( dataValue ) )
+            .build();
     }
 
     private ProgramStageInstance programStageInstance()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -157,12 +157,17 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         List<Pair<String, TrackerIdSchemeParam>> data = buildDataSet( "XXXvX50cXC0", "COCA", "COCAname" );
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
-            Event event = new Event();
-            event.setAttributeOptionCombo( pair.getLeft() );
-            TrackerImportParams params = buildParams( event,
-                builder().categoryOptionComboIdScheme( pair.getRight() ).build() );
+            String id = pair.getLeft();
+            TrackerIdSchemeParam param = pair.getRight();
+            Event event = Event.builder()
+                .attributeOptionCombo( param.toMetadataIdentifier( id ) )
+                .build();
+
+            TrackerImportParams params = buildParams( event, builder().categoryOptionComboIdScheme( param ).build() );
+
             TrackerPreheat preheat = trackerPreheatService.preheat( params );
-            assertPreheatedObjectExists( preheat, CategoryOptionCombo.class, pair.getRight(), pair.getLeft() );
+
+            assertPreheatedObjectExists( preheat, CategoryOptionCombo.class, param, id );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -124,13 +124,14 @@ class TrackerPreheatTest extends DhisConvenienceTest
 
         String optionsString = concatCategoryOptions( identifiers.getCategoryOptionComboIdScheme(), options );
         assertFalse( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        assertNull( preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
+        assertEquals( MetadataIdentifier.ofUid( null ),
+            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
         assertNull( preheat.getCategoryOptionCombo( aoc.getUid() ) );
 
         preheat.putCategoryOptionCombo( categoryCombo, options, aoc );
 
         assertTrue( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        assertEquals( identifiers.getCategoryOptionComboIdScheme().getIdentifier( aoc ),
+        assertEquals( identifiers.toMetadataIdentifier( aoc ),
             preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
         assertEquals( aoc, preheat.getCategoryOptionCombo( aoc.getUid() ),
             "option combo should also be stored in the preheat map" );
@@ -154,9 +155,9 @@ class TrackerPreheatTest extends DhisConvenienceTest
 
         preheat.putCategoryOptionCombo( categoryCombo, options, aoc );
 
-        assertEquals( identifiers.getCategoryOptionComboIdScheme().getIdentifier( aoc ),
+        assertEquals( identifiers.toMetadataIdentifier( aoc ),
             preheat.getCategoryOptionComboIdentifier( categoryCombo, option1.getUid() + ";" + option2.getUid() ) );
-        assertEquals( identifiers.getCategoryOptionComboIdScheme().getIdentifier( aoc ),
+        assertEquals( identifiers.toMetadataIdentifier( aoc ),
             preheat.getCategoryOptionComboIdentifier( categoryCombo, option2.getUid() + ";" + option1.getUid() ) );
     }
 
@@ -177,7 +178,8 @@ class TrackerPreheatTest extends DhisConvenienceTest
         assertTrue( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
         String optionsString = concatCategoryOptions( identifiers.getCategoryOptionComboIdScheme(), options );
         assertNull( preheat.getCategoryOptionCombo( categoryCombo, options ) );
-        assertNull( preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
+        assertEquals( MetadataIdentifier.ofUid( null ),
+            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
         assertNull( preheat.getCategoryOptionCombo( aoc.getUid() ),
             "option combo should not be added to preheat map if null" );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
@@ -96,6 +96,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
@@ -140,6 +141,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .programStage( identifierParams.toMetadataIdentifier( stage ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
@@ -179,6 +181,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event, event );
@@ -221,6 +224,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event, event );
@@ -262,6 +266,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
@@ -295,7 +300,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
-            .attributeOptionCombo( identifierParams.getCategoryOptionComboIdScheme().getIdentifier( aoc ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
         List<Event> events = List.of( event );
@@ -326,6 +331,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Set<CategoryOption> options = aoc.getCategoryOptions();
 
         Event event = Event.builder()
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
@@ -364,6 +370,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .programStage( identifierParams.toMetadataIdentifier( stage ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
@@ -401,7 +408,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
-            .attributeOptionCombo( identifierParams.getCategoryOptionComboIdScheme().getIdentifier( aoc ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -433,7 +440,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .attributeOptionCombo( identifierParams.getCategoryOptionComboIdScheme().getIdentifier( aoc ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -465,6 +472,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
+            .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
@@ -148,6 +148,7 @@ class EventProgramPreProcessorTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( null ) )
             .programStage( MetadataIdentifier.ofUid( programStage.getUid() ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).preheat( preheat )
             .build();
@@ -232,7 +233,7 @@ class EventProgramPreProcessorTest
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
         CategoryOptionCombo categoryOptionCombo = createCategoryOptionCombo( 'A' );
         when( preheat.getCategoryOptionComboIdentifier( categoryCombo, "123;235" ) )
-            .thenReturn( categoryOptionCombo.getCode() );
+            .thenReturn( identifierParams.toMetadataIdentifier( categoryOptionCombo ) );
 
         TrackerBundle bundle = TrackerBundle.builder()
             .events( Collections.singletonList( event ) )
@@ -241,7 +242,8 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        assertEquals( categoryOptionCombo.getCode(), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
+        assertEquals( MetadataIdentifier.ofCode( categoryOptionCombo.getCode() ),
+            bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
         assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
@@ -261,6 +263,8 @@ class EventProgramPreProcessorTest
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
         event.setAttributeCategoryOptions( "123;235" );
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
+        when( preheat.getCategoryOptionComboIdentifier( categoryCombo, event.getAttributeCategoryOptions() ) )
+            .thenReturn( MetadataIdentifier.ofCode( null ) );
 
         TrackerBundle bundle = TrackerBundle.builder()
             .events( Collections.singletonList( event ) )
@@ -269,7 +273,7 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        assertNull( bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
+        assertEquals( MetadataIdentifier.ofCode( null ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
         assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
@@ -296,7 +300,7 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        assertNull( bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
+        assertEquals( MetadataIdentifier.ofUid( null ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
         assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
@@ -314,7 +318,7 @@ class EventProgramPreProcessorTest
         program.setCategoryCombo( categoryCombo );
         Event event = completeTrackerEvent();
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
-        event.setAttributeOptionCombo( "9871" );
+        event.setAttributeOptionCombo( MetadataIdentifier.ofCode( "9871" ) );
         event.setAttributeCategoryOptions( "123;235" );
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
 
@@ -325,7 +329,7 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        assertEquals( "9871", bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
+        assertEquals( MetadataIdentifier.ofCode( "9871" ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
         assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
@@ -343,7 +347,7 @@ class EventProgramPreProcessorTest
         program.setCategoryCombo( categoryCombo );
         Event event = completeTrackerEvent();
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
-        event.setAttributeOptionCombo( "9871" );
+        event.setAttributeOptionCombo( MetadataIdentifier.ofCode( "9871" ) );
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
 
         TrackerBundle bundle = TrackerBundle.builder()
@@ -353,7 +357,7 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        assertEquals( "9871", bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
+        assertEquals( MetadataIdentifier.ofCode( "9871" ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
     }
 
     @Test
@@ -379,7 +383,7 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        assertNull( bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
+        assertEquals( MetadataIdentifier.ofUid( null ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
         assertNull( bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
@@ -438,6 +442,7 @@ class EventProgramPreProcessorTest
         return Event.builder()
             .program( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
     }
 
@@ -446,15 +451,17 @@ class EventProgramPreProcessorTest
         return Event.builder()
             .program( MetadataIdentifier.ofUid( null ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
     }
 
     private Event completeProgramEvent()
     {
-        Event event = new Event();
-        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ) );
-        event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ) );
-        return event;
+        return Event.builder()
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ) )
+            .program( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
+            .build();
     }
 
     private Event trackerEventWithProgramStage()
@@ -462,6 +469,7 @@ class EventProgramPreProcessorTest
         return Event.builder()
             .program( MetadataIdentifier.ofUid( null ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
     }
 
@@ -470,14 +478,16 @@ class EventProgramPreProcessorTest
         return Event.builder()
             .program( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
     }
 
     private Event completeTrackerEvent()
     {
-        Event event = new Event();
-        event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ) );
-        event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ) );
-        return event;
+        return Event.builder()
+            .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ) )
+            .program( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
+            .build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -269,6 +269,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .enrollment( ENROLLMENT_ID )
             .build();
 
@@ -301,6 +302,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -331,6 +333,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -365,6 +368,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .enrollment( ENROLLMENT_ID )
             .build();
 
@@ -401,6 +405,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .enrollment( ENROLLMENT_ID )
             .build();
 
@@ -530,10 +535,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -550,10 +555,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo defaultCC = defaultCategoryCombo();
         program.setCategoryCombo( defaultCC );
         CategoryOptionCombo defaultAOC = firstCategoryOptionCombo( defaultCC );
-        when( preheat.getCategoryOptionCombo( defaultAOC.getUid() ) ).thenReturn( defaultAOC );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) ) )
+            .thenReturn( defaultAOC );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( defaultAOC.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -569,10 +575,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( defaultCategoryCombo() );
 
         String UNKNOWN_AOC_ID = CodeGenerator.generateUid();
-        when( preheat.getCategoryOptionCombo( UNKNOWN_AOC_ID ) ).thenReturn( null );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( UNKNOWN_AOC_ID )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -589,10 +595,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( categoryCombo() );
 
         String UNKNOWN_AOC_ID = CodeGenerator.generateUid();
-        when( preheat.getCategoryOptionCombo( UNKNOWN_AOC_ID ) ).thenReturn( null );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( UNKNOWN_AOC_ID )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -609,10 +615,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( categoryCombo( 'A' ) );
 
         CategoryOptionCombo aoc = firstCategoryOptionCombo( categoryCombo( 'B' ) );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -631,10 +637,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( categoryCombo( 'A' ) );
 
         CategoryOptionCombo defaultAOC = firstCategoryOptionCombo( defaultCategoryCombo() );
-        when( preheat.getCategoryOptionCombo( defaultAOC.getUid() ) ).thenReturn( defaultAOC );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) ) )
+            .thenReturn( defaultAOC );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( defaultAOC.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -651,10 +658,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( defaultCategoryCombo() );
 
         CategoryOptionCombo aoc = firstCategoryOptionCombo( categoryCombo( 'B' ) );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -674,14 +681,15 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo defaultCC = defaultCategoryCombo();
         program.setCategoryCombo( defaultCC );
         CategoryOptionCombo defaultAOC = firstCategoryOptionCombo( defaultCC );
-        when( preheat.getCategoryOptionCombo( defaultAOC.getUid() ) ).thenReturn( defaultAOC );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) ) )
+            .thenReturn( defaultAOC );
 
         CategoryOption defaultCO = defaultCC.getCategoryOptions().get( 0 );
         program.setCategoryCombo( defaultCC );
         when( preheat.getCategoryOption( defaultCO.getUid() ) ).thenReturn( defaultCO );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( defaultAOC.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) )
             .attributeCategoryOptions( defaultCO.getUid() )
             .build();
 
@@ -701,10 +709,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryOption co = cc.getCategoryOptions().get( 0 );
         when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .attributeCategoryOptions( co.getUid() )
             .build();
 
@@ -725,10 +733,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
 
         String UNKNOWN_AOC_ID = CodeGenerator.generateUid();
-        when( preheat.getCategoryOptionCombo( UNKNOWN_AOC_ID ) ).thenReturn( null );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( UNKNOWN_AOC_ID )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
             .attributeCategoryOptions( co.getUid() )
             .build();
 
@@ -750,10 +758,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
 
         CategoryOptionCombo defaultAOC = firstCategoryOptionCombo( defaultCategoryCombo() );
-        when( preheat.getCategoryOptionCombo( defaultAOC.getUid() ) ).thenReturn( defaultAOC );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) ) )
+            .thenReturn( defaultAOC );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( defaultAOC.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) )
             .attributeCategoryOptions( co.getUid() )
             .build();
 
@@ -772,13 +781,13 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         String UNKNOWN_CO_ID = CodeGenerator.generateUid();
         when( preheat.getCategoryOption( UNKNOWN_CO_ID ) ).thenReturn( null );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .attributeCategoryOptions( UNKNOWN_CO_ID )
             .build();
 
@@ -805,10 +814,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOption( UNKNOWN_CO_ID2 ) ).thenReturn( null );
 
         String UNKNOWN_AOC_ID = CodeGenerator.generateUid();
-        when( preheat.getCategoryOptionCombo( UNKNOWN_AOC_ID ) ).thenReturn( null );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( UNKNOWN_AOC_ID )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
             .attributeCategoryOptions( UNKNOWN_CO_ID1 + ";" + co.getUid() + ";" + UNKNOWN_CO_ID2 )
             .build();
 
@@ -831,13 +840,13 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         CategoryOption eventCO = createCategoryOption( 'C' );
         when( preheat.getCategoryOption( eventCO.getUid() ) ).thenReturn( eventCO );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .attributeCategoryOptions( eventCO.getUid() )
             .build();
 
@@ -862,10 +871,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOption( co1.getUid() ) ).thenReturn( co1 );
 
         CategoryOptionCombo aoc2 = cc.getSortedOptionCombos().get( 1 );
-        when( preheat.getCategoryOptionCombo( aoc2.getUid() ) ).thenReturn( aoc2 );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc2.getUid() ) ) ).thenReturn( aoc2 );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc2.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc2.getUid() ) )
             .attributeCategoryOptions( co1.getUid() )
             .build();
 
@@ -886,12 +895,12 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( cc );
 
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
-        when( preheat.getCategoryOptionCombo( aoc.getUid() ) ).thenReturn( aoc );
+        when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
         CategoryOption co1 = (CategoryOption) aoc.getCategoryOptions().toArray()[0];
         when( preheat.getCategoryOption( co1.getUid() ) ).thenReturn( co1 );
 
         Event event = eventBuilder()
-            .attributeOptionCombo( aoc.getUid() )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
             .attributeCategoryOptions( co1.getUid() )
             .build();
 
@@ -1114,6 +1123,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .programStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) )
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
+            .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
             .enrollment( ENROLLMENT_ID );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
@@ -137,7 +137,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -168,7 +171,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
@@ -57,7 +57,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "KKKKX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "KKKKX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
@@ -56,7 +56,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk;XXXrKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -95,7 +98,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "XXXvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "XXXvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -134,7 +140,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -173,7 +182,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -212,7 +224,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -251,7 +266,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -322,7 +340,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -393,7 +414,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -137,7 +137,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -177,7 +180,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -217,7 +223,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -257,7 +266,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -297,7 +309,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -337,7 +352,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -409,7 +427,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
@@ -481,7 +502,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
@@ -59,6 +59,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [
         {
           "createdAt": "2019-01-28T12:10:38.113",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
@@ -59,6 +59,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [
         {
           "createdAt": "2019-01-28T12:10:38.113",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
@@ -57,7 +57,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
@@ -57,7 +57,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_and_one_new_and_one_invalid_event.json
@@ -59,6 +59,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     },
@@ -88,6 +91,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     },
@@ -117,6 +123,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_event_and_one_new_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/one_update_event_and_one_new_event.json
@@ -59,6 +59,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     },
@@ -88,6 +91,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/ownership_event.json
@@ -61,6 +61,9 @@
       "updatedAtClient": "2019-01-28T10:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
@@ -56,7 +56,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/single_event.json
@@ -61,6 +61,9 @@
       "updatedAtClient": "2019-01-28T10:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
@@ -100,6 +100,9 @@
       "updatedAt": "2019-01-28T12:10:38.109",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [
         {
           "createdAt": "2019-01-28T12:10:38.113",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
@@ -301,6 +301,9 @@
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     },
@@ -331,6 +334,9 @@
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/event-data-delete.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/event-data-delete.json
@@ -45,6 +45,9 @@
       "relationships": [],
       "followup": false,
       "deleted": false,
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
@@ -53,7 +53,10 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "x2S2qeADpA9",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "x2S2qeADpA9"
+      },
       "attributeCategoryOptions": "Aj6SFQQBBFU",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
@@ -53,7 +53,10 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "wpVV2AvPM89",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "wpVV2AvPM89"
+      },
       "attributeCategoryOptions": "Aj6SFQQBBFU",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-cat-write-access.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-cat-write-access.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "KKKKX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "KKKKX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-data.json
@@ -55,7 +55,10 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": [
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-notes-update-data.json
@@ -55,7 +55,10 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": [
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-registration.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with-registration.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [
         {
           "createdAt": "2019-01-28T12:10:38.113",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
@@ -56,7 +56,10 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [
         {
           "createdAt": "2019-01-28T12:10:38.113",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
@@ -52,6 +52,9 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "attributeCategoryOptions": "Aj6SFQQBBFU",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
@@ -57,7 +57,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "z8lvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "z8lvX50cXC0"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
@@ -53,6 +53,9 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "attributeCategoryOptions": "zRXSQ4AQu7I",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-opt-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-opt-combo.json
@@ -54,7 +54,10 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "UuuvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "UuuvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
@@ -54,6 +54,9 @@
       "scheduledAt": "2019-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "attributeCategoryOptions": "xYerKDKCefk",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
@@ -58,6 +58,9 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
       "attributeCategoryOptions": "LYerKDKCefZ",
       "dataValues": [],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_combo-date-wrong.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_combo-date-wrong.json
@@ -52,7 +52,10 @@
       "occurredAt": "2018-12-31T06:13:07.000",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "OOlvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "OOlvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     },
@@ -75,7 +78,10 @@
       "scheduledAt": "2020-08-19T13:59:13.688",
       "followup": false,
       "deleted": false,
-      "attributeOptionCombo": "OOlvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "OOlvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-programStage-access.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-programStage-access.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-uncomplete.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_error-no-uncomplete.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-default-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-default-combo.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part1.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part2.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_non-repeatable-programstage_part2.json
@@ -58,7 +58,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/program_and_tracker_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/program_and_tracker_events.json
@@ -57,7 +57,10 @@
       "followup": false,
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     },
@@ -83,7 +86,10 @@
       "deleted": false,
       "createdAt": "2019-08-19T13:58:26.964",
       "updatedAt": "2019-08-19T13:59:13.694",
-      "attributeOptionCombo": "HllvX50cXC0",
+      "attributeOptionCombo": {
+        "idScheme": "UID",
+        "identifier": "HllvX50cXC0"
+      },
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
@@ -46,5 +46,6 @@ interface EventMapper extends DomainMapper<Event, org.hisp.dhis.tracker.domain.E
     @Mapping( target = "program", source = "program", qualifiedByName = "programToMetadataIdentifier" )
     @Mapping( target = "programStage", source = "programStage", qualifiedByName = "programStageToMetadataIdentifier" )
     @Mapping( target = "orgUnit", source = "orgUnit", qualifiedByName = "orgUnitToMetadataIdentifier" )
+    @Mapping( target = "attributeOptionCombo", source = "attributeOptionCombo", qualifiedByName = "attributeOptionComboToMetadataIdentifier" )
     org.hisp.dhis.tracker.domain.Event from( Event event, @Context TrackerIdSchemeParams idSchemeParams );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
@@ -56,4 +56,11 @@ interface MetadataIdentifierMapper
     {
         return idSchemeParams.getOrgUnitIdScheme().toMetadataIdentifier( identifier );
     }
+
+    @Named( "attributeOptionComboToMetadataIdentifier" )
+    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromAttributeOptionCombo( String identifier,
+        @Context TrackerIdSchemeParams idSchemeParams )
+    {
+        return idSchemeParams.getCategoryOptionComboIdScheme().toMetadataIdentifier( identifier );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/RelationshipItemMapper.java
@@ -41,7 +41,7 @@ import org.mapstruct.Mapper;
     DataValueMapper.class,
     NoteMapper.class,
     InstantMapper.class,
-    UserMapper.class,
+    UserMapper.class
 } )
 interface RelationshipItemMapper
     extends DomainMapper<RelationshipItem, org.hisp.dhis.tracker.domain.RelationshipItem>

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -173,4 +173,48 @@ class MetadataIdentifierMapperTest
         assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
         assertNull( id.getIdentifier() );
     }
+
+    @Test
+    void attributeOptionComboIdentifierFromUID()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromAttributeOptionCombo( "RiNIt1yJoge", params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+    }
+
+    @Test
+    void attributeOptionComboIdentifierFromAttribute()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .categoryOptionComboIdScheme( TrackerIdSchemeParam.ofAttribute( "RiNIt1yJoge" ) )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromAttributeOptionCombo( "clouds", params );
+
+        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( "clouds", id.getAttributeValue() );
+    }
+
+    @Test
+    void attributeOptionComboIdentifierFromUIDIfNull()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromAttributeOptionCombo( null, params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertNull( id.getIdentifier() );
+    }
 }


### PR DESCRIPTION
## This PR

* migrate Event.attributeOptionCombo to MetadataIdentifier

## Background on changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in the query parameters (not in the body) and only on import. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute
* DataValue.dataElement
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo :heavy_check_mark:
* Event.attributeCategoryOptions
* TrackedEntity.trackedEntityType
* Relationship.relationshipType
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:}.program
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,TrackedEntity :heavy_check_mark:}.orgUnit

will become idScheme aware.