### PR TITLE
chore: cleanup Metadata query [DHIS2-13158]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Conjunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Conjunction.java
@@ -32,7 +32,7 @@ import org.hisp.dhis.schema.Schema;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class Conjunction extends Junction
+public final class Conjunction extends Junction
 {
     public Conjunction( Schema schema )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Criteria.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Criteria.java
@@ -27,11 +27,15 @@
  */
 package org.hisp.dhis.query;
 
+import static java.util.Arrays.asList;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import lombok.Getter;
 
 import org.hisp.dhis.schema.Schema;
 
@@ -40,56 +44,34 @@ import org.hisp.dhis.schema.Schema;
  */
 public abstract class Criteria
 {
-    protected List<Criterion> criterions = new ArrayList<>();
+    @Getter
+    protected final List<Criterion> criterions = new ArrayList<>();
 
-    protected Set<String> aliases = new HashSet<>();
+    @Getter
+    private final Set<String> aliases = new HashSet<>();
 
     protected final Schema schema;
 
-    public Criteria( Schema schema )
+    Criteria( Schema schema )
     {
         this.schema = schema;
     }
 
-    public List<Criterion> getCriterions()
-    {
-        return criterions;
-    }
-
-    public Set<String> getAliases()
-    {
-        return aliases;
-    }
-
     public Criteria add( Criterion criterion )
     {
-        if ( !(criterion instanceof Restriction) )
-        {
-            this.criterions.add( criterion ); // if conjunction/disjunction just
-                                              // add it and move forward
-            return this;
-        }
-
-        Restriction restriction = (Restriction) criterion;
-
-        this.criterions.add( restriction );
-
+        this.criterions.add( criterion );
         return this;
     }
 
     public Criteria add( Criterion... criterions )
     {
-        for ( Criterion criterion : criterions )
-        {
-            add( criterion );
-        }
-
+        this.criterions.addAll( asList( criterions ) );
         return this;
     }
 
     public Criteria add( Collection<Criterion> criterions )
     {
-        criterions.forEach( this::add );
+        this.criterions.addAll( criterions );
         return this;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
@@ -127,14 +127,8 @@ public class DefaultJpaQueryParser
             return Restrictions.eq( path, QueryUtils.parseValue( property.getKlass(), arg ) );
         }
         case "!eq":
-        {
-            return Restrictions.ne( path, QueryUtils.parseValue( property.getKlass(), arg ) );
-        }
-        case "ne":
-        {
-            return Restrictions.ne( path, QueryUtils.parseValue( property.getKlass(), arg ) );
-        }
         case "neq":
+        case "ne":
         {
             return Restrictions.ne( path, QueryUtils.parseValue( property.getKlass(), arg ) );
         }
@@ -147,17 +141,11 @@ public class DefaultJpaQueryParser
             return Restrictions.lt( path, QueryUtils.parseValue( property.getKlass(), arg ) );
         }
         case "gte":
-        {
-            return Restrictions.ge( path, QueryUtils.parseValue( property.getKlass(), arg ) );
-        }
         case "ge":
         {
             return Restrictions.ge( path, QueryUtils.parseValue( property.getKlass(), arg ) );
         }
         case "lte":
-        {
-            return Restrictions.le( path, QueryUtils.parseValue( property.getKlass(), arg ) );
-        }
         case "le":
         {
             return Restrictions.le( path, QueryUtils.parseValue( property.getKlass(), arg ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultQueryService.java
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.query;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.common.IdentifiableObject;
@@ -46,7 +45,8 @@ import org.springframework.stereotype.Component;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Slf4j
-@Component( "org.hisp.dhis.query.QueryService" )
+@Component
+@AllArgsConstructor
 public class DefaultQueryService
     implements QueryService
 {
@@ -58,22 +58,7 @@ public class DefaultQueryService
 
     private final InMemoryQueryEngine<? extends IdentifiableObject> inMemoryQueryEngine;
 
-    private final Junction.Type DEFAULT_JUNCTION_TYPE = Junction.Type.AND;
-
-    public DefaultQueryService( QueryParser queryParser, QueryPlanner queryPlanner,
-        JpaCriteriaQueryEngine<? extends IdentifiableObject> criteriaQueryEngine,
-        InMemoryQueryEngine<? extends IdentifiableObject> inMemoryQueryEngine )
-    {
-        checkNotNull( queryParser );
-        checkNotNull( queryPlanner );
-        checkNotNull( criteriaQueryEngine );
-        checkNotNull( inMemoryQueryEngine );
-
-        this.queryParser = queryParser;
-        this.queryPlanner = queryPlanner;
-        this.criteriaQueryEngine = criteriaQueryEngine;
-        this.inMemoryQueryEngine = inMemoryQueryEngine;
-    }
+    private static final Junction.Type DEFAULT_JUNCTION_TYPE = Junction.Type.AND;
 
     @Override
     public List<? extends IdentifiableObject> query( Query query )
@@ -154,10 +139,7 @@ public class DefaultQueryService
             objects = inMemoryQueryEngine.query( npQuery );
             return objects.size();
         }
-        else
-        {
-            return criteriaQueryEngine.count( pQuery );
-        }
+        return criteriaQueryEngine.count( pQuery );
     }
 
     private List<? extends IdentifiableObject> queryObjects( Query query )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Disjunction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Disjunction.java
@@ -32,7 +32,7 @@ import org.hisp.dhis.schema.Schema;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class Disjunction extends Junction
+public final class Disjunction extends Junction
 {
     public Disjunction( Schema schema )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Junction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Junction.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.query;
 
+import lombok.Getter;
+
 import org.hisp.dhis.schema.Schema;
 
 /**
@@ -40,17 +42,13 @@ public abstract class Junction extends Criteria implements Criterion
         OR
     }
 
-    protected Type type;
+    @Getter
+    protected final Type type;
 
-    public Junction( Schema schema, Type type )
+    Junction( Schema schema, Type type )
     {
         super( schema );
         this.type = type;
-    }
-
-    public Type getType()
-    {
-        return type;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Pagination.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Pagination.java
@@ -27,25 +27,31 @@
  */
 package org.hisp.dhis.query;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
 /**
  * Simple POJO containing the pagination directive from the HTTP Request
  *
  * @author Luciano Fiandesio
  */
+@ToString
+@AllArgsConstructor( access = AccessLevel.PRIVATE )
 public class Pagination
 {
-    private int firstResult;
+    @Getter
+    private final int firstResult;
 
-    private int size;
+    @Getter
+    private final int size;
 
-    private boolean hasPagination = false;
+    private final boolean hasPagination;
 
     public Pagination( int firstResult, int size )
     {
-        assert (size > 0);
-        this.firstResult = firstResult;
-        this.size = size;
-        this.hasPagination = true;
+        this( firstResult, size, true );
     }
 
     /**
@@ -53,17 +59,7 @@ public class Pagination
      */
     public Pagination()
     {
-        // empty constructor
-    }
-
-    public int getFirstResult()
-    {
-        return firstResult;
-    }
-
-    public int getSize()
-    {
-        return size;
+        this( 0, 0, false );
     }
 
     public boolean hasPagination()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
@@ -30,8 +30,13 @@ package org.hisp.dhis.query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
-import org.apache.commons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.fieldfilter.Defaults;
 import org.hisp.dhis.schema.Schema;
@@ -42,28 +47,47 @@ import com.google.common.base.MoreObjects;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Accessors( chain = true )
 public class Query extends Criteria
 {
+    @Getter
+    @Setter
     private User user;
 
+    @Getter
+    @Setter
     private String locale;
 
-    private List<Order> orders = new ArrayList<>();
+    @Getter
+    private final List<Order> orders = new ArrayList<>();
 
+    @Getter
+    @Setter
     private boolean skipPaging;
 
+    @Setter
     private Integer firstResult = 0;
 
+    @Setter
     private Integer maxResults = Integer.MAX_VALUE;
 
-    private Junction.Type rootJunctionType = Junction.Type.AND;
+    @Getter
+    private final Junction.Type rootJunctionType;
 
+    @Getter
+    @Setter
     private boolean plannedQuery;
 
+    @Getter
+    @Setter
     private Defaults defaults = Defaults.EXCLUDE;
 
+    @Getter
+    @Setter
     private boolean cacheable = true;
 
+    @Getter
+    @Setter
     private List<? extends IdentifiableObject> objects;
 
     public static Query from( Schema schema )
@@ -92,7 +116,7 @@ public class Query extends Criteria
 
     private Query( Schema schema )
     {
-        super( schema );
+        this( schema, Junction.Type.AND );
     }
 
     private Query( Schema schema, Junction.Type rootJunctionType )
@@ -111,22 +135,9 @@ public class Query extends Criteria
         return criterions.isEmpty() && orders.isEmpty();
     }
 
-    public List<Order> getOrders()
-    {
-        return orders;
-    }
-
     public boolean ordersPersisted()
     {
-        for ( Order order : orders )
-        {
-            if ( order.isNonPersisted() )
-            {
-                return false;
-            }
-        }
-
-        return true;
+        return orders.stream().noneMatch( Order::isNonPersisted );
     }
 
     public void clearOrders()
@@ -134,62 +145,9 @@ public class Query extends Criteria
         orders.clear();
     }
 
-    public User getUser()
-    {
-        return user;
-    }
-
-    public Query setUser( User user )
-    {
-        this.user = user;
-        return this;
-    }
-
-    public boolean isCacheable()
-    {
-        return cacheable;
-    }
-
-    public void setCacheable( boolean cacheable )
-    {
-        this.cacheable = cacheable;
-    }
-
-    public String getLocale()
-    {
-        return locale;
-    }
-
-    public boolean hasLocale()
-    {
-        return !StringUtils.isEmpty( locale );
-    }
-
-    public void setLocale( String locale )
-    {
-        this.locale = locale;
-    }
-
-    public boolean isSkipPaging()
-    {
-        return skipPaging;
-    }
-
-    public Query setSkipPaging( boolean skipPaging )
-    {
-        this.skipPaging = skipPaging;
-        return this;
-    }
-
     public Integer getFirstResult()
     {
         return skipPaging ? 0 : firstResult;
-    }
-
-    public Query setFirstResult( Integer firstResult )
-    {
-        this.firstResult = firstResult;
-        return this;
     }
 
     public Integer getMaxResults()
@@ -197,66 +155,36 @@ public class Query extends Criteria
         return skipPaging ? Integer.MAX_VALUE : maxResults;
     }
 
-    public Query setMaxResults( Integer maxResults )
-    {
-        this.maxResults = maxResults;
-        return this;
-    }
-
-    public Junction.Type getRootJunctionType()
-    {
-        return rootJunctionType;
-    }
-
-    public boolean isPlannedQuery()
-    {
-        return plannedQuery;
-    }
-
-    public Query setPlannedQuery( boolean plannedQuery )
-    {
-        this.plannedQuery = plannedQuery;
-        return this;
-    }
-
-    public Defaults getDefaults()
-    {
-        return defaults;
-    }
-
-    public Query setDefaults( Defaults defaults )
-    {
-        this.defaults = defaults;
-        return this;
-    }
-
-    public List<? extends IdentifiableObject> getObjects()
-    {
-        return objects;
-    }
-
-    public Query setObjects( List<? extends IdentifiableObject> objects )
-    {
-        this.objects = objects;
-        return this;
-    }
-
     public Query addOrder( Order... orders )
     {
-        for ( Order order : orders )
-        {
-            if ( order != null )
-            {
-                this.orders.add( order );
-            }
-        }
-
+        Stream.of( orders ).filter( Objects::nonNull ).forEach( this.orders::add );
         return this;
     }
 
     public Query addOrders( Collection<Order> orders )
     {
         this.orders.addAll( orders );
+        return this;
+    }
+
+    @Override
+    public Query add( Criterion criterion )
+    {
+        super.add( criterion );
+        return this;
+    }
+
+    @Override
+    public Query add( Criterion... criterions )
+    {
+        super.add( criterions );
+        return this;
+    }
+
+    @Override
+    public Query add( Collection<Criterion> criterions )
+    {
+        super.add( criterions );
         return this;
     }
 
@@ -284,12 +212,6 @@ public class Query extends Criteria
     public Conjunction conjunction()
     {
         return new Conjunction( schema );
-    }
-
-    public Query forceDefaultOrder()
-    {
-        orders.clear();
-        return setDefaultOrder();
     }
 
     public Query setDefaultOrder()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Query.java
@@ -47,47 +47,31 @@ import com.google.common.base.MoreObjects;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Getter
+@Setter
 @Accessors( chain = true )
 public class Query extends Criteria
 {
-    @Getter
-    @Setter
     private User user;
 
-    @Getter
-    @Setter
     private String locale;
 
-    @Getter
     private final List<Order> orders = new ArrayList<>();
 
-    @Getter
-    @Setter
     private boolean skipPaging;
 
-    @Setter
     private Integer firstResult = 0;
 
-    @Setter
     private Integer maxResults = Integer.MAX_VALUE;
 
-    @Getter
     private final Junction.Type rootJunctionType;
 
-    @Getter
-    @Setter
     private boolean plannedQuery;
 
-    @Getter
-    @Setter
     private Defaults defaults = Defaults.EXCLUDE;
 
-    @Getter
-    @Setter
     private boolean cacheable = true;
 
-    @Getter
-    @Setter
     private List<? extends IdentifiableObject> objects;
 
     public static Query from( Schema schema )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -58,6 +58,11 @@ import com.google.common.collect.Lists;
  */
 public final class QueryUtils
 {
+    private QueryUtils()
+    {
+        throw new UnsupportedOperationException( "util" );
+    }
+
     public static <T> T parseValue( Class<?> klass, Object objectValue )
     {
         return parseValue( klass, null, objectValue );
@@ -71,7 +76,7 @@ public final class QueryUtils
             return (T) objectValue;
         }
 
-        if ( !String.class.isInstance( objectValue ) )
+        if ( !(objectValue instanceof String) )
         {
             return (T) objectValue;
         }
@@ -89,7 +94,7 @@ public final class QueryUtils
                 throw new QueryParserException( "Unable to parse `" + value + "` as `Integer`." );
             }
         }
-        else if ( Boolean.class.isAssignableFrom( klass ) )
+        if ( Boolean.class.isAssignableFrom( klass ) )
         {
             try
             {
@@ -100,7 +105,7 @@ public final class QueryUtils
                 throw new QueryParserException( "Unable to parse `" + value + "` as `Boolean`." );
             }
         }
-        else if ( Float.class.isAssignableFrom( klass ) )
+        if ( Float.class.isAssignableFrom( klass ) )
         {
             try
             {
@@ -111,7 +116,7 @@ public final class QueryUtils
                 throw new QueryParserException( "Unable to parse `" + value + "` as `Float`." );
             }
         }
-        else if ( Double.class.isAssignableFrom( klass ) )
+        if ( Double.class.isAssignableFrom( klass ) )
         {
             try
             {
@@ -122,7 +127,7 @@ public final class QueryUtils
                 throw new QueryParserException( "Unable to parse `" + value + "` as `Double`." );
             }
         }
-        else if ( Date.class.isAssignableFrom( klass ) )
+        if ( Date.class.isAssignableFrom( klass ) )
         {
             try
             {
@@ -134,7 +139,7 @@ public final class QueryUtils
                 throw new QueryParserException( "Unable to parse `" + value + "` as `Date`." );
             }
         }
-        else if ( Enum.class.isAssignableFrom( klass ) )
+        if ( Enum.class.isAssignableFrom( klass ) )
         {
             T enumValue = getEnumValue( klass, value );
 
@@ -198,12 +203,9 @@ public final class QueryUtils
         {
             return (T) enumValue.get();
         }
-        else
-        {
-            Object[] possibleValues = klass.getEnumConstants();
-            throw new QueryParserException( "Unable to parse `" + value + "` as `" + klass + "`, available values are: "
-                + Arrays.toString( possibleValues ) );
-        }
+        Object[] possibleValues = klass.getEnumConstants();
+        throw new QueryParserException( "Unable to parse `" + value + "` as `" + klass + "`, available values are: "
+            + Arrays.toString( possibleValues ) );
     }
 
     public static Object parseValue( String value )
@@ -212,14 +214,11 @@ public final class QueryUtils
         {
             return null;
         }
-        else if ( NumberUtils.isNumber( value ) )
+        if ( NumberUtils.isNumber( value ) )
         {
             return value;
         }
-        else
-        {
-            return "'" + value + "'";
-        }
+        return "'" + value + "'";
     }
 
     /**
@@ -236,19 +235,16 @@ public final class QueryUtils
         {
             return " * ";
         }
-        else
+        StringBuilder str = new StringBuilder( StringUtils.EMPTY );
+        for ( int i = 0; i < fields.size(); i++ )
         {
-            String str = StringUtils.EMPTY;
-            for ( int i = 0; i < fields.size(); i++ )
+            str.append( fields.get( i ) );
+            if ( i < fields.size() - 1 )
             {
-                str += fields.get( i );
-                if ( i < fields.size() - 1 )
-                {
-                    str += ",";
-                }
+                str.append( "," );
             }
-            return str;
         }
+        return str.toString();
     }
 
     /**
@@ -272,24 +268,24 @@ public final class QueryUtils
 
         String[] split = value.substring( 1, value.length() - 1 ).split( "," );
         List<String> items = Lists.newArrayList( split );
-        String str = "(";
+        StringBuilder str = new StringBuilder( "(" );
 
         for ( int i = 0; i < items.size(); i++ )
         {
             Object item = QueryUtils.parseValue( items.get( i ) );
             if ( item != null )
             {
-                str += item;
+                str.append( item );
                 if ( i < items.size() - 1 )
                 {
-                    str += ",";
+                    str.append( "," );
                 }
             }
         }
 
-        str += ")";
+        str.append( ")" );
 
-        return str;
+        return str.toString();
     }
 
     /**
@@ -316,13 +312,7 @@ public final class QueryUtils
             return "= " + QueryUtils.parseValue( value );
         }
         case "!eq":
-        {
-            return "!= " + QueryUtils.parseValue( value );
-        }
         case "ne":
-        {
-            return "!= " + QueryUtils.parseValue( value );
-        }
         case "neq":
         {
             return "!= " + QueryUtils.parseValue( value );
@@ -336,17 +326,11 @@ public final class QueryUtils
             return "< " + QueryUtils.parseValue( value );
         }
         case "gte":
-        {
-            return ">= " + QueryUtils.parseValue( value );
-        }
         case "ge":
         {
             return ">= " + QueryUtils.parseValue( value );
         }
         case "lte":
-        {
-            return "<= " + QueryUtils.parseValue( value );
-        }
         case "le":
         {
             return "<= " + QueryUtils.parseValue( value );
@@ -478,7 +462,7 @@ public final class QueryUtils
             {
                 continue;
             }
-            else if ( split.length == 2 )
+            if ( split.length == 2 )
             {
                 direction = split[1].toLowerCase();
             }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Restriction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Restriction.java
@@ -29,35 +29,44 @@ package org.hisp.dhis.query;
 
 import javax.persistence.criteria.Predicate;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
 import org.hisp.dhis.query.operators.Operator;
 import org.hisp.dhis.query.planner.QueryPath;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class Restriction implements Criterion
+@Getter
+@Accessors( chain = true )
+public final class Restriction implements Criterion
 {
     /**
      * Path to property you want to restrict only, one first-level properties
      * are currently supported.
      */
-    private String path;
+    private final String path;
 
     /**
      * Operator for restriction.
      */
-    private Operator operator;
+    private final Operator<?> operator;
 
     /**
      * Query Path.
      */
+    @Setter
     private QueryPath queryPath;
 
+    @Setter
     private Predicate predicate;
 
     public Restriction( String path, Predicate predicate )
     {
         this.path = path;
+        this.operator = null;
         this.predicate = predicate;
     }
 
@@ -65,42 +74,6 @@ public class Restriction implements Criterion
     {
         this.path = path;
         this.operator = operator;
-    }
-
-    public String getPath()
-    {
-        return path;
-    }
-
-    public Operator getOperator()
-    {
-        return operator;
-    }
-
-    public QueryPath getQueryPath()
-    {
-        return queryPath;
-    }
-
-    public Restriction setQueryPath( QueryPath queryPath )
-    {
-        this.queryPath = queryPath;
-        return this;
-    }
-
-    public Predicate getPredicate()
-    {
-        return predicate;
-    }
-
-    public void setPredicate( Predicate predicate )
-    {
-        this.predicate = predicate;
-    }
-
-    public boolean haveQueryPath()
-    {
-        return queryPath != null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Restriction.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Restriction.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.query;
 
-import javax.persistence.criteria.Predicate;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -59,16 +57,6 @@ public final class Restriction implements Criterion
      */
     @Setter
     private QueryPath queryPath;
-
-    @Setter
-    private Predicate predicate;
-
-    public Restriction( String path, Predicate predicate )
-    {
-        this.path = path;
-        this.operator = null;
-        this.predicate = predicate;
-    }
 
     public Restriction( String path, Operator operator )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Type.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Type.java
@@ -32,7 +32,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import com.google.common.base.MoreObjects;
+import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Simple class for caching of object type. Mainly for usage in speeding up
@@ -40,142 +41,53 @@ import com.google.common.base.MoreObjects;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class Type
+@Getter
+@ToString
+public final class Type
 {
-    private boolean isString;
+    private final boolean isString;
 
-    private boolean isChar;
+    private final boolean isChar;
 
-    private boolean isByte;
+    private final boolean isByte;
 
-    private boolean isNumber;
+    private final boolean isNumber;
 
-    private boolean isInteger;
+    private final boolean isInteger;
 
-    private boolean isFloat;
+    private final boolean isFloat;
 
-    private boolean isDouble;
+    private final boolean isDouble;
 
-    private boolean isBoolean;
+    private final boolean isBoolean;
 
-    private boolean isEnum;
+    private final boolean isEnum;
 
-    private boolean isDate;
+    private final boolean isDate;
 
-    private boolean isCollection;
+    private final boolean isCollection;
 
-    private boolean isList;
+    private final boolean isList;
 
-    private boolean isSet;
+    private final boolean isSet;
 
-    private boolean isNull;
+    private final boolean isNull;
 
     public Type( Object object )
     {
         isNull = object == null;
-        isString = String.class.isInstance( object );
-        isChar = Character.class.isInstance( object );
-        isByte = Byte.class.isInstance( object );
-        isNumber = Number.class.isInstance( object );
-        isInteger = Integer.class.isInstance( object );
-        isFloat = Float.class.isInstance( object );
-        isDouble = Double.class.isInstance( object );
-        isBoolean = Boolean.class.isInstance( object );
-        isEnum = Enum.class.isInstance( object );
-        isDate = Date.class.isInstance( object );
-        isCollection = Collection.class.isInstance( object );
-        isList = List.class.isInstance( object );
-        isSet = Set.class.isInstance( object );
-    }
-
-    public boolean isNull()
-    {
-        return isNull;
-    }
-
-    public boolean isString()
-    {
-        return isString;
-    }
-
-    public boolean isChar()
-    {
-        return isChar;
-    }
-
-    public boolean isByte()
-    {
-        return isByte;
-    }
-
-    public boolean isNumber()
-    {
-        return isNumber;
-    }
-
-    public boolean isInteger()
-    {
-        return isInteger;
-    }
-
-    public boolean isFloat()
-    {
-        return isFloat;
-    }
-
-    public boolean isDouble()
-    {
-        return isDouble;
-    }
-
-    public boolean isBoolean()
-    {
-        return isBoolean;
-    }
-
-    public boolean isEnum()
-    {
-        return isEnum;
-    }
-
-    public boolean isDate()
-    {
-        return isDate;
-    }
-
-    public boolean isCollection()
-    {
-        return isCollection;
-    }
-
-    public boolean isList()
-    {
-        return isList;
-    }
-
-    public boolean isSet()
-    {
-        return isSet;
-    }
-
-    @Override
-    public String toString()
-    {
-        return MoreObjects.toStringHelper( this )
-            .add( "isString", isString )
-            .add( "isChar", isChar )
-            .add( "isByte", isByte )
-            .add( "isNumber", isNumber )
-            .add( "isInteger", isInteger )
-            .add( "isFloat", isFloat )
-            .add( "isDouble", isDouble )
-            .add( "isBoolean", isBoolean )
-            .add( "isEnum", isEnum )
-            .add( "isDate", isDate )
-            .add( "isCollection", isCollection )
-            .add( "isList", isList )
-            .add( "isSet", isSet )
-            .add( "isNull", isNull )
-            .toString();
+        isString = object instanceof String;
+        isChar = object instanceof Character;
+        isByte = object instanceof Byte;
+        isNumber = object instanceof Number;
+        isInteger = object instanceof Integer;
+        isFloat = object instanceof Float;
+        isDouble = object instanceof Double;
+        isBoolean = object instanceof Boolean;
+        isEnum = object instanceof Enum;
+        isDate = object instanceof Date;
+        isCollection = object instanceof Collection;
+        isList = object instanceof List;
+        isSet = object instanceof Set;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Typed.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/Typed.java
@@ -27,9 +27,13 @@
  */
 package org.hisp.dhis.query;
 
-import org.hisp.dhis.schema.Klass;
+import static java.util.Arrays.stream;
 
-import com.google.common.collect.Iterators;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.hisp.dhis.schema.Klass;
 
 /**
  * Simple class for checking if an object is one of several allowed classes,
@@ -37,19 +41,11 @@ import com.google.common.collect.Iterators;
  *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class Typed
+@Getter
+@AllArgsConstructor( access = AccessLevel.PRIVATE )
+public final class Typed
 {
     private final Class<?>[] klasses;
-
-    public Typed( Class<?>[] klasses )
-    {
-        this.klasses = klasses;
-    }
-
-    public Class<?>[] getKlasses()
-    {
-        return klasses;
-    }
 
     public boolean isValid( Klass klass )
     {
@@ -62,16 +58,7 @@ public class Typed
         {
             return true;
         }
-
-        for ( Class<?> k : klasses )
-        {
-            if ( k != null && k.isAssignableFrom( klass ) )
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return stream( klasses ).anyMatch( k -> k != null && k.isAssignableFrom( klass ) );
     }
 
     public static Typed from( Class<?>... klasses )
@@ -79,8 +66,4 @@ public class Typed
         return new Typed( klasses );
     }
 
-    public static Typed from( Iterable<? extends Class<?>> iterable )
-    {
-        return new Typed( Iterators.toArray( iterable.iterator(), Class.class ) );
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/BetweenOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/BetweenOperator.java
@@ -80,7 +80,7 @@ public class BetweenOperator<T extends Comparable<? super T>> extends Operator<T
 
             return s1 >= min && s1 <= max;
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class, value );
             Integer min = getValue( Integer.class, 0 );
@@ -88,7 +88,7 @@ public class BetweenOperator<T extends Comparable<? super T>> extends Operator<T
 
             return s1 >= min && s1 <= max;
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date min = getValue( Date.class, 0 );
             Date max = getValue( Date.class, 1 );
@@ -96,7 +96,7 @@ public class BetweenOperator<T extends Comparable<? super T>> extends Operator<T
 
             return (s2.equals( min ) || s2.after( min )) && (s2.before( max ) || s2.equals( max ));
         }
-        else if ( type.isCollection() )
+        if ( type.isCollection() )
         {
             Collection<?> collection = (Collection<?>) value;
             Integer min = getValue( Integer.class, 0 );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/EqualOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/EqualOperator.java
@@ -114,44 +114,44 @@ public class EqualOperator<T extends Comparable<? super T>> extends Operator<T>
             String s1 = getValue( String.class );
             String s2 = (String) value;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isBoolean() )
+        if ( type.isBoolean() )
         {
             Boolean s1 = getValue( Boolean.class );
             Boolean s2 = (Boolean) value;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isInteger() )
+        if ( type.isInteger() )
         {
             Integer s1 = getValue( Integer.class );
             Integer s2 = (Integer) value;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class );
             Float s2 = (Float) value;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isCollection() )
+        if ( type.isCollection() )
         {
             Collection<?> collection = (Collection<?>) value;
             Integer size = getValue( Integer.class );
 
             return size != null && collection.size() == size;
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date s1 = getValue( Date.class );
             Date s2 = (Date) value;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isEnum() )
+        if ( type.isEnum() )
         {
             String s1 = String.valueOf( args.get( 0 ) );
             String s2 = String.valueOf( value );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterEqualOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterEqualOperator.java
@@ -119,21 +119,21 @@ public class GreaterEqualOperator<T extends Comparable<? super T>> extends Opera
 
             return s1 != null && s2 >= s1;
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class );
             Float s2 = (Float) value;
 
             return s1 != null && s2 >= s1;
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date s1 = getValue( Date.class );
             Date s2 = (Date) value;
 
             return s1 != null && (s2.after( s1 ) || s2.equals( s1 ));
         }
-        else if ( type.isCollection() )
+        if ( type.isCollection() )
         {
             Collection<?> collection = (Collection<?>) value;
             Integer size = getValue( Integer.class );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterThanOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/GreaterThanOperator.java
@@ -112,28 +112,28 @@ public class GreaterThanOperator<T extends Comparable<? super T>> extends Operat
 
             return s1 != null && s2.compareTo( s1 ) > 0;
         }
-        else if ( type.isInteger() )
+        if ( type.isInteger() )
         {
             Integer s1 = getValue( Integer.class );
             Integer s2 = (Integer) value;
 
             return s1 != null && s2 > s1;
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class );
             Float s2 = (Float) value;
 
             return s1 != null && s2 > s1;
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date s1 = getValue( Date.class );
             Date s2 = (Date) value;
 
             return s1 != null && s2.after( s1 );
         }
-        else if ( type.isCollection() )
+        if ( type.isCollection() )
         {
             Collection<?> collection = (Collection<?>) value;
             Integer size = getValue( Integer.class );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/InOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/InOperator.java
@@ -109,10 +109,7 @@ public class InOperator<T extends Comparable<? super T>> extends Operator<T>
         }
         else
         {
-            if ( compareCollection( value, items ) )
-            {
-                return true;
-            }
+            return compareCollection( value, items );
         }
 
         return false;
@@ -140,42 +137,42 @@ public class InOperator<T extends Comparable<? super T>> extends Operator<T>
             String s1 = getValue( String.class, lside );
             String s2 = (String) rside;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isBoolean() )
+        if ( type.isBoolean() )
         {
             Boolean s1 = getValue( Boolean.class, lside );
             Boolean s2 = (Boolean) rside;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isInteger() )
+        if ( type.isInteger() )
         {
             Integer s1 = getValue( Integer.class, lside );
             Integer s2 = (Integer) rside;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class, lside );
             Float s2 = (Float) rside;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date s1 = getValue( Date.class, lside );
             Date s2 = (Date) rside;
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
-        else if ( type.isEnum() )
+        if ( type.isEnum() )
         {
             String s1 = String.valueOf( lside );
             String s2 = String.valueOf( rside );
 
-            return s1 != null && s2.equals( s1 );
+            return s2.equals( s1 );
         }
 
         return false;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessEqualOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessEqualOperator.java
@@ -112,28 +112,28 @@ public class LessEqualOperator<T extends Comparable<? super T>> extends Operator
 
             return s1 != null && (s2.equals( s1 ) || s2.compareTo( s1 ) < 0);
         }
-        else if ( type.isInteger() )
+        if ( type.isInteger() )
         {
             Integer s1 = getValue( Integer.class );
             Integer s2 = (Integer) value;
 
             return s1 != null && s2 <= s1;
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class );
             Float s2 = (Float) value;
 
             return s1 != null && s2 <= s1;
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date s1 = getValue( Date.class );
             Date s2 = (Date) value;
 
             return s1 != null && (s2.before( s1 ) || s2.equals( s1 ));
         }
-        else if ( type.isCollection() )
+        if ( type.isCollection() )
         {
             Collection<?> collection = (Collection<?>) value;
             Integer size = getValue( Integer.class );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessThanOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LessThanOperator.java
@@ -112,28 +112,28 @@ public class LessThanOperator<T extends Comparable<? super T>> extends Operator<
 
             return s1 != null && s2.compareTo( s1 ) < 0;
         }
-        else if ( type.isInteger() )
+        if ( type.isInteger() )
         {
             Integer s1 = getValue( Integer.class );
             Integer s2 = (Integer) value;
 
             return s1 != null && s2 < s1;
         }
-        else if ( type.isFloat() )
+        if ( type.isFloat() )
         {
             Float s1 = getValue( Float.class );
             Float s2 = (Float) value;
 
             return s1 != null && s2 < s1;
         }
-        else if ( type.isDate() )
+        if ( type.isDate() )
         {
             Date s1 = getValue( Date.class );
             Date s2 = (Date) value;
 
             return s1 != null && (s2.before( s1 ));
         }
-        else if ( type.isCollection() )
+        if ( type.isCollection() )
         {
             Collection<?> collection = (Collection<?>) value;
             Integer size = getValue( Integer.class );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LikeOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/LikeOperator.java
@@ -89,12 +89,9 @@ public class LikeOperator<T extends Comparable<? super T>> extends Operator<T>
                 String.valueOf( args.get( 0 ) ).replace( "%", "" ),
                 jpaMatchMode );
         }
-        else
-        {
-            return JpaQueryUtils.stringPredicateIgnoreCase( builder, root.get( queryPath.getPath() ),
-                String.valueOf( args.get( 0 ) ).replace( "%", "" ),
-                jpaMatchMode );
-        }
+        return JpaQueryUtils.stringPredicateIgnoreCase( builder, root.get( queryPath.getPath() ),
+            String.valueOf( args.get( 0 ) ).replace( "%", "" ),
+            jpaMatchMode );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotLikeOperator.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/operators/NotLikeOperator.java
@@ -65,11 +65,8 @@ public class NotLikeOperator<T extends Comparable<? super T>> extends Operator<T
             return Restrictions.like( queryPath.getPath(), String.valueOf( args.get( 0 ) ).replace( "%", "\\%" ),
                 matchMode );
         }
-        else
-        {
-            return Restrictions.ilike( queryPath.getPath(), String.valueOf( args.get( 0 ) ).replace( "%", "\\%" ),
-                matchMode );
-        }
+        return Restrictions.ilike( queryPath.getPath(), String.valueOf( args.get( 0 ) ).replace( "%", "\\%" ),
+            matchMode );
     }
 
     @Override
@@ -81,12 +78,9 @@ public class NotLikeOperator<T extends Comparable<? super T>> extends Operator<T
                 String.valueOf( args.get( 0 ) ).replace( "%", "" ),
                 jpaMatchMode );
         }
-        else
-        {
-            return JpaQueryUtils.stringPredicateIgnoreCase( builder, root.get( queryPath.getPath() ),
-                String.valueOf( args.get( 0 ) ).replace( "%", "" ),
-                jpaMatchMode );
-        }
+        return JpaQueryUtils.stringPredicateIgnoreCase( builder, root.get( queryPath.getPath() ),
+            String.valueOf( args.get( 0 ) ).replace( "%", "" ),
+            jpaMatchMode );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPath.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPath.java
@@ -29,6 +29,9 @@ package org.hisp.dhis.query.planner;
 
 import java.util.Arrays;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 import org.hisp.dhis.schema.Property;
 
 import com.google.common.base.Joiner;
@@ -37,31 +40,21 @@ import com.google.common.base.MoreObjects;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Getter
+@AllArgsConstructor
 public class QueryPath
 {
     private final Property property;
 
     private final boolean persisted;
 
-    private String[] alias = new String[] {};
+    private final String[] alias;
 
     private static final Joiner PATH_JOINER = Joiner.on( "." );
 
     public QueryPath( Property property, boolean persisted )
     {
-        this.property = property;
-        this.persisted = persisted;
-    }
-
-    public QueryPath( Property property, boolean persisted, String[] alias )
-    {
-        this( property, persisted );
-        this.alias = alias;
-    }
-
-    public Property getProperty()
-    {
-        return property;
+        this( property, persisted, new String[0] );
     }
 
     public String getPath()
@@ -76,19 +69,9 @@ public class QueryPath
         return haveAlias() ? PATH_JOINER.join( alias ) + "." + fieldName : fieldName;
     }
 
-    public boolean isPersisted()
-    {
-        return persisted;
-    }
-
-    public String[] getAlias()
-    {
-        return alias;
-    }
-
     public boolean haveAlias()
     {
-        return alias != null && alias.length > 0;
+        return haveAlias( 0 );
     }
 
     public boolean haveAlias( int n )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/planner/QueryPlan.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.query.planner;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.user.User;
@@ -34,27 +38,14 @@ import org.hisp.dhis.user.User;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Getter
+@Builder
+@AllArgsConstructor
 public class QueryPlan
 {
     private final Query persistedQuery;
 
     private final Query nonPersistedQuery;
-
-    private QueryPlan( Query persistedQuery, Query nonPersistedQuery )
-    {
-        this.persistedQuery = persistedQuery;
-        this.nonPersistedQuery = nonPersistedQuery;
-    }
-
-    public Query getPersistedQuery()
-    {
-        return persistedQuery;
-    }
-
-    public Query getNonPersistedQuery()
-    {
-        return nonPersistedQuery;
-    }
 
     public Schema getSchema()
     {
@@ -62,11 +53,10 @@ public class QueryPlan
         {
             return persistedQuery.getSchema();
         }
-        else if ( nonPersistedQuery != null )
+        if ( nonPersistedQuery != null )
         {
             return nonPersistedQuery.getSchema();
         }
-
         return null;
     }
 
@@ -76,11 +66,10 @@ public class QueryPlan
         {
             return persistedQuery.getUser();
         }
-        else if ( nonPersistedQuery != null )
+        if ( nonPersistedQuery != null )
         {
             return nonPersistedQuery.getUser();
         }
-
         return null;
     }
 
@@ -94,39 +83,6 @@ public class QueryPlan
         if ( nonPersistedQuery != null )
         {
             nonPersistedQuery.setUser( user );
-        }
-    }
-
-    public static final class QueryPlanBuilder
-    {
-        private Query persistedQuery;
-
-        private Query nonPersistedQuery;
-
-        private QueryPlanBuilder()
-        {
-        }
-
-        public static QueryPlanBuilder newBuilder()
-        {
-            return new QueryPlanBuilder();
-        }
-
-        public QueryPlanBuilder persistedQuery( Query persistedQuery )
-        {
-            this.persistedQuery = persistedQuery;
-            return this;
-        }
-
-        public QueryPlanBuilder nonPersistedQuery( Query nonPersistedQuery )
-        {
-            this.nonPersistedQuery = nonPersistedQuery;
-            return this;
-        }
-
-        public QueryPlan build()
-        {
-            return new QueryPlan( persistedQuery, nonPersistedQuery );
         }
     }
 }


### PR DESCRIPTION
This is a cleanup run through the `query` package.

* use `final` on classes and fields where possible
* use `@Getter` / `@Setter` where possible
* use lombol generated constructor 
* use `this` to delegate to all args constructor in constructors with less arguments
* use `List.of` for list that should not change
* use `@Builder` instead of hand written builders
* avoid `if else` when there is a `return` prior so a `if` is sufficient
* do instance-of tests with the `instanceof` operator
* use streams to reduce a collection to a boolean
* join identical `case` blocks
* **remove unused code**
* use `@ToString` for "value types" with only simple fields
* use `StringBuilder` instead of `+=` (automatic refactoring)
* add wildcard generics when missing
* remove unnecessary `!= null` checks (e.g. arguments passed to an `equals` method are always allowed to be null)
* make constructors of abstract classes less visible where possible
* simplify logic