### PR TITLE
fix: metadata idSchemes attribute UID null on default DHIS2-12760

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsBuilder.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsBuilder.java
@@ -117,16 +117,16 @@ public class TrackerImportParamsBuilder
 
     public static TrackerIdSchemeParams getTrackerIdentifiers( Map<String, List<String>> parameters )
     {
-        TrackerIdScheme idScheme = getEnumWithDefault( TrackerIdScheme.class, parameters, ID_SCHEME_KEY, UID );
+        TrackerIdSchemeParam idScheme = globalIdScheme( parameters );
 
         return TrackerIdSchemeParams.builder()
-            .idScheme( bySchemeAndKey( parameters, ID_SCHEME_KEY, idScheme ) )
-            .orgUnitIdScheme( bySchemeAndKey( parameters, ORG_UNIT_ID_SCHEME_KEY, idScheme ) )
-            .programIdScheme( bySchemeAndKey( parameters, PROGRAM_ID_SCHEME_KEY, idScheme ) )
-            .programStageIdScheme( bySchemeAndKey( parameters, PROGRAM_STAGE_ID_SCHEME_KEY, idScheme ) )
-            .dataElementIdScheme( bySchemeAndKey( parameters, DATA_ELEMENT_ID_SCHEME_KEY, idScheme ) )
-            .categoryOptionComboIdScheme( bySchemeAndKey( parameters, CATEGORY_OPTION_COMBO_ID_SCHEME_KEY, idScheme ) )
-            .categoryOptionIdScheme( bySchemeAndKey( parameters, CATEGORY_OPTION_ID_SCHEME_KEY, idScheme ) )
+            .idScheme( idScheme )
+            .orgUnitIdScheme( idScheme( parameters, ORG_UNIT_ID_SCHEME_KEY, idScheme ) )
+            .programIdScheme( idScheme( parameters, PROGRAM_ID_SCHEME_KEY, idScheme ) )
+            .programStageIdScheme( idScheme( parameters, PROGRAM_STAGE_ID_SCHEME_KEY, idScheme ) )
+            .dataElementIdScheme( idScheme( parameters, DATA_ELEMENT_ID_SCHEME_KEY, idScheme ) )
+            .categoryOptionComboIdScheme( idScheme( parameters, CATEGORY_OPTION_COMBO_ID_SCHEME_KEY, idScheme ) )
+            .categoryOptionIdScheme( idScheme( parameters, CATEGORY_OPTION_ID_SCHEME_KEY, idScheme ) )
             .build();
     }
 
@@ -172,16 +172,36 @@ public class TrackerImportParamsBuilder
         return null;
     }
 
-    private static TrackerIdSchemeParam bySchemeAndKey( Map<String, List<String>> parameters,
-        TrackerImportParamKey trackerImportParameterKey,
-        TrackerIdScheme defaultIdScheme )
+    /**
+     * Extracts the "global" idScheme from the request parameters. Global
+     * meaning the idScheme that will be defaulted to for each metadata type if
+     * no metadata specific idScheme parameter like "programIdScheme" has been
+     * given.
+     *
+     * @param parameters request parameters
+     * @return tracker id scheme parameter
+     */
+    private static TrackerIdSchemeParam globalIdScheme( Map<String, List<String>> parameters )
+    {
+        TrackerIdScheme trackerIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters, ID_SCHEME_KEY, UID );
+
+        return TrackerIdSchemeParam.of( trackerIdScheme, getAttributeUidOrNull( parameters, ID_SCHEME_KEY ) );
+    }
+
+    private static TrackerIdSchemeParam idScheme( Map<String, List<String>> parameters,
+        TrackerImportParamKey parameterKey, TrackerIdSchemeParam defaultIdSchemeParam )
     {
 
-        TrackerIdScheme trackerIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters,
-            trackerImportParameterKey, defaultIdScheme );
+        if ( parameters == null || parameters.get( parameterKey.getKey() ) == null
+            || parameters.get( parameterKey.getKey() ).isEmpty() )
+        {
+            return defaultIdSchemeParam;
+        }
 
-        return TrackerIdSchemeParam.of( trackerIdScheme,
-            getAttributeUidOrNull( parameters, trackerImportParameterKey ) );
+        TrackerIdScheme trackerIdScheme = getEnumWithDefault( TrackerIdScheme.class, parameters,
+            parameterKey, defaultIdSchemeParam.getIdScheme() );
+
+        return TrackerIdSchemeParam.of( trackerIdScheme, getAttributeUidOrNull( parameters, parameterKey ) );
     }
 
     enum TrackerImportParamKey

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsBuilderTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsBuilderTest.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportParam
 import static org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportParamsBuilder.TrackerImportParamKey.IMPORT_MODE_KEY;
 import static org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportParamsBuilder.TrackerImportParamKey.IMPORT_STRATEGY_KEY;
 import static org.hisp.dhis.webapi.controller.tracker.imports.TrackerImportParamsBuilder.TrackerImportParamKey.VALIDATION_MODE_KEY;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -119,6 +119,38 @@ class TrackerImportParamsBuilderTest
     }
 
     @Test
