### PR TITLE
fix: Remove ANTRL versions warning from logs

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -63,7 +63,7 @@
         <!-- *Dependencies* -->
 
         <!-- DHIS2 Rule Engine-->
-        <dhis2-rule-engine.version>2.0.38</dhis2-rule-engine.version>
+        <dhis2-rule-engine.version>2.0.39</dhis2-rule-engine.version>
 
         <!-- HISP Quick and Staxwax -->
         <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>
@@ -215,7 +215,7 @@
         <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <jrebel-x-maven-plugin.version>1.1.10</jrebel-x-maven-plugin.version>
-        <dhis-antlr-expression-parser.version>1.0.27</dhis-antlr-expression-parser.version>
+        <dhis-antlr-expression-parser.version>1.0.28</dhis-antlr-expression-parser.version>
         <jai-imageio.version>1.1.1</jai-imageio.version>
         <ow2.asm.version>9.3</ow2.asm.version>
         <gson.version>2.8.9</gson.version>


### PR DESCRIPTION
dhis2-antlr-expression-parser was using different versions for the antlr plugin and the antlr library and this was throwing a warning in the logs