### PR TITLE
fix: Indicator summing boolean values DHIS2-13227

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.analytics.AggregationType.COUNT;
 import static org.hisp.dhis.analytics.AggregationType.NONE;
 import static org.hisp.dhis.analytics.AggregationType.SUM;
 import static org.hisp.dhis.common.ValueType.BOOLEAN;
+import static org.hisp.dhis.common.ValueType.DATE;
 import static org.hisp.dhis.common.ValueType.INTEGER;
 import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.expression.Operator.equal_to;
@@ -143,6 +144,8 @@ class AnalyticsServiceTest
     private DataElement deF;
 
     private DataElement deG;
+
+    private DataElement deH;
 
     private OrganisationUnit ouA;
 
@@ -293,6 +296,7 @@ class AnalyticsServiceTest
         deE = createDataElement( 'E', INTEGER, SUM );
         deF = createDataElement( 'F', BOOLEAN, COUNT );
         deG = createDataElement( 'G', TEXT, NONE );
+        deH = createDataElement( 'H', DATE, NONE );
 
         dataElementService.addDataElement( deA );
         dataElementService.addDataElement( deB );
@@ -301,6 +305,7 @@ class AnalyticsServiceTest
         dataElementService.addDataElement( deE );
         dataElementService.addDataElement( deF );
         dataElementService.addDataElement( deG );
+        dataElementService.addDataElement( deH );
 
         ouA = createOrganisationUnit( 'A' );
 
@@ -492,7 +497,7 @@ class AnalyticsServiceTest
             dataValue.setValue( line[3] );
             dataValueService.addDataValue( dataValue );
         }
-        assertEquals( 29, dataValueService.getAllDataValues().size(),
+        assertEquals( 30, dataValueService.getAllDataValues().size(),
             "Import of data values failed, number of imports are wrong" );
     }
 
