### PR TITLE
fix: Options not returned when results rows are empty [DHIS2-13140]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -28,12 +28,14 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ORG_UNIT_NAME_HIERARCHY;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.PAGER;
+import static org.hisp.dhis.analytics.event.data.QueryItemHelper.getItemOptions;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
@@ -44,14 +46,12 @@ import static org.hisp.dhis.common.ValueType.COORDINATE;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.getParentGraphMap;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.getParentNameGraphMap;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
@@ -119,7 +119,7 @@ public abstract class AbstractAnalyticsService
         List<DimensionItemKeywords.Keyword> periodKeywords = params.getDimensions().stream().map(
             DimensionalObject::getDimensionItemKeywords )
             .filter( dimensionItemKeywords -> dimensionItemKeywords != null && !dimensionItemKeywords.isEmpty() )
-            .flatMap( dk -> dk.getKeywords().stream() ).collect( Collectors.toList() );
+            .flatMap( dk -> dk.getKeywords().stream() ).collect( toList() );
 
         params = new EventQueryParams.Builder( params )
             .withStartEndDatesForPeriods()
@@ -304,7 +304,7 @@ public abstract class AbstractAnalyticsService
         {
             final Map<String, Object> metadata = new HashMap<>();
 
-            List<Option> options = getItemOptions( grid );
+            List<Option> options = getItemOptions( grid, params );
 
             metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, options ) );
 
@@ -331,43 +331,6 @@ public abstract class AbstractAnalyticsService
 
             grid.setMetaData( metadata );
         }
