### PR TITLE
feat: Support 'legend' in EventVisualization [DHIS2-13264]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualization.java
@@ -64,8 +64,6 @@ import org.hisp.dhis.common.RegressionType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.i18n.I18nFormat;
-import org.hisp.dhis.legend.LegendDisplayStrategy;
-import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.Program;
@@ -76,6 +74,7 @@ import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.visualization.LegendDefinitions;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -125,9 +124,10 @@ public class EventVisualization extends BaseAnalyticalObject
 
     protected Integer rangeAxisDecimals;
 
-    protected LegendSet legendSet;
-
-    protected LegendDisplayStrategy legendDisplayStrategy;
+    /**
+     * The legend and legend set definitions.
+     */
+    private LegendDefinitions legendDefinitions;
 
     // -------------------------------------------------------------------------
     // Dimensional properties
@@ -651,29 +651,16 @@ public class EventVisualization extends BaseAnalyticalObject
         this.rangeAxisDecimals = rangeAxisDecimals;
     }
 
-    @JsonProperty
-    @JsonSerialize( as = BaseIdentifiableObject.class )
+    @JsonProperty( "legend" )
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    public LegendSet getLegendSet()
+    public LegendDefinitions getLegendDefinitions()
     {
-        return legendSet;
+        return legendDefinitions;
     }
 
