### PR TITLE
chore: simplify RelationshipItem in domain DHIS2-12563

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.Constants;
 import org.hisp.dhis.TestRunStorage;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
-import org.hisp.dhis.jsontree.JsonString;
 
 import com.google.gson.JsonObject;
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
+import org.hisp.dhis.jsontree.JsonResponse;
 
 import com.google.gson.JsonObject;
 
@@ -41,7 +42,6 @@ import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.hisp.dhis.jsontree.JsonResponse;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -138,8 +138,9 @@ public class ApiResponse
         return new JsonObjectBuilder( getBody() );
     }
 
-    public JsonResponse getBodyAsJson() {
-        return new JsonResponse(raw.asString());
+    public JsonResponse getBodyAsJson()
+    {
+        return new JsonResponse( raw.asString() );
     }
 
     public boolean isEntityCreated()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -86,18 +86,11 @@ public class RelationshipTrackerConverterService
     private RelationshipItem convertRelationshipType( org.hisp.dhis.relationship.RelationshipItem from )
     {
         RelationshipItem relationshipItem = new RelationshipItem();
-        RelationshipItem.Enrollment enrollment = RelationshipItem.Enrollment.builder()
-            .enrollment( from.getProgramInstance() != null ? from.getProgramInstance().getUid() : null )
-            .build();
-        relationshipItem.setEnrollment( enrollment );
-        RelationshipItem.Event event = RelationshipItem.Event.builder()
-            .event( from.getProgramStageInstance() != null ? from.getProgramStageInstance().getUid() : null )
-            .build();
-        relationshipItem.setEvent( event );
-        RelationshipItem.TrackedEntity trackedEntity = RelationshipItem.TrackedEntity.builder()
-            .trackedEntity( from.getTrackedEntityInstance() != null ? from.getTrackedEntityInstance().getUid() : null )
-            .build();
-        relationshipItem.setTrackedEntity( trackedEntity );
+        relationshipItem.setEnrollment( from.getProgramInstance() != null ? from.getProgramInstance().getUid() : null );
+        relationshipItem
+            .setEvent( from.getProgramStageInstance() != null ? from.getProgramStageInstance().getUid() : null );
+        relationshipItem.setTrackedEntity(
+            from.getTrackedEntityInstance() != null ? from.getTrackedEntityInstance().getUid() : null );
         return relationshipItem;
     }
 
@@ -150,18 +143,18 @@ public class RelationshipTrackerConverterService
         if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
             fromItem.setTrackedEntityInstance( preheat.getTrackedEntity(
-                fromRelationship.getFrom().getTrackedEntity().getTrackedEntity() ) );
+                fromRelationship.getFrom().getTrackedEntity() ) );
         }
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
         {
             fromItem.setProgramInstance(
                 preheat.getEnrollment(
-                    fromRelationship.getFrom().getEnrollment().getEnrollment() ) );
+                    fromRelationship.getFrom().getEnrollment() ) );
         }
         else if ( relationshipType.getFromConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
             fromItem.setProgramStageInstance(
-                preheat.getEvent( fromRelationship.getFrom().getEvent().getEvent() ) );
+                preheat.getEvent( fromRelationship.getFrom().getEvent() ) );
         }
 
         // TO
@@ -170,18 +163,18 @@ public class RelationshipTrackerConverterService
         if ( relationshipType.getToConstraint().getRelationshipEntity().equals( TRACKED_ENTITY_INSTANCE ) )
         {
             toItem.setTrackedEntityInstance( preheat.getTrackedEntity(
-                fromRelationship.getTo().getTrackedEntity().getTrackedEntity() ) );
+                fromRelationship.getTo().getTrackedEntity() ) );
         }
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_INSTANCE ) )
         {
             toItem.setProgramInstance(
                 preheat.getEnrollment(
-                    fromRelationship.getTo().getEnrollment().getEnrollment() ) );
+                    fromRelationship.getTo().getEnrollment() ) );
         }
         else if ( relationshipType.getToConstraint().getRelationshipEntity().equals( PROGRAM_STAGE_INSTANCE ) )
         {
             toItem.setProgramStageInstance(
-                preheat.getEvent( fromRelationship.getTo().getEvent().getEvent() ) );
+                preheat.getEvent( fromRelationship.getTo().getEvent() ) );
         }
 
         toRelationship.setFrom( fromItem );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
@@ -27,20 +27,12 @@
  */
 package org.hisp.dhis.tracker.domain;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.tracker.TrackerType;
