### PR TITLE
fix: /resourceTables jobs return conflict when job is already running [DHIS2-12367]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -118,6 +118,14 @@ public interface SchedulingManager
     void cancel( JobType type );
 
     /**
+     * Check if this job configuration is currently running
+     *
+     * @param type type of job to check
+     * @return true/false
+     */
+    boolean isRunning( JobType type );
+
+    /**
      * @return a set of job types for which a job is running currently
      */
     Collection<JobType> getRunningTypes();

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/WebTestConfiguration.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.scheduling.AbstractSchedulingManager;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobService;
+import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.security.SystemAuthoritiesProvider;
 import org.hisp.dhis.startup.DefaultAdminUserPopulator;
@@ -237,6 +238,8 @@ public class WebTestConfiguration
     {
         private boolean enabled = true;
 
+        private boolean isRunning = false;
+
         public TestSchedulingManager( JobService jobService, JobConfigurationService jobConfigurationService,
             MessageService messageService, Notifier notifier, LeaderManager leaderManager, CacheProvider cacheProvider )
         {
@@ -266,15 +269,26 @@ public class WebTestConfiguration
         {
             if ( enabled )
             {
-                execute( configuration );
+                return execute( configuration );
             }
-            return true;
+            return !isRunning;
+        }
+
+        @Override
+        public boolean isRunning( JobType type )
+        {
+            return isRunning;
         }
 
         public void setEnabled( boolean enabled )
         {
 
             this.enabled = enabled;
+        }
+
+        public void setRunning( boolean running )
+        {
+            isRunning = running;
         }
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ResourceTableControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/ResourceTableControllerTest.java
@@ -27,9 +27,12 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.WebTestConfiguration.TestSchedulingManager;
+import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +59,9 @@ class ResourceTableControllerTest extends DhisControllerConvenienceTest
     @AfterEach
     void tearDown()
     {
-        ((TestSchedulingManager) schedulingManager).setEnabled( true );
+        TestSchedulingManager testSchedulingManager = (TestSchedulingManager) schedulingManager;
+        testSchedulingManager.setEnabled( true );
+        testSchedulingManager.setRunning( false );
     }
 
     @Test
@@ -64,6 +69,22 @@ class ResourceTableControllerTest extends DhisControllerConvenienceTest
     {
         assertWebMessage( "OK", 200, "OK", "Initiated inMemoryAnalyticsJob",
             POST( "/resourceTables/analytics" ).content( HttpStatus.OK ) );
+    }
+
+    @Test
+    void testAnalytics_SecondRequestWhileRunning()
+    {
+        assertWebMessage( "OK", 200, "OK", "Initiated inMemoryAnalyticsJob",
+            POST( "/resourceTables/analytics" ).content( HttpStatus.OK ) );
+
+        // we fake that the first request above would internally still run (in
+        // tests it never starts)
+        ((TestSchedulingManager) schedulingManager).setRunning( true );
+
+        JsonWebMessage message = assertWebMessage( "Conflict", 409, "ERROR",
+            "Job of type ANALYTICS_TABLE is already running",
+            POST( "/resourceTables/analytics" ).content( HttpStatus.CONFLICT ) );
+        assertEquals( "FAILED", message.getResponse().getString( "jobStatus" ).string() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -91,7 +91,6 @@ public class JobConfigurationController
 
     @PostMapping( value = "{uid}/execute", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public ObjectReport executeJobConfiguration( @PathVariable( "uid" ) String uid )
-        throws WebMessageException
     {
         JobConfiguration jobConfiguration = jobConfigurationService.getJobConfigurationByUid( uid );
 


### PR DESCRIPTION
### Summary
The endpoints in `/resourceTables` would try to execute jobs ad-hoc using the scheduler but did not consider the return value of `executeNow` always returning that the job was scheduled. This was not necessarily the case.
Now the return value is considered and the returned web message will reflect the status more consistent with what actually happened. 

Still success here only refers to adding the task for scheduling. It might still never run if it has a collision with another job running when it is due to be executed by the scheduler. The internal propagation of the difference was improved a bit but can only go as far as the point when a `Runnable` task is scheduled for execution using the underlying execution service.

### Automatic Testing
To be able to test this sort of scenarios where a task is already running the test scheduler got extended with a setter that allows to fake the running status. This affects all jobs at the same time.

A new test scenario was added to check the conflict status is returned by the controller.

### Manual Testing
* `POST /api/resourceTables/analytics` => OK
* `POST /api/resourceTables/analytics` again (while it is still running) => Conflict
* `POST /api/resourceTables/analytics?skipResourceTables=true` (or any other parameter combination) again (while it is still running) => Conflict
* test same thing for other endpoints `/api/resourceTables` and `/api/resourceTables/monitoring`

### Example Output
New response in case task could not be executed because another job of that type is already running:
```json
{
  "httpStatus":"Conflict",
  "httpStatusCode":409,
  "status":"ERROR",
  "message":"Job of type ANALYTICS_TABLE is already running",
  "response":{
    "name":"inMemoryAnalyticsJob",
    "id":"iZkVbeuQ66z",
    "created":"2022-05-12T16:44:25.060",
    "jobType":"ANALYTICS_TABLE",
    "jobStatus":"FAILED",
    "jobParameters":{
      "skipTableTypes":[
        
      ],
      "skipPrograms":[
        
      ],
      "skipResourceTables":false
    },
    "relativeNotifierEndpoint":"/api/system/tasks/ANALYTICS_TABLE/iZkVbeuQ66z"
  }
}
```