### PR TITLE
feat: attribute as property in gist API fields and filters [DHIS2-13158]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/UserActions.java
@@ -35,7 +35,6 @@ import org.hisp.dhis.Constants;
 import org.hisp.dhis.TestRunStorage;
 import org.hisp.dhis.dto.ApiResponse;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
-import org.hisp.dhis.jsontree.JsonString;
 
 import com.google.gson.JsonObject;
 

--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/dto/ApiResponse.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.helpers.JsonObjectBuilder;
+import org.hisp.dhis.jsontree.JsonResponse;
 
 import com.google.gson.JsonObject;
 
@@ -41,7 +42,6 @@ import io.restassured.path.json.config.JsonParserType;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.hisp.dhis.jsontree.JsonResponse;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -138,8 +138,9 @@ public class ApiResponse
         return new JsonObjectBuilder( getBody() );
     }
 
-    public JsonResponse getBodyAsJson() {
-        return new JsonResponse(raw.asString());
+    public JsonResponse getBodyAsJson()
+    {
+        return new JsonResponse( raw.asString() );
     }
 
     public boolean isEntityCreated()

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.function.Function;
+
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Tests the Gist API allows attribute UIDs being used as properties in the
+ * {@code fields} and {@code filter} parameters.
+ *
+ * @author Jan Bernitt
+ */
+class GistAttributeControllerTest extends AbstractGistControllerTest
+{
+    /**
+     * A text attribute used in the tests
+     */
+    private String attrId;
+
+    /**
+     * A group having the text attribute
+     */
+    private String group1Id;
+
+    /**
+     * Another group having the text attribute but with a different value
+     */
+    private String group2Id;
+
+    @BeforeEach
+    void setUp()
+    {
+        // create user group with custom attribute value
+        attrId = assertStatus( HttpStatus.CREATED, POST( "/attributes", "{" + "'name':'extra', "
+            + "'valueType':'TEXT', " + "'" + Attribute.ObjectType.USER_GROUP.getPropertyName() + "':true}" ) );
+        group1Id = assertStatus( HttpStatus.CREATED,
+            POST( "/userGroups/",
+                "{"
+                    + "'name':'G1', "
+                    + "'attributeValues':[{'attribute': {'id':'" + attrId + "'}, 'value':'extra-value'}]"
+                    + "}" ) );
+        group2Id = assertStatus( HttpStatus.CREATED,
+            POST( "/userGroups/",
+                "{"
+                    + "'name':'G2', "
+                    + "'attributeValues':[{'attribute': {'id':'" + attrId + "'}, 'value':'different'}]"
+                    + "}" ) );
+    }
+
+    @Test
+    void testField_ObjectSingleField()
+    {
+        assertEquals( "extra-value",
+            GET( "/userGroups/{uid}/gist?fields={attr}", group1Id, attrId ).content().string() );
+    }
+
+    @Test
+    void testField_ObjectMultipleFields()
+    {
+        JsonObject group = GET( "/userGroups/{uid}/gist?fields=id,name,{attr}", group1Id, attrId )
+            .content();
+        assertEquals( group1Id, group.getString( "id" ).string() );
+        assertEquals( "G1", group.getString( "name" ).string() );
+        assertEquals( "extra-value", group.getString( attrId ).string() );
+    }
+
+    @Test
+    void testField_ObjectMultipleFieldsWithAlias()
+    {
+        JsonObject group = GET( "/userGroups/{uid}/gist?fields=id,name,{attr}::rename(extra)", group1Id, attrId )
+            .content();
+        assertEquals( group1Id, group.getString( "id" ).string() );
+        assertEquals( "G1", group.getString( "name" ).string() );
+        assertEquals( "extra-value", group.getString( "extra" ).string() );
+    }
+
+    @Test
+    void testField_ListMultipleFields()
+    {
+        JsonArray groups = GET( "/userGroups/gist?fields=id,name,{attr}&headless=true", attrId ).content();
+        assertEquals( 2,
+            groups.asList( JsonObject.class ).count( Function.identity(), g -> !g.get( attrId ).isUndefined() ) );
+    }
+
+    @Test
+    void testField_ListMultipleFieldsWithAlias()
+    {
+        JsonArray groups = GET( "/userGroups/gist?fields=id,name,{attr}::rename(extra)&headless=true", attrId )
+            .content();
+        assertEquals( 2,
+            groups.asList( JsonObject.class ).count( Function.identity(), g -> !g.get( "extra" ).isUndefined() ) );
+    }
+
+    @Test
+    void testFilter_Eq()
+    {
+        String url = "/userGroups/gist?fields=id,name&headless=true&filter={attr}:eq:extra-value";
+        assertEquals( 1, GET( url, attrId ).content().size() );
+    }
+
+    @Test
+    void testFilter_NotEq()
+    {
+        String url = "/userGroups/gist?fields=id,name&headless=true&filter={attr}:neq:extra-value";
+        JsonArray groups = GET( url, attrId ).content();
+        assertEquals( 1, groups.size() );
+        assertEquals( "different", groups.getObject( 0 ).getString( attrId ).string() );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
@@ -136,8 +136,8 @@ class GistAttributeControllerTest extends AbstractGistControllerTest
     @Test
     void testFilter_NotEq()
     {
-        String url = "/userGroups/gist?fields=id,name&headless=true&filter={attr}:neq:extra-value";
-        JsonArray groups = GET( url, attrId ).content();
+        String url = "/userGroups/gist?fields=id,name,{attr}&headless=true&filter={attr}:neq:extra-value";
+        JsonArray groups = GET( url, attrId, attrId ).content();
         assertEquals( 1, groups.size() );
         assertEquals( "different", groups.getObject( 0 ).getString( attrId ).string() );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -35,11 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
@@ -51,7 +49,6 @@ import org.springframework.http.HttpStatus;
  */
 class GistFieldsControllerTest extends AbstractGistControllerTest
 {
-
     @Test
     void testField_Sharing_EmbedsObject()
     {
@@ -188,37 +185,6 @@ class GistFieldsControllerTest extends AbstractGistControllerTest
         assertTrue( access.getBoolean( "read" ).booleanValue() );
         assertTrue( access.getBoolean( "update" ).booleanValue() );
         assertTrue( access.getBoolean( "delete" ).booleanValue() );
-    }
-
-    @Test
-    @Disabled( "unstable for unknown reason - needs investigation" )
-    void testField_Attribute()
-    {
-        // setup a DE with custom attribute value
-        String attrId = assertStatus( HttpStatus.CREATED, POST( "/attributes", "{" + "'name':'extra', "
-            + "'valueType':'TEXT', " + "'" + ObjectType.DATA_ELEMENT.getPropertyName() + "':true}" ) );
-        String ccId = GET(
-            "/categoryCombos/gist?fields=id,categoryOptionCombos::ids&pageSize=1&headless=true&filter=name:eq:default" )
-                .content().getObject( 0 ).getString( "id" ).string();
-        String deId = assertStatus( HttpStatus.CREATED,
-            POST( "/dataElements/",
-                "{'name':'My data element', 'shortName':'DE1', 'code':'DE1', 'valueType':'INTEGER', "
-                    + "'aggregationType':'SUM', 'zeroIsSignificant':false, 'domainType':'AGGREGATE', "
-                    + "'categoryCombo': {'id': '" + ccId + "'}," + "'attributeValues':[{'attribute': {'id':'" + attrId
-                    + "'}, 'value':'extra-value'}]" + "}" ) );
-        // test single field
-        assertEquals( "extra-value", GET( "/dataElements/{de}/gist?fields={attr}", deId, attrId ).content().string() );
-        // test multiple fields also with an alias 'extra'
-        JsonObject dataElement = GET( "/dataElements/{de}/gist?fields=id,name,{attr}::rename(extra)", deId, attrId )
-            .content();
-        assertEquals( deId, dataElement.getString( "id" ).string() );
-        assertEquals( "My data element", dataElement.getString( "name" ).string() );
-        assertEquals( "extra-value", dataElement.getString( "extra" ).string() );
-        // test in listing
-        JsonArray dataElements = GET( "/dataElements/gist?fields=id,name,{attr}::rename(extra)&headless=true", attrId )
-            .content();
-        assertEquals( 1, dataElements.size() );
-        assertEquals( "extra-value", dataElements.getObject( 0 ).getString( "extra" ).string() );
     }
 
     @Test


### PR DESCRIPTION
### Summary
This is "part1" of allowing attribute UIDs as properties. The Gist API already had this feature - this PR is only improving the test situation to make sure the feature works.

### Automatic Tests
were added