### PR TITLE
fix: job progress - clean complete after cancel [DHIS2-13125] (2.38)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -276,13 +276,21 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             // run the actual job
             jobService.getJob( type ).execute( configuration, progress );
 
+            Process process = progress.getProcesses().peekLast();
+            if ( process != null && process.getStatus() != JobProgress.Status.RUNNING )
+            {
+                progress.failedProcess( (String) null );
+            }
             if ( configuration.getLastExecutedStatus() == RUNNING )
             {
-                configuration.setLastExecutedStatus( JobStatus.COMPLETED );
+                boolean wasSuccessfulRun = progress.getProcesses().stream()
+                    .allMatch( p -> p.getStatus() == JobProgress.Status.SUCCESS );
+                configuration.setLastExecutedStatus( wasSuccessfulRun ? JobStatus.COMPLETED : JobStatus.FAILED );
             }
         }
         catch ( Exception ex )
         {
+            progress.failedProcess( ex );
             whenRunThrewException( configuration, ex );
         }
         finally


### PR DESCRIPTION
Backport based on cherry-pick of #10648 with manual changes to adjust to the changes to job progress that were not backported like the per stage failure handling (#10507). This also includes the logging of tracked info added in #10501.