### PR TITLE
fix: reference master branch for Capture app [TECH-1180]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
+++ b/dhis-2/dhis-web/dhis-web-apps/apps-to-bundle.json
@@ -2,7 +2,7 @@
     "https://github.com/d2-ci/approval-app#master",
     "https://github.com/d2-ci/app-management-app#master",
     "https://github.com/d2-ci/cache-cleaner-app#master",
-    "https://github.com/d2-ci/capture-app#v38",
+    "https://github.com/d2-ci/capture-app#master",
     "https://github.com/d2-ci/dashboard-app#v38",
     "https://github.com/d2-ci/data-administration-app#v38",
     "https://github.com/d2-ci/data-visualizer-app#38.x",


### PR DESCRIPTION
In the next 2.38 release (2.38.1), the Capture App should be based on the master branch. This is due to the Capture App having been migrated to continuous delivery.