-import org.locationtech.jts.geom.Geometry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -61,53 +53,6 @@ public class RelationshipItem
     {
         @JsonProperty
         private String trackedEntity;
-
-        @JsonProperty
-        private String trackedEntityType;
-
-        @JsonProperty
-        private Instant createdAt;
-
-        @JsonProperty
-        private Instant createdAtClient;
-
-        @JsonProperty
-        private Instant updatedAt;
-
-        @JsonProperty
-        private Instant updatedAtClient;
-
-        @JsonProperty
-        private String orgUnit;
-
-        @JsonProperty
-        private boolean inactive;
-
-        @JsonProperty
-        private boolean deleted;
-
-        @JsonProperty
-        private boolean potentialDuplicate;
-
-        @JsonProperty
-        private Geometry geometry;
-
-        @JsonProperty
-        private String storedBy;
-
-        @JsonProperty
-        private User createdBy;
-
-        @JsonProperty
-        private User updatedBy;
-
-        @JsonProperty
-        @Builder.Default
-        private List<Attribute> attributes = new ArrayList<>();
-
-        @JsonProperty
-        @Builder.Default
-        private List<Enrollment> enrollments = new ArrayList<>();
 
         @Override
         public String getUid()
@@ -131,75 +76,6 @@ public class RelationshipItem
         @JsonProperty
         private String enrollment;
 
-        @JsonProperty
-        private Instant createdAt;
-
-        @JsonProperty
-        private Instant createdAtClient;
-
-        @JsonProperty
-        private Instant updatedAt;
-
-        @JsonProperty
-        private Instant updatedAtClient;
-
-        @JsonProperty
-        private String trackedEntity;
-
-        @JsonProperty
-        private String program;
-
-        @JsonProperty
-        private EnrollmentStatus status;
-
-        @JsonProperty
-        private String orgUnit;
-
-        @JsonProperty
-        private String orgUnitName;
-
-        @JsonProperty
-        private Instant enrolledAt;
-
-        @JsonProperty
-        private Instant occurredAt;
-
-        @JsonProperty
-        private boolean followUp;
-
-        @JsonProperty
-        private String completedBy;
-
-        @JsonProperty
-        private Instant completedAt;
-
-        @JsonProperty
-        private boolean deleted;
-
-        @JsonProperty
-        private String storedBy;
-
-        @JsonProperty
-        private User createdBy;
-
-        @JsonProperty
-        private User updatedBy;
-
-        @JsonProperty
-        private Geometry geometry;
-
-        @JsonProperty
-        @Builder.Default
-        private List<Event> events = new ArrayList<>();
-
-        @JsonProperty
-        @Builder.Default
-        private List<Attribute> attributes = new ArrayList<>();
-
-        @JsonProperty
-        @Builder.Default
-        private List<Note> notes = new ArrayList<>();
-
         @Override
         public String getUid()
         {
@@ -219,86 +95,9 @@ public class RelationshipItem
     @AllArgsConstructor
     public static class Event implements TrackerDto
     {
+
         @JsonProperty
         private String event;
-
-        @JsonProperty
-        @Builder.Default
-        private EventStatus status = EventStatus.ACTIVE;
-
-        @JsonProperty
-        private String program;
-
-        @JsonProperty
-        private String programStage;
-
-        @JsonProperty
-        private String enrollment;
-
-        @JsonProperty
-        private String orgUnit;
-
-        @JsonProperty
-        private String orgUnitName;
-
-        @JsonProperty
-        private Instant occurredAt;
-
-        @JsonProperty
-        private Instant scheduledAt;
-
-        @JsonProperty
-        private String storedBy;
-
-        @JsonProperty
-        private boolean followup;
-
-        @JsonProperty
-        private boolean deleted;
-
-        @JsonProperty
-        private Instant createdAt;
-
-        @JsonProperty
-        private Instant createdAtClient;
-
-        @JsonProperty
-        private Instant updatedAt;
-
-        @JsonProperty
-        private Instant updatedAtClient;
-
-        @JsonProperty
-        private String attributeOptionCombo;
-
-        @JsonProperty
-        private String attributeCategoryOptions;
-
-        @JsonProperty
-        private String completedBy;
-
-        @JsonProperty
-        private Instant completedAt;
-
-        @JsonProperty
-        private Geometry geometry;
-
-        @JsonProperty
-        private User assignedUser;
-
-        @JsonProperty
-        private User createdBy;
-
-        @JsonProperty
-        private User updatedBy;
-
-        @JsonProperty
-        @Builder.Default
-        private Set<DataValue> dataValues = new HashSet<>();
-
-        @JsonProperty
-        @Builder.Default
-        private List<Note> notes = new ArrayList<>();
 
         @Override
         public String getUid()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
@@ -32,8 +32,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import org.hisp.dhis.tracker.TrackerType;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -45,79 +43,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @AllArgsConstructor
 public class RelationshipItem
 {
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TrackedEntity implements TrackerDto
-    {
-        @JsonProperty
-        private String trackedEntity;
-
-        @Override
-        public String getUid()
-        {
-            return this.trackedEntity;
-        }
-
-        @Override
-        public TrackerType getTrackerType()
-        {
-            return TrackerType.TRACKED_ENTITY;
-        }
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Enrollment implements TrackerDto
-    {
-        @JsonProperty
-        private String enrollment;
-
-        @Override
-        public String getUid()
-        {
-            return this.enrollment;
-        }
-
-        @Override
-        public TrackerType getTrackerType()
-        {
-            return TrackerType.ENROLLMENT;
-        }
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Event implements TrackerDto
-    {
-
-        @JsonProperty
-        private String event;
-
-        @Override
-        public String getUid()
-        {
-            return this.event;
-        }
-
-        @Override
-        public TrackerType getTrackerType()
-        {
-            return TrackerType.EVENT;
-        }
-    }
 
     @JsonProperty
-    private TrackedEntity trackedEntity;
+    private String trackedEntity;
 
     @JsonProperty
-    private Enrollment enrollment;
+    private String enrollment;
 
     @JsonProperty
-    private Event event;
+    private String event;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/RelationshipPreheatKeySupport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/RelationshipPreheatKeySupport.java
@@ -81,12 +81,9 @@ public class RelationshipPreheatKeySupport
         if ( Objects.nonNull( relationshipItem ) )
         {
             return RelationshipKey.RelationshipItemKey.builder()
-                .trackedEntity( trimToEmpty( relationshipItem.getTrackedEntity() == null ? null
-                    : relationshipItem.getTrackedEntity().getTrackedEntity() ) )
-                .enrollment( trimToEmpty( relationshipItem.getEnrollment() == null ? null
-                    : relationshipItem.getEnrollment().getEnrollment() ) )
-                .event(
-                    trimToEmpty( relationshipItem.getEvent() == null ? null : relationshipItem.getEvent().getEvent() ) )
+                .trackedEntity( trimToEmpty( relationshipItem.getTrackedEntity() ) )
+                .enrollment( trimToEmpty( relationshipItem.getEnrollment() ) )
+                .event( trimToEmpty( relationshipItem.getEvent() ) )
                 .build();
         }
         throw new IllegalStateException( "Unable to determine uid for relationship item" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipValidationUtils.java
@@ -40,15 +40,15 @@ public class RelationshipValidationUtils
 {
     public static TrackerType relationshipItemValueType( RelationshipItem item )
     {
-        if ( item.getTrackedEntity() != null && StringUtils.isNotEmpty( item.getTrackedEntity().getTrackedEntity() ) )
+        if ( StringUtils.isNotEmpty( item.getTrackedEntity() ) )
         {
             return TrackerType.TRACKED_ENTITY;
         }
-        else if ( item.getEnrollment() != null && StringUtils.isNotEmpty( item.getEnrollment().getEnrollment() ) )
+        else if ( StringUtils.isNotEmpty( item.getEnrollment() ) )
         {
             return TrackerType.ENROLLMENT;
         }
-        else if ( item.getEvent() != null && StringUtils.isNotEmpty( item.getEvent().getEvent() ) )
+        else if ( StringUtils.isNotEmpty( item.getEvent() ) )
         {
             return TrackerType.EVENT;
         }
@@ -59,15 +59,15 @@ public class RelationshipValidationUtils
     {
         if ( item.getTrackedEntity() != null )
         {
-            return Optional.of( item.getTrackedEntity().getTrackedEntity() );
+            return Optional.of( item.getTrackedEntity() );
         }
         else if ( item.getEnrollment() != null )
         {
-            return Optional.of( item.getEnrollment().getEnrollment() );
+            return Optional.of( item.getEnrollment() );
         }
         else if ( item.getEvent() != null )
         {
-            return Optional.of( item.getEvent().getEvent() );
+            return Optional.of( item.getEvent() );
         }
         return Optional.empty();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipValidationUtils.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import java.util.Optional;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
@@ -57,18 +58,7 @@ public class RelationshipValidationUtils
 
     public static Optional<String> getUidFromRelationshipItem( RelationshipItem item )
     {
-        if ( item.getTrackedEntity() != null )
-        {
-            return Optional.of( item.getTrackedEntity() );
-        }
-        else if ( item.getEnrollment() != null )
-        {
-            return Optional.of( item.getEnrollment() );
-        }
-        else if ( item.getEvent() != null )
-        {
-            return Optional.of( item.getEvent() );
-        }
-        return Optional.empty();
+        return Optional
+            .ofNullable( ObjectUtils.firstNonNull( item.getTrackedEntity(), item.getEnrollment(), item.getEvent() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -51,7 +51,6 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -165,7 +164,7 @@ public class RelationshipsValidationHook
                 // constraint
                 //
                 getRelationshipTypeUidFromTrackedEntity( reporter.getBundle(),
-                    item.getTrackedEntity().getTrackedEntity() )
+                    item.getTrackedEntity() )
                         .ifPresent( type -> {
 
                             if ( !type.equals( constraint.getTrackedEntityType().getUid() ) )
@@ -200,8 +199,7 @@ public class RelationshipsValidationHook
         {
             return false;
         }
-        return Stream.of( item.getTrackedEntity(), item.getEnrollment(), item.getEvent() ).filter( Objects::nonNull )
-            .map( TrackerDto::getUid )
+        return Stream.of( item.getTrackedEntity(), item.getEnrollment(), item.getEvent() )
             .filter( StringUtils::isNotBlank )
             .count() > 1;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessorTest.java
@@ -225,14 +225,14 @@ class DuplicateRelationshipsPreProcessorTest
     private RelationshipItem trackedEntityRelationshipItem( String trackedEntityUid )
     {
         return RelationshipItem.builder()
-            .trackedEntity( RelationshipItem.TrackedEntity.builder().trackedEntity( trackedEntityUid ).build() )
+            .trackedEntity( trackedEntityUid )
             .build();
     }
 
     private RelationshipItem enrollmentRelationshipItem( String enrollmentUid )
     {
         return RelationshipItem.builder()
-            .enrollment( RelationshipItem.Enrollment.builder().enrollment( enrollmentUid ).build() )
+            .enrollment( enrollmentUid )
             .build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -1146,7 +1146,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
     private RelationshipItem trackedEntityRelationshipItem( String trackedEntityUid )
     {
         return RelationshipItem.builder()
-            .trackedEntity( RelationshipItem.TrackedEntity.builder().trackedEntity( trackedEntityUid ).build() )
+            .trackedEntity( trackedEntityUid )
             .build();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -387,8 +387,8 @@ class PreCheckMandatoryFieldsValidationHookTest
             is( "Missing required " + entity + " property: `" + property + "`." ) );
     }
 
-    private RelationshipItem.TrackedEntity trackedEntity()
+    private String trackedEntity()
     {
-        return RelationshipItem.TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
+        return CodeGenerator.generateUid();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -368,7 +368,7 @@ class RelationshipsValidationHookTest
             .relationshipType( relType.getUid() )
             .build();
         TrackerErrorReport error = TrackerErrorReport.builder()
-            .uid( relationship.getTo().getTrackedEntity().getTrackedEntity() )
+            .uid( relationship.getTo().getTrackedEntity() )
             .trackerType( TRACKED_ENTITY )
             .errorCode( TrackerErrorCode.E9999 )
             .build( bundle );
@@ -453,7 +453,7 @@ class RelationshipsValidationHookTest
     private RelationshipItem trackedEntityRelationshipItem( String trackedEntityUid )
     {
         return RelationshipItem.builder()
-            .trackedEntity( trackedEntity( trackedEntityUid ) )
+            .trackedEntity( trackedEntityUid )
             .build();
     }
 
@@ -471,23 +471,18 @@ class RelationshipsValidationHookTest
             .build();
     }
 
-    private RelationshipItem.TrackedEntity trackedEntity()
+    private String trackedEntity()
     {
-        return trackedEntity( CodeGenerator.generateUid() );
+        return CodeGenerator.generateUid();
     }
 
-    private RelationshipItem.TrackedEntity trackedEntity( String uid )
+    private String enrollment()
     {
-        return RelationshipItem.TrackedEntity.builder().trackedEntity( uid ).build();
+        return CodeGenerator.generateUid();
     }
 
-    private RelationshipItem.Enrollment enrollment()
+    private String event()
     {
-        return RelationshipItem.Enrollment.builder().enrollment( CodeGenerator.generateUid() ).build();
-    }
-
-    private RelationshipItem.Event event()
-    {
-        return RelationshipItem.Event.builder().event( CodeGenerator.generateUid() ).build();
+        return CodeGenerator.generateUid();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationshipToUpdate.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationshipToUpdate.json
@@ -41,24 +41,10 @@
       "updatedAt": "2019-10-01T12:17:30.163",
       "bidirectional": false,
       "from": {
-        "trackedEntity": {
-          "trackedEntity": "IOR1AXXl24H",
-          "inactive": false,
-          "deleted": false,
-          "potentialDuplicate": false,
-          "attributes": [],
-          "enrollments": []
-        }
+        "trackedEntity": "IOR1AXXl24H"
       },
       "to": {
-        "enrollment": {
-          "enrollment": "TvctPPhpD8u",
-          "followUp": false,
-          "deleted": false,
-          "events": [],
-          "attributes": [],
-          "notes": []
-        }
+        "enrollment": "TvctPPhpD8u"
       }
     }
   ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationships.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/relationships.json
@@ -41,24 +41,10 @@
       "updatedAt": "2018-10-01T12:17:30.163",
       "bidirectional": false,
       "from": {
-        "trackedEntity": {
-          "trackedEntity": "IOR1AXXl24H",
-          "inactive": false,
-          "deleted": false,
-          "potentialDuplicate": false,
-          "attributes": [],
-          "enrollments": []
-        }
+        "trackedEntity": "IOR1AXXl24H"
       },
       "to": {
-        "enrollment": {
-          "enrollment": "TvctPPhpD8u",
-          "followUp": false,
-          "deleted": false,
-          "events": [],
-          "attributes": [],
-          "notes": []
-        }
+        "enrollment": "TvctPPhpD8u"
       }
     },
     {
@@ -68,24 +54,10 @@
       "updatedAt": "2018-10-01T12:17:30.163",
       "bidirectional": false,
       "from": {
-        "trackedEntity": {
-          "trackedEntity": "IOR1AXXl24H",
-          "inactive": false,
-          "deleted": false,
-          "potentialDuplicate": false,
-          "attributes": [],
-          "enrollments": []
-        }
+        "trackedEntity": "IOR1AXXl24H"
       },
       "to": {
-        "event": {
-          "event": "D9PbzJY8bJO",
-          "status": "ACTIVE",
-          "followup": false,
-          "deleted": false,
-          "dataValues": [],
-          "notes": []
-        }
+        "event": "D9PbzJY8bJO"
       }
     }
   ],

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/RelationshipItemMapper.java
@@ -30,19 +30,12 @@ package org.hisp.dhis.webapi.controller.tracker.imports;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
-import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.RelationshipItem;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 
-@Mapper( uses = {
-    AttributeMapper.class,
-    DataValueMapper.class,
-    NoteMapper.class,
-    InstantMapper.class,
-    UserMapper.class
-} )
+@Mapper
 interface RelationshipItemMapper
     extends DomainMapper<RelationshipItem, org.hisp.dhis.tracker.domain.RelationshipItem>
 {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/RelationshipItemMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/RelationshipItemMapper.java
@@ -28,26 +28,18 @@
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
-import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
-import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.RelationshipItem;
-import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper
 interface RelationshipItemMapper
     extends DomainMapper<RelationshipItem, org.hisp.dhis.tracker.domain.RelationshipItem>
 {
+    @Mapping( target = "trackedEntity", source = "trackedEntity.trackedEntity" )
+    @Mapping( target = "enrollment", source = "enrollment.enrollment" )
+    @Mapping( target = "event", source = "event.event" )
     org.hisp.dhis.tracker.domain.RelationshipItem from( RelationshipItem relationshipItem,
-        @Context TrackerIdSchemeParams idSchemeParams );
-
-    org.hisp.dhis.tracker.domain.RelationshipItem.TrackedEntity from( TrackedEntity trackedEntity,
-        @Context TrackerIdSchemeParams idSchemeParams );
-
-    org.hisp.dhis.tracker.domain.RelationshipItem.Enrollment from( Enrollment enrollment,
-        @Context TrackerIdSchemeParams idSchemeParams );
-
-    org.hisp.dhis.tracker.domain.RelationshipItem.Event from( Event event,
         @Context TrackerIdSchemeParams idSchemeParams );
 }


### PR DESCRIPTION
## This PR

Now that we have separate models for our domain and the view (JSON exposed to users) only the TEI, enrollment, event ids are needed in the tracker domain RelationshipItem.

See https://github.com/dhis2/dhis2-core/pull/9841 if you need more context why these fields where introduced before we had domain and view models.

## Background on changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in the query parameters (not in the body) and only on import. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute
* DataValue.dataElement
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo :heavy_check_mark:
* Event.attributeCategoryOptions
* TrackedEntity.trackedEntityType
* Relationship.relationshipType
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:}.program
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,TrackedEntity :heavy_check_mark:}.orgUnit

will become idScheme aware.