+    void testIdSchemeUsingIdSchemeName()
+    {
+        TrackerImportParams params = TrackerImportParamsBuilder
+            .build( Map.of( "idScheme", Collections.singletonList( "NAME" ) ) );
+
+        TrackerIdSchemeParam expected = TrackerIdSchemeParam.of( TrackerIdScheme.NAME, null );
+        assertEquals( expected, params.getIdSchemes().getIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getDataElementIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getOrgUnitIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getProgramIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getProgramStageIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getCategoryOptionComboIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getCategoryOptionIdScheme() );
+    }
+
+    @Test
+    void testIdSchemeUsingIdSchemeAttribute()
+    {
+        TrackerImportParams params = TrackerImportParamsBuilder
+            .build( Map.of( "idScheme", Collections.singletonList( "ATTRIBUTE:WSiOAALYocA" ) ) );
+
+        TrackerIdSchemeParam expected = TrackerIdSchemeParam.ofAttribute( "WSiOAALYocA" );
+        assertEquals( expected, params.getIdSchemes().getIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getDataElementIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getOrgUnitIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getProgramIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getProgramStageIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getCategoryOptionComboIdScheme() );
+        assertEquals( expected, params.getIdSchemes().getCategoryOptionIdScheme() );
+    }
+
+    @Test
     void testOrgUnitIdentifier()
     {
         Arrays.stream( TrackerIdScheme.values() ).forEach( e -> {
@@ -146,8 +178,8 @@ class TrackerImportParamsBuilderTest
         paramMap.put( "programIdScheme", Collections.singletonList( "UID:WSiOAALYocA" ) );
         TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
 
-        assertThat( params.getIdSchemes().getProgramIdScheme().getIdScheme(), is( TrackerIdScheme.UID ) );
-        assertNull( params.getIdSchemes().getProgramIdScheme().getAttributeUid() );
+        assertEquals( TrackerIdSchemeParam.of( TrackerIdScheme.UID, null ),
+            params.getIdSchemes().getProgramIdScheme() );
     }
 
     @Test
@@ -158,8 +190,8 @@ class TrackerImportParamsBuilderTest
         paramMap.put( "programIdScheme", Collections.singletonList( "CODE:WSiOAALYocA" ) );
         TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
 
-        assertThat( params.getIdSchemes().getProgramIdScheme().getIdScheme(), is( TrackerIdScheme.UID ) );
-        assertNull( params.getIdSchemes().getProgramIdScheme().getAttributeUid() );
+        assertEquals( TrackerIdSchemeParam.of( TrackerIdScheme.UID, null ),
+            params.getIdSchemes().getProgramIdScheme() );
     }
 
     @Test
@@ -170,8 +202,8 @@ class TrackerImportParamsBuilderTest
         paramMap.put( "programIdScheme", Collections.singletonList( "NAME:WSiOAALYocA" ) );
         TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
 
-        assertThat( params.getIdSchemes().getProgramIdScheme().getIdScheme(), is( TrackerIdScheme.UID ) );
-        assertNull( params.getIdSchemes().getProgramIdScheme().getAttributeUid() );
+        assertEquals( TrackerIdSchemeParam.of( TrackerIdScheme.UID, null ),
+            params.getIdSchemes().getProgramIdScheme() );
     }
 
     @Test
@@ -180,8 +212,27 @@ class TrackerImportParamsBuilderTest
         paramMap.put( "programIdScheme", Collections.singletonList( "ATTRIBUTE:WSiOAALYocA" ) );
         TrackerImportParams params = TrackerImportParamsBuilder.build( paramMap );
 
-        assertThat( params.getIdSchemes().getProgramIdScheme().getIdScheme(), is( TrackerIdScheme.ATTRIBUTE ) );
-        assertThat( params.getIdSchemes().getProgramIdScheme().getAttributeUid(), is( "WSiOAALYocA" ) );
+        assertEquals( TrackerIdSchemeParam.ofAttribute( "WSiOAALYocA" ), params.getIdSchemes().getProgramIdScheme() );
+    }
+
+    @Test
+    void testProgramIdentifierUsingIdSchemeAttributeGivenInvalidUid()
+    {
+        TrackerImportParams params = TrackerImportParamsBuilder
+            .build( Map.of( "programIdScheme", Collections.singletonList( "ATTRIBUTE:abc" ) ) );
+
+        assertEquals( TrackerIdSchemeParam.of( TrackerIdScheme.UID, null ),
+            params.getIdSchemes().getProgramIdScheme() );
+    }
+
+    @Test
+    void testProgramIdentifierUsingUnsupportedIdScheme()
+    {
+        TrackerImportParams params = TrackerImportParamsBuilder
+            .build( Map.of( "programIdScheme", Collections.singletonList( "SOMEUNSUPPORTEDIDSCHEME" ) ) );
+
+        assertEquals( TrackerIdSchemeParam.of( TrackerIdScheme.UID, null ),
+            params.getIdSchemes().getProgramIdScheme() );
     }
 
     @Test


### PR DESCRIPTION
when only passing query parameter `idScheme=ATTRIBUTE:someUID` metadata type specific idScheme parameters like programIdScheme got `idScheme=ATTRIBUTE` `attributeUid=null` instead of `someUID`