### PR TITLE
fix: Map labels on program dates, in events [DHIS2-13212]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
@@ -123,9 +123,11 @@ public class DefaultEnrollmentAnalyticsService
             .addHeader( new GridHeader(
                 ITEM_TEI, NAME_TEI, TEXT, false, true ) )
             .addHeader( new GridHeader(
-                ITEM_ENROLLMENT_DATE, NAME_ENROLLMENT_DATE, DATE, false, true ) )
+                ITEM_ENROLLMENT_DATE, LabelMapper.getEnrollmentDateLabel( params.getProgram(), NAME_ENROLLMENT_DATE ),
+                DATE, false, true ) )
             .addHeader( new GridHeader(
-                ITEM_INCIDENT_DATE, NAME_INCIDENT_DATE, DATE, false, true ) )
+                ITEM_INCIDENT_DATE, LabelMapper.getIncidentDateLabel( params.getProgram(), NAME_INCIDENT_DATE ), DATE,
+                false, true ) )
             .addHeader( new GridHeader(
                 ITEM_STORED_BY, NAME_STORED_BY, TEXT, false, true ) )
             .addHeader( new GridHeader(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
@@ -118,7 +118,7 @@ public class LabelMapper
      */
     static String getIncidentDateLabel( final Program program, final String defaultLabel )
     {
-        if ( program != null && program != null && isNotBlank( program.getDisplayIncidentDateLabel() ) )
+        if ( program != null && isNotBlank( program.getDisplayIncidentDateLabel() ) )
         {
             return program.getDisplayIncidentDateLabel();
         }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 
 /**
@@ -51,9 +52,9 @@ public class LabelMapper
      */
     static String getEventDateLabel( final ProgramStage programStage, final String defaultLabel )
     {
-        if ( programStage != null && isNotBlank( programStage.getExecutionDateLabel() ) )
+        if ( programStage != null && isNotBlank( programStage.getDisplayExecutionDateLabel() ) )
         {
-            return programStage.getExecutionDateLabel();
+            return programStage.getDisplayExecutionDateLabel();
         }
 
         return defaultLabel;
@@ -68,9 +69,9 @@ public class LabelMapper
     static String getEnrollmentDateLabel( final ProgramStage programStage, final String defaultLabel )
     {
         if ( programStage != null && programStage.getProgram() != null
-            && isNotBlank( programStage.getProgram().getEnrollmentDateLabel() ) )
+            && isNotBlank( programStage.getProgram().getDisplayEnrollmentDateLabel() ) )
         {
-            return programStage.getProgram().getEnrollmentDateLabel();
+            return programStage.getProgram().getDisplayEnrollmentDateLabel();
         }
 
         return defaultLabel;
@@ -85,9 +86,41 @@ public class LabelMapper
     static String getIncidentDateLabel( final ProgramStage programStage, final String defaultLabel )
     {
         if ( programStage != null && programStage.getProgram() != null
-            && isNotBlank( programStage.getProgram().getIncidentDateLabel() ) )
+            && isNotBlank( programStage.getProgram().getDisplayIncidentDateLabel() ) )
         {
-            return programStage.getProgram().getIncidentDateLabel();
+            return programStage.getProgram().getDisplayIncidentDateLabel();
+        }
+
+        return defaultLabel;
+    }
+
+    /**
+     * Finds for a custom label for enrollment date if one exists.
+     *
+     * @param program
+     * @return the custom label, otherwise the default one
+     */
+    static String getEnrollmentDateLabel( final Program program, final String defaultLabel )
+    {
+        if ( program != null && isNotBlank( program.getDisplayEnrollmentDateLabel() ) )
+        {
+            return program.getDisplayEnrollmentDateLabel();
+        }
+
+        return defaultLabel;
+    }
+
+    /**
+     * Finds for a custom label for incident date if one exists.
+     *
+     * @param program
+     * @return the custom label, otherwise the default one
+     */
+    static String getIncidentDateLabel( final Program program, final String defaultLabel )
+    {
+        if ( program != null && program != null && isNotBlank( program.getDisplayIncidentDateLabel() ) )
+        {
+            return program.getDisplayIncidentDateLabel();
         }
 
         return defaultLabel;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.Test;
  */
 class LabelMapperTest
 {
-
     public static final String EVENT_DATE = "Event date";
 
     public static final String INCIDENT_DATE = "Incident date";
@@ -56,7 +55,7 @@ class LabelMapperTest
         // When
         final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithLabels, EVENT_DATE );
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getExecutionDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getDisplayExecutionDateLabel() ) );
     }
 
     @Test
@@ -67,7 +66,7 @@ class LabelMapperTest
         // When
         final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithLabels, ENROLLMENT_DATE );
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getEnrollmentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getDisplayEnrollmentDateLabel() ) );
     }
 
     @Test
@@ -78,7 +77,7 @@ class LabelMapperTest
         // When
         final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithLabels, INCIDENT_DATE );
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getIncidentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getDisplayIncidentDateLabel() ) );
     }
 
     @Test


### PR DESCRIPTION
This PR aims to map the date attributes to their respective header display labels.
It ensures that the dates in the headers of the grid are equally displayed in the download endpoint.