### PR TITLE
chore: Event.attributeCategoryOptions is a MetadataIdentifier DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
@@ -32,6 +32,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -137,6 +138,20 @@ public class TrackerIdSchemeParams
     public MetadataIdentifier toMetadataIdentifier( CategoryOptionCombo categoryOptionCombo )
     {
         return categoryOptionComboIdScheme.toMetadataIdentifier( categoryOptionCombo );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code categoryOption} using
+     * {@link #categoryOptionIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param categoryOption to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         categoryOptionIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( CategoryOption categoryOption )
+    {
+        return categoryOptionIdScheme.toMetadataIdentifier( categoryOption );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -34,14 +34,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
@@ -62,7 +60,6 @@ import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.RelationshipPreheatKeySupport;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -170,10 +167,8 @@ public class TrackerIdentifierCollector
             addIdentifier( identifiers, ProgramStage.class, event.getProgramStage() );
             addIdentifier( identifiers, OrganisationUnit.class, event.getOrgUnit() );
 
-            Stream
-                .of( MoreObjects.firstNonNull( event.getAttributeCategoryOptions(), "" ).split( TextUtils.SEMICOLON ) )
-                .forEach(
-                    s -> addIdentifier( identifiers, CategoryOption.class, s ) );
+            event.getAttributeCategoryOptions()
+                .forEach( s -> addIdentifier( identifiers, CategoryOption.class, s ) );
 
             addIdentifier( identifiers, CategoryOptionCombo.class, event.getAttributeOptionCombo() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -126,8 +126,10 @@ public class EventTrackerConverterService
             event.setEnrollment( psi.getProgramInstance().getUid() );
             event.setProgramStage( MetadataIdentifier.ofUid( psi.getProgramStage().getUid() ) );
             event.setAttributeOptionCombo( MetadataIdentifier.ofUid( psi.getAttributeOptionCombo().getUid() ) );
-            event.setAttributeCategoryOptions( psi.getAttributeOptionCombo()
-                .getCategoryOptions().stream().map( CategoryOption::getUid ).collect( Collectors.joining( ";" ) ) );
+            event.setAttributeCategoryOptions( psi.getAttributeOptionCombo().getCategoryOptions().stream()
+                .map( CategoryOption::getUid )
+                .map( MetadataIdentifier::ofUid )
+                .collect( Collectors.toSet() ) );
 
             Set<EventDataValue> dataValues = psi.getEventDataValues();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -112,7 +112,8 @@ public class Event
     private MetadataIdentifier attributeOptionCombo;
 
     @JsonProperty
-    private String attributeCategoryOptions;
+    @Builder.Default
+    private Set<MetadataIdentifier> attributeCategoryOptions = new HashSet<>();
 
     @JsonProperty
     private String completedBy;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -31,7 +31,6 @@ import static org.hisp.dhis.tracker.preheat.RelationshipPreheatKeySupport.getRel
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +52,6 @@ import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -145,7 +143,7 @@ public class TrackerPreheat
      * Category option combo value will be in the idScheme defined by the user
      * on import.
      */
-    private final Map<Pair<String, Set<String>>, String> cosToCOC = new HashMap<>();
+    private final Map<Pair<String, Set<MetadataIdentifier>>, MetadataIdentifier> cosToCOC = new HashMap<>();
 
     /**
      * Store mapping of category combo + category options identifiers(key) to
@@ -158,24 +156,21 @@ public class TrackerPreheat
     public void putCategoryOptionCombo( CategoryCombo categoryCombo, Set<CategoryOption> categoryOptions,
         CategoryOptionCombo categoryOptionCombo )
     {
-        if ( categoryOptionCombo != null )
-        {
-            TrackerIdSchemeParam optionComboIdScheme = this.getIdSchemes().getCategoryOptionComboIdScheme();
-            this.cosToCOC.put( categoryOptionComboCacheKey( categoryCombo, categoryOptions ),
-                optionComboIdScheme.getIdentifier( categoryOptionCombo ) );
-            this.put( categoryOptionCombo );
-        }
-        else
+        if ( categoryOptionCombo == null )
         {
             this.cosToCOC.put( categoryOptionComboCacheKey( categoryCombo, categoryOptions ), null );
         }
+
+        this.cosToCOC.put( categoryOptionComboCacheKey( categoryCombo, categoryOptions ),
+            this.getIdSchemes().toMetadataIdentifier( categoryOptionCombo ) );
+        this.put( categoryOptionCombo );
     }
 
-    private Pair<String, Set<String>> categoryOptionComboCacheKey( CategoryCombo categoryCombo,
+    private Pair<String, Set<MetadataIdentifier>> categoryOptionComboCacheKey( CategoryCombo categoryCombo,
         Set<CategoryOption> categoryOptions )
     {
-        Set<String> coIds = categoryOptions.stream()
-            .map( this.getIdSchemes().getCategoryOptionIdScheme()::getIdentifier )
+        Set<MetadataIdentifier> coIds = categoryOptions.stream()
+            .map( co -> this.getIdSchemes().toMetadataIdentifier( co ) )
             .collect( Collectors.toSet() );
         return Pair.of( categoryCombo.getUid(), coIds );
     }
@@ -213,9 +208,8 @@ public class TrackerPreheat
 
     /**
      * Get the identifier of a category option combo for given category combo
-     * and semicolon separated list of category options. For the category option
-     * combo to exist it has to be stored before using
-     * {@link #putCategoryOptionCombo}.
+     * and category options. For the category option combo to exist it has to be
+     * stored before using {@link #putCategoryOptionCombo}.
      *
      * Category option identifiers needs to match the idScheme used when storing
      * the category option combo using {@link #putCategoryOptionCombo}. Category
@@ -223,35 +217,19 @@ public class TrackerPreheat
      * import.
      *
      * @param categoryCombo category combo
-     * @param categoryOptions semicolon separated list of category options
+     * @param categoryOptions category options
      * @return category option combo identifier
      */
-    public MetadataIdentifier getCategoryOptionComboIdentifier( CategoryCombo categoryCombo, String categoryOptions )
+    public MetadataIdentifier getCategoryOptionComboIdentifier( CategoryCombo categoryCombo,
+        Set<MetadataIdentifier> categoryOptions )
     {
         CategoryOptionCombo categoryOptionCombo = this.getCategoryOptionCombo(
-            this.cosToCOC.get( categoryOptionComboCacheKey( categoryCombo, categoryOptions ) ) );
+            this.cosToCOC.get( Pair.of( categoryCombo.getUid(), categoryOptions ) ) );
         if ( categoryOptionCombo == null )
         {
             return idSchemes.toMetadataIdentifier( (CategoryOptionCombo) null );
         }
         return idSchemes.toMetadataIdentifier( categoryOptionCombo );
-    }
-
-    private Pair<String, Set<String>> categoryOptionComboCacheKey( CategoryCombo categoryCombo,
-        String categoryOptions )
-    {
-        return Pair.of( categoryCombo.getUid(), parseCategoryOptions( categoryOptions ) );
-    }
-
-    private Set<String> parseCategoryOptions( String categoryOptions )
-    {
-        String cos = StringUtils.strip( categoryOptions );
-        if ( StringUtils.isBlank( cos ) )
-        {
-            return Collections.emptySet();
-        }
-
-        return TextUtils.splitToSet( cos, TextUtils.SEMICOLON );
     }
 
     /**
@@ -432,6 +410,11 @@ public class TrackerPreheat
         String key )
     {
         return (T) map.getOrDefault( klass, new HashMap<>() ).get( key );
+    }
+
+    public CategoryOption getCategoryOption( MetadataIdentifier id )
+    {
+        return get( CategoryOption.class, id );
     }
 
     public CategoryOption getCategoryOption( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -172,7 +172,13 @@ public class TrackerPreheat
         Set<MetadataIdentifier> coIds = categoryOptions.stream()
             .map( co -> this.getIdSchemes().toMetadataIdentifier( co ) )
             .collect( Collectors.toSet() );
-        return Pair.of( categoryCombo.getUid(), coIds );
+        return toCategoryOptionComboCacheKey( categoryCombo, coIds );
+    }
+
+    private Pair<String, Set<MetadataIdentifier>> toCategoryOptionComboCacheKey( CategoryCombo categoryCombo,
+        Set<MetadataIdentifier> categoryOptions )
+    {
+        return Pair.of( categoryCombo.getUid(), categoryOptions );
     }
 
     /**
@@ -224,7 +230,7 @@ public class TrackerPreheat
         Set<MetadataIdentifier> categoryOptions )
     {
         CategoryOptionCombo categoryOptionCombo = this.getCategoryOptionCombo(
-            this.cosToCOC.get( Pair.of( categoryCombo.getUid(), categoryOptions ) ) );
+            this.cosToCOC.get( toCategoryOptionComboCacheKey( categoryCombo, categoryOptions ) ) );
         if ( categoryOptionCombo == null )
         {
             return idSchemes.toMetadataIdentifier( (CategoryOptionCombo) null );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.preprocess;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -117,8 +115,7 @@ public class EventProgramPreProcessor
 
         TrackerPreheat preheat = bundle.getPreheat();
         List<Event> events = bundle.getEvents().stream()
-            .filter( e -> e.getAttributeOptionCombo().isBlank()
-                && !isBlank( e.getAttributeCategoryOptions() ) )
+            .filter( e -> e.getAttributeOptionCombo().isBlank() && !e.getAttributeCategoryOptions().isEmpty() )
             .filter( e -> preheat.getProgram( e.getProgram() ) != null )
             .collect( Collectors.toList() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -43,19 +43,18 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4012;
 import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils.getUidFromRelationshipItem;
 import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils.relationshipItemValueType;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
@@ -65,6 +64,7 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
@@ -229,13 +229,12 @@ public class PreCheckDataRelationsValidationHook
         }
 
         boolean allCOsExist = true;
-        Set<String> categoryOptions = parseCategoryOptions( event );
         TrackerPreheat preheat = reporter.getBundle().getPreheat();
-        for ( String id : categoryOptions )
+        for ( MetadataIdentifier id : event.getAttributeCategoryOptions() )
         {
             if ( preheat.getCategoryOption( id ) == null )
             {
-                reporter.addError( event, E1116, id );
+                reporter.addError( event, E1116, id.getIdentifierOrAttributeValue() );
                 allCOsExist = false;
             }
         }
@@ -244,20 +243,7 @@ public class PreCheckDataRelationsValidationHook
 
     private boolean hasNoAttributeCategoryOptionsSet( Event event )
     {
-        return StringUtils.isBlank( event.getAttributeCategoryOptions() );
-    }
-
-    private Set<String> parseCategoryOptions( Event event )
-    {
-
-        String cos = StringUtils.strip( event.getAttributeCategoryOptions() );
-        if ( StringUtils.isBlank( cos ) )
-        {
-            return Collections.emptySet();
-        }
-
-        return TextUtils
-            .splitToSet( cos, TextUtils.SEMICOLON );
+        return event.getAttributeCategoryOptions().isEmpty();
     }
 
     /**
@@ -345,8 +331,7 @@ public class PreCheckDataRelationsValidationHook
     {
 
         Set<CategoryOption> categoryOptions = new HashSet<>();
-        Set<String> categoryOptionIds = parseCategoryOptions( event );
-        for ( String id : categoryOptionIds )
+        for ( MetadataIdentifier id : event.getAttributeCategoryOptions() )
         {
             categoryOptions.add( preheat.getCategoryOption( id ) );
         }
@@ -388,13 +373,15 @@ public class PreCheckDataRelationsValidationHook
         if ( hasNoAttributeOptionComboSet( event ) )
         {
             reporter.addError( event, TrackerErrorCode.E1117, program.getCategoryCombo(),
-                event.getAttributeCategoryOptions() );
+                event.getAttributeCategoryOptions().stream().map( MetadataIdentifier::getIdentifierOrAttributeValue )
+                    .collect( Collectors.toSet() ).toString() );
         }
         else
         {
             reporter.addError( event, TrackerErrorCode.E1117,
                 event.getAttributeOptionCombo().getIdentifierOrAttributeValue(),
-                event.getAttributeCategoryOptions() );
+                event.getAttributeCategoryOptions().stream().map( MetadataIdentifier::getIdentifierOrAttributeValue )
+                    .collect( Collectors.toSet() ).toString() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -142,12 +143,16 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         List<Pair<String, TrackerIdSchemeParam>> data = buildDataSet( "XXXrKDKCefk", "COA", "COAname" );
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
-            Event event = new Event();
-            event.setAttributeCategoryOptions( pair.getLeft() );
-            TrackerImportParams params = buildParams( event,
-                builder().categoryOptionIdScheme( pair.getRight() ).build() );
+            String id = pair.getLeft();
+            TrackerIdSchemeParam param = pair.getRight();
+            Event event = Event.builder()
+                .attributeCategoryOptions( Set.of( param.toMetadataIdentifier( id ) ) )
+                .build();
+            TrackerImportParams params = buildParams( event, builder().categoryOptionIdScheme( param ).build() );
+
             TrackerPreheat preheat = trackerPreheatService.preheat( params );
-            assertPreheatedObjectExists( preheat, CategoryOption.class, pair.getRight(), pair.getLeft() );
+
+            assertPreheatedObjectExists( preheat, CategoryOption.class, param, id );
         }
     }
 
@@ -162,7 +167,6 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
             Event event = Event.builder()
                 .attributeOptionCombo( param.toMetadataIdentifier( id ) )
                 .build();
-
             TrackerImportParams params = buildParams( event, builder().categoryOptionComboIdScheme( param ).build() );
 
             TrackerPreheat preheat = trackerPreheatService.preheat( params );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -98,8 +98,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.setIdSchemes( identifierParams );
 
         assertFalse( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        Set<MetadataIdentifier> optionIds = categoryOptionIds( identifierParams.getCategoryOptionIdScheme(),
-            options );
+        Set<MetadataIdentifier> optionIds = categoryOptionIds( identifierParams, options );
         assertEquals( MetadataIdentifier.ofCode( null ),
             preheat.getCategoryOptionComboIdentifier( categoryCombo, optionIds ) );
         assertNull( preheat.getCategoryOptionCombo( categoryCombo, options ) );
@@ -130,8 +129,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.putCategoryOptionCombo( categoryCombo, options, null );
 
         assertTrue( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        Set<MetadataIdentifier> optionIds = categoryOptionIds( identifiers.getCategoryOptionComboIdScheme(),
-            options );
+        Set<MetadataIdentifier> optionIds = categoryOptionIds( identifiers, options );
         assertEquals( MetadataIdentifier.ofUid( null ),
             preheat.getCategoryOptionComboIdentifier( categoryCombo, optionIds ) );
         assertNull( preheat.getCategoryOptionCombo( categoryCombo, options ) );
@@ -476,11 +474,10 @@ class TrackerPreheatTest extends DhisConvenienceTest
         assertThat( reference4.get().getParentUid(), is( allPs.get( 1 ).getUid() ) );
     }
 
-    private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParam idSchemeParam,
-        Set<CategoryOption> options )
+    private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParams params, Set<CategoryOption> options )
     {
         return options.stream()
-            .map( idSchemeParam::toMetadataIdentifier )
+            .map( params::toMetadataIdentifier )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -84,7 +83,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
     }
 
     @Test
-    void testPreheatCategoryOptionComboUsingSet()
+    void testPreheatCategoryOptionCombo()
     {
 
         CategoryCombo categoryCombo = categoryCombo();
@@ -99,66 +98,21 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.setIdSchemes( identifierParams );
 
         assertFalse( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
+        Set<MetadataIdentifier> optionIds = categoryOptionIds( identifierParams.getCategoryOptionIdScheme(),
+            options );
+        assertEquals( MetadataIdentifier.ofCode( null ),
+            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionIds ) );
         assertNull( preheat.getCategoryOptionCombo( categoryCombo, options ) );
         assertNull( preheat.getCategoryOptionCombo( "ABC" ) );
 
         preheat.putCategoryOptionCombo( categoryCombo, options, aoc );
 
         assertTrue( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
+        assertEquals( identifierParams.toMetadataIdentifier( aoc ),
+            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionIds ) );
         assertEquals( aoc, preheat.getCategoryOptionCombo( categoryCombo, options ) );
         assertEquals( aoc, preheat.getCategoryOptionCombo( "ABC" ),
             "option combo should also be stored in the preheat map" );
-    }
-
-    @Test
-    void testPreheatCategoryOptionComboUsingString()
-    {
-
-        CategoryCombo categoryCombo = categoryCombo();
-        CategoryOptionCombo aoc = firstCategoryOptionCombo( categoryCombo );
-        Set<CategoryOption> options = aoc.getCategoryOptions();
-
-        TrackerPreheat preheat = new TrackerPreheat();
-        TrackerIdSchemeParams identifiers = new TrackerIdSchemeParams();
-        preheat.setIdSchemes( identifiers );
-
-        String optionsString = concatCategoryOptions( identifiers.getCategoryOptionComboIdScheme(), options );
-        assertFalse( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        assertEquals( MetadataIdentifier.ofUid( null ),
-            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
-        assertNull( preheat.getCategoryOptionCombo( aoc.getUid() ) );
-
-        preheat.putCategoryOptionCombo( categoryCombo, options, aoc );
-
-        assertTrue( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        assertEquals( identifiers.toMetadataIdentifier( aoc ),
-            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
-        assertEquals( aoc, preheat.getCategoryOptionCombo( aoc.getUid() ),
-            "option combo should also be stored in the preheat map" );
-    }
-
-    @Test
-    void testPreheatCategoryOptionComboUsingStringIsOrderIndependent()
-    {
-
-        CategoryCombo categoryCombo = categoryCombo();
-        CategoryOptionCombo aoc = firstCategoryOptionCombo( categoryCombo );
-        Set<CategoryOption> options = aoc.getCategoryOptions();
-        assertEquals( 2, aoc.getCategoryOptions().size() );
-        Iterator<CategoryOption> it = aoc.getCategoryOptions().iterator();
-        CategoryOption option1 = it.next();
-        CategoryOption option2 = it.next();
-
-        TrackerPreheat preheat = new TrackerPreheat();
-        TrackerIdSchemeParams identifiers = new TrackerIdSchemeParams();
-        preheat.setIdSchemes( identifiers );
-
-        preheat.putCategoryOptionCombo( categoryCombo, options, aoc );
-
-        assertEquals( identifiers.toMetadataIdentifier( aoc ),
-            preheat.getCategoryOptionComboIdentifier( categoryCombo, option1.getUid() + ";" + option2.getUid() ) );
-        assertEquals( identifiers.toMetadataIdentifier( aoc ),
-            preheat.getCategoryOptionComboIdentifier( categoryCombo, option2.getUid() + ";" + option1.getUid() ) );
     }
 
     @Test
@@ -176,10 +130,11 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.putCategoryOptionCombo( categoryCombo, options, null );
 
         assertTrue( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
-        String optionsString = concatCategoryOptions( identifiers.getCategoryOptionComboIdScheme(), options );
-        assertNull( preheat.getCategoryOptionCombo( categoryCombo, options ) );
+        Set<MetadataIdentifier> optionIds = categoryOptionIds( identifiers.getCategoryOptionComboIdScheme(),
+            options );
         assertEquals( MetadataIdentifier.ofUid( null ),
-            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionsString ) );
+            preheat.getCategoryOptionComboIdentifier( categoryCombo, optionIds ) );
+        assertNull( preheat.getCategoryOptionCombo( categoryCombo, options ) );
         assertNull( preheat.getCategoryOptionCombo( aoc.getUid() ),
             "option combo should not be added to preheat map if null" );
     }
@@ -521,11 +476,12 @@ class TrackerPreheatTest extends DhisConvenienceTest
         assertThat( reference4.get().getParentUid(), is( allPs.get( 1 ).getUid() ) );
     }
 
-    private String concatCategoryOptions( TrackerIdSchemeParam idSchemeParam, Set<CategoryOption> options )
+    private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParam idSchemeParam,
+        Set<CategoryOption> options )
     {
         return options.stream()
-            .map( idSchemeParam::getIdentifier )
-            .collect( Collectors.joining( ";" ) );
+            .map( idSchemeParam::toMetadataIdentifier )
+            .collect( Collectors.toSet() );
     }
 
     private CategoryCombo categoryCombo()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -97,7 +98,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -107,7 +108,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
         options.forEach(
-            o -> when( preheat.getCategoryOption( identifierParams.getCategoryOptionIdScheme().getIdentifier( o ) ) )
+            o -> when( preheat.getCategoryOption( identifierParams.toMetadataIdentifier( o ) ) )
                 .thenReturn( o ) );
         when( preheat.containsCategoryOptionCombo( program.getCategoryCombo(), aoc.getCategoryOptions() ) )
             .thenReturn( false );
@@ -142,7 +143,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .programStage( identifierParams.toMetadataIdentifier( stage ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -150,9 +151,9 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
             .events( events )
             .build();
 
-        when( preheat.get( ProgramStage.class, event.getProgramStage() ) ).thenReturn( stage );
+        when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( stage );
         options.forEach(
-            o -> when( preheat.getCategoryOption( identifierParams.getCategoryOptionIdScheme().getIdentifier( o ) ) )
+            o -> when( preheat.getCategoryOption( identifierParams.toMetadataIdentifier( o ) ) )
                 .thenReturn( o ) );
         when( preheat.containsCategoryOptionCombo( program.getCategoryCombo(), aoc.getCategoryOptions() ) )
             .thenReturn( false );
@@ -182,7 +183,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event, event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -192,7 +193,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
         options.forEach(
-            o -> when( preheat.getCategoryOption( identifierParams.getCategoryOptionIdScheme().getIdentifier( o ) ) )
+            o -> when( preheat.getCategoryOption( identifierParams.toMetadataIdentifier( o ) ) )
                 .thenReturn( o ) );
         when( preheat.containsCategoryOptionCombo( program.getCategoryCombo(), aoc.getCategoryOptions() ) )
             .thenReturn( false ) // first event will not have its AOC in the
@@ -225,7 +226,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event, event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -235,7 +236,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
         options.forEach(
-            o -> when( preheat.getCategoryOption( identifierParams.getCategoryOptionIdScheme().getIdentifier( o ) ) )
+            o -> when( preheat.getCategoryOption( identifierParams.toMetadataIdentifier( o ) ) )
                 .thenReturn( o ) );
         when( preheat.containsCategoryOptionCombo( program.getCategoryCombo(), aoc.getCategoryOptions() ) )
             .thenReturn( false ) // first event will not have the result of
@@ -267,7 +268,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -299,7 +300,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Set<CategoryOption> options = aoc.getCategoryOptions();
 
         Event event = Event.builder()
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
@@ -332,7 +333,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
         List<Event> events = List.of( event );
@@ -371,7 +372,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .programStage( identifierParams.toMetadataIdentifier( stage ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -379,7 +380,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
             .events( events )
             .build();
 
-        when( preheat.get( ProgramStage.class, event.getProgramStage() ) ).thenReturn( stage );
+        when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( stage );
         options.forEach(
             o -> when( preheat.getCategoryOption( identifierParams.getCategoryOptionIdScheme().getIdentifier( o ) ) )
                 .thenReturn( o ) );
@@ -407,7 +408,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .attributeCategoryOptions( concatCategoryOptions( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .build();
         List<Event> events = List.of( event );
@@ -441,6 +442,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
+            .attributeCategoryOptions( Collections.emptySet() )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -473,6 +475,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
+            .attributeCategoryOptions( Collections.emptySet() )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -488,11 +491,12 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         verify( preheat, times( 0 ) ).putCategoryOptionCombo( any(), any(), any() );
     }
 
-    private String concatCategoryOptions( TrackerIdSchemeParam idSchemeParam, Set<CategoryOption> options )
+    private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParam idSchemeParam,
+        Set<CategoryOption> options )
     {
         return options.stream()
-            .map( idSchemeParam::getIdentifier )
-            .collect( Collectors.joining( ";" ) );
+            .map( idSchemeParam::toMetadataIdentifier )
+            .collect( Collectors.toSet() );
     }
 
     private CategoryCombo categoryCombo()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -442,7 +441,6 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
-            .attributeCategoryOptions( Collections.emptySet() )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -475,7 +473,6 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( Collections.emptySet() )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplierTest.java
@@ -98,7 +98,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -143,7 +143,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .programStage( identifierParams.toMetadataIdentifier( stage ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -183,7 +183,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .build();
         List<Event> events = List.of( event, event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -226,7 +226,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .build();
         List<Event> events = List.of( event, event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -268,7 +268,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -300,7 +300,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Set<CategoryOption> options = aoc.getCategoryOptions();
 
         Event event = Event.builder()
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
@@ -333,7 +333,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .programStage( MetadataIdentifier.ofUid( null ) )
             .build();
         List<Event> events = List.of( event );
@@ -372,7 +372,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         Event event = Event.builder()
             .programStage( identifierParams.toMetadataIdentifier( stage ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( (CategoryOptionCombo) null ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .build();
         List<Event> events = List.of( event );
         TrackerImportParams params = TrackerImportParams.builder()
@@ -408,7 +408,7 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
 
         Event event = Event.builder()
             .program( MetadataIdentifier.ofUid( program.getUid() ) )
-            .attributeCategoryOptions( categoryOptionIds( identifierParams.getCategoryOptionIdScheme(), options ) )
+            .attributeCategoryOptions( categoryOptionIds( identifierParams, options ) )
             .attributeOptionCombo( identifierParams.toMetadataIdentifier( aoc ) )
             .build();
         List<Event> events = List.of( event );
@@ -491,11 +491,10 @@ class EventCategoryOptionComboSupplierTest extends DhisConvenienceTest
         verify( preheat, times( 0 ) ).putCategoryOptionCombo( any(), any(), any() );
     }
 
-    private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParam idSchemeParam,
-        Set<CategoryOption> options )
+    private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParams params, Set<CategoryOption> options )
     {
         return options.stream()
-            .map( idSchemeParam::toMetadataIdentifier )
+            .map( params::toMetadataIdentifier )
             .collect( Collectors.toSet() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
@@ -32,13 +32,14 @@ import static org.hisp.dhis.DhisConvenienceTest.createCategoryOptionCombo;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramStage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.Set;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -149,6 +150,7 @@ class EventProgramPreProcessorTest
             .program( MetadataIdentifier.ofUid( null ) )
             .programStage( MetadataIdentifier.ofUid( programStage.getUid() ) )
             .attributeOptionCombo( MetadataIdentifier.ofUid( null ) )
+            .attributeCategoryOptions( Collections.emptySet() )
             .build();
         TrackerBundle bundle = TrackerBundle.builder().events( Collections.singletonList( event ) ).preheat( preheat )
             .build();
@@ -229,10 +231,13 @@ class EventProgramPreProcessorTest
         program.setCategoryCombo( categoryCombo );
         Event event = completeTrackerEvent();
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
-        event.setAttributeCategoryOptions( "123;235" );
+        Set<MetadataIdentifier> categoryOptions = Set.of( MetadataIdentifier.ofUid( "123" ),
+            MetadataIdentifier.ofUid( "235" ) );
+        event.setAttributeCategoryOptions(
+            categoryOptions );
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
         CategoryOptionCombo categoryOptionCombo = createCategoryOptionCombo( 'A' );
-        when( preheat.getCategoryOptionComboIdentifier( categoryCombo, "123;235" ) )
+        when( preheat.getCategoryOptionComboIdentifier( categoryCombo, categoryOptions ) )
             .thenReturn( identifierParams.toMetadataIdentifier( categoryOptionCombo ) );
 
         TrackerBundle bundle = TrackerBundle.builder()
@@ -244,7 +249,8 @@ class EventProgramPreProcessorTest
 
         assertEquals( MetadataIdentifier.ofCode( categoryOptionCombo.getCode() ),
             bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
-        assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
+        assertEquals( categoryOptions,
+            bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
     @Test
@@ -261,7 +267,8 @@ class EventProgramPreProcessorTest
         program.setCategoryCombo( categoryCombo );
         Event event = completeTrackerEvent();
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
-        event.setAttributeCategoryOptions( "123;235" );
+        event.setAttributeCategoryOptions(
+            Set.of( MetadataIdentifier.ofUid( "123" ), MetadataIdentifier.ofUid( "235" ) ) );
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
         when( preheat.getCategoryOptionComboIdentifier( categoryCombo, event.getAttributeCategoryOptions() ) )
             .thenReturn( MetadataIdentifier.ofCode( null ) );
@@ -274,7 +281,8 @@ class EventProgramPreProcessorTest
         preprocessor.process( bundle );
 
         assertEquals( MetadataIdentifier.ofCode( null ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
-        assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
+        assertEquals( Set.of( MetadataIdentifier.ofUid( "123" ), MetadataIdentifier.ofUid( "235" ) ),
+            bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
     @Test
@@ -291,7 +299,8 @@ class EventProgramPreProcessorTest
         program.setCategoryCombo( categoryCombo );
         Event event = completeTrackerEvent();
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
-        event.setAttributeCategoryOptions( "123;235" );
+        event.setAttributeCategoryOptions(
+            Set.of( MetadataIdentifier.ofUid( "123" ), MetadataIdentifier.ofUid( "235" ) ) );
 
         TrackerBundle bundle = TrackerBundle.builder()
             .events( Collections.singletonList( event ) )
@@ -301,7 +310,8 @@ class EventProgramPreProcessorTest
         preprocessor.process( bundle );
 
         assertEquals( MetadataIdentifier.ofUid( null ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
-        assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
+        assertEquals( Set.of( MetadataIdentifier.ofUid( "123" ), MetadataIdentifier.ofUid( "235" ) ),
+            bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
     @Test
@@ -319,7 +329,8 @@ class EventProgramPreProcessorTest
         Event event = completeTrackerEvent();
         event.setProgram( MetadataIdentifier.ofUid( program.getUid() ) );
         event.setAttributeOptionCombo( MetadataIdentifier.ofCode( "9871" ) );
-        event.setAttributeCategoryOptions( "123;235" );
+        event.setAttributeCategoryOptions(
+            Set.of( MetadataIdentifier.ofUid( "123" ), MetadataIdentifier.ofUid( "235" ) ) );
         when( preheat.getProgram( event.getProgram() ) ).thenReturn( program );
 
         TrackerBundle bundle = TrackerBundle.builder()
@@ -330,7 +341,8 @@ class EventProgramPreProcessorTest
         preprocessor.process( bundle );
 
         assertEquals( MetadataIdentifier.ofCode( "9871" ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
-        assertEquals( "123;235", bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
+        assertEquals( Set.of( MetadataIdentifier.ofUid( "123" ), MetadataIdentifier.ofUid( "235" ) ),
+            bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
     }
 
     @Test
@@ -384,7 +396,7 @@ class EventProgramPreProcessorTest
         preprocessor.process( bundle );
 
         assertEquals( MetadataIdentifier.ofUid( null ), bundle.getEvents().get( 0 ).getAttributeOptionCombo() );
-        assertNull( bundle.getEvents().get( 0 ).getAttributeCategoryOptions() );
+        assertTrue( bundle.getEvents().get( 0 ).getAttributeCategoryOptions().isEmpty() );
     }
 
     private ProgramStage programStageWithRegistration()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.DhisConvenienceTest;
@@ -440,10 +441,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOption co = cc.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
 
         Event event = eventBuilder()
-            .attributeCategoryOptions( co.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -464,12 +465,12 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( defaultCC );
 
         CategoryOption defaultCO = defaultCC.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( defaultCO.getUid() ) ).thenReturn( defaultCO );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( defaultCO.getUid() ) ) ).thenReturn( defaultCO );
         CategoryOptionCombo defaultAOC = firstCategoryOptionCombo( defaultCC );
         when( preheat.getDefault( CategoryOptionCombo.class ) ).thenReturn( defaultAOC );
 
         Event event = eventBuilder()
-            .attributeCategoryOptions( defaultCO.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( defaultCO.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -489,10 +490,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         CategoryCombo cc = categoryCombo();
         CategoryOption co = cc.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
 
         Event event = eventBuilder()
-            .attributeCategoryOptions( co.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -512,10 +513,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         program.setCategoryCombo( cc );
 
         CategoryOption co = createCategoryOption( 'B' );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
 
         Event event = eventBuilder()
-            .attributeCategoryOptions( co.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -686,11 +687,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         CategoryOption defaultCO = defaultCC.getCategoryOptions().get( 0 );
         program.setCategoryCombo( defaultCC );
-        when( preheat.getCategoryOption( defaultCO.getUid() ) ).thenReturn( defaultCO );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( defaultCO.getUid() ) ) ).thenReturn( defaultCO );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) )
-            .attributeCategoryOptions( defaultCO.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( defaultCO.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -707,13 +708,13 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOption co = cc.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
-            .attributeCategoryOptions( co.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -730,14 +731,14 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOption co = cc.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
 
         String UNKNOWN_AOC_ID = CodeGenerator.generateUid();
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
-            .attributeCategoryOptions( co.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -755,7 +756,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOption co = cc.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
 
         CategoryOptionCombo defaultAOC = firstCategoryOptionCombo( defaultCategoryCombo() );
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) ) )
@@ -763,7 +764,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC.getUid() ) )
-            .attributeCategoryOptions( co.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -784,11 +785,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         String UNKNOWN_CO_ID = CodeGenerator.generateUid();
-        when( preheat.getCategoryOption( UNKNOWN_CO_ID ) ).thenReturn( null );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( UNKNOWN_CO_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
-            .attributeCategoryOptions( UNKNOWN_CO_ID )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( UNKNOWN_CO_ID ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -806,19 +807,20 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryCombo cc = categoryCombo();
         program.setCategoryCombo( cc );
         CategoryOption co = cc.getCategoryOptions().get( 0 );
-        when( preheat.getCategoryOption( co.getUid() ) ).thenReturn( co );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co.getUid() ) ) ).thenReturn( co );
 
         String UNKNOWN_CO_ID1 = CodeGenerator.generateUid();
-        when( preheat.getCategoryOption( UNKNOWN_CO_ID1 ) ).thenReturn( null );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( UNKNOWN_CO_ID1 ) ) ).thenReturn( null );
         String UNKNOWN_CO_ID2 = CodeGenerator.generateUid();
-        when( preheat.getCategoryOption( UNKNOWN_CO_ID2 ) ).thenReturn( null );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( UNKNOWN_CO_ID2 ) ) ).thenReturn( null );
 
         String UNKNOWN_AOC_ID = CodeGenerator.generateUid();
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) ) ).thenReturn( null );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
-            .attributeCategoryOptions( UNKNOWN_CO_ID1 + ";" + co.getUid() + ";" + UNKNOWN_CO_ID2 )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( UNKNOWN_CO_ID1 ),
+                MetadataIdentifier.ofUid( co.getUid() ), MetadataIdentifier.ofUid( UNKNOWN_CO_ID2 ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -843,11 +845,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
 
         CategoryOption eventCO = createCategoryOption( 'C' );
-        when( preheat.getCategoryOption( eventCO.getUid() ) ).thenReturn( eventCO );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( eventCO.getUid() ) ) ).thenReturn( eventCO );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
-            .attributeCategoryOptions( eventCO.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( eventCO.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -868,14 +870,14 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         CategoryOptionCombo aoc1 = cc.getSortedOptionCombos().get( 0 );
         CategoryOption co1 = (CategoryOption) aoc1.getCategoryOptions().toArray()[0];
-        when( preheat.getCategoryOption( co1.getUid() ) ).thenReturn( co1 );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co1.getUid() ) ) ).thenReturn( co1 );
 
         CategoryOptionCombo aoc2 = cc.getSortedOptionCombos().get( 1 );
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc2.getUid() ) ) ).thenReturn( aoc2 );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc2.getUid() ) )
-            .attributeCategoryOptions( co1.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co1.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );
@@ -897,11 +899,11 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         CategoryOptionCombo aoc = firstCategoryOptionCombo( cc );
         when( preheat.getCategoryOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) ) ).thenReturn( aoc );
         CategoryOption co1 = (CategoryOption) aoc.getCategoryOptions().toArray()[0];
-        when( preheat.getCategoryOption( co1.getUid() ) ).thenReturn( co1 );
+        when( preheat.getCategoryOption( MetadataIdentifier.ofUid( co1.getUid() ) ) ).thenReturn( co1 );
 
         Event event = eventBuilder()
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc.getUid() ) )
-            .attributeCategoryOptions( co1.getUid() )
+            .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co1.getUid() ) ) )
             .build();
 
         hook.validateEvent( reporter, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment.json
@@ -141,7 +141,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [],
@@ -175,7 +180,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
@@ -61,7 +61,12 @@
         "idScheme": "UID",
         "identifier": "KKKKX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
@@ -60,7 +60,16 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk;XXXrKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "XXXrKDKCefk"
+        },
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -102,7 +111,12 @@
         "idScheme": "UID",
         "identifier": "XXXvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -144,7 +158,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -186,7 +205,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -228,7 +252,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -270,7 +299,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -344,7 +378,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -418,7 +457,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -141,7 +141,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -184,7 +189,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -227,7 +237,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -270,7 +285,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -313,7 +333,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -356,7 +381,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -431,7 +461,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [
@@ -506,7 +541,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
@@ -61,7 +61,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
@@ -61,7 +61,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/program_event.json
@@ -60,7 +60,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tracker_basic_data_before_deletion.json
@@ -298,12 +298,17 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeCategoryOptions": "xYerKDKCefk",
-      "completedBy": "admin",
-      "completedAt": "2019-01-28T00:00:00.000",
       "attributeOptionCombo": {
         "idScheme": "UID"
       },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [],
       "notes": []
     },
@@ -331,12 +336,17 @@
       "deleted": false,
       "createdAt": "2019-01-28T12:10:38.108",
       "updatedAt": "2019-01-28T12:10:38.109",
-      "attributeCategoryOptions": "xYerKDKCefk",
-      "completedBy": "admin",
-      "completedAt": "2019-01-28T00:00:00.000",
       "attributeOptionCombo": {
         "idScheme": "UID"
       },
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-and-co-dont-match.json
@@ -57,7 +57,12 @@
         "idScheme": "UID",
         "identifier": "x2S2qeADpA9"
       },
-      "attributeCategoryOptions": "Aj6SFQQBBFU",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "Aj6SFQQBBFU"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-aoc-not-in-program-cc.json
@@ -57,7 +57,12 @@
         "idScheme": "UID",
         "identifier": "wpVV2AvPM89"
       },
-      "attributeCategoryOptions": "Aj6SFQQBBFU",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "Aj6SFQQBBFU"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_no_program.json
@@ -60,7 +60,12 @@
         "idScheme": "UID",
         "identifier": "HllvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
       "dataValues": [],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-without-attribute-option-combo.json
@@ -55,7 +55,12 @@
       "attributeOptionCombo": {
         "idScheme": "UID"
       },
-      "attributeCategoryOptions": "Aj6SFQQBBFU",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "Aj6SFQQBBFU"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-but-co-exists.json
@@ -61,7 +61,12 @@
         "idScheme": "UID",
         "identifier": "z8lvX50cXC0"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-aoc-with-subset-of-cos.json
@@ -56,7 +56,12 @@
       "attributeOptionCombo": {
         "idScheme": "UID"
       },
-      "attributeCategoryOptions": "zRXSQ4AQu7I",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "zRXSQ4AQu7I"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json
@@ -57,7 +57,12 @@
       "attributeOptionCombo": {
         "idScheme": "UID"
       },
-      "attributeCategoryOptions": "xYerKDKCefk",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "xYerKDKCefk"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events_cant-find-cat-option.json
@@ -61,7 +61,12 @@
       "attributeOptionCombo": {
         "idScheme": "UID"
       },
-      "attributeCategoryOptions": "LYerKDKCefZ",
+      "attributeCategoryOptions": [
+        {
+          "idScheme": "UID",
+          "identifier": "LYerKDKCefZ"
+        }
+      ],
       "dataValues": [],
       "notes": []
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/EventMapper.java
@@ -47,5 +47,6 @@ interface EventMapper extends DomainMapper<Event, org.hisp.dhis.tracker.domain.E
     @Mapping( target = "programStage", source = "programStage", qualifiedByName = "programStageToMetadataIdentifier" )
     @Mapping( target = "orgUnit", source = "orgUnit", qualifiedByName = "orgUnitToMetadataIdentifier" )
     @Mapping( target = "attributeOptionCombo", source = "attributeOptionCombo", qualifiedByName = "attributeOptionComboToMetadataIdentifier" )
+    @Mapping( target = "attributeCategoryOptions", source = "attributeCategoryOptions", qualifiedByName = "attributeCategoryOptionsToMetadataIdentifier" )
     org.hisp.dhis.tracker.domain.Event from( Event event, @Context TrackerIdSchemeParams idSchemeParams );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
@@ -27,7 +27,16 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import static java.util.function.Predicate.not;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Named;
@@ -37,30 +46,46 @@ interface MetadataIdentifierMapper
 {
 
     @Named( "programToMetadataIdentifier" )
-    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromProgram( String identifier,
+    default MetadataIdentifier fromProgram( String identifier,
         @Context TrackerIdSchemeParams idSchemeParams )
     {
         return idSchemeParams.getProgramIdScheme().toMetadataIdentifier( identifier );
     }
 
     @Named( "programStageToMetadataIdentifier" )
-    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromProgramStage( String identifier,
+    default MetadataIdentifier fromProgramStage( String identifier,
         @Context TrackerIdSchemeParams idSchemeParams )
     {
         return idSchemeParams.getProgramStageIdScheme().toMetadataIdentifier( identifier );
     }
 
     @Named( "orgUnitToMetadataIdentifier" )
-    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromOrgUnit( String identifier,
+    default MetadataIdentifier fromOrgUnit( String identifier,
         @Context TrackerIdSchemeParams idSchemeParams )
     {
         return idSchemeParams.getOrgUnitIdScheme().toMetadataIdentifier( identifier );
     }
 
     @Named( "attributeOptionComboToMetadataIdentifier" )
-    default org.hisp.dhis.tracker.domain.MetadataIdentifier fromAttributeOptionCombo( String identifier,
+    default MetadataIdentifier fromAttributeOptionCombo( String identifier,
         @Context TrackerIdSchemeParams idSchemeParams )
     {
         return idSchemeParams.getCategoryOptionComboIdScheme().toMetadataIdentifier( identifier );
+    }
+
+    @Named( "attributeCategoryOptionsToMetadataIdentifier" )
+    default Set<MetadataIdentifier> fromAttributeCategoryOptions( String identifiers,
+        @Context TrackerIdSchemeParams idSchemeParams )
+    {
+        if ( identifiers == null || StringUtils.isBlank( identifiers ) )
+        {
+            return Collections.emptySet();
+        }
+
+        return TextUtils.splitToSet( identifiers, TextUtils.SEMICOLON ).stream()
+            .map( String::trim )
+            .filter( not( String::isEmpty ) )
+            .map( id -> idSchemeParams.getCategoryOptionIdScheme().toMetadataIdentifier( id ) )
+            .collect( Collectors.toSet() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
@@ -77,7 +77,7 @@ interface MetadataIdentifierMapper
     default Set<MetadataIdentifier> fromAttributeCategoryOptions( String identifiers,
         @Context TrackerIdSchemeParams idSchemeParams )
     {
-        if ( identifiers == null || StringUtils.isBlank( identifiers ) )
+        if ( StringUtils.isBlank( identifiers ) )
         {
             return Collections.emptySet();
         }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -27,8 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
 
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
@@ -216,5 +220,59 @@ class MetadataIdentifierMapperTest
 
         assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
         assertNull( id.getIdentifier() );
+    }
+
+    @Test
+    void attributeCategoryOptionsIdentifierFromUIDWithWhitespaces()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        Set<MetadataIdentifier> ids = MAPPER.fromAttributeCategoryOptions( " RiNIt1yJoge;AiNIt1yJoge  ; ", params );
+
+        assertContainsOnly( ids, MetadataIdentifier.ofUid( "RiNIt1yJoge" ), MetadataIdentifier.ofUid( "AiNIt1yJoge" ) );
+    }
+
+    @Test
+    void attributeCategoryOptionsIdentifierFromAttribute()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .categoryOptionIdScheme( TrackerIdSchemeParam.ofAttribute( "RiNIt1yJoge" ) )
+            .build();
+
+        Set<MetadataIdentifier> ids = MAPPER.fromAttributeCategoryOptions( "clouds;fruits", params );
+
+        assertContainsOnly( ids, MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ),
+            MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "fruits" ) );
+    }
+
+    @Test
+    void attributeCategoryOptionsIdentifierFromUIDIfNull()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        Set<MetadataIdentifier> ids = MAPPER.fromAttributeCategoryOptions( null, params );
+
+        assertTrue( ids.isEmpty() );
+    }
+
+    @Test
+    void attributeCategoryOptionsIdentifierFromUIDIfEmpty()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        Set<MetadataIdentifier> ids = MAPPER.fromAttributeCategoryOptions( "  ", params );
+
+        assertTrue( ids.isEmpty() );
     }
 }


### PR DESCRIPTION
## This PR

* migrate Event.attributeCategoryOptions to MetadataIdentifier

We parse the event.attributeCategoryOptions JSON field "RiNIt1yJoge;AiNIt1yJoge" when mapping into our domain model into a Set<MetadataIdentifier>. This removes the need for us to parse the input multiple times (preheat, validation, ...) and aligns with the APIs we use internally expecting Set<CategoryOption>.

## Background on changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in the query parameters (not in the body) and only on import. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute
* DataValue.dataElement
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo :heavy_check_mark:
* Event.attributeCategoryOptions :heavy_check_mark:
* TrackedEntity.trackedEntityType
* Relationship.relationshipType
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:}.program
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,TrackedEntity :heavy_check_mark:}.orgUnit

will become idScheme aware.