### PR TITLE
fix: Log4JLogConfigInitializer should check log4j version 2 config DHIS2-13163 [2.35]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
@@ -90,7 +90,7 @@ public class Log4JLogConfigInitializer
 
     private static final String AUDIT_LOGGER_FILENAME = "dhis-audit.log";
 
-    private static final String LOG4J_CONF_PROP = "log4j.configuration";
+    private static final String LOG4J_CONF_PROP = "log4j2.configurationFile";
 
     private final LocationManager locationManager;
 
@@ -108,16 +108,16 @@ public class Log4JLogConfigInitializer
     @Override
     public void initConfig()
     {
-        if ( !locationManager.externalDirectorySet() )
-        {
-            log.warn( "Could not initialize additional log configuration, external home directory not set" );
-            return;
-        }
-
         if ( isNotBlank( System.getProperty( LOG4J_CONF_PROP ) ) )
         {
             log.info( "Aborting default log config, external config set through system prop " + LOG4J_CONF_PROP + ": "
                 + System.getProperty( LOG4J_CONF_PROP ) );
+            return;
+        }
+
+        if ( !locationManager.externalDirectorySet() )
+        {
+            log.warn( "Could not initialize additional log configuration, external home directory not set" );
             return;
         }
 


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/10641 except for the exclusion of log4j version 1. debezium prior to 1.9 brings in a dependency on log4j version 1. Since debezium is responsible for replication backporting an upgrade of debezium seems risky.

Log4JLogConfigInitializer will not make any config changes if the user provides
their own logging configuration. The check relies on the log4j config property.
Log4JLogConfigInitializer should check the log4j version 2 config not version 1, as
we rely on version 2.