### PR TITLE
fix: Fix SQL queries for deleted relationships [DHIS2-11320]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2RelationshipCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2RelationshipCount.java
@@ -80,6 +80,8 @@ public class D2RelationshipCount
 
         return "(select count(*) from relationship r" + relationshipIdConstraint +
             " join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid" +
-            " join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)";
+            " join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei"
+            +
+            " where r.deleted is false)";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
@@ -312,16 +312,16 @@ class ProgramIndicatorServiceD2FunctionTest extends DhisSpringTest
     void testD2RelationshipCount()
     {
         assertEquals(
-            "(select count(*) from relationship r join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)",
+            "(select count(*) from relationship r join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei where r.deleted is false)",
             getSql( "d2:relationshipCount()" ) );
         assertEquals(
-            "(select count(*) from relationship r join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)",
+            "(select count(*) from relationship r join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei where r.deleted is false)",
             getSqlEnrollment( "d2:relationshipCount()" ) );
         assertEquals(
-            "(select count(*) from relationship r join relationshiptype rt on r.relationshiptypeid = rt.relationshiptypeid and rt.uid = 'RelatioTypA' join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)",
+            "(select count(*) from relationship r join relationshiptype rt on r.relationshiptypeid = rt.relationshiptypeid and rt.uid = 'RelatioTypA' join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei where r.deleted is false)",
             getSql( "d2:relationshipCount('RelatioTypA')" ) );
         assertEquals(
-            "(select count(*) from relationship r join relationshiptype rt on r.relationshiptypeid = rt.relationshiptypeid and rt.uid = 'RelatioTypA' join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)",
+            "(select count(*) from relationship r join relationshiptype rt on r.relationshiptypeid = rt.relationshiptypeid and rt.uid = 'RelatioTypA' join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei where r.deleted is false)",
             getSqlEnrollment( "d2:relationshipCount('RelatioTypA')" ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -367,7 +367,9 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
         String sql = test( "d2:relationshipCount()" );
         assertThat( sql, is( "(select count(*) from relationship r " +
             "join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid " +
-            "join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)" ) );
+            "join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei"
+            +
+            " where r.deleted is false)" ) );
     }
 
     @Test