-    }
-
-    /**
-     * Returns a map of metadata item options and {@link Option}.
-     *
-     * @param grid the Grid instance.
-     * @return a list of options.
-     */
-    protected List<Option> getItemOptions( Grid grid )
-    {
-        List<Option> options = new ArrayList<>();
-
-        for ( int i = 0; i < grid.getHeaders().size(); ++i )
-        {
-            GridHeader gridHeader = grid.getHeaders().get( i );
-
-            if ( gridHeader.hasOptionSet() )
-            {
-                final int columnIndex = i;
-
-                options.addAll( gridHeader
-                    .getOptionSetObject()
-                    .getOptions()
-                    .stream()
-                    .filter( opt -> opt != null && grid.getRows().stream().anyMatch( r -> {
-                        Object o = r.get( columnIndex );
-                        if ( o instanceof String )
-                        {
-                            return ((String) o).equalsIgnoreCase( opt.getCode() );
-                        }
-
-                        return false;
-                    } ) ).collect( Collectors.toList() ) );
-            }
-        }
-
-        return options.stream().distinct().collect( Collectors.toList() );
     }
 
     /**
@@ -575,7 +538,7 @@ public abstract class AbstractAnalyticsService
         {
             return itemOptions.stream()
                 .map( BaseIdentifiableObject::getUid )
-                .collect( Collectors.toList() );
+                .collect( toList() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
@@ -27,11 +27,22 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.option.Option;
@@ -44,6 +55,10 @@ public class QueryItemHelper
     private static final String ITEM_NAME_SEP = ": ";
 
     private static final String NA = "[N/A]";
+
+    private QueryItemHelper()
+    {
+    }
 
     /**
      * Returns an item value (legend) for OutputIdScheme (Code, Name, Id, Uid).
@@ -116,5 +131,136 @@ public class QueryItemHelper
 
             return value + itemValue;
         }
+    }
+
+    /**
+     * Returns a list of options {@link Option}.
+     *
+     * Based on the given Grid and EventQueryParams, this method will return the
+     * options correct list of options.
+     *
+     * When the Grid has no rows, it will return the options specified as
+     * element "filter", ie.: Zj7UnCAulEk.K6uUAvq500H:IN:A03, where "A03" is the
+     * option code.
+     *
+     * When the Grid has rows, this method will return only the options that are
+     * part of the row object.
+     *
+     * @param grid the Grid instance
+     * @param params the EventQueryParams
+     * @return a list of options based on the Grid/EventQueryParams
+     */
+    public static List<Option> getItemOptions( final Grid grid, final EventQueryParams params )
+    {
+        final List<Option> options = new ArrayList<>();
+
+        for ( int i = 0; i < grid.getHeaders().size(); ++i )
+        {
+            final GridHeader gridHeader = grid.getHeaders().get( i );
+
+            if ( gridHeader.hasOptionSet() && isNotEmpty( grid.getRows() ) )
+            {
+                options.addAll( getItemOptionsThatMatchesRows( grid, i ) );
+            }
+            else if ( gridHeader.hasOptionSet() && isEmpty( grid.getRows() ) )
+            {
+                options.addAll( getItemOptionsForEmptyRows( params ) );
+            }
+        }
+
+        return options.stream().distinct().collect( toList() );
+    }
+
+    /**
+     * This method will extract the options (based on their codes) from the
+     * element filter.
+     *
+     * @param params the EventQueryParams
+     * @return the options for empty rows
+     */
+    private static List<Option> getItemOptionsForEmptyRows( final EventQueryParams params )
+    {
+        final List<Option> options = new ArrayList<>();
+
+        if ( isNotEmpty( params.getItems() ) )
+        {
+            final List<QueryItem> items = params.getItems();
+
+            for ( final QueryItem item : items )
+            {
+                final boolean hasOptions = item.getOptionSet() != null
+                    && isNotEmpty( item.getOptionSet().getOptions() );
+
+                if ( hasOptions && isNotEmpty( item.getFilters() ) )
+                {
+                    options.addAll( getItemOptionsForFilter( item ) );
+                }
+            }
+        }
+
+        return options;
+    }
+
+    /**
+     * For the list of rows, in the Grid, it will return only the options that
+     * are part of each row object. It picks each option, from the list of all
+     * options available, that matches the current header.
+     *
+     * @param grid the Grid
+     * @param columnIndex
+     * @return the list of matching options
+     */
+    private static List<Option> getItemOptionsThatMatchesRows( final Grid grid, final int columnIndex )
+    {
+        final List<Option> options = new ArrayList<>();
+        final GridHeader gridHeader = grid.getHeaders().get( columnIndex );
+
+        options.addAll( gridHeader
+            .getOptionSetObject()
+            .getOptions()
+            .stream()
+            .filter( opt -> opt != null && grid.getRows().stream().anyMatch( r -> {
+                Object o = r.get( columnIndex );
+                if ( o instanceof String )
+                {
+                    return ((String) o).equalsIgnoreCase( opt.getCode() );
+                }
+
+                return false;
+            } ) ).collect( toList() ) );
+
+        return options;
+    }
+
+    /**
+     * Returns the options specified as element "filter" (option code), ie.:
+     * Zj7UnCAulEk.K6uUAvq500H:IN:A03;B01, where "A03;B01" are the options
+     * codes.
+     *
+     * The codes are split by the token ";" and the respective Option objects
+     * are returned.
+     *
+     * @param item the QueryItem
+     * @return the list of options found in the filter
+     */
+    private static List<Option> getItemOptionsForFilter( final QueryItem item )
+    {
+        final List<Option> options = new ArrayList<>();
+
+        for ( final Option option : item.getOptionSet().getOptions() )
+        {
+            for ( final QueryFilter filter : item.getFilters() )
+            {
+                final List<String> filterSplit = Arrays
+                    .stream( trimToEmpty( filter.getFilter() ).split( ";" ) )
+                    .collect( toList() );
+                if ( filterSplit.contains( trimToEmpty( option.getCode() ) ) )
+                {
+                    options.add( option );
+                }
+            }
+        }
+
+        return options;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
@@ -27,19 +27,29 @@
  */
 package org.hisp.dhis.analytics.data;
 
+import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.data.QueryItemHelper;
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.RepeatableStageParams;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
+import org.hisp.dhis.system.grid.ListGrid;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -138,5 +148,87 @@ class QueryItemHelperTest extends DhisConvenienceTest
         assertEquals( UID_B, optionValueB );
         assertEquals( UID_A, legendValueA );
         assertEquals( UID_B, legendValueB );
+    }
+
+    @Test
+    void testGetItemOptionsWhenRowsArePresent()
+    {
+        // Given
+        final Option option = new Option( "Opt-A", "Code-A" );
+        final OptionSet optionSet = new OptionSet();
+        optionSet.addOption( option );
+
+        final Grid grid = stubGridWithRowsAndOptionSet( optionSet );
+        final QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        queryItem.addFilter( new QueryFilter( IN, "Code-A" ) );
+
+        final EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).build();
+        params.getItems().add( queryItem );
+
+        // When
+        final List<Option> options = QueryItemHelper.getItemOptions( grid, params );
+
+        // Then
+        assertTrue( options.contains( option ) );
+    }
+
+    @Test
+    void testGetItemOptionsWhenRowsAreEmpty()
+    {
+        // Given
+        final Option option = new Option( "Opt-A", "Code-A" );
+        final OptionSet optionSet = new OptionSet();
+        optionSet.addOption( option );
+
+        final Grid grid = stubGridWithEmptyRowsAndOptionSet( optionSet );
+        final QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        queryItem.addFilter( new QueryFilter( IN, "Code-A" ) );
+
+        final EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).build();
+        params.getItems().add( queryItem );
+
+        // When
+        final List<Option> options = QueryItemHelper.getItemOptions( grid, params );
+
+        // Then
+        assertTrue( options.contains( option ) );
+    }
+
+    private Grid stubGridWithRowsAndOptionSet( final OptionSet optionSet )
+    {
+        final Grid grid = new ListGrid();
+        final GridHeader headerA = new GridHeader( "ColA", "colA", ValueType.TEXT, false, true,
+            optionSet, null, "programStage", new RepeatableStageParams() );
+        final GridHeader headerB = new GridHeader( "ColB", "colB", ValueType.TEXT, false, true );
+
+        grid.addHeader( headerA );
+        grid.addHeader( headerB );
+        grid.addRow();
+        grid.addValue( "Code-A" );
+        grid.addValue( 11 );
+        grid.addRow();
+        grid.addValue( 21 );
+        grid.addValue( 22 );
+        grid.addRow();
+        grid.addValue( 31 );
+        grid.addValue( 32 );
+        grid.addRow();
+        grid.addValue( 41 );
+        grid.addValue( 42 );
+
+        return grid;
+    }
+
+    private Grid stubGridWithEmptyRowsAndOptionSet( final OptionSet optionSet )
+    {
+        final Grid grid = new ListGrid();
+        final GridHeader headerA = new GridHeader( "ColA", "colA", ValueType.TEXT, false, true,
+            optionSet, null, "programStage", new RepeatableStageParams() );
+        final GridHeader headerB = new GridHeader( "ColB", "colB", ValueType.TEXT, false, true );
+
+        grid.addHeader( headerA );
+        grid.addHeader( headerB );
+
+        return grid;
     }
 }


### PR DESCRIPTION
**_[Backport from master/2.39]_**

When consuming the endpoint "/analytics/events/query", and a DataElement filters by Option (from OptionSet) but no results are found (which means empty rows in the response), we should still get back the Options as part of the "metaData/items" element.

After this fix, the following GET request should return the respective option as part of `metaData/items`. Ie.:
``` 
https://play.dhis2.org/dev/api/39/analytics/events/query/eBAyeGv0exc?dimension=ou:USER_ORGUNIT,Zj7UnCAulEk.K6uUAvq500H:IN:A03&headers=ouname,eventdate,Zj7UnCAulEk.K6uUAvq500H&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&asc=ouname
```
Should return the `A03` option, even if there are no rows in the response.
```
"metaData": {
...
"items": {
"the-option-uid": {
"uid": "the-option-uid",
"code": "A03",
"name": "A03 Shigellosis"
},
```