### PR TITLE
fix: "last value" aggregation type is broken in later versions for data elements and program indicators in the analytics API [2.38-dhis2-12989-backport]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -140,7 +140,26 @@ public class ProgramIndicator
      */
     public AggregationType getAggregationTypeFallback()
     {
-        return aggregationType != null ? aggregationType : AggregationType.AVERAGE;
+        if ( aggregationType == null )
+        {
+            return AggregationType.AVERAGE;
+        }
+
+        switch ( aggregationType )
+        {
+        case AVERAGE_SUM_ORG_UNIT:
+        case FIRST:
+        case LAST:
+        case LAST_IN_PERIOD:
+            return AggregationType.SUM;
+        case FIRST_AVERAGE_ORG_UNIT:
+        case LAST_AVERAGE_ORG_UNIT:
+        case LAST_IN_PERIOD_AVERAGE_ORG_UNIT:
+        case DEFAULT:
+            return AggregationType.AVERAGE;
+        default:
+            return aggregationType;
+        }
     }
 
     public void addProgramIndicatorGroup( ProgramIndicatorGroup group )

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -61,6 +61,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.category.CategoryService;
@@ -562,6 +563,65 @@ class DataIntegrityServiceTest
 
         verify( expressionService, times( 0 ) ).getExpressionDescription( anyString(), any() );
         assertTrue( issues.isEmpty() );
+    }
+
+    @Test
+    public void programIndicatorGetAggregationTypeFallbackReturnsRelatedAggregationType()
+    {
+        // arrange
+        ProgramIndicator programIndicator = new ProgramIndicator();
+        programIndicator.setName( "Test-PI" );
+        programIndicator.setExpression( "#{someuid} + 1" );
+
+        // act
+        // assert
+        programIndicator.setAggregationType( AggregationType.AVERAGE_SUM_ORG_UNIT );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST_IN_PERIOD );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.FIRST );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.FIRST_AVERAGE_ORG_UNIT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.LAST_AVERAGE_ORG_UNIT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( null );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.CUSTOM );
+        assertEquals( AggregationType.CUSTOM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.AVERAGE );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.SUM );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.STDDEV );
+        assertEquals( AggregationType.STDDEV, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.COUNT );
+        assertEquals( AggregationType.COUNT, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.MAX );
+        assertEquals( AggregationType.MAX, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.MIN );
+        assertEquals( AggregationType.MIN, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.DEFAULT );
+        assertEquals( AggregationType.AVERAGE, programIndicator.getAggregationTypeFallback() );
     }
 
     private Map<String, DataElement> createRandomDataElements( int quantity, String uidSeed )


### PR DESCRIPTION
backport - see https://jira.dhis2.org/browse/DHIS2-12989