### PR TITLE
chore(deps): remove old exclusions from jclouds

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -1719,49 +1719,21 @@
         <groupId>org.apache.jclouds</groupId>
         <artifactId>jclouds-core</artifactId>
         <version>${jclouds.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-gson</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.jclouds</groupId>
         <artifactId>jclouds-blobstore</artifactId>
         <version>${jclouds.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.jclouds.api</groupId>
         <artifactId>filesystem</artifactId>
         <version>${jclouds.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.jclouds.api</groupId>
         <artifactId>s3</artifactId>
         <version>${jclouds.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <!--ExpressionParser -->


### PR DESCRIPTION
jclouds does not ship the excluded libraries anymore.

This is a snippet of our dependency tree (including jclouds)

+- com.google.code.gson:gson:jar:2.8.9:compile
+- org.apache.jclouds:jclouds-core:jar:2.5.0:compile
|  +- com.google.inject:guice:jar:5.0.1:compile
|  |  +- javax.inject:javax.inject:jar:1:compile
|  |  \- aopalliance:aopalliance:jar:1.0:compile
|  +- com.google.inject.extensions:guice-assistedinject:jar:5.0.1:compile
|  +- javax.ws.rs:javax.ws.rs-api:jar:2.0.1:compile
|  \- com.sun.xml.bind:jaxb-impl:jar:2.3.3:compile
|     +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:compile
|     \- com.sun.activation:jakarta.activation:jar:1.2.2:runtime
+- org.apache.jclouds:jclouds-blobstore:jar:2.5.0:compile
+- org.apache.jclouds.api:filesystem:jar:2.5.0:compile
+- org.apache.jclouds.api:s3:jar:2.5.0:compile
|  \- org.apache.jclouds.api:sts:jar:2.5.0:compile