### PR TITLE
fix: rule engine attribute identifiers are UIDs DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -92,12 +92,17 @@ public class TrackerIdentifierCollector
         identifiers.put( TrackedEntityType.class, ImmutableSet.of( ID_WILDCARD ) );
         identifiers.put( RelationshipType.class, ImmutableSet.of( ID_WILDCARD ) );
 
-        collectProgramRulesFields( params.getIdSchemes(), identifiers );
+        collectProgramRulesFields( identifiers );
         return identifiers;
     }
 
-    private void collectProgramRulesFields( TrackerIdSchemeParams idSchemes, Map<Class<?>, Set<String>> map )
+    private void collectProgramRulesFields( Map<Class<?>, Set<String>> map )
     {
+        // collecting program rule dataElement/attributes deliberately using
+        // UIDs
+        // Rule engine rules only know UIDs, so we need to be able to get
+        // dataElements/attributes from rule actions
+        // out of the preheat using UIDs
         List<ProgramRule> programRules = programRuleService.getProgramRulesLinkedToTeaOrDe();
         Set<String> dataElements = programRules.stream()
             .flatMap( pr -> pr.getProgramRuleActions().stream() )
@@ -107,12 +112,10 @@ public class TrackerIdentifierCollector
 
         dataElements.forEach( de -> addIdentifier( map, DataElement.class, de ) );
 
-        // collect program rule attribute ids using user defined idScheme; so
-        // ids are in the same idScheme as user provided attributes
         Set<String> attributes = programRules.stream()
             .flatMap( pr -> pr.getProgramRuleActions().stream() )
             .filter( a -> Objects.nonNull( a.getAttribute() ) )
-            .map( a -> idSchemes.getIdScheme().getIdentifier( a.getAttribute() ) )
+            .map( a -> a.getAttribute().getUid() )
             .collect( Collectors.toSet() );
 
         attributes.forEach( attribute -> addIdentifier( map, TrackedEntityAttribute.class, attribute ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.tracker.programrule;
 
 import java.util.List;
-import java.util.Optional;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -37,7 +36,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.tracker.domain.Attribute;
-import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 
 @Getter
 @RequiredArgsConstructor
@@ -51,7 +49,7 @@ public class EnrollmentActionRule
 
     private final String data;
 
-    private final MetadataIdentifier field;
+    private final String field;
 
     private final AttributeType attributeType;
 
@@ -75,29 +73,5 @@ public class EnrollmentActionRule
             stringBuilder.append( data );
         }
         return stringBuilder.toString();
-    }
-
-    public Optional<Attribute> getAttribute()
-    {
-        if ( attributeType.equals( AttributeType.TRACKED_ENTITY_ATTRIBUTE ) )
-        {
-            return getAttributes()
-                .stream()
-                .filter( at -> at.getAttribute().equals( field ) )
-                .findAny();
-        }
-
-        return Optional.empty();
-
-    }
-
-    public String getField()
-    {
-        return this.field.getIdentifierOrAttributeValue();
-    }
-
-    public MetadataIdentifier getFieldMetadataIdentifier()
-    {
-        return this.field;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -44,14 +44,12 @@ import org.hisp.dhis.rules.models.AttributeType;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionAttribute;
 import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.EnrollmentActionRule;
 import org.hisp.dhis.tracker.programrule.EventActionRule;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
@@ -200,20 +198,14 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
                     List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
                         payloadTeiAttributes );
 
-                    TrackerPreheat preheat = bundle.getPreheat();
-                    TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
-
                     List<EnrollmentActionRule> enrollmentActionRules = e.getValue()
                         .stream()
                         .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
                         .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
                             getAttributeType( effect.ruleAction() ) == TRACKED_ENTITY_ATTRIBUTE )
-                        .filter(
-                            effect -> preheat.getTrackedEntityAttribute( getField( (T) effect.ruleAction() ) ) != null )
                         .map( effect -> new EnrollmentActionRule( effect.ruleId(),
                             enrollment.getEnrollment(), effect.data(),
-                            idSchemes.toMetadataIdentifier(
-                                preheat.getTrackedEntityAttribute( getField( (T) effect.ruleAction() ) ) ),
+                            getField( (T) effect.ruleAction() ),
                             getAttributeType( effect.ruleAction() ),
                             getContent( (T) effect.ruleAction() ), attributes ) )
                         .collect( Collectors.toList() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -192,6 +192,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     @Test
     void testValidateOkMandatoryFieldsForEnrollment()
     {
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( attribute );
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet() ) );
 
         Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEnrollments( bundle );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -52,7 +52,6 @@ import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionSetMandatoryField;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleEffects;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