@@ -379,7 +381,9 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
         assertThat( sql, is( "(select count(*) from relationship r " +
             "join relationshiptype rt on r.relationshiptypeid = rt.relationshiptypeid and rt.uid = 'RelatnTypeA' " +
             "join relationshipitem rifrom on rifrom.relationshipid = r.relationshipid " +
-            "join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei)" ) );
+            "join trackedentityinstance tei on rifrom.trackedentityinstanceid = tei.trackedentityinstanceid and tei.uid = ax.tei"
+            +
+            " where r.deleted is false)" ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EnrollmentAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EnrollmentAggregate.java
@@ -89,7 +89,7 @@ public class EnrollmentAggregate
 
         final CompletableFuture<Multimap<String, Relationship>> relationshipAsync = conditionalAsyncFetch(
             ctx.getParams().isIncludeRelationships(),
-            () -> enrollmentStore.getRelationships( enrollmentIds ), getPool() );
+            () -> enrollmentStore.getRelationships( enrollmentIds, ctx ), getPool() );
 
         final CompletableFuture<Multimap<String, Note>> notesAsync = asyncFetch(
             () -> enrollmentStore.getNotes( enrollmentIds ), getPool() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EventAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EventAggregate.java
@@ -88,7 +88,7 @@ public class EventAggregate
          * isIncludeRelationships = true)
          */
         final CompletableFuture<Multimap<String, Relationship>> relationshipAsync = conditionalAsyncFetch(
-            ctx.getParams().isIncludeRelationships(), () -> eventStore.getRelationships( eventIds ), getPool() );
+            ctx.getParams().isIncludeRelationships(), () -> eventStore.getRelationships( eventIds, ctx ), getPool() );
 
         /*
          * Async fetch Notes for the given Event ids

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -163,7 +163,7 @@ public class TrackedEntityInstanceAggregate
          * (only if isIncludeRelationships = true)
          */
         final CompletableFuture<Multimap<String, Relationship>> relationshipsAsync = conditionalAsyncFetch(
-            ctx.getParams().isIncludeRelationships(), () -> trackedEntityInstanceStore.getRelationships( ids ),
+            ctx.getParams().isIncludeRelationships(), () -> trackedEntityInstanceStore.getRelationships( ids, ctx ),
             getPool() );
 
         /*

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -553,7 +553,7 @@ public class JdbcEventStore implements EventStore
         }
 
         final Multimap<String, Relationship> map = eventStore
-            .getRelationshipsByIds( relationshipIds );
+            .getRelationshipsByIds( relationshipIds, params );
 
         if ( !map.isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AbstractStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AbstractStore.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.dxf2.events.aggregates.AggregateContext;
+import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 import org.hisp.dhis.dxf2.events.trackedentity.store.mapper.AbstractMapper;
 import org.hisp.dhis.dxf2.events.trackedentity.store.mapper.RelationshipRowCallbackHandler;
@@ -100,27 +101,34 @@ public abstract class AbstractStore
         return parameters;
     }
 
-    public Multimap<String, Relationship> getRelationships( List<Long> ids )
+    public Multimap<String, Relationship> getRelationships( List<Long> ids, AggregateContext ctx )
     {
         List<List<Long>> partitionedIds = Lists.partition( ids, PARITITION_SIZE );
 
         Multimap<String, Relationship> relationshipMultimap = ArrayListMultimap.create();
 
-        partitionedIds.forEach( partition -> relationshipMultimap.putAll( getRelationshipsPartitioned( partition ) ) );
+        partitionedIds
+            .forEach( partition -> relationshipMultimap.putAll( getRelationshipsPartitioned( partition, ctx ) ) );
 
         return relationshipMultimap;
     }
 
-    private Multimap<String, Relationship> getRelationshipsPartitioned( List<Long> ids )
+    private Multimap<String, Relationship> getRelationshipsPartitioned( List<Long> ids, AggregateContext ctx )
     {
-        String getRelationshipsHavingIdSQL = String.format( GET_RELATIONSHIP_ID_BY_ENTITY_ID_SQL,
-            getRelationshipEntityColumn(), getRelationshipEntityColumn() );
+        StringBuilder getRelationshipsHavingIdSQL = new StringBuilder(
+            String.format( GET_RELATIONSHIP_ID_BY_ENTITY_ID_SQL, getRelationshipEntityColumn(),
+                getRelationshipEntityColumn() ) );
 
+        if ( !ctx.getParams().isIncludeDeleted() )
+        {
+            getRelationshipsHavingIdSQL.append( " AND r.delete is false" );
+        }
         // Get all the relationship ids that have at least one relationship item
         // having
         // the ids in the tei|pi|psi column (depending on the subclass)
 
-        List<Long> relationshipIds = getRelationshipIds( getRelationshipsHavingIdSQL, createIdsParam( ids ) );
+        List<Long> relationshipIds = getRelationshipIds( getRelationshipsHavingIdSQL.toString(),
+            createIdsParam( ids ) );
 
         if ( !relationshipIds.isEmpty() )
         {
@@ -131,24 +139,30 @@ public abstract class AbstractStore
         return ArrayListMultimap.create();
     }
 
-    public Multimap<String, Relationship> getRelationshipsByIds( List<Long> ids )
+    public Multimap<String, Relationship> getRelationshipsByIds( List<Long> ids, EventSearchParams params )
     {
         List<List<Long>> partitionedIds = Lists.partition( ids, PARITITION_SIZE );
 
         Multimap<String, Relationship> relationshipMultimap = ArrayListMultimap.create();
 
         partitionedIds
-            .forEach( partition -> relationshipMultimap.putAll( getRelationshipsByIdsPartitioned( partition ) ) );
+            .forEach(
+                partition -> relationshipMultimap.putAll( getRelationshipsByIdsPartitioned( partition, params ) ) );
 
         return relationshipMultimap;
     }
 
-    private Multimap<String, Relationship> getRelationshipsByIdsPartitioned( List<Long> ids )
+    private Multimap<String, Relationship> getRelationshipsByIdsPartitioned( List<Long> ids, EventSearchParams params )
     {
         if ( !ids.isEmpty() )
         {
             RelationshipRowCallbackHandler handler = new RelationshipRowCallbackHandler();
-            jdbcTemplate.query( GET_RELATIONSHIP_BY_RELATIONSHIP_ID, createIdsParam( ids ), handler );
+            StringBuilder query = new StringBuilder( GET_RELATIONSHIP_BY_RELATIONSHIP_ID );
+            if ( !params.isIncludeDeleted() )
+            {
+                query.append( " AND r.deleted is false" );
+            }
+            jdbcTemplate.query( query.toString(), createIdsParam( ids ), handler );
             return handler.getItems();
         }
         return ArrayListMultimap.create();

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AbstractStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/AbstractStore.java
@@ -121,7 +121,7 @@ public abstract class AbstractStore
 
         if ( !ctx.getParams().isIncludeDeleted() )
         {
-            getRelationshipsHavingIdSQL.append( " AND r.delete is false" );
+            getRelationshipsHavingIdSQL.append( " AND r.deleted is false" );
         }
         // Get all the relationship ids that have at least one relationship item
         // having

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EnrollmentStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EnrollmentStore.java
@@ -65,5 +65,5 @@ public interface EnrollmentStore
      * @return a MultiMap where key is a {@see Enrollment} uid and the key a
      *         List of {@see Relationship} objects
      */
