### PR TITLE
fix: DataValue.dataElement is a MetadataIdentifier DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java
@@ -35,6 +35,7 @@ import lombok.NoArgsConstructor;
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -165,6 +166,19 @@ public class TrackerIdSchemeParams
     public MetadataIdentifier toMetadataIdentifier( CategoryOption categoryOption )
     {
         return categoryOptionIdScheme.toMetadataIdentifier( categoryOption );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code dataElement} using
+     * {@link #dataElementIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param dataElement to create metadata identifier for
+     * @return metadata identifier representing dataElement using the idScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( DataElement dataElement )
+    {
+        return dataElementIdScheme.toMetadataIdentifier( dataElement );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -94,7 +94,7 @@ public class TrackerIdentifierCollector
         return identifiers;
     }
 
-    private void collectProgramRulesFields(Map<Class<?>, Set<String>> map )
+    private void collectProgramRulesFields( Map<Class<?>, Set<String>> map )
     {
         // collecting program rule dataElement/attributes deliberately using
         // UIDs
@@ -113,7 +113,7 @@ public class TrackerIdentifierCollector
         Set<String> attributes = programRules.stream()
             .flatMap( pr -> pr.getProgramRuleActions().stream() )
             .filter( a -> Objects.nonNull( a.getAttribute() ) )
-            .map( a -> a.getAttribute().getUid())
+            .map( a -> a.getAttribute().getUid() )
             .collect( Collectors.toSet() );
         attributes.forEach( attribute -> addIdentifier( map, TrackedEntityAttribute.class, attribute ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -104,12 +104,12 @@ public class TrackerIdentifierCollector
         // dataElements/attributes from rule actions
         // out of the preheat using UIDs
         List<ProgramRule> programRules = programRuleService.getProgramRulesLinkedToTeaOrDe();
+
         Set<String> dataElements = programRules.stream()
             .flatMap( pr -> pr.getProgramRuleActions().stream() )
             .filter( a -> Objects.nonNull( a.getDataElement() ) )
             .map( a -> a.getDataElement().getUid() )
             .collect( Collectors.toSet() );
-
         dataElements.forEach( de -> addIdentifier( map, DataElement.class, de ) );
 
         Set<String> attributes = programRules.stream()
@@ -117,7 +117,6 @@ public class TrackerIdentifierCollector
             .filter( a -> Objects.nonNull( a.getAttribute() ) )
             .map( a -> a.getAttribute().getUid() )
             .collect( Collectors.toSet() );
-
         attributes.forEach( attribute -> addIdentifier( map, TrackedEntityAttribute.class, attribute ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -58,8 +58,6 @@ import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.ImmutableSet;
-
 /**
  * This class "collects" identifiers from all input objects. This resulting map
  * of all identifiers will then be used to "preheat/cache" all the objects
@@ -89,14 +87,14 @@ public class TrackerIdentifierCollector
         collectRelationships( identifiers, params.getRelationships() );
         // Using "*" signals that all the entities of the given type have to be
         // preloaded in the Preheat
-        identifiers.put( TrackedEntityType.class, ImmutableSet.of( ID_WILDCARD ) );
-        identifiers.put( RelationshipType.class, ImmutableSet.of( ID_WILDCARD ) );
+        identifiers.put( TrackedEntityType.class, Set.of( ID_WILDCARD ) );
+        identifiers.put( RelationshipType.class, Set.of( ID_WILDCARD ) );
 
         collectProgramRulesFields( identifiers );
         return identifiers;
     }
 
-    private void collectProgramRulesFields( Map<Class<?>, Set<String>> map )
+    private void collectProgramRulesFields(Map<Class<?>, Set<String>> map )
     {
         // collecting program rule dataElement/attributes deliberately using
         // UIDs
@@ -115,7 +113,7 @@ public class TrackerIdentifierCollector
         Set<String> attributes = programRules.stream()
             .flatMap( pr -> pr.getProgramRuleActions().stream() )
             .filter( a -> Objects.nonNull( a.getAttribute() ) )
-            .map( a -> a.getAttribute().getUid() )
+            .map( a -> a.getAttribute().getUid())
             .collect( Collectors.toSet() );
         attributes.forEach( attribute -> addIdentifier( map, TrackedEntityAttribute.class, attribute ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/DataValue.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/DataValue.java
@@ -58,8 +58,7 @@ public class DataValue
     private boolean providedElsewhere;
 
     @JsonProperty
-    @Builder.Default
-    private String dataElement = "";
+    private MetadataIdentifier dataElement;
 
     @JsonProperty
     private String value;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -431,6 +431,16 @@ public class TrackerPreheat
         return (T) map.getOrDefault( klass, new HashMap<>() ).get( key );
     }
 
+    public DataElement getDataElement( MetadataIdentifier id )
+    {
+        return get( DataElement.class, id );
+    }
+
+    public DataElement getDataElement( String id )
+    {
+        return get( DataElement.class, id );
+    }
+
     public CategoryOption getCategoryOption( MetadataIdentifier id )
     {
         return get( CategoryOption.class, id );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
@@ -41,7 +41,8 @@ import org.hisp.dhis.tracker.domain.Attribute;
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class EnrollmentActionRule
-    implements ActionRule {
+    implements ActionRule
+{
     private final String ruleUid;
 
     private final String enrollment;
@@ -56,16 +57,20 @@ public class EnrollmentActionRule
 
     private final List<Attribute> attributes;
 
-    public String getValue() {
+    public String getValue()
+    {
         StringBuilder stringBuilder = new StringBuilder();
-        if (!StringUtils.isEmpty(content)) {
-            stringBuilder.append(data);
+        if ( !StringUtils.isEmpty( content ) )
+        {
+            stringBuilder.append( data );
         }
-        if (!StringUtils.isEmpty(stringBuilder.toString())) {
-            stringBuilder.append(" ");
+        if ( !StringUtils.isEmpty( stringBuilder.toString() ) )
+        {
+            stringBuilder.append( " " );
         }
-        if (!StringUtils.isEmpty(data)) {
-            stringBuilder.append(data);
+        if ( !StringUtils.isEmpty( data ) )
+        {
+            stringBuilder.append( data );
         }
         return stringBuilder.toString();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
@@ -41,8 +41,7 @@ import org.hisp.dhis.tracker.domain.Attribute;
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class EnrollmentActionRule
-    implements ActionRule
-{
+    implements ActionRule {
     private final String ruleUid;
 
     private final String enrollment;
@@ -57,20 +56,16 @@ public class EnrollmentActionRule
 
     private final List<Attribute> attributes;
 
-    public String getValue()
-    {
+    public String getValue() {
         StringBuilder stringBuilder = new StringBuilder();
-        if ( !StringUtils.isEmpty( content ) )
-        {
-            stringBuilder.append( data );
+        if (!StringUtils.isEmpty(content)) {
+            stringBuilder.append(data);
         }
-        if ( !StringUtils.isEmpty( stringBuilder.toString() ) )
-        {
-            stringBuilder.append( " " );
+        if (!StringUtils.isEmpty(stringBuilder.toString())) {
+            stringBuilder.append(" ");
         }
-        if ( !StringUtils.isEmpty( data ) )
-        {
-            stringBuilder.append( data );
+        if (!StringUtils.isEmpty(data)) {
+            stringBuilder.append(data);
         }
         return stringBuilder.toString();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EventActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EventActionRule.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.programrule;
 
-import java.util.Optional;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
@@ -74,19 +73,5 @@ public class EventActionRule
             stringBuilder.append( data );
         }
         return stringBuilder.toString();
-    }
-
-    public Optional<DataValue> getDataValue()
-    {
-        if ( attributeType.equals( AttributeType.DATA_ELEMENT ) )
-        {
-            return getDataValues()
-                .stream()
-                .filter( dv -> dv.getDataElement().equals( field ) )
-                .findAny();
-        }
-
-        return Optional.empty();
-
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -44,14 +44,12 @@ import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionAttribute;
 import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.EnrollmentActionRule;
 import org.hisp.dhis.tracker.programrule.EventActionRule;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
@@ -200,24 +198,14 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
                     List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
                         payloadTeiAttributes );
 
-                    TrackerPreheat preheat = bundle.getPreheat();
-                    TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
-
                     List<EnrollmentActionRule> enrollmentActionRules = e.getValue()
                         .stream()
                         .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
                         .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
                             getAttributeType( effect.ruleAction() ) == TRACKED_ENTITY_ATTRIBUTE )
-                        .filter(
-                            effect -> preheat.getTrackedEntityAttribute( getField( (T) effect.ruleAction() ) ) != null )
                         .map( effect -> new EnrollmentActionRule( effect.ruleId(),
                             enrollment.getEnrollment(), effect.data(),
-<<<<<<< HEAD
                             getField( (T) effect.ruleAction() ),
-=======
-                            idSchemes.toMetadataIdentifier(
-                                preheat.getTrackedEntityAttribute( getField( (T) effect.ruleAction() ) ) ),
->>>>>>> a5ddb4ee61 (fix: rule engine attribute identifiers are UIDs)
                             getAttributeType( effect.ruleAction() ),
                             getContent( (T) effect.ruleAction() ), attributes ) )
                         .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -198,6 +198,8 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
                     List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
                         payloadTeiAttributes );
 
+                    // TODO(DHIS2-12563) do we need to map the UID of getField(
+                    // (T) effect.ruleAction() ) here?
                     List<EnrollmentActionRule> enrollmentActionRules = e.getValue()
                         .stream()
                         .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -198,8 +198,6 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
                     List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
                         payloadTeiAttributes );
 
-                    // TODO(DHIS2-12563) do we need to map the UID of getField(
-                    // (T) effect.ruleAction() ) here?
                     List<EnrollmentActionRule> enrollmentActionRules = e.getValue()
                         .stream()
                         .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -44,12 +44,14 @@ import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionAttribute;
 import org.hisp.dhis.rules.models.RuleEffect;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.EnrollmentActionRule;
 import org.hisp.dhis.tracker.programrule.EventActionRule;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
@@ -198,14 +200,24 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
                     List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
                         payloadTeiAttributes );
 
+                    TrackerPreheat preheat = bundle.getPreheat();
+                    TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
+
                     List<EnrollmentActionRule> enrollmentActionRules = e.getValue()
                         .stream()
                         .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
                         .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
                             getAttributeType( effect.ruleAction() ) == TRACKED_ENTITY_ATTRIBUTE )
+                        .filter(
+                            effect -> preheat.getTrackedEntityAttribute( getField( (T) effect.ruleAction() ) ) != null )
                         .map( effect -> new EnrollmentActionRule( effect.ruleId(),
                             enrollment.getEnrollment(), effect.data(),
+<<<<<<< HEAD
                             getField( (T) effect.ruleAction() ),
+=======
+                            idSchemes.toMetadataIdentifier(
+                                preheat.getTrackedEntityAttribute( getField( (T) effect.ruleAction() ) ) ),
+>>>>>>> a5ddb4ee61 (fix: rule engine attribute identifiers are UIDs)
                             getAttributeType( effect.ruleAction() ),
                             getContent( (T) effect.ruleAction() ), attributes ) )
                         .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -138,8 +138,7 @@ public class AssignValueImplementer
             else
             {
                 issues.add( new ProgramRuleIssue( actionRule.getRuleUid(), TrackerErrorCode.E1309,
-                    Lists.newArrayList( actionRule.getField(),
-                        actionRule.getEnrollment() ),
+                    Lists.newArrayList( actionRule.getField(), actionRule.getEnrollment() ),
                     IssueType.ERROR ) );
             }
         }
@@ -182,11 +181,6 @@ public class AssignValueImplementer
     {
         TrackedEntityAttribute attribute = preheat.getTrackedEntityAttribute( actionRule.getField() );
         String value = actionRule.getValue();
-        // NOTE: since rule engine has no notion of idSchemes the attribute
-        // identifiers have to be mapped to UIDs
-        // here we "escape" the safety of MetadataIdentifier and assume it
-        // contains a UID; thus directly comparing
-        // the identifier String to the field String
         Optional<Attribute> optionalAttribute = actionRule.getAttributes().stream()
             .filter( at -> at.getAttribute().isEqualTo( attribute ) )
             .findAny();
@@ -239,11 +233,6 @@ public class AssignValueImplementer
         if ( trackedEntity.isPresent() )
         {
             attributes = trackedEntity.get().getAttributes();
-            // NOTE: since rule engine has no notion of idSchemes the attribute
-            // identifiers have to be mapped to UIDs
-            // here we "escape" the safety of MetadataIdentifier and assume it
-            // contains a UID; thus directly comparing
-            // the identifier String to the field String
             Optional<Attribute> optionalAttribute = attributes.stream()
                 .filter( at -> at.getAttribute().isEqualTo( attribute ) )
                 .findAny();
@@ -255,11 +244,6 @@ public class AssignValueImplementer
         }
 
         attributes = enrollment.getAttributes();
-        // NOTE: since rule engine has no notion of idSchemes the attribute
-        // identifiers have to be mapped to UIDs
-        // here we "escape" the safety of MetadataIdentifier and assume it
-        // contains a UID; thus directly comparing
-        // the identifier String to the field String
         Optional<Attribute> optionalAttribute = attributes.stream()
             .filter( at -> at.getAttribute().isEqualTo( attribute ) )
             .findAny();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -95,9 +95,10 @@ public class AssignValueImplementer
         Boolean canOverwrite = systemSettingManager
             .getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE );
 
+        TrackerPreheat preheat = bundle.getPreheat();
         for ( EventActionRule actionRule : eventClasses.getValue() )
         {
-            if ( !actionRule.getDataValue().isPresent() ||
+            if ( getDataValue( actionRule, preheat ).isEmpty() ||
                 Boolean.TRUE.equals( canOverwrite ) ||
                 isTheSameValue( actionRule, bundle.getPreheat() ) )
             {
@@ -115,6 +116,20 @@ public class AssignValueImplementer
         return issues;
     }
 
+    public Optional<DataValue> getDataValue( EventActionRule actionRule, TrackerPreheat preheat )
+    {
+        if ( AttributeType.DATA_ELEMENT != actionRule.getAttributeType() )
+        {
+            return Optional.empty();
+        }
+
+        DataElement dataElement = preheat.getDataElement( actionRule.getField() );
+        return actionRule.getDataValues()
+            .stream()
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElement ) )
+            .findAny();
+    }
+
     @Override
     public List<ProgramRuleIssue> applyToEnrollments(
         Map.Entry<String, List<EnrollmentActionRule>> enrollmentActionRules,
@@ -126,7 +141,7 @@ public class AssignValueImplementer
 
         for ( EnrollmentActionRule actionRule : enrollmentActionRules.getValue() )
         {
-            if ( !getAttribute( actionRule, bundle.getPreheat() ).isPresent() ||
+            if ( getAttribute( actionRule, bundle.getPreheat() ).isEmpty() ||
                 Boolean.TRUE.equals( canOverwrite ) ||
                 isTheSameValue( actionRule, bundle.getPreheat() ) )
             {
@@ -148,26 +163,25 @@ public class AssignValueImplementer
 
     private Optional<Attribute> getAttribute( EnrollmentActionRule actionRule, TrackerPreheat preheat )
     {
-        TrackedEntityAttribute attribute = preheat.getTrackedEntityAttribute( actionRule.getField() );
 
-        if ( AttributeType.TRACKED_ENTITY_ATTRIBUTE == actionRule.getAttributeType() )
+        if ( AttributeType.TRACKED_ENTITY_ATTRIBUTE != actionRule.getAttributeType() )
         {
-            return actionRule.getAttributes()
-                .stream()
-                .filter( at -> at.getAttribute().isEqualTo( attribute ) )
-                .findAny();
+            return Optional.empty();
         }
 
-        return Optional.empty();
-
+        TrackedEntityAttribute attribute = preheat.getTrackedEntityAttribute( actionRule.getField() );
+        return actionRule.getAttributes()
+            .stream()
+            .filter( at -> at.getAttribute().isEqualTo( attribute ) )
+            .findAny();
     }
 
     private boolean isTheSameValue( EventActionRule actionRule, TrackerPreheat preheat )
     {
-        DataElement dataElement = preheat.get( DataElement.class, actionRule.getField() );
+        DataElement dataElement = preheat.getDataElement( actionRule.getField() );
         String dataValue = actionRule.getValue();
         Optional<DataValue> optionalDataValue = actionRule.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().equals( actionRule.getField() ) )
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElement ) )
             .findAny();
         if ( optionalDataValue.isPresent() )
         {
@@ -207,10 +221,11 @@ public class AssignValueImplementer
 
     private void addOrOverwriteDataValue( EventActionRule actionRule, TrackerBundle bundle )
     {
+        DataElement dataElement = bundle.getPreheat().getDataElement( actionRule.getField() );
         Set<DataValue> dataValues = bundle.getEvent( actionRule.getEvent() )
             .map( Event::getDataValues ).orElse( Sets.newHashSet() );
         Optional<DataValue> dataValue = dataValues.stream()
-            .filter( dv -> dv.getDataElement().equals( actionRule.getField() ) )
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElement ) )
             .findAny();
 
         if ( dataValue.isPresent() )
@@ -219,7 +234,8 @@ public class AssignValueImplementer
         }
         else
         {
-            dataValues.add( createDataValue( actionRule.getField(), actionRule.getValue() ) );
+            dataValues.add( createDataValue( bundle.getPreheat().getIdSchemes().toMetadataIdentifier( dataElement ),
+                actionRule.getValue() ) );
         }
     }
 
@@ -266,11 +282,11 @@ public class AssignValueImplementer
             .build();
     }
 
-    private DataValue createDataValue( String dataElementUid, String newValue )
+    private DataValue createDataValue( MetadataIdentifier dataElement, String newValue )
     {
-        DataValue dataValue = new DataValue();
-        dataValue.setDataElement( dataElementUid );
-        dataValue.setValue( newValue );
-        return dataValue;
+        return DataValue.builder()
+            .dataElement( dataElement )
+            .value( newValue )
+            .build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -182,6 +182,11 @@ public class AssignValueImplementer
     {
         TrackedEntityAttribute attribute = preheat.getTrackedEntityAttribute( actionRule.getField() );
         String value = actionRule.getValue();
+        // NOTE: since rule engine has no notion of idSchemes the attribute
+        // identifiers have to be mapped to UIDs
+        // here we "escape" the safety of MetadataIdentifier and assume it
+        // contains a UID; thus directly comparing
+        // the identifier String to the field String
         Optional<Attribute> optionalAttribute = actionRule.getAttributes().stream()
             .filter( at -> at.getAttribute().isEqualTo( attribute ) )
             .findAny();
@@ -234,6 +239,11 @@ public class AssignValueImplementer
         if ( trackedEntity.isPresent() )
         {
             attributes = trackedEntity.get().getAttributes();
+            // NOTE: since rule engine has no notion of idSchemes the attribute
+            // identifiers have to be mapped to UIDs
+            // here we "escape" the safety of MetadataIdentifier and assume it
+            // contains a UID; thus directly comparing
+            // the identifier String to the field String
             Optional<Attribute> optionalAttribute = attributes.stream()
                 .filter( at -> at.getAttribute().isEqualTo( attribute ) )
                 .findAny();
@@ -245,6 +255,11 @@ public class AssignValueImplementer
         }
 
         attributes = enrollment.getAttributes();
+        // NOTE: since rule engine has no notion of idSchemes the attribute
+        // identifiers have to be mapped to UIDs
+        // here we "escape" the safety of MetadataIdentifier and assume it
+        // contains a UID; thus directly comparing
+        // the identifier String to the field String
         Optional<Attribute> optionalAttribute = attributes.stream()
             .filter( at -> at.getAttribute().isEqualTo( attribute ) )
             .findAny();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidator.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.tracker.programrule.implementers;
 
-import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.validateMandatoryDataValue;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,6 +44,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.EnrollmentActionRule;
 import org.hisp.dhis.tracker.programrule.EventActionRule;
@@ -53,6 +52,7 @@ import org.hisp.dhis.tracker.programrule.IssueType;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.validation.hooks.ValidationUtils;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
@@ -86,6 +86,27 @@ public class SetMandatoryFieldValidator
             bundle );
     }
 
+    private List<ProgramRuleIssue> checkMandatoryDataElement( Event event, List<EventActionRule> actionRules,
+        TrackerBundle bundle )
+    {
+        TrackerPreheat preheat = bundle.getPreheat();
+        ProgramStage programStage = preheat.getProgramStage( event.getProgramStage() );
+        TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
+
+        Map<MetadataIdentifier, EventActionRule> mandatoryDataElementsByActionRule = actionRules.stream()
+            .filter( r -> r.getAttributeType() == AttributeType.DATA_ELEMENT )
+            .collect( Collectors.toMap( r -> idSchemes.toMetadataIdentifier( preheat.getDataElement( r.getField() ) ),
+                Function.identity() ) );
+
+        return ValidationUtils.validateMandatoryDataValue( programStage, event,
+            Lists.newArrayList( mandatoryDataElementsByActionRule.keySet() ) )
+            .stream()
+            .map( e -> new ProgramRuleIssue( mandatoryDataElementsByActionRule.get( e ).getRuleUid(),
+                TrackerErrorCode.E1301,
+                Lists.newArrayList( e.getIdentifierOrAttributeValue() ), IssueType.ERROR ) )
+            .collect( Collectors.toList() );
+    }
+
     @Override
     List<ProgramRuleIssue> applyToEnrollments( Map.Entry<String, List<EnrollmentActionRule>> enrollmentActionRules,
         TrackerBundle bundle )
@@ -107,7 +128,7 @@ public class SetMandatoryFieldValidator
                 Optional<Attribute> any = enrollment.getAttributes().stream()
                     .filter( attribute -> attribute.getAttribute().isEqualTo( ruleAttribute ) )
                     .findAny();
-                if ( !any.isPresent() || StringUtils.isEmpty( any.get().getValue() ) )
+                if ( any.isEmpty() || StringUtils.isEmpty( any.get().getValue() ) )
                 {
                     return new ProgramRuleIssue( action.getRuleUid(),
                         TrackerErrorCode.E1306,
@@ -122,23 +143,5 @@ public class SetMandatoryFieldValidator
             } )
             .filter( Objects::nonNull )
             .collect( Collectors.toList() );
-    }
-
-    private List<ProgramRuleIssue> checkMandatoryDataElement( Event event, List<EventActionRule> actionRules,
-        TrackerBundle bundle )
-    {
-        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
-
-        Map<String, EventActionRule> mandatoryDataElementsByActionRule = actionRules.stream()
-            .filter( eventActionRule -> eventActionRule.getAttributeType() == AttributeType.DATA_ELEMENT )
-            .collect( Collectors.toMap( EventActionRule::getField, Function.identity() ) );
-
-        return validateMandatoryDataValue( programStage, event,
-            Lists.newArrayList( mandatoryDataElementsByActionRule.keySet() ) )
-                .stream()
-                .map( e -> new ProgramRuleIssue( mandatoryDataElementsByActionRule.get( e ).getRuleUid(),
-                    TrackerErrorCode.E1301,
-                    Lists.newArrayList( e ), IssueType.ERROR ) )
-                .collect( Collectors.toList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -73,7 +74,7 @@ public class EventDataValuesValidationHook
             // event dates (createdAt, updatedAt) are ignored and set by the
             // system
             TrackerPreheat preheat = reporter.getBundle().getPreheat();
-            DataElement dataElement = preheat.get( DataElement.class, dataValue.getDataElement() );
+            DataElement dataElement = preheat.getDataElement( dataValue.getDataElement() );
 
             if ( dataElement == null )
             {
@@ -97,16 +98,15 @@ public class EventDataValuesValidationHook
 
         TrackerPreheat preheat = reporter.getBundle().getPreheat();
         ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
-        final List<String> mandatoryDataElements = programStage.getProgramStageDataElements()
+        final List<MetadataIdentifier> mandatoryDataElements = programStage.getProgramStageDataElements()
             .stream()
             .filter( ProgramStageDataElement::isCompulsory )
-            .map( de -> preheat.getIdSchemes().getDataElementIdScheme()
-                .getIdentifier( de.getDataElement() ) )
+            .map( de -> preheat.getIdSchemes().toMetadataIdentifier( de.getDataElement() ) )
             .collect( Collectors.toList() );
-        List<String> missingDataValue = validateMandatoryDataValue( programStage, event,
+        List<MetadataIdentifier> missingDataValue = validateMandatoryDataValue( programStage, event,
             mandatoryDataElements );
         missingDataValue
-            .forEach( de -> reporter.addError( event, E1303, de ) );
+            .forEach( de -> reporter.addError( event, E1303, de.getIdentifierOrAttributeValue() ) );
     }
 
     private void validateDataValue( ValidationErrorReporter reporter, DataElement dataElement,
@@ -172,21 +172,20 @@ public class EventDataValuesValidationHook
         ProgramStage programStage )
     {
         TrackerPreheat preheat = reporter.getBundle().getPreheat();
-        final Set<String> dataElements = programStage.getProgramStageDataElements()
+        final Set<MetadataIdentifier> dataElements = programStage.getProgramStageDataElements()
             .stream()
-            .map( de -> preheat.getIdSchemes().getDataElementIdScheme()
-                .getIdentifier( de.getDataElement() ) )
+            .map( de -> preheat.getIdSchemes().toMetadataIdentifier( de.getDataElement() ) )
             .collect( Collectors.toSet() );
 
-        Set<String> payloadDataElements = event.getDataValues().stream()
+        Set<MetadataIdentifier> payloadDataElements = event.getDataValues().stream()
             .map( DataValue::getDataElement )
             .collect( Collectors.toSet() );
 
-        for ( String payloadDataElement : payloadDataElements )
+        for ( MetadataIdentifier payloadDataElement : payloadDataElements )
         {
             if ( !dataElements.contains( payloadDataElement ) )
             {
-                reporter.addError( event, TrackerErrorCode.E1305, payloadDataElement,
+                reporter.addError( event, TrackerErrorCode.E1305, payloadDataElement.getIdentifierOrAttributeValue(),
                     programStage.getUid() );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.program.ValidationStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
@@ -123,21 +124,21 @@ public class ValidationUtils
         return notes;
     }
 
-    public static List<String> validateMandatoryDataValue( ProgramStage programStage,
-        Event event, List<String> mandatoryDataElements )
+    public static List<MetadataIdentifier> validateMandatoryDataValue( ProgramStage programStage,
+        Event event, List<MetadataIdentifier> mandatoryDataElements )
     {
-        List<String> notPresentMandatoryDataElements = Lists.newArrayList();
+        List<MetadataIdentifier> notPresentMandatoryDataElements = Lists.newArrayList();
 
         if ( !needsToValidateDataValues( event, programStage ) )
         {
             return notPresentMandatoryDataElements;
         }
 
-        Set<String> eventDataElements = event.getDataValues().stream()
+        Set<MetadataIdentifier> eventDataElements = event.getDataValues().stream()
             .map( DataValue::getDataElement )
             .collect( Collectors.toSet() );
 
-        for ( String mandatoryDataElement : mandatoryDataElements )
+        for ( MetadataIdentifier mandatoryDataElement : mandatoryDataElements )
         {
             if ( !eventDataElements.contains( mandatoryDataElement ) )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -140,7 +140,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         DataElement dataElement = new DataElement();
         dataElement.setUid( CodeGenerator.generateUid() );
-        when( preheat.get( DataElement.class, dataElement.getUid() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElement.getUid() ) ) ).thenReturn( dataElement );
 
         User user = User.builder().username( USERNAME ).build();
 
@@ -151,7 +151,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         dataValue.setCreatedAt( Instant.now() );
         dataValue.setStoredBy( USERNAME );
         dataValue.setUpdatedAt( Instant.now() );
-        dataValue.setDataElement( dataElement.getUid() );
+        dataValue.setDataElement( MetadataIdentifier.ofUid( dataElement.getUid() ) );
         Event event = event( dataValue );
 
         ProgramStageInstance programStageInstance = converter.from( preheat, event );
@@ -178,7 +178,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         DataElement dataElement = new DataElement();
         dataElement.setUid( CodeGenerator.generateUid() );
-        when( preheat.get( DataElement.class, dataElement.getUid() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElement.getUid() ) ) ).thenReturn( dataElement );
 
         DataValue dataValue = dataValue( dataElement.getUid(), "900" );
         Event event = event( dataValue );
@@ -195,7 +195,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         assertEquals( ORGANISATION_UNIT_UID, programStageInstance.getOrganisationUnit().getUid() );
         assertEquals( 1, programStageInstance.getEventDataValues().size() );
         EventDataValue actual = programStageInstance.getEventDataValues().stream().findFirst().get();
-        assertEquals( dataValue.getDataElement(), actual.getDataElement() );
+        assertEquals( dataValue.getDataElement(), MetadataIdentifier.ofUid( actual.getDataElement() ) );
         assertEquals( dataValue.getValue(), actual.getValue() );
         assertTrue( actual.getProvidedElsewhere() );
         assertEquals( USERNAME, actual.getCreatedByUserInfo().getUsername() );
@@ -213,7 +213,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         DataElement dataElement = new DataElement();
         dataElement.setUid( CodeGenerator.generateUid() );
-        when( preheat.get( DataElement.class, dataElement.getUid() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElement.getUid() ) ) ).thenReturn( dataElement );
 
         // event refers to a different dataElement then currently associated
         // with the event in the DB; thus both
@@ -229,7 +229,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         expect1.setDataElement( existingDataValue.getDataElement() );
         expect1.setValue( existingDataValue.getValue() );
         EventDataValue expect2 = new EventDataValue();
-        expect2.setDataElement( newDataValue.getDataElement() );
+        expect2.setDataElement( dataElement.getUid() );
         expect2.setValue( newDataValue.getValue() );
         assertContainsOnly( programStageInstance.getEventDataValues(), expect1, expect2 );
     }
@@ -241,7 +241,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         DataElement dataElement = new DataElement();
         dataElement.setUid( CodeGenerator.generateUid() );
-        when( preheat.get( DataElement.class, dataElement.getUid() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElement.getUid() ) ) ).thenReturn( dataElement );
 
         ProgramStageInstance existingPsi = programStageInstance();
         existingPsi.setEventDataValues( Set.of( eventDataValue( dataElement.getUid(), "658" ) ) );
@@ -256,7 +256,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
 
         assertEquals( 1, programStageInstance.getEventDataValues().size() );
         EventDataValue expect1 = new EventDataValue();
-        expect1.setDataElement( updatedValue.getDataElement() );
+        expect1.setDataElement( dataElement.getUid() );
         expect1.setValue( updatedValue.getValue() );
         assertContainsOnly( programStageInstance.getEventDataValues(), expect1 );
     }
@@ -274,7 +274,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         DataElement dataElement = new DataElement();
         dataElement.setUid( CodeGenerator.generateUid() );
         dataElement.setCode( "DE_424050" );
-        when( preheat.get( DataElement.class, dataElement.getCode() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofCode( dataElement.getCode() ) ) ).thenReturn( dataElement );
 
         ProgramStageInstance existingPsi = programStageInstance();
         existingPsi.setEventDataValues( Set.of( eventDataValue( dataElement.getUid(), "658" ) ) );
@@ -364,16 +364,16 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
     {
         User user = User.builder().username( USERNAME ).build();
 
-        DataValue dataValue = new DataValue();
-        dataValue.setDataElement( dataElement );
-        dataValue.setValue( value );
-        dataValue.setProvidedElsewhere( true );
-        dataValue.setCreatedBy( user );
-        dataValue.setUpdatedBy( user );
-        dataValue.setCreatedAt( Instant.now() );
-        dataValue.setStoredBy( USERNAME );
-        dataValue.setUpdatedAt( Instant.now() );
-        return dataValue;
+        return DataValue.builder()
+            .dataElement( MetadataIdentifier.ofUid( dataElement ) )
+            .value( value )
+            .providedElsewhere( true )
+            .createdBy( user )
+            .updatedBy( user )
+            .createdAt( Instant.now() )
+            .storedBy( USERNAME )
+            .updatedAt( Instant.now() )
+            .build();
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatIdentifiersTest.java
@@ -125,15 +125,21 @@ class TrackerPreheatIdentifiersTest extends TrackerTest
         List<Pair<String, TrackerIdSchemeParam>> data = buildDataSet( "DSKTW8qFP0z", "DEAGE", "DE Age" );
         for ( Pair<String, TrackerIdSchemeParam> pair : data )
         {
-            Event event = new Event();
-            event.setProgramStage( MetadataIdentifier.ofUid( "NpsdDv6kKSO" ) );
-            DataValue dv1 = new DataValue();
-            dv1.setDataElement( pair.getLeft() );
-            dv1.setValue( "val1" );
-            event.setDataValues( Collections.singleton( dv1 ) );
-            TrackerImportParams params = buildParams( event, builder().dataElementIdScheme( pair.getRight() ).build() );
+            String id = pair.getLeft();
+            TrackerIdSchemeParam param = pair.getRight();
+            DataValue dv1 = DataValue.builder()
+                .dataElement( param.toMetadataIdentifier( id ) )
+                .value( "val1" )
+                .build();
+            Event event = Event.builder()
+                .programStage( MetadataIdentifier.ofUid( "NpsdDv6kKSO" ) )
+                .dataValues( Collections.singleton( dv1 ) )
+                .build();
+            TrackerImportParams params = buildParams( event, builder().dataElementIdScheme( param ).build() );
+
             TrackerPreheat preheat = trackerPreheatService.preheat( params );
-            assertPreheatedObjectExists( preheat, DataElement.class, pair.getRight(), pair.getLeft() );
+
+            assertPreheatedObjectExists( preheat, DataElement.class, param, id );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -168,8 +168,8 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.put( TrackerIdSchemeParam.CODE, de2 );
 
         assertEquals( 2, preheat.getAll( DataElement.class ).size() );
-        assertThat( preheat.get( DataElement.class, de1.getCode() ), is( de1 ) );
-        assertThat( preheat.get( DataElement.class, de2.getCode() ), is( de2 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofCode( de1.getCode() ) ), is( de1 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofCode( de2.getCode() ) ), is( de2 ) );
     }
 
     @Test
@@ -185,8 +185,8 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.put( TrackerIdSchemeParam.NAME, de2 );
 
         assertEquals( 2, preheat.getAll( DataElement.class ).size() );
-        assertThat( preheat.get( DataElement.class, de1.getName() ), is( de1 ) );
-        assertThat( preheat.get( DataElement.class, de2.getName() ), is( de2 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofName( de1.getName() ) ), is( de1 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofName( de2.getName() ) ), is( de2 ) );
     }
 
     @Test
@@ -206,7 +206,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
             de1 );
 
         assertEquals( 1, preheat.getAll( DataElement.class ).size() );
-        assertThat( preheat.get( DataElement.class, "value1" ), is( notNullValue() ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofUid( "value1" ) ), is( notNullValue() ) );
     }
 
     @Test
@@ -226,8 +226,8 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.put( de2 );
 
         assertEquals( 2, preheat.getAll( DataElement.class ).size() );
-        assertThat( preheat.get( DataElement.class, de1.getCode() ), is( de1 ) );
-        assertThat( preheat.get( DataElement.class, de2.getCode() ), is( de2 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofCode( de1.getCode() ) ), is( de1 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofCode( de2.getCode() ) ), is( de2 ) );
     }
 
     @Test
@@ -245,8 +245,8 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.put( de2 );
 
         assertEquals( 2, preheat.getAll( DataElement.class ).size() );
-        assertThat( preheat.get( DataElement.class, de1.getName() ), is( de1 ) );
-        assertThat( preheat.get( DataElement.class, de2.getName() ), is( de2 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofName( de1.getName() ) ), is( de1 ) );
+        assertThat( preheat.getDataElement( MetadataIdentifier.ofName( de2.getName() ) ), is( de2 ) );
     }
 
     @Test
@@ -310,7 +310,7 @@ class TrackerPreheatTest extends DhisConvenienceTest
 
         assertEquals( attribute, preheat.get( Attribute.class, MetadataIdentifier.ofName( "best" ) ) );
         assertEquals( de1,
-            preheat.get( DataElement.class, MetadataIdentifier.ofAttribute( attribute.getUid(), "value1" ) ) );
+            preheat.getDataElement( MetadataIdentifier.ofAttribute( attribute.getUid(), "value1" ) ) );
     }
 
     @Test
@@ -335,9 +335,9 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.put( TrackerIdSchemeParam.UID, de2 );
         preheat.put( TrackerIdSchemeParam.UID, de3 );
         assertFalse( preheat.isEmpty() );
-        assertEquals( de1.getUid(), preheat.get( DataElement.class, de1.getUid() ).getUid() );
-        assertEquals( de2.getUid(), preheat.get( DataElement.class, de2.getUid() ).getUid() );
-        assertEquals( de3.getUid(), preheat.get( DataElement.class, de3.getUid() ).getUid() );
+        assertEquals( de1.getUid(), preheat.getDataElement( MetadataIdentifier.ofUid( de1.getUid() ) ).getUid() );
+        assertEquals( de2.getUid(), preheat.getDataElement( MetadataIdentifier.ofUid( de2.getUid() ) ).getUid() );
+        assertEquals( de3.getUid(), preheat.getDataElement( MetadataIdentifier.ofUid( de3.getUid() ) ).getUid() );
     }
 
     @Test
@@ -357,9 +357,9 @@ class TrackerPreheatTest extends DhisConvenienceTest
         preheat.put( TrackerIdSchemeParam.CODE, de2 );
         preheat.put( TrackerIdSchemeParam.CODE, de3 );
         assertFalse( preheat.isEmpty() );
-        assertEquals( de1.getCode(), preheat.get( DataElement.class, de1.getCode() ).getCode() );
-        assertEquals( de2.getCode(), preheat.get( DataElement.class, de2.getCode() ).getCode() );
-        assertEquals( de3.getCode(), preheat.get( DataElement.class, de3.getCode() ).getCode() );
+        assertEquals( de1.getCode(), preheat.getDataElement( MetadataIdentifier.ofCode( de1.getCode() ) ).getCode() );
+        assertEquals( de2.getCode(), preheat.getDataElement( MetadataIdentifier.ofCode( de2.getCode() ) ).getCode() );
+        assertEquals( de3.getCode(), preheat.getDataElement( MetadataIdentifier.ofCode( de3.getCode() ) ).getCode() );
     }
 
     @Test
@@ -374,9 +374,9 @@ class TrackerPreheatTest extends DhisConvenienceTest
         de3.setAutoFields();
         preheat.put( TrackerIdSchemeParam.UID, Lists.newArrayList( de1, de2, de3 ) );
         assertFalse( preheat.isEmpty() );
-        assertEquals( de1.getUid(), preheat.get( DataElement.class, de1.getUid() ).getUid() );
-        assertEquals( de2.getUid(), preheat.get( DataElement.class, de2.getUid() ).getUid() );
-        assertEquals( de3.getUid(), preheat.get( DataElement.class, de3.getUid() ).getUid() );
+        assertEquals( de1.getUid(), preheat.getDataElement( MetadataIdentifier.ofUid( de1.getUid() ) ).getUid() );
+        assertEquals( de2.getUid(), preheat.getDataElement( MetadataIdentifier.ofUid( de2.getUid() ) ).getUid() );
+        assertEquals( de3.getUid(), preheat.getDataElement( MetadataIdentifier.ofUid( de3.getUid() ) ).getUid() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
@@ -175,19 +175,19 @@ class FileResourceSupplierTest extends DhisConvenienceTest
     private Event getEvent()
     {
         DataValue fileResourceDataValue = new DataValue();
-        fileResourceDataValue.setDataElement( FILE_RESOURCE_DATA_ELEMENT_UID );
+        fileResourceDataValue.setDataElement( MetadataIdentifier.ofUid( FILE_RESOURCE_DATA_ELEMENT_UID ) );
         fileResourceDataValue.setValue( FILE_RESOURCE_UID );
 
         DataValue emptyFileResourceDataValue = new DataValue();
-        emptyFileResourceDataValue.setDataElement( EMPTY_FILE_RESOURCE_DATA_ELEMENT_UID );
+        emptyFileResourceDataValue.setDataElement( MetadataIdentifier.ofUid( EMPTY_FILE_RESOURCE_DATA_ELEMENT_UID ) );
         emptyFileResourceDataValue.setValue( "" );
 
         DataValue nullFileResourceDataValue = new DataValue();
-        nullFileResourceDataValue.setDataElement( NULL_FILE_RESOURCE_DATA_ELEMENT_UID );
+        nullFileResourceDataValue.setDataElement( MetadataIdentifier.ofUid( NULL_FILE_RESOURCE_DATA_ELEMENT_UID ) );
         nullFileResourceDataValue.setValue( null );
 
         DataValue numericDataValue = new DataValue();
-        numericDataValue.setDataElement( NUMERIC_DATA_ELEMENT_UID );
+        numericDataValue.setDataElement( MetadataIdentifier.ofUid( NUMERIC_DATA_ELEMENT_UID ) );
         numericDataValue.setValue( "3" );
 
         Event event = new Event();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
@@ -69,6 +69,7 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.implementers.AssignValueImplementer;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,6 +98,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     private final static String SECOND_EVENT_ID = "CompletedEventUid";
 
     private final static String DATA_ELEMENT_ID = "DataElementId";
+
+    private final static String DATA_ELEMENT_CODE = "DataElementCode";
 
     private final static String ANOTHER_DATA_ELEMENT_ID = "AnotherDataElementId";
 
@@ -146,6 +149,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         attributeA.setValueType( ValueType.NUMBER );
         dataElementA = createDataElement( 'A' );
         dataElementA.setUid( DATA_ELEMENT_ID );
+        dataElementA.setCode( DATA_ELEMENT_CODE );
         ProgramStageDataElement programStageDataElementA = createProgramStageDataElement( firstProgramStage,
             dataElementA, 0 );
         firstProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementA ) );
@@ -156,12 +160,11 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( secondProgramStage,
             dataElementB, 0 );
         secondProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
             .thenReturn( firstProgramStage );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage ) ) )
             .thenReturn( secondProgramStage );
-        when( preheat.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementA.getUid() ) ) ).thenReturn( dataElementA );
         when( preheat.getTrackedEntityAttribute( attributeA.getUid() ) )
             .thenReturn( attributeA );
         when( preheat.getTrackedEntityAttribute( MetadataIdentifier.ofUid( attributeA.getUid() ) ) )
@@ -175,13 +178,17 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignDataElementValueForEventsWhenDataElementIsEmpty()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         List<Event> events = Lists.newArrayList( getEventWithDataValueNOTSet() );
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
+
         Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( SECOND_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().equals( dataElementA.getUid() ) ).findAny();
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_NEW_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
@@ -195,10 +202,12 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( getEventWithDataValueNOTSetInDifferentProgramStage() );
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
+
         Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( SECOND_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().equals( dataElementA.getUid() ) ).findAny();
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
         assertTrue( !newDataValue.isPresent() );
         assertTrue( eventIssues.isEmpty() );
     }
@@ -206,30 +215,65 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignDataElementValueForEventsWhenDataElementIsAlreadyPresent()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         List<Event> events = Lists.newArrayList( getEventWithDataValueSet() );
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
+
         Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().equals( dataElementA.getUid() ) ).findAny();
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_OLD_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
         assertEquals( 1, eventIssues.get( FIRST_EVENT_ID ).size() );
+        assertEquals( ERROR, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( TrackerErrorCode.E1307, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueCode() );
+    }
+
+    @Test
+    void testAssignDataElementValueForEventsWhenDataElementIsAlreadyPresentUsingIdSchemeCode()
+    {
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder()
+            .dataElementIdScheme( TrackerIdSchemeParam.CODE )
+            .build();
+        when( preheat.getIdSchemes() ).thenReturn( idSchemes );
+        when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
+
+        List<Event> events = Lists.newArrayList( getEventWithDataValueSet( idSchemes ) );
+        bundle.setEvents( events );
+        bundle.setRuleEffects( getRuleEventEffects( events ) );
+
+        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+
+        Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
+        Optional<DataValue> newDataValue = event.getDataValues().stream()
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
+        assertTrue( newDataValue.isPresent() );
+        assertEquals( DATA_ELEMENT_OLD_VALUE, newDataValue.get().getValue() );
+        assertEquals( 1, eventIssues.size() );
+        assertEquals( 1, eventIssues.get( FIRST_EVENT_ID ).size() );
+        assertEquals( TrackerErrorCode.E1307, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueCode() );
         assertEquals( ERROR, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueType() );
     }
 
     @Test
     void testAssignDataElementValueForEventsWhenDataElementIsAlreadyPresentAndHasSameValue()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         List<Event> events = Lists.newArrayList( getEventWithDataValueSetSameValue() );
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
+
         Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().equals( dataElementA.getUid() ) ).findAny();
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_NEW_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
@@ -240,15 +284,19 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignDataElementValueForEventsWhenDataElementIsAlreadyPresentAndSystemSettingToOverwriteIsTrue()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
         List<Event> events = Lists.newArrayList( getEventWithDataValueSet() );
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.TRUE );
+
         Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
-            .filter( dv -> dv.getDataElement().equals( dataElementA.getUid() ) ).findAny();
+            .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_NEW_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
@@ -259,6 +307,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignAttributeValueForEnrollmentsWhenAttributeIsEmpty()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         List<TrackedEntity> trackedEntities = Lists.newArrayList( getTrackedEntitiesWithAttributeNOTSet() );
         List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeNOTSet() );
         bundle.setTrackedEntities( trackedEntities );
@@ -432,6 +481,17 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         return event;
     }
 
+    private Event getEventWithDataValueSet( TrackerIdSchemeParams idSchemes )
+    {
+
+        return Event.builder()
+            .event( FIRST_EVENT_ID )
+            .status( EventStatus.ACTIVE )
+            .programStage( idSchemes.toMetadataIdentifier( firstProgramStage ) )
+            .dataValues( getEventDataValues( idSchemes ) )
+            .build();
+    }
+
     private Event getEventWithDataValueSetSameValue()
     {
         Event event = new Event();
@@ -462,17 +522,28 @@ class AssignValueImplementerTest extends DhisConvenienceTest
 
     private Set<DataValue> getEventDataValues()
     {
-        DataValue dataValue = new DataValue();
-        dataValue.setValue( DATA_ELEMENT_OLD_VALUE );
-        dataValue.setDataElement( DATA_ELEMENT_ID );
+        DataValue dataValue = DataValue.builder()
+            .value( DATA_ELEMENT_OLD_VALUE )
+            .dataElement( MetadataIdentifier.ofUid( DATA_ELEMENT_ID ) )
+            .build();
+        return Sets.newHashSet( dataValue );
+    }
+
+    private Set<DataValue> getEventDataValues( TrackerIdSchemeParams idSchemes )
+    {
+        DataValue dataValue = DataValue.builder()
+            .value( DATA_ELEMENT_OLD_VALUE )
+            .dataElement( idSchemes.toMetadataIdentifier( dataElementA ) )
+            .build();
         return Sets.newHashSet( dataValue );
     }
 
     private Set<DataValue> getEventDataValuesSameValue()
     {
-        DataValue dataValue = new DataValue();
-        dataValue.setValue( DATA_ELEMENT_NEW_VALUE_PAYLOAD );
-        dataValue.setDataElement( DATA_ELEMENT_ID );
+        DataValue dataValue = DataValue.builder()
+            .value( DATA_ELEMENT_NEW_VALUE_PAYLOAD )
+            .dataElement( MetadataIdentifier.ofUid( DATA_ELEMENT_ID ) )
+            .build();
         return Sets.newHashSet( dataValue );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -108,7 +108,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
 
     private TrackedEntityAttribute attribute;
 
-    private SetMandatoryFieldValidator implementerToTest = new SetMandatoryFieldValidator();
+    private final SetMandatoryFieldValidator implementerToTest = new SetMandatoryFieldValidator();
 
     private TrackerBundle bundle;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -52,8 +52,11 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionSetMandatoryField;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleEffects;
+<<<<<<< HEAD
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
+=======
+>>>>>>> 64beb29a4a (test: make test strict and fix testing wrong method)
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
@@ -132,10 +135,13 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             dataElementB, 0 );
         secondProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
 
+<<<<<<< HEAD
         attribute = createTrackedEntityAttribute( 'A' );
         attribute.setUid( ATTRIBUTE_ID );
         attribute.setCode( ATTRIBUTE_CODE );
 
+=======
+>>>>>>> 64beb29a4a (test: make test strict and fix testing wrong method)
         bundle = TrackerBundle.builder().build();
         bundle.setRuleEffects( getRuleEventAndEnrollmentEffects() );
         bundle.setPreheat( preheat );
@@ -316,7 +322,11 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     private Attribute getAttribute( TrackerIdSchemeParams idSchemes )
     {
         return Attribute.builder()
+<<<<<<< HEAD
             .attribute( idSchemes.toMetadataIdentifier( attribute ) )
+=======
+            .attribute( idSchemes.getIdScheme().toMetadataIdentifier( ATTRIBUTE_ID ) )
+>>>>>>> 64beb29a4a (test: make test strict and fix testing wrong method)
             .value( ATTRIBUTE_VALUE )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -144,6 +144,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     @Test
     void testValidateOkMandatoryFieldsForEvents()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( DATA_ELEMENT_ID ) ).thenReturn( dataElementA );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet() ) );
@@ -154,8 +156,27 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     }
 
     @Test
+    void testValidateOkMandatoryFieldsForEventsUsingIdSchemeCode()
+    {
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder()
+            .dataElementIdScheme( TrackerIdSchemeParam.CODE )
+            .build();
+        when( preheat.getIdSchemes() ).thenReturn( idSchemes );
+        when( preheat.getDataElement( DATA_ELEMENT_ID ) ).thenReturn( dataElementA );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
+            .thenReturn( firstProgramStage );
+        bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet( idSchemes ) ) );
+
+        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+
+        assertTrue( errors.isEmpty() );
+    }
+
+    @Test
     void testValidateWithErrorMandatoryFieldsForEvents()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( DATA_ELEMENT_ID ) ).thenReturn( dataElementA );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(), getEventWithMandatoryValueNOTSet() ) );
@@ -177,6 +198,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     @Test
     void testValidateOkMandatoryFieldsForValidEventAndNotValidEventInDifferentProgramStage()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getDataElement( DATA_ELEMENT_ID ) ).thenReturn( dataElementA );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
             .thenReturn( firstProgramStage );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage ) ) )
@@ -238,14 +261,24 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         } );
     }
 
+    private Event getEventWithMandatoryValueSet( TrackerIdSchemeParams idSchemes )
+    {
+        return Event.builder()
+            .event( FIRST_EVENT_ID )
+            .status( EventStatus.ACTIVE )
+            .programStage( idSchemes.toMetadataIdentifier( firstProgramStage ) )
+            .dataValues( getActiveEventDataValues( idSchemes ) )
+            .build();
+    }
+
     private Event getEventWithMandatoryValueSet()
     {
-        Event event = new Event();
-        event.setEvent( FIRST_EVENT_ID );
-        event.setStatus( EventStatus.ACTIVE );
-        event.setProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) );
-        event.setDataValues( getActiveEventDataValues() );
-        return event;
+        return Event.builder()
+            .event( FIRST_EVENT_ID )
+            .status( EventStatus.ACTIVE )
+            .programStage( MetadataIdentifier.ofUid( firstProgramStage ) )
+            .dataValues( getActiveEventDataValues() )
+            .build();
     }
 
     private Event getEventWithMandatoryValueNOTSet()
@@ -266,11 +299,21 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         return event;
     }
 
+    private Set<DataValue> getActiveEventDataValues( TrackerIdSchemeParams idSchemes )
+    {
+        DataValue dataValue = DataValue.builder()
+            .value( DATA_ELEMENT_VALUE )
+            .dataElement( idSchemes.toMetadataIdentifier( dataElementA ) )
+            .build();
+        return Sets.newHashSet( dataValue );
+    }
+
     private Set<DataValue> getActiveEventDataValues()
     {
-        DataValue dataValue = new DataValue();
-        dataValue.setValue( DATA_ELEMENT_VALUE );
-        dataValue.setDataElement( DATA_ELEMENT_ID );
+        DataValue dataValue = DataValue.builder()
+            .value( DATA_ELEMENT_VALUE )
+            .dataElement( MetadataIdentifier.ofUid( DATA_ELEMENT_ID ) )
+            .build();
         return Sets.newHashSet( dataValue );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -52,11 +52,8 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionSetMandatoryField;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleEffects;
-<<<<<<< HEAD
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
-=======
->>>>>>> 64beb29a4a (test: make test strict and fix testing wrong method)
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
@@ -135,13 +132,10 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             dataElementB, 0 );
         secondProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
 
-<<<<<<< HEAD
         attribute = createTrackedEntityAttribute( 'A' );
         attribute.setUid( ATTRIBUTE_ID );
         attribute.setCode( ATTRIBUTE_CODE );
 
-=======
->>>>>>> 64beb29a4a (test: make test strict and fix testing wrong method)
         bundle = TrackerBundle.builder().build();
         bundle.setRuleEffects( getRuleEventAndEnrollmentEffects() );
         bundle.setPreheat( preheat );
@@ -322,11 +316,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     private Attribute getAttribute( TrackerIdSchemeParams idSchemes )
     {
         return Attribute.builder()
-<<<<<<< HEAD
             .attribute( idSchemes.toMetadataIdentifier( attribute ) )
-=======
-            .attribute( idSchemes.getIdScheme().toMetadataIdentifier( ATTRIBUTE_ID ) )
->>>>>>> 64beb29a4a (test: make test strict and fix testing wrong method)
             .value( ATTRIBUTE_VALUE )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -99,7 +99,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -123,7 +123,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -149,7 +149,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -175,7 +175,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( null );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( null );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -200,7 +200,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
         programStage.setAutoFields();
@@ -211,7 +211,7 @@ class EventDataValuesValidationHookTest
         mandatoryStageElement1.setCompulsory( true );
         ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
         DataElement mandatoryElement2 = new DataElement();
-        mandatoryElement2.setUid( dataValue().getDataElement() );
+        mandatoryElement2.setUid( dataElementUid );
         mandatoryStageElement2.setDataElement( mandatoryElement2 );
         mandatoryStageElement2.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
@@ -237,7 +237,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = new ProgramStage();
         programStage.setAutoFields();
@@ -248,7 +248,7 @@ class EventDataValuesValidationHookTest
         mandatoryStageElement1.setCompulsory( true );
         ProgramStageDataElement mandatoryStageElement2 = new ProgramStageDataElement();
         DataElement mandatoryElement2 = new DataElement();
-        mandatoryElement2.setUid( dataValue().getDataElement() );
+        mandatoryElement2.setUid( dataElementUid );
         mandatoryStageElement2.setDataElement( mandatoryElement2 );
         mandatoryStageElement2.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1, mandatoryStageElement2 ) );
@@ -280,7 +280,7 @@ class EventDataValuesValidationHookTest
 
         DataElement dataElement = dataElement();
         dataElement.setCode( "DE_424050" );
-        when( preheat.get( DataElement.class, dataElement.getCode() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofCode( dataElement.getCode() ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement, true );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -289,7 +289,7 @@ class EventDataValuesValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue dataValue = dataValue();
-        dataValue.setDataElement( "DE_424050" );
+        dataValue.setDataElement( MetadataIdentifier.ofCode( "DE_424050" ) );
         Event event = Event.builder()
             .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
@@ -306,17 +306,18 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement dataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         DataElement notPresentDataElement = dataElement();
         notPresentDataElement.setUid( "de_not_present_in_program_stage" );
-        when( preheat.get( DataElement.class, "de_not_present_in_program_stage" ) ).thenReturn( notPresentDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( "de_not_present_in_program_stage" ) ) )
+            .thenReturn( notPresentDataElement );
 
         ProgramStage programStage = new ProgramStage();
         programStage.setAutoFields();
         ProgramStageDataElement mandatoryStageElement1 = new ProgramStageDataElement();
         DataElement mandatoryElement1 = new DataElement();
-        mandatoryElement1.setUid( dataValue().getDataElement() );
+        mandatoryElement1.setUid( dataElementUid );
         mandatoryStageElement1.setDataElement( mandatoryElement1 );
         mandatoryStageElement1.setCompulsory( true );
         programStage.setProgramStageDataElements( Set.of( mandatoryStageElement1 ) );
@@ -326,7 +327,7 @@ class EventDataValuesValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue notPresentDataValue = dataValue();
-        notPresentDataValue.setDataElement( "de_not_present_in_program_stage" );
+        notPresentDataValue.setDataElement( MetadataIdentifier.ofUid( "de_not_present_in_program_stage" ) );
         Event event = Event.builder()
             .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
@@ -351,7 +352,7 @@ class EventDataValuesValidationHookTest
 
         DataElement dataElement = dataElement();
         dataElement.setCode( "DE_424050" );
-        when( preheat.get( DataElement.class, dataElement.getCode() ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofCode( dataElement.getCode() ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -360,7 +361,7 @@ class EventDataValuesValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue dataValue = dataValue();
-        dataValue.setDataElement( "DE_424050" );
+        dataValue.setDataElement( MetadataIdentifier.ofCode( "DE_424050" ) );
         Event event = Event.builder()
             .programStage( params.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
@@ -378,7 +379,7 @@ class EventDataValuesValidationHookTest
 
         DataElement dataElement = dataElement();
         DataElement invalidDataElement = dataElement( null );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( invalidDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( invalidDataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -404,7 +405,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         DataValue validDataValue = dataValue( "QX4LpiTZmUH" );
         when( preheat.get( FileResource.class, validDataValue.getValue() ) ).thenReturn( null );
@@ -435,7 +436,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, false );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -462,7 +463,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -490,7 +491,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
@@ -519,7 +520,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
@@ -548,7 +549,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
@@ -576,7 +577,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
@@ -605,7 +606,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -632,7 +633,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, true );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -659,7 +660,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement();
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement, false );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -686,7 +687,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         ProgramStage programStage = programStage( validDataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -755,7 +756,7 @@ class EventDataValuesValidationHookTest
 
         DataElement dataElement = dataElement();
         dataElement.setOptionSet( optionSet );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -780,7 +781,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataValue validDataValue = dataValue( "value" );
-        validDataValue.setDataElement( dataElementUid );
+        validDataValue.setDataElement( MetadataIdentifier.ofUid( dataElementUid ) );
 
         OptionSet optionSet = new OptionSet();
         Option option = new Option();
@@ -791,7 +792,7 @@ class EventDataValuesValidationHookTest
 
         DataElement dataElement = dataElement();
         dataElement.setOptionSet( optionSet );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( dataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
         ProgramStage programStage = programStage( dataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -819,7 +820,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.ORGANISATION_UNIT );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         DataValue invalidDataValue = dataValue( "invlaid_org_unit" );
         when( preheat.get( OrganisationUnit.class, invalidDataValue.getValue() ) ).thenReturn( null );
@@ -848,7 +849,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.ORGANISATION_UNIT );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( validDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         OrganisationUnit validOrgUnit = organisationUnit();
 
@@ -877,7 +878,7 @@ class EventDataValuesValidationHookTest
         TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement invalidDataElement = dataElement( valueType );
-        when( preheat.get( DataElement.class, dataElementUid ) ).thenReturn( invalidDataElement );
+        when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( invalidDataElement );
 
         ProgramStage programStage = programStage( dataElement() );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -886,7 +887,7 @@ class EventDataValuesValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         DataValue validDataValue = dataValue();
-        validDataValue.setDataElement( dataElementUid );
+        validDataValue.setDataElement( MetadataIdentifier.ofUid( dataElementUid ) );
         validDataValue.setValue( value );
         Event event = Event.builder()
             .programStage( params.toMetadataIdentifier( programStage ) )
@@ -940,7 +941,7 @@ class EventDataValuesValidationHookTest
         dataValue.setCreatedAt( DateUtils.instantFromDateAsString( "2020-10-10" ) );
         dataValue.setUpdatedAt( DateUtils.instantFromDateAsString( "2020-10-10" ) );
         dataValue.setValue( "text" );
-        dataValue.setDataElement( dataElementUid );
+        dataValue.setDataElement( MetadataIdentifier.ofUid( dataElementUid ) );
         return dataValue;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment_with_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_and_enrollment_with_data_values.json
@@ -160,7 +160,10 @@
         "updatedAt": "2019-01-28T12:10:38.113",
         "storedBy": "admin",
         "providedElsewhere": false,
-        "dataElement": "DATAEL00001",
+        "dataElement": {
+          "idScheme": "UID",
+          "identifier": "DATAEL00001"
+        },
         "value": "value1"
       }],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_basic_data_for_deletion.json
@@ -75,7 +75,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DSKTW8qFP0z",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DSKTW8qFP0z"
+          },
           "value": "2017-01-27T17:00:00.000Z"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events.json
@@ -78,7 +78,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DSKTW8qFP0z",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DSKTW8qFP0z"
+          },
           "value": "2017-01-27T17:00:00.000Z"
         }
       ],
@@ -125,7 +128,10 @@
           "updatedAt": "2019-01-28T12:10:38.115",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "VD2olWcRozZ",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "VD2olWcRozZ"
+          },
           "value": "2019-01-28"
         }
       ],
@@ -172,7 +178,10 @@
           "updatedAt": "2019-01-28T12:10:38.116",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "WS3e6pInnuA",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "WS3e6pInnuA"
+          },
           "value": "2019-01-27T18:00:00.000Z"
         }
       ],
@@ -219,7 +228,10 @@
           "updatedAt": "2019-01-28T12:10:38.116",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "h7hXjNVMiRl",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "h7hXjNVMiRl"
+          },
           "value": "test@dhis2.org"
         }
       ],
@@ -266,7 +278,10 @@
           "updatedAt": "2019-01-28T12:10:38.121",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "KCLriKKezWO",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "KCLriKKezWO"
+          },
           "value": "123"
         }
       ],
@@ -313,7 +328,10 @@
           "updatedAt": "2019-01-28T12:10:38.122",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "A8qxpcalLtf",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "A8qxpcalLtf"
+          },
           "value": "Test text for LongText data element."
         },
         {
@@ -321,7 +339,10 @@
           "updatedAt": "2019-01-28T12:10:38.123",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "wIUShyK7lIa",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "wIUShyK7lIa"
+          },
           "value": "/PlKwabX2xRW"
         },
         {
@@ -329,7 +350,10 @@
           "updatedAt": "2019-01-28T12:10:38.122",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "kAfSfT69m0E",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "kAfSfT69m0E"
+          },
           "value": "123"
         },
         {
@@ -337,7 +361,10 @@
           "updatedAt": "2019-01-28T12:10:38.123",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "ICfA0klVxkd",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "ICfA0klVxkd"
+          },
           "value": "23"
         },
         {
@@ -345,7 +372,10 @@
           "updatedAt": "2019-01-28T12:10:38.122",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "zal5vkVEpV0",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "zal5vkVEpV0"
+          },
           "value": "-123"
         }
       ],
@@ -392,7 +422,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "Kvm949EFjjv",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "Kvm949EFjjv"
+          },
           "value": "123"
         },
         {
@@ -400,7 +433,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "xaQ4gqDYGL9",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "xaQ4gqDYGL9"
+          },
           "value": "0"
         },
         {
@@ -408,7 +444,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "MqGMwzt7M7w",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "MqGMwzt7M7w"
+          },
           "value": "Test text for Text data element."
         },
         {
@@ -416,7 +455,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "WdTLfnn4S1I",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "WdTLfnn4S1I"
+          },
           "value": "4:00"
         },
         {
@@ -424,7 +466,10 @@
           "updatedAt": "2019-01-28T12:10:38.123",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "xaPkxL28aPx",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "xaPkxL28aPx"
+          },
           "value": "1231231"
         }
       ],
@@ -471,7 +516,10 @@
           "updatedAt": "2019-01-28T12:10:38.136",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "gfEoDU4GtXK",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "gfEoDU4GtXK"
+          },
           "value": "true"
         },
         {
@@ -479,7 +527,10 @@
           "updatedAt": "2019-01-28T12:10:38.135",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "JXF90RhgNiI",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "JXF90RhgNiI"
+          },
           "value": "admin"
         },
         {
@@ -487,7 +538,10 @@
           "updatedAt": "2019-01-28T12:10:38.136",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "qw67QlOlzdp",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "qw67QlOlzdp"
+          },
           "value": "true"
         },
         {
@@ -495,7 +549,10 @@
           "updatedAt": "2019-01-28T12:10:38.134",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "hxUvZqnmBDv",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "hxUvZqnmBDv"
+          },
           "value": "http://dhis2.org"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_events_and_enrollment.json
@@ -161,7 +161,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DSKTW8qFP0z",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DSKTW8qFP0z"
+          },
           "value": "2017-01-27T17:00:00.000Z"
         }
       ],
@@ -209,7 +212,10 @@
           "updatedAt": "2019-01-28T12:10:38.115",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "VD2olWcRozZ",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "VD2olWcRozZ"
+          },
           "value": "2019-01-28"
         }
       ],
@@ -257,7 +263,10 @@
           "updatedAt": "2019-01-28T12:10:38.116",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "WS3e6pInnuA",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "WS3e6pInnuA"
+          },
           "value": "2019-01-27T18:00:00.000Z"
         }
       ],
@@ -305,7 +314,10 @@
           "updatedAt": "2019-01-28T12:10:38.116",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "h7hXjNVMiRl",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "h7hXjNVMiRl"
+          },
           "value": "test@dhis2.org"
         }
       ],
@@ -353,7 +365,10 @@
           "updatedAt": "2019-01-28T12:10:38.121",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "KCLriKKezWO",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "KCLriKKezWO"
+          },
           "value": "123"
         }
       ],
@@ -401,7 +416,10 @@
           "updatedAt": "2019-01-28T12:10:38.122",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "A8qxpcalLtf",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "A8qxpcalLtf"
+          },
           "value": "Test text for LongText data element."
         },
         {
@@ -409,7 +427,10 @@
           "updatedAt": "2019-01-28T12:10:38.123",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "wIUShyK7lIa",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "wIUShyK7lIa"
+          },
           "value": "/PlKwabX2xRW"
         },
         {
@@ -417,7 +438,10 @@
           "updatedAt": "2019-01-28T12:10:38.122",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "kAfSfT69m0E",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "kAfSfT69m0E"
+          },
           "value": "123"
         },
         {
@@ -425,7 +449,10 @@
           "updatedAt": "2019-01-28T12:10:38.123",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "ICfA0klVxkd",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "ICfA0klVxkd"
+          },
           "value": "23"
         },
         {
@@ -433,7 +460,10 @@
           "updatedAt": "2019-01-28T12:10:38.122",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "zal5vkVEpV0",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "zal5vkVEpV0"
+          },
           "value": "-123"
         }
       ],
@@ -481,7 +511,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "Kvm949EFjjv",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "Kvm949EFjjv"
+          },
           "value": "123"
         },
         {
@@ -489,7 +522,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "xaQ4gqDYGL9",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "xaQ4gqDYGL9"
+          },
           "value": "0"
         },
         {
@@ -497,7 +533,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "MqGMwzt7M7w",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "MqGMwzt7M7w"
+          },
           "value": "Test text for Text data element."
         },
         {
@@ -505,7 +544,10 @@
           "updatedAt": "2019-01-28T12:10:38.124",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "WdTLfnn4S1I",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "WdTLfnn4S1I"
+          },
           "value": "4:00"
         },
         {
@@ -513,7 +555,10 @@
           "updatedAt": "2019-01-28T12:10:38.123",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "xaPkxL28aPx",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "xaPkxL28aPx"
+          },
           "value": "1231231"
         }
       ],
@@ -561,7 +606,10 @@
           "updatedAt": "2019-01-28T12:10:38.136",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "gfEoDU4GtXK",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "gfEoDU4GtXK"
+          },
           "value": "true"
         },
         {
@@ -569,7 +617,10 @@
           "updatedAt": "2019-01-28T12:10:38.135",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "JXF90RhgNiI",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "JXF90RhgNiI"
+          },
           "value": "admin"
         },
         {
@@ -577,7 +628,10 @@
           "updatedAt": "2019-01-28T12:10:38.136",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "qw67QlOlzdp",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "qw67QlOlzdp"
+          },
           "value": "true"
         },
         {
@@ -585,7 +639,10 @@
           "updatedAt": "2019-01-28T12:10:38.134",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "hxUvZqnmBDv",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "hxUvZqnmBDv"
+          },
           "value": "http://dhis2.org"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_datavalue.json
@@ -69,7 +69,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00002",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00002"
+          },
           "value": "NEWTEXT"
         },
         {
@@ -77,7 +80,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00001",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          },
           "value": "NEWTEXT"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_update_no_datavalue.json
@@ -69,7 +69,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00002",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00002"
+          },
           "value": "NEWTEXT"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values.json
@@ -75,7 +75,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00002",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00002"
+          },
           "value": "Second"
         },
         {
@@ -83,7 +86,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00001",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          },
           "value": "First"
         },
         {
@@ -91,7 +97,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00003",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00003"
+          },
           "value": "Third"
         },
         {
@@ -99,7 +108,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00004",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00004"
+          },
           "value": "Fourth"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values_for_delete_audit.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values_for_delete_audit.json
@@ -53,7 +53,8 @@
       "relationships": [],
       "attributes": [],
       "notes": []
-    }],
+    }
+  ],
   "events": [
     {
       "event": "D9PbzJY8bJO",
@@ -97,7 +98,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00001"
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          }
         }
       ],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values_for_update_audit.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_data_values_for_update_audit.json
@@ -53,7 +53,8 @@
       "relationships": [],
       "attributes": [],
       "notes": []
-    }],
+    }
+  ],
   "events": [
     {
       "event": "D9PbzJY8bJO",
@@ -97,7 +98,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00001",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          },
           "value": "value2-updated"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/event_with_updated_data_values.json
@@ -75,7 +75,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00004",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00004"
+          },
           "value": "Fourth updated"
         },
         {
@@ -83,7 +86,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00001",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          },
           "value": "First"
         },
         {
@@ -91,7 +97,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00003"
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00003"
+          }
         }
       ],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/tei_enrollment_event.json
@@ -113,7 +113,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "DATAEL00002",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00002"
+          },
           "value": "text"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_invalid_option_value.json
@@ -69,7 +69,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "LjQPcfuEI6S",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "LjQPcfuEI6S"
+          },
           "value": "mle"
         }
       ],

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/events-with_valid_option_value.json
@@ -69,7 +69,10 @@
           "updatedAt": "2019-01-28T12:10:38.113",
           "storedBy": "admin",
           "providedElsewhere": false,
-          "dataElement": "LjQPcfuEI6S",
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "LjQPcfuEI6S"
+          },
           "value": "male"
         }
       ],

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DataValueMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DataValueMapper.java
@@ -32,9 +32,15 @@ import org.hisp.dhis.webapi.controller.tracker.view.DataValue;
 import org.hisp.dhis.webapi.controller.tracker.view.InstantMapper;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
-@Mapper( uses = { InstantMapper.class, UserMapper.class } )
+@Mapper( uses = {
+    InstantMapper.class,
+    UserMapper.class,
+    MetadataIdentifierMapper.class
+} )
 public interface DataValueMapper extends DomainMapper<DataValue, org.hisp.dhis.tracker.domain.DataValue>
 {
+    @Mapping( target = "dataElement", source = "dataElement", qualifiedByName = "dataElementToMetadataIdentifier" )
     org.hisp.dhis.tracker.domain.DataValue from( DataValue dataValue, @Context TrackerIdSchemeParams idSchemeParams );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapper.java
@@ -45,6 +45,13 @@ import org.mapstruct.Named;
 interface MetadataIdentifierMapper
 {
 
+    @Named( "dataElementToMetadataIdentifier" )
+    default MetadataIdentifier fromDataElement( String identifier,
+        @Context TrackerIdSchemeParams idSchemeParams )
+    {
+        return idSchemeParams.getDataElementIdScheme().toMetadataIdentifier( identifier );
+    }
+
     @Named( "programToMetadataIdentifier" )
     default MetadataIdentifier fromProgram( String identifier,
         @Context TrackerIdSchemeParams idSchemeParams )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -47,6 +47,50 @@ class MetadataIdentifierMapperTest
     private static final MetadataIdentifierMapper MAPPER = Mappers.getMapper( MetadataIdentifierMapper.class );
 
     @Test
+    void dataElementIdentifierFromUID()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromDataElement( "RiNIt1yJoge", params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+    }
+
+    @Test
+    void dataElementIdentifierFromAttribute()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .dataElementIdScheme( TrackerIdSchemeParam.ofAttribute( "RiNIt1yJoge" ) )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromDataElement( "clouds", params );
+
+        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
+        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( "clouds", id.getAttributeValue() );
+    }
+
+    @Test
+    void dataElementIdentifierFromUIDIfNull()
+    {
+
+        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+            .idScheme( TrackerIdSchemeParam.CODE )
+            .build();
+
+        MetadataIdentifier id = MAPPER.fromDataElement( null, params );
+
+        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
+        assertNull( id.getIdentifier() );
+    }
+
+    @Test
     void programIdentifierFromUID()
     {
 


### PR DESCRIPTION
## This PR (final field migration :tada:)

* migrate DataValue.dataElement to MetadataIdentifier

## Background on changes in [DHIS2-12563](https://jira.dhis2.org/browse/DHIS2-12563)

* metadata identifier fields in org.hisp.dhis.tracker.domain will gradually be made idScheme aware.
* tracker view (JSON import/export) and domain models are split since users only specify idSchemes in the query parameters (not in the body) and only on import. The metadata identifier fields in the user-facing import/export JSON are strings containing only the identifier without idScheme.

all metadata identifiers in the tracker domain
* Attribute.attribute :heavy_check_mark:
* DataValue.dataElement :heavy_check_mark:
* Event.programStage :heavy_check_mark:
* Event.attributeOptionCombo :heavy_check_mark:
* Event.attributeCategoryOptions :heavy_check_mark:
* TrackedEntity.trackedEntityType :heavy_check_mark:
* Relationship.relationshipType :heavy_check_mark:
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:}.program
* {Enrollment :heavy_check_mark:,Event :heavy_check_mark:,TrackedEntity :heavy_check_mark:}.orgUnit

will become idScheme aware.