@@ -69,13 +68,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-@MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
 class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
 {
@@ -129,11 +125,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         ProgramStageDataElement programStageDataElementB = createProgramStageDataElement( secondProgramStage,
             dataElementB, 0 );
         secondProgramStage.setProgramStageDataElements( Sets.newHashSet( programStageDataElementB ) );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
-        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
-            .thenReturn( firstProgramStage );
-        when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage ) ) )
-            .thenReturn( secondProgramStage );
+
         bundle = TrackerBundle.builder().build();
         bundle.setRuleEffects( getRuleEventAndEnrollmentEffects() );
         bundle.setPreheat( preheat );
@@ -142,16 +134,24 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     @Test
     void testValidateOkMandatoryFieldsForEvents()
     {
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
+            .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet() ) );
+
         Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+
         assertTrue( errors.isEmpty() );
     }
 
     @Test
     void testValidateWithErrorMandatoryFieldsForEvents()
     {
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
+            .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(), getEventWithMandatoryValueNOTSet() ) );
+
         Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+
         assertFalse( errors.isEmpty() );
         List<ProgramRuleIssue> errorMessages = errors.values().stream().flatMap( Collection::stream )
             .collect( Collectors.toList() );
@@ -167,9 +167,15 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     @Test
     void testValidateOkMandatoryFieldsForValidEventAndNotValidEventInDifferentProgramStage()
     {
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( firstProgramStage ) ) )
+            .thenReturn( firstProgramStage );
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( secondProgramStage ) ) )
+            .thenReturn( secondProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(),
             getEventWithMandatoryValueNOTSetInDifferentProgramStage() ) );
+
         Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+
         assertTrue( errors.isEmpty() );
     }
 
@@ -177,7 +183,9 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     void testValidateOkMandatoryFieldsForEnrollment()
     {
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet() ) );
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+
+        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEnrollments( bundle );
+
         assertTrue( errors.isEmpty() );
     }
 
@@ -186,10 +194,9 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
     {
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet(),
             getEnrollmentWithMandatoryAttributeNOTSet() ) );
-        TrackedEntityAttribute tea = new TrackedEntityAttribute();
-        tea.setUid( ATTRIBUTE_ID );
-        when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( tea );
+
         Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEnrollments( bundle );
+
         assertFalse( errors.isEmpty() );
         List<ProgramRuleIssue> errorMessages = errors.values().stream().flatMap( Collection::stream )
             .collect( Collectors.toList() );
@@ -238,6 +245,16 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         return Sets.newHashSet( dataValue );
     }
 
+    private Enrollment getEnrollmentWithMandatoryAttributeSet( TrackerIdSchemeParams idSchemes )
+    {
+        return Enrollment.builder()
+            .enrollment( ACTIVE_ENROLLMENT_ID )
+            .trackedEntity( TEI_ID )
+            .status( EnrollmentStatus.ACTIVE )
+            .attributes( getAttributes( idSchemes ) )
+            .build();
+    }
+
     private Enrollment getEnrollmentWithMandatoryAttributeSet()
     {
         return Enrollment.builder()
@@ -257,9 +274,22 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .build();
     }
 
+    private List<Attribute> getAttributes( TrackerIdSchemeParams idSchemes )
+    {
+        return Lists.newArrayList( getAttribute( idSchemes ) );
+    }
+
     private List<Attribute> getAttributes()
     {
         return Lists.newArrayList( getAttribute() );
+    }
+
+    private Attribute getAttribute( TrackerIdSchemeParams idSchemes )
+    {
+        return Attribute.builder()
+            .attribute( idSchemes.getIdScheme().toMetadataIdentifier( ATTRIBUTE_ID ) )
+            .value( ATTRIBUTE_VALUE )
+            .build();
     }
 
     private Attribute getAttribute()


### PR DESCRIPTION
Therefore
* collect/preheat rule engine dataElements/attributes using UIDs (TrackerIdentifierCollector)
* get dataElements/attributes from the preheat before matching on any of
  these entities in the program rule engine tracker code in each rule implementer

The previous approach did not work since EnrollmentActionRule.field will always be a UID as its coming from rule engine. If we preheat rule engine attributes in the user defined idScheme we will then not find them in the preheat using a UID.

EnrollmentActionRule.field can be `""` in some Rules, so having the rule implementers do the mapping/interpretation of what the `field` is is easier to understand and safer.