-    Multimap<String, Relationship> getRelationships( List<Long> ids );
+    Multimap<String, Relationship> getRelationships( List<Long> ids, AggregateContext ctx );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/EventStore.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.hisp.dhis.dxf2.events.aggregates.AggregateContext;
 import org.hisp.dhis.dxf2.events.event.DataValue;
 import org.hisp.dhis.dxf2.events.event.Event;
+import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.Note;
 import org.hisp.dhis.dxf2.events.trackedentity.Relationship;
 
@@ -72,7 +73,7 @@ public interface EventStore
      * @return a MultiMap where key is a {@see Enrollment} uid and the value a
      *         List of {@see Relationship} objects
      */
-    Multimap<String, Relationship> getRelationships( List<Long> ids );
+    Multimap<String, Relationship> getRelationships( List<Long> ids, AggregateContext ctx );
 
     /**
      * Fetch all the relationships based on provided relationship ids and return
@@ -82,7 +83,7 @@ public interface EventStore
      * @return Multimap containing entity uid as key and its associated list of
      *         Relationships as value.
      */
-    Multimap<String, Relationship> getRelationshipsByIds( List<Long> ids );
+    Multimap<String, Relationship> getRelationshipsByIds( List<Long> ids, EventSearchParams params );
 
     Multimap<String, Note> getNotes( List<Long> eventIds );
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/TrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/TrackedEntityInstanceStore.java
@@ -60,7 +60,7 @@ public interface TrackedEntityInstanceStore
      * @return a MultiMap where key is a {@see TrackedEntityInstance} uid and
      *         the key a List of {@see Relationship} objects
      */
-    Multimap<String, Relationship> getRelationships( List<Long> ids );
+    Multimap<String, Relationship> getRelationships( List<Long> ids, AggregateContext ctx );
 
     /**
      *

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -181,10 +181,6 @@ public class TrackerBundle
     @Builder.Default
     private Map<TrackerType, Map<String, TrackerImportStrategy>> resolvedStrategyMap = initStrategyMap();
 
-    private TrackerBundle()
-    {
-    }
-
     private static Map<TrackerType, Map<String, TrackerImportStrategy>> initStrategyMap()
     {
         Map<TrackerType, Map<String, TrackerImportStrategy>> resolvedStrategyMap = new EnumMap<>( TrackerType.class );


### PR DESCRIPTION
Relationship is now a soft deletable entity. Stores and other services that are using plain sql to retrieve relationships now need to be aware if the relationship is soft deleted or not.
Changes are needed:

- In the old tracker importer when retrieving TEIs and linked Relationships. We need to check `includeDeleted` param.
- In the old tracker importer when retrieving Enrollments and linked Relationships. We need to check `includeDeleted` param.
- In the old tracker importer when retrieving Events and linked Relationships. We need to check `includeDeleted` param.
- When counting relationships using `d2:relationshipCount` function for indicators. @jimgrace please have a careful look at this part