### PR TITLE
fix: Slow PSQL queries when retrieving /events [ DHIS2-12039 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 
@@ -120,7 +119,7 @@ public class EventSearchParams
 
     private Set<String> assignedUsers = new HashSet<>();
 
-    private TrackedEntityInstance trackedEntityInstance;
+    private String trackedEntityInstance;
 
     private Date startDate;
 
@@ -414,12 +413,12 @@ public class EventSearchParams
         return this;
     }
 
-    public TrackedEntityInstance getTrackedEntityInstance()
+    public String getTrackedEntityInstance()
     {
         return trackedEntityInstance;
     }
 
-    public EventSearchParams setTrackedEntityInstance( TrackedEntityInstance trackedEntityInstance )
+    public EventSearchParams setTrackedEntityInstance( String trackedEntityInstance )
     {
         this.trackedEntityInstance = trackedEntityInstance;
         return this;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1123,7 +1123,7 @@ public class JdbcEventStore implements EventStore
         if ( params.getTrackedEntityInstance() != null )
         {
             sqlBuilder.append(
-                hlp.whereAnd() + " tei.trackedentityinstanceid=" + params.getTrackedEntityInstance().getId() + " " );
+                hlp.whereAnd() + " tei.uid=" + "'" + params.getTrackedEntityInstance() + "'" );
         }
 
         if ( params.getProgram() != null )

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_45__Add_index_lastupdated_programstageinstance.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_45__Add_index_lastupdated_programstageinstance.sql
@@ -1,1 +1,1 @@
-CREATE INDEX programstageinstance_lastupdated ON public.programstageinstance USING btree (lastupdated);
+CREATE INDEX if not exists programstageinstance_lastupdated ON public.programstageinstance USING btree (lastupdated);

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_45__Add_index_lastupdated_programstageinstance.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.38/V2_38_45__Add_index_lastupdated_programstageinstance.sql
@@ -1,0 +1,1 @@
+CREATE INDEX programstageinstance_lastupdated ON public.programstageinstance USING btree (lastupdated);

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
@@ -71,7 +71,6 @@ import org.hisp.dhis.query.QueryUtils;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -187,9 +186,8 @@ public class RequestToSearchParamsMapper
             throw new IllegalQueryException( "User has no access to program stage: " + ps.getUid() );
         }
 
-        TrackedEntityInstance tei = entityInstanceService.getTrackedEntityInstance( trackedEntityInstance );
-
-        if ( !StringUtils.isEmpty( trackedEntityInstance ) && tei == null )
+        if ( !StringUtils.isEmpty( trackedEntityInstance )
+            && !entityInstanceService.trackedEntityInstanceExists( trackedEntityInstance ) )
         {
             throw new IllegalQueryException(
                 "Tracked entity instance is specified but does not exist: " + trackedEntityInstance );
@@ -257,7 +255,8 @@ public class RequestToSearchParamsMapper
                 .collect( Collectors.toSet() );
         }
 
-        return params.setProgram( pr ).setProgramStage( ps ).setOrgUnit( ou ).setTrackedEntityInstance( tei )
+        return params.setProgram( pr ).setProgramStage( ps ).setOrgUnit( ou )
+            .setTrackedEntityInstance( trackedEntityInstance )
             .setProgramStatus( programStatus ).setFollowUp( followUp ).setOrgUnitSelectionMode( orgUnitSelectionMode )
             .setAssignedUserSelectionMode( assignedUserSelectionMode ).setAssignedUsers( assignedUsers )
             .setStartDate( startDate ).setEndDate( endDate ).setDueDateStart( dueDateStart ).setDueDateEnd( dueDateEnd )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToParamsMapperTest.java
@@ -49,7 +49,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
@@ -110,7 +109,6 @@ class EventRequestToParamsMapperTest
         Program program = new Program();
         User user = new User();
         OrganisationUnit ou = new OrganisationUnit();
-        TrackedEntityInstance tei = new TrackedEntityInstance();
         DataElement de = new DataElement();
 
         when( currentUserService.getCurrentUser() ).thenReturn( user );
@@ -119,7 +117,7 @@ class EventRequestToParamsMapperTest
 
         when( organisationUnitService.isInUserHierarchy( ou ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
-        when( entityInstanceService.getTrackedEntityInstance( any() ) ).thenReturn( tei );
+        when( entityInstanceService.trackedEntityInstanceExists( any() ) ).thenReturn( true );
         when( dataElementService.getDataElement( any() ) ).thenReturn( de );
     }
 


### PR DESCRIPTION
This is an attempt to improve performance while accessing /events endpoint.
An index has been added to programstageinstance table for **lastupdated** column, which is ordering the result set.

Main reasons for this attempt :
1) This is significantly reducing the cost of the queries
2) During local performance tests, the distribution of the response time during around 5 minutes has moved a bit to lower percentiles and reduced the average response time over a much higher Request per second.
Locally psi table is not big as in a production env though, so results need to be validated

Also, a minor update not to retrieve a full Tei for existence
