### PR TITLE
fix: allow any page to fail during data sync [DHIS2-13206]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
@@ -149,7 +149,7 @@ public class CompleteDataSetRegistrationSynchronization implements DataSynchroni
             + " completed data set registrations to synchronize were found.\n";
         msg += "Remote server URL for completeness POST synchronization: " + context.getInstance().getUrl();
 
-        progress.startingProcess( msg );
+        progress.startingStage( msg );
         return progress.runStage( false, () -> sendSyncRequest( context ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/DataValueSynchronization.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
 import java.util.Date;
 import java.util.stream.IntStream;
@@ -149,7 +149,7 @@ public class DataValueSynchronization implements DataSynchronizationWithPaging
         msg += "DataValueSynchronization job has " + context.getPages() + " pages to sync. With page size: "
             + context.getPageSize();
 
-        progress.startingStage( msg, context.getPages(), SKIP_ITEM_OUTLIER );
+        progress.startingStage( msg, context.getPages(), SKIP_ITEM );
         progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> synchronizePage( page, context ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/EventSynchronization.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 
 import java.util.Date;
 import java.util.List;
@@ -149,7 +150,7 @@ public class EventSynchronization implements DataSynchronizationWithPaging
         msg += "Remote server URL for Event programs POST synchronization: " + context.getInstance().getUrl() + "\n";
         msg += "Event programs data synchronization job has " + context.getPages()
             + " pages to synchronize. With page size: " + context.getPageSize();
-        progress.startingStage( msg, context.getPages() );
+        progress.startingStage( msg, context.getPages(), SKIP_ITEM );
         progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> synchronizePage( page, context ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/TrackerSynchronization.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.dxf2.sync;
 
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
 import static org.hisp.dhis.setting.SettingKey.SKIP_SYNCHRONIZATION_FOR_DATA_CHANGED_BEFORE;
 
 import java.util.Date;
@@ -145,7 +145,7 @@ public class TrackerSynchronization implements DataSynchronizationWithPaging
         msg += "Tracker programs data synchronization job has " + context.getPages()
             + " pages to synchronize. With page size: " + context.getPageSize();
 
-        progress.startingStage( msg, context.getPages(), SKIP_ITEM_OUTLIER );
+        progress.startingStage( msg, context.getPages(), SKIP_ITEM );
         progress.runStage( IntStream.range( 1, context.getPages() + 1 ).boxed(),
             page -> format( "Synchronizing page %d with page size %d", page, context.getPageSize() ),
             page -> {


### PR DESCRIPTION
Changes policy from `SKIP_ITEM_OUTLIER` to `SKIP_ITEM`. 
Also found that the stage was mistakenly started using `startingProcess` instead of `startingStage` in one occasion.

Also want to point out that in the `EventSynchronization#synchronizePage` the page is not explicitly part of the database query but a true/false filter is used in the assumption that the last page sync has flipped this flag causing the next call to return the next page. At least this is how I understand it.