### PR TITLE
fix: Interpretation URL for 2.38 patch [DHIS2-13109]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
@@ -372,7 +372,7 @@ public class DefaultInterpretationService
                 + "&interpretationid=" + interpretation.getUid();
             break;
         case EVENT_VISUALIZATION:
-            path = "/dhis-web-event-visualizer/index.html?id=" + interpretation.getEventVisualization().getUid()
+            path = "/dhis-web-event-reports/index.html?id=" + interpretation.getEventVisualization().getUid()
                 + "&interpretationid=" + interpretation.getUid();
             break;
         case EVENT_CHART:


### PR DESCRIPTION
Make the URL of Event Visualization the same as Event Report during the "migration/deprecation" phase.

_**NEEDS APPROVAL FROM THE RELEASE CONTROL TEAM.**_