### PR TITLE
fix: datastore query API nesting and alias syntax [DHIS2-13193] (2.38)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreQuery.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datastore/DatastoreQuery.java
@@ -395,11 +395,11 @@ public final class DatastoreQuery
             {
                 addNonEmptyTo( flat, parentPath, field );
             }
-            else if ( next == '[' )
+            else if ( next == '[' || next == '(' )
             {
                 parentPath += field + ".";
             }
-            else if ( next == ']' )
+            else if ( next == ']' || next == ')' )
             {
                 addNonEmptyTo( flat, parentPath, field );
                 parentPath = parentPath.substring( 0, parentPath.lastIndexOf( '.', parentPath.length() - 2 ) + 1 );
@@ -441,9 +441,9 @@ public final class DatastoreQuery
     {
         if ( !field.isEmpty() )
         {
-            int aliasStart = field.indexOf( '(' );
+            int aliasStart = field.indexOf( "~hoist(" );
             String name = aliasStart > 0 ? field.substring( 0, aliasStart ) : field;
-            String alias = aliasStart > 0 ? field.substring( aliasStart + 1, field.length() - 1 ) : null;
+            String alias = aliasStart > 0 ? field.substring( aliasStart + 7, field.length() - 1 ) : null;
             fields.add( new Field( parent + name, alias ) );
         }
     }
@@ -473,7 +473,7 @@ public final class DatastoreQuery
      */
     private static int findAliasEnd( String fields, int start )
     {
-        if ( start >= fields.length() || fields.charAt( start ) != '(' )
+        if ( start >= fields.length() || fields.charAt( start ) != '~' )
         {
             return start;
         }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreFieldsControllerTest.java
@@ -106,7 +106,7 @@ class DatastoreFieldsControllerTest extends AbstractDatastoreControllerTest
     void testFields_RootAlias()
     {
         assertJson( "[{'key':'horse','name':'Fury'}]",
-            GET( "/dataStore/pets?fields=.(name)&headless=true&filter=_:eq:horse" ) );
+            GET( "/dataStore/pets?fields=.~hoist(name)&headless=true&filter=_:eq:horse" ) );
     }
 
     @Test
@@ -137,25 +137,29 @@ class DatastoreFieldsControllerTest extends AbstractDatastoreControllerTest
     @Test
     void testFields_PathStringWithAlias()
     {
-        assertJson( "["
+        String expected = "["
             + "{'key':'cat','food':{'name':'tuna'}},"
             + "{'key':'cow','food':{'name':'gras'}},"
             + "{'key':'hamster','food':{'name':'veggies'}},"
             + "{'key':'pig','food':{'name':'carrots'}}"
-            + "]",
-            GET( "/dataStore/pets?fields=eats.0(food)&headless=true" ) );
+            + "]";
+        assertJson( expected, GET( "/dataStore/pets?fields=eats.0~hoist(food)&headless=true" ) );
+        assertJson( expected, GET( "/dataStore/pets?fields=eats[0~hoist(food)]&headless=true" ) );
+        assertJson( expected, GET( "/dataStore/pets?fields=eats(0~hoist(food))&headless=true" ) );
     }
 
     @Test
     void testFields_Multiple()
     {
-        assertJson( "["
+        String expected = "["
             + "{'key':'cat','name':'Miao','food':'tuna'},"
             + "{'key':'cow','name':'Muuhh','food':'gras'},"
             + "{'key':'hamster','name':'Speedy','food':'veggies'},"
             + "{'key':'pig','name':'Oink','food':'carrots'}"
-            + "]",
-            GET( "/dataStore/pets?fields=name,eats.0.name(food)&headless=true" ) );
+            + "]";
+        assertJson( expected, GET( "/dataStore/pets?fields=name,eats.0.name~hoist(food)&headless=true" ) );
+        assertJson( expected, GET( "/dataStore/pets?fields=name,eats[0[name~hoist(food)]]&headless=true" ) );
+        assertJson( expected, GET( "/dataStore/pets?fields=name,eats(0(name~hoist(food)))&headless=true" ) );
     }
 
     @Test


### PR DESCRIPTION
backport of #10673