-    public void setLegendSet( LegendSet legendSet )
+    public void setLegendDefinitions( LegendDefinitions legendDefinitions )
     {
-        this.legendSet = legendSet;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    public LegendDisplayStrategy getLegendDisplayStrategy()
-    {
-        return legendDisplayStrategy;
-    }
-
-    public void setLegendDisplayStrategy( LegendDisplayStrategy legendDisplayStrategy )
-    {
-        this.legendDisplayStrategy = legendDisplayStrategy;
+        this.legendDefinitions = legendDefinitions;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -218,6 +218,9 @@ public class Visualization
      */
     private List<Axis> optionalAxes = new ArrayList<>();
 
+    /**
+     * The legend and legend set definitions.
+     */
     private LegendDefinitions legendDefinitions;
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization.hibernate/EventVisualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/eventvisualization.hibernate/EventVisualization.hbm.xml
@@ -153,6 +153,31 @@
 
         <property name="hideSubtitle"/>
 
+        <component name="legendDefinitions" class="org.hisp.dhis.visualization.LegendDefinitions">
+            <property name="legendDisplayStyle" length="40">
+                <type name="org.hibernate.type.EnumType">
+                    <param name="enumClass">org.hisp.dhis.legend.LegendDisplayStyle</param>
+                    <param name="useNamed">true</param>
+                    <param name="type">12</param>
+                </type>
+            </property>
+
+            <property name="legendDisplayStrategy" length="40">
+                <type name="org.hibernate.type.EnumType">
+                    <param name="enumClass">org.hisp.dhis.legend.LegendDisplayStrategy</param>
+                    <param name="useNamed">true</param>
+                    <param name="type">12</param>
+                </type>
+            </property>
+
+            <property name="showKey">
+                <column name="legendshowkey" default="false"/>
+            </property>
+
+            <many-to-one name="legendSet" class="org.hisp.dhis.legend.LegendSet" column="legendsetid"
+                         foreign-key="fk_evisualization_legendsetid"/>
+        </component>
+
         <set name="interpretations" inverse="true">
             <key column="eventvisualizationid"/>
             <one-to-many class="org.hisp.dhis.interpretation.Interpretation"/>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_11__Add_LegendSet_Column_Into_EV.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_11__Add_LegendSet_Column_Into_EV.sql
@@ -1,0 +1,20 @@
+-- This script relates to the ticket https://jira.dhis2.org/browse/DHIS2-13264
+-- It adds new columns into the Event Visualization table.
+
+ALTER TABLE eventvisualization ADD COLUMN IF NOT EXISTS legendsetid int8 null;
+
+DO $$
+BEGIN
+  BEGIN
+    ALTER TABLE eventvisualization ADD CONSTRAINT fk_evisualization_legendsetid FOREIGN KEY (legendsetid) REFERENCES maplegendset(maplegendsetid);
+  EXCEPTION
+  	WHEN OTHERS THEN
+    	RAISE NOTICE 'Table constraint % already exists', 'fk_evisualization_legendsetid';
+  END;
+END $$;
+
+ALTER TABLE eventvisualization ADD COLUMN IF NOT EXISTS legenddisplaystrategy character varying(40);
+
+ALTER TABLE eventvisualization ADD COLUMN IF NOT EXISTS legenddisplaystyle character varying(40);
+
+ALTER TABLE eventvisualization ADD COLUMN IF NOT EXISTS legendshowkey boolean;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationController.java
@@ -93,12 +93,23 @@ public class VisualizationController
             visualization.getRowDimensions().addAll( getDimensions( visualization.getRows() ) );
             visualization.getFilterDimensions().addAll( getDimensions( visualization.getFilters() ) );
 
-            if ( visualization.getLegendDefinitions() != null
-                && visualization.getLegendDefinitions().getLegendSet() != null )
-            {
-                visualization.getLegendDefinitions().setLegendSet(
-                    legendSetService.getLegendSet( visualization.getLegendDefinitions().getLegendSet().getUid() ) );
-            }
+            maybeLoadLegendSetInto( visualization );
+        }
+    }
+
+    /**
+     * Load the current/existing legendSet (if any is set) into the current
+     * visualization object, so the relationship can be persisted.
+     *
+     * @param visualization
+     */
+    private void maybeLoadLegendSetInto( final Visualization visualization )
+    {
+        if ( visualization.getLegendDefinitions() != null
+            && visualization.getLegendDefinitions().getLegendSet() != null )
+        {
+            visualization.getLegendDefinitions().setLegendSet(
+                legendSetService.getLegendSet( visualization.getLegendDefinitions().getLegendSet().getUid() ) );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventVisualizationController.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationService;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.legend.LegendSetService;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.period.Period;
@@ -87,6 +88,8 @@ public class EventVisualizationController
     AbstractCrudController<EventVisualization>
 {
     private final DimensionService dimensionService;
+
+    private final LegendSetService legendSetService;
 
     private final OrganisationUnitService organisationUnitService;
 
@@ -226,6 +229,24 @@ public class EventVisualizationController
         eventVisualization.getRowDimensions().addAll( getDimensions( eventVisualization.getRows() ) );
         eventVisualization.getFilterDimensions().addAll( getDimensions( eventVisualization.getFilters() ) );
         eventVisualization.associateSimpleDimensions();
+
+        maybeLoadLegendSetInto( eventVisualization );
+    }
+
+    /**
+     * Load the current/existing legendSet (if any is set) into the current
+     * visualization object, so the relationship can be persisted.
+     *
+     * @param eventVisualization
+     */
+    private void maybeLoadLegendSetInto( final EventVisualization eventVisualization )
+    {
+        if ( eventVisualization.getLegendDefinitions() != null
+            && eventVisualization.getLegendDefinitions().getLegendSet() != null )
+        {
+            eventVisualization.getLegendDefinitions().setLegendSet(
+                legendSetService.getLegendSet( eventVisualization.getLegendDefinitions().getLegendSet().getUid() ) );
+        }
     }
 
     private void doesNotAllowPivotAndReportChart( final EventVisualization eventVisualization )


### PR DESCRIPTION
This PR simply adds a new attribute to the `EventVisualization` object.
It works exactly as the existing `legend` in `Visualization`.

It relates to the API `/eventVisualizations`.
A brief example of the `legend` attribute:

```
  "legend": {
    "set": {
      "id": "gFJUXah1uRH"
    },
    "showKey": false,
    "style": "FILL",
    "strategy": "FIXED"
  }
```