@@ -581,10 +586,12 @@ class AnalyticsServiceTest
     @Test
     void test_de_avg_2017_03()
     {
+        List<DataElement> dataElements = List.of( deA, deB, deC, deD, deE );
+
         assertDataValues(
             Map.of( "deabcdefghC-201703", 6.75 ),
             DataQueryParams.newBuilder()
-                .withDataElements( dataElementService.getAllDataElements() )
+                .withDataElements( dataElements )
                 .withAggregationType( AnalyticsAggregationType.AVERAGE )
                 .withSkipRounding( true )
                 .withPeriod( peMar )
@@ -792,6 +799,21 @@ class AnalyticsServiceTest
 
         assertDataValues(
             Map.of( "indicatorId-ouabcdefghA-201701", 5.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peJan, peFeb ) )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorSubexpressionDate()
+    {
+        withIndicator( "subExpression( if( #{" + deH.getUid() + "} >= '2017-01-01', 7, 8 ) )" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201701", 7.0 ),
             DataQueryParams.newBuilder()
                 .withOrganisationUnit( ouA )
                 .withIndicators( Lists.newArrayList( indicatorA ) )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -28,6 +28,12 @@
 package org.hisp.dhis.analytics.data;
 
 import static java.util.Collections.emptyList;
+import static org.hisp.dhis.analytics.AggregationType.COUNT;
+import static org.hisp.dhis.analytics.AggregationType.NONE;
+import static org.hisp.dhis.analytics.AggregationType.SUM;
+import static org.hisp.dhis.common.ValueType.BOOLEAN;
+import static org.hisp.dhis.common.ValueType.INTEGER;
+import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.expression.Operator.equal_to;
 import static org.hisp.dhis.utils.Assertions.assertMapEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,7 +63,6 @@ import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.AnalyticalObject;
 import org.hisp.dhis.common.DataDimensionType;
 import org.hisp.dhis.common.ReportingRate;
-import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dataset.CompleteDataSetRegistration;
@@ -135,6 +140,10 @@ class AnalyticsServiceTest
 
     private DataElement deE;
 
+    private DataElement deF;
+
+    private DataElement deG;
+
     private OrganisationUnit ouA;
 
     private OrganisationUnit ouB;
@@ -149,7 +158,7 @@ class AnalyticsServiceTest
 
     private DataSet dataSetB;
 
-    private IndicatorType indicatorTypeA;
+    private Indicator indicatorA;
 
     private ReportingRate reportingRateA;
 
@@ -281,14 +290,17 @@ class AnalyticsServiceTest
         deB = createDataElement( 'B' );
         deC = createDataElement( 'C' );
         deD = createDataElement( 'D' );
-        deE = createDataElement( 'E' );
-        deE.setValueType( ValueType.INTEGER );
+        deE = createDataElement( 'E', INTEGER, SUM );
+        deF = createDataElement( 'F', BOOLEAN, COUNT );
+        deG = createDataElement( 'G', TEXT, NONE );
 
         dataElementService.addDataElement( deA );
         dataElementService.addDataElement( deB );
         dataElementService.addDataElement( deC );
         dataElementService.addDataElement( deD );
         dataElementService.addDataElement( deE );
+        dataElementService.addDataElement( deF );
+        dataElementService.addDataElement( deG );
 
         ouA = createOrganisationUnit( 'A' );
 
@@ -364,9 +376,13 @@ class AnalyticsServiceTest
         dataSetService.addDataSet( dataSetA );
         dataSetService.addDataSet( dataSetB );
 
-        indicatorTypeA = createIndicatorType( 'A' );
+        IndicatorType indicatorTypeA = createIndicatorType( 'A' );
         indicatorTypeA.setFactor( 1 );
         indicatorService.addIndicatorType( indicatorTypeA );
+
+        indicatorA = createIndicator( 'A', indicatorTypeA );
+        indicatorA.setUid( "indicatorId" );
+        indicatorService.addIndicator( indicatorA );
 
         reportingRateA = new ReportingRate( dataSetA );
         reportingRateB = new ReportingRate( dataSetB );
@@ -476,7 +492,7 @@ class AnalyticsServiceTest
             dataValue.setValue( line[3] );
             dataValueService.addDataValue( dataValue );
         }
-        assertEquals( 27, dataValueService.getAllDataValues().size(),
+        assertEquals( 29, dataValueService.getAllDataValues().size(),
             "Import of data values failed, number of imports are wrong" );
     }
 
@@ -519,6 +535,19 @@ class AnalyticsServiceTest
     // --------------------------------------------------------------------------
     // Test helpers
     // --------------------------------------------------------------------------
+
+    private void withIndicator( String numerator )
+    {
+        withIndicator( numerator, "1" );
+    }
+
+    private void withIndicator( String numerator, String denominator )
+    {
+        indicatorA.setNumerator( numerator );
+        indicatorA.setDenominator( denominator );
+
+        indicatorService.updateIndicator( indicatorA );
+    }
 
     private void assertDataValues( Map<String, Object> expected, DataQueryParams params )
     {
@@ -613,15 +642,12 @@ class AnalyticsServiceTest
     }
 
     @Test
-    void test_inA_2017()
+    void testIndicatorWithDataElementOperand()
     {
-        Indicator indicatorA = createIndicator( 'A', indicatorTypeA,
-            "#{" + deA.getUid() + "." + ocDef.getUid() + "}",
-            "1" );
-        indicatorService.addIndicator( indicatorA );
+        withIndicator( "#{" + deA.getUid() + "." + ocDef.getUid() + "}" );
 
         assertDataValues(
-            Map.of( "inabcdefghA-2017", 308.0 ),
+            Map.of( "indicatorId-2017", 308.0 ),
             DataQueryParams.newBuilder()
                 .withIndicators( List.of( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
@@ -630,115 +656,147 @@ class AnalyticsServiceTest
     }
 
     @Test
-    void test_inB_deB_deC_2017_Q01()
+    void testIndicatorWithTwoDataElementOperands()
     {
-        Indicator indicatorB = createIndicator( 'B', indicatorTypeA,
-            "#{" + deB.getUid() + "." + ocDef.getUid() + "}" + "+#{" + deC.getUid() + "." + ocDef.getUid() + "}",
-            "1" );
-        indicatorService.addIndicator( indicatorB );
+        withIndicator(
+            "#{" + deB.getUid() + "." + ocDef.getUid() + "}" + "+#{" + deC.getUid() + "." + ocDef.getUid() + "}" );
 
         assertDataValues(
-            Map.of( "inabcdefghB-2017Q1", 567.0 ),
+            Map.of( "indicatorId-2017Q1", 567.0 ),
             DataQueryParams.newBuilder()
-                .withIndicators( List.of( indicatorB ) )
+                .withIndicators( List.of( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
                 .withPeriod( quarter )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 
     @Test
-    void test_inC_deB_deC_2017_Q01()
+    void testIndicatorDividingByConstantDenominator()
     {
-        Indicator indicatorC = createIndicator( 'C', indicatorTypeA,
+        withIndicator(
             "#{" + deB.getUid() + "." + ocDef.getUid() + "}" + "*#{" + deC.getUid() + "." + ocDef.getUid() + "}",
             "100" );
-        indicatorService.addIndicator( indicatorC );
 
         assertDataValues(
-            Map.of( "inabcdefghC-2017Q1", 258.50 ),
+            Map.of( "indicatorId-2017Q1", 258.50 ),
             DataQueryParams.newBuilder()
-                .withIndicators( List.of( indicatorC ) )
+                .withIndicators( List.of( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
                 .withPeriod( quarter )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
 
         assertMapEquals(
-            Map.of( "inabcdefghC-2017Q1-ouabcdefghA", 258.50 ),
+            Map.of( "indicatorId-2017Q1-ouabcdefghA", 258.50 ),
             getDataValueMapping( new Visualization( "deA_ouA_2017_Q01", emptyList(),
-                List.of( indicatorC ), emptyList(), List.of( quarter ), List.of( ouA ),
+                List.of( indicatorA ), emptyList(), List.of( quarter ), List.of( ouA ),
                 true, true, true ) ) );
     }
 
     @Test
-    void test_inD_deA_deB_deC_2017_Q01()
+    void testIndicatorDividingByDeoDenominator()
     {
-        Indicator indicatorD = createIndicator( 'D', indicatorTypeA,
+        withIndicator(
             "#{" + deA.getUid() + "." + ocDef.getUid() + "}" + "*#{" + deC.getUid() + "." + ocDef.getUid() + "}",
             "#{" + deB.getUid() + "." + ocDef.getUid() + "}" );
-        indicatorService.addIndicator( indicatorD );
 
         assertDataValues(
-            Map.of( "inabcdefghD-2017Q1", 29.8 ),
+            Map.of( "indicatorId-2017Q1", 29.8 ),
             DataQueryParams.newBuilder()
-                .withIndicators( List.of( indicatorD ) )
+                .withIndicators( List.of( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
                 .withPeriod( quarter )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 
     @Test
-    void test_inE_deA_reRateB_2017_Q01()
+    void testIndicatorWithReportingRateA()
     {
-        Indicator indicatorE = createIndicator( 'E', indicatorTypeA,
-            "#{" + deA.getUid() + "." + ocDef.getUid() + "}"
-                + "*(R{" + reportingRateB.getUid() + ".REPORTING_RATE} / 100)",
-            "1" );
-        indicatorService.addIndicator( indicatorE );
+        withIndicator( "#{" + deA.getUid() + "." + ocDef.getUid() + "}"
+            + "*(R{" + reportingRateA.getUid() + ".REPORTING_RATE} / 100)" );
 
         assertDataValues(
-            Map.of( "inabcdefghE-ouabcdefghD-2017Q1", 99.6 ),
+            Map.of( "indicatorId-ouabcdefghD-2017Q1", 199.4 ),
             DataQueryParams.newBuilder()
                 .withOrganisationUnit( ouD )
-                .withIndicators( List.of( indicatorE ) )
+                .withIndicators( List.of( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
                 .withPeriod( quarter )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 
     @Test
-    void test_inF_deA_reRateA_2017_Q01()
+    void testIndicatorWithReportingRateB()
     {
-        Indicator indicatorF = createIndicator( 'F', indicatorTypeA,
-            "#{" + deA.getUid() + "." + ocDef.getUid() + "}"
-                + "*(R{" + reportingRateA.getUid() + ".REPORTING_RATE} / 100)",
-            "1" );
-        indicatorService.addIndicator( indicatorF );
+        withIndicator( "#{" + deA.getUid() + "." + ocDef.getUid() + "}"
+            + "*(R{" + reportingRateB.getUid() + ".REPORTING_RATE} / 100)" );
 
         assertDataValues(
-            Map.of( "inabcdefghF-ouabcdefghD-2017Q1", 199.4 ),
+            Map.of( "indicatorId-ouabcdefghD-2017Q1", 99.6 ),
             DataQueryParams.newBuilder()
                 .withOrganisationUnit( ouD )
-                .withIndicators( List.of( indicatorF ) )
+                .withIndicators( List.of( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
                 .withPeriod( quarter )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 
     @Test
-    void test_inG_deE_periodOffsets_2017_07()
+    void testIndicatorWithPeriodOffsets()
     {
-        Indicator indicatorG = createIndicator( 'G', indicatorTypeA,
-            "#{" + deE.getUid() + "}.periodOffset(-1) + #{" + deE.getUid() + "}.periodOffset(-2)",
-            "1" );
-        indicatorService.addIndicator( indicatorG );
+        withIndicator( "#{" + deE.getUid() + "}.periodOffset(-1) + #{" + deE.getUid() + "}.periodOffset(-2)" );
 
         assertDataValues(
-            Map.of( "inabcdefghG-ouabcdefghA-201707", 3.0 ),
+            Map.of( "indicatorId-ouabcdefghA-201707", 3.0 ),
             DataQueryParams.newBuilder()
                 .withOrganisationUnit( ouA )
-                .withIndicators( Lists.newArrayList( indicatorG ) )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
                 .withPeriod( peJuly )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorSummingBooleans()
+    {
+        withIndicator( "#{" + deF.getUid() + "}" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201701", 1.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peJan, peFeb ) )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorSubexpressionBoolean()
+    {
+        withIndicator( "subExpression( if( #{" + deF.getUid() + "}, 3, 4 ) )" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201701", 3.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peJan, peFeb ) )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorSubexpressionText()
+    {
+        withIndicator( "subExpression( if( #{" + deG.getUid() + "} == 'abc', 5, 6 ) )" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201701", 5.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peJan, peFeb ) )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/resources/csv/dataValues.csv
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/resources/csv/dataValues.csv
@@ -26,4 +26,5 @@
 "deabcdefghE",    "2017-05",   "ouabcdefghA",   "1"
 "deabcdefghE",    "2017-06",   "ouabcdefghA",   "2"
 "deabcdefghE",    "2017-07",   "ouabcdefghA",   "4"
-
+"deabcdefghF",    "2017-01",   "ouabcdefghA",   "true"
+"deabcdefghG",    "2017-01",   "ouabcdefghA",   "abc"

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/resources/csv/dataValues.csv
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/resources/csv/dataValues.csv
@@ -28,3 +28,4 @@
 "deabcdefghE",    "2017-07",   "ouabcdefghA",   "4"
 "deabcdefghF",    "2017-01",   "ouabcdefghA",   "true"
 "deabcdefghG",    "2017-01",   "ouabcdefghA",   "abc"
+"deabcdefghH",    "2017-01",   "ouabcdefghA",   "2017-01-01"

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
@@ -67,7 +67,7 @@ public class DimItemDataElementAndOperand
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        if ( !visitor.getState().isSqlForSubExpression() )
+        if ( !visitor.getState().isInSubexpression() )
         {
             throw new ParserExceptionWithoutContext(
                 "Not valid to generate DataElement or DataElementOperand SQL here: " + ctx.getText() );
@@ -78,6 +78,12 @@ public class DimItemDataElementAndOperand
         if ( dataElement == null )
         {
             throw new ParserExceptionWithoutContext( "DataElement not found: " + ctx.uid0.getText() );
+        }
+
+        // Boolean is stored as 1 or 0. Convert to SQL bool in subexpression:
+        if ( dataElement.getValueType().isBoolean() )
+        {
+            return dataElement.getValueColumn() + "::int::bool";
         }
 
         return dataElement.getValueColumn();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionSubExpression.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/function/FunctionSubExpression.java
@@ -86,7 +86,9 @@ public class FunctionSubExpression
     private DimensionalItemId getDimItemId( ExprContext ctx, CommonExpressionVisitor visitor )
     {
         CommonExpressionVisitor infoVisitor = visitor.toBuilder()
-            .itemMethod( ITEM_GET_EXPRESSION_INFO ).info( new ExpressionInfo() ).build();
+            .itemMethod( ITEM_GET_EXPRESSION_INFO )
+            .info( new ExpressionInfo() )
+            .state( getSubExpressionState( visitor ) ).build();
 
         Object returnObject = infoVisitor.visit( ctx.expr( 0 ) );
 
@@ -131,14 +133,21 @@ public class FunctionSubExpression
      */
     private String getSubExpressionSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        ExpressionState state = new ExpressionState();
-        state.setSqlForSubExpression( true );
-
-        CommonExpressionVisitor sqlVisitor = visitor.toBuilder().itemMethod( ITEM_GET_SQL ).state( state ).build();
+        CommonExpressionVisitor sqlVisitor = visitor.toBuilder()
+            .itemMethod( ITEM_GET_SQL )
+            .state( getSubExpressionState( visitor ) ).build();
 
         sqlVisitor.setExpressionLiteral( new SqlLiteral() );
 
         return sqlVisitor.castStringVisit( ctx.expr( 0 ) );
+    }
+
+    /**
+     * Gets the current state adding that we are in a subexpression.
+     */
+    private ExpressionState getSubExpressionState( CommonExpressionVisitor visitor )
+    {
+        return visitor.getState().builder().inSubexpression( true ).build();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -1339,9 +1339,6 @@ class ExpressionServiceTest extends DhisSpringTest
         assertNull( error( "true && 2" ) );
         assertNull( error( "!5" ) );
         assertNull( error( "true / ( #{dataElemenA} - #{dataElemenB} )" ) );
-        assertNull( error( "#{dataElemenF}" ) );
-        assertNull( error( "#{dataElemenG}" ) );
-        assertNull( error( "#{dataElemenH}" ) );
         assertNull( error( "#{dataElemenA}.aggregationType(NOT_AN_AGGREGATION_TYPE)" ) );
         assertNull( error( "#{dataElemenA}.periodOffset('notANumber')" ) );
         assertNull( error( "#{dataElemenA}.maxDate(2022-13-01)" ) );

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ExpressionState.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ExpressionState.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.parser.expression;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import org.hisp.dhis.common.QueryModifiers;
@@ -45,42 +48,52 @@ import org.hisp.dhis.system.util.ValidationUtils;
  */
 @Getter
 @Setter
+@Builder( toBuilder = true )
+@NoArgsConstructor
+@AllArgsConstructor
 public class ExpressionState
 {
     /**
      * By default, replace nulls with a default value.
      */
+    @Builder.Default
     private boolean replaceNulls = true;
 
     /**
      * Item query modifiers, if any, in effect during parsing.
      */
+    @Builder.Default
     private QueryModifiers queryMods = null;
 
     /**
      * Current program stage offset in effect.
      */
+    @Builder.Default
     private int stageOffset = Integer.MIN_VALUE;
 
     /**
      * Flag to check if a null date was found.
      */
+    @Builder.Default
     private boolean unprotectedNullDateFound = false;
 
     /**
      * Count of dimension items found.
      */
+    @Builder.Default
     private int itemsFound = 0;
 
     /**
      * Count of dimension item values found.
      */
+    @Builder.Default
     private int itemValuesFound = 0;
 
     /**
-     * True if we are currently generating SQL for a subexpression.
+     * True if we are currently within a subexpression.
      */
-    private boolean sqlForSubExpression = false;
+    @Builder.Default
+    private boolean inSubexpression = false;
 
     // -------------------------------------------------------------------------
     // Logic


### PR DESCRIPTION
See [DHIS2-13227](https://jira.dhis2.org/browse/DHIS2-13227). Since 2.36.7, expressions can process non-numeric data elements. To support this, expressions do type-checking based on the data element's ValueType. For example, a boolean data element can be used as the true or false test in an if() function within a validation rule or predictor. However this introduced a problem because previously a boolean data data element could be used in an expression to produce a numeric value. This is because booleans are stored as numeric values (1 or 0) in the analytics tables and can be aggregated to show the count of true values (1's). The type checking broke this functionality.

The fix is to allow for boolean values that will be aggregated in an indicator to be considered to return a numeric value for the purpose of type checking.

However boolean, text, and date values within subexpressions are parsed as the types they are, to be used that way in subexpressions.

In `DimItemDataElementAndOperand`, SQL is added to cast a boolean value (stored as a double value) to boolean so it can be used that way in subexpressions. (It must be cast first to an int and then to a bool, since PostgreSQL does not allow casting directly from double to bool.)

Integration test cases were added to `AnalyticsServiceTest` to verify the handling of booleans as numeric when aggregated in indicators, and accessing boolean, text, and date values as the types they are within subexpressions.

`AnalyticsServiceTest` was also refactored to allow the same indicator to be updated for various indicator tests, to make it easier to add additional indicator tests without having to add a new indicator for each test with a new identifier character. The indicator tests were renamed to say what functionality they are testing, not which indicator they are using.