### PR TITLE
fix: error when download visualization as png

### DIFF
--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -298,6 +298,10 @@
       <artifactId>fop</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -739,6 +739,7 @@
               <ignoredUnusedDeclaredDependency>io.lettuce:lettuce-core</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.springframework:spring-context-support</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-codec</ignoredUnusedDeclaredDependency>
 
               <!-- Removing these dependencies from the pom makes some tests 
                 fail -->
@@ -1932,6 +1933,12 @@
             <artifactId>batik-anim</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>batik-codec</artifactId>
+        <version>${batik-transcoder.version}</version>
       </dependency>
 
       <!-- Jackson JSON Mapper -->


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-13251

### Issue


```
org.springframework.web.util.NestedServletException: Request processing failed; nested exception is org.apache.batik.transcoder.TranscoderException: null
Enclosed Exception:
Could not write PNG file because no WriteAdapter is availble
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
```

### Fix
- Current version of `batik` need a `WriteAdapter` in order to generate a PNG file. 
We need to include `batik-codec` in pom file for that.

_PNGTranscoder.java_
```
PNGTranscoder.WriteAdapter adapter = this.getWriteAdapter("org.apache.batik.ext.awt.image.codec.png.PNGTranscoderInternalCodecWriteAdapter");
if (adapter == null) {
    adapter = this.getWriteAdapter("org.apache.batik.transcoder.image.PNGTranscoderImageIOWriteAdapter");
}

if (adapter == null) {
    throw new TranscoderException("Could not write PNG file because no WriteAdapter is availble");
} else {
    adapter.writeImage(this, img, output);
}
```

