### PR TITLE
fix: Param scheduledDate does not respect status [DHIS2-12309]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -1104,6 +1104,10 @@ public class EventQueryParams
                 }
             }
         }
+        else if ( containsScheduledDatePeriod() )
+        {
+            return Set.of( SCHEDULE );
+        }
 
         return DEFAULT_EVENT_STATUS;
     }


### PR DESCRIPTION
Small bug fix, so the `scheduledDate` enforces the correct event status (`SCHEDULE`)