### PR TITLE
fix: update Option.sortOrder resulted with null sortOrders

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -76,6 +76,45 @@ public class OptionObjectBundleHook extends AbstractObjectBundleHook<Option>
         }
     }
 
+    @Override
+    public void preUpdate( Option option, Option persistedObject, ObjectBundle bundle )
+    {
+        if ( option.getOptionSet() == null )
+        {
+            return;
+        }
+
+        OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
+            option.getOptionSet().getUid() );
+
+        if ( optionSet != null )
+        {
+            // Remove the existed option from OptionSet, will add the updating
+            // one
+            // in postUpdate()
+            optionSet.getOptions().remove( persistedObject );
+        }
+    }
+
+    @Override
+    public void postUpdate( Option option, ObjectBundle bundle )
+    {
+        if ( option.getOptionSet() == null )
+        {
+            return;
+        }
+
+        OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
+            option.getOptionSet().getUid() );
+
+        if ( optionSet != null )
+        {
+            // Add the updated Option to OptionSet, this will allow Hibernate to
+            // re-organize sortOrder gaps if any.
+            optionSet.addOption( option );
+        }
+    }
+
     /**
      * Check for duplication of Option's name OR code within given OptionSet
      */

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/OptionControllerTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class OptionControllerTest extends DhisControllerConvenienceTest
+{
+    @Test
+    void testUpdateOptionWithSortOrderGap()
+    {
+        // Create OptionSet with two Options
+        POST( "/metadata", "{\"optionSets\":\n" +
+            "    [{\"name\": \"Device category\",\"id\": \"RHqFlB1Wm4d\",\"version\": 2,\"valueType\": \"TEXT\",\"options\":[{\"id\": \"Uh4HvjK6zg3\"},{\"id\": \"BQMei56UBl6\"}]}],\n"
+            +
+            "\"options\":\n" +
+            "    [{\"code\": \"Vaccine freezer\",\"name\": \"Vaccine freezer\",\"id\": \"BQMei56UBl6\",\"sortOrder\": 1,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}},\n"
+            +
+            "    {\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 2,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        JsonResponse response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+
+        // sortOrder is 1 and 2
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertEquals( 1, response.getNumber( "options[0].sortOrder" ).intValue() );
+        assertEquals( 2, response.getNumber( "options[1].sortOrder" ).intValue() );
+
+        // Update option sortOrder 2 to 20
+        POST( "/metadata", "{\"options\":\n" +
+            "[{\"code\": \"Icelined refrigerator\",\"name\": \"Icelined refrigerator\",\"id\": \"Uh4HvjK6zg3\",\"sortOrder\": 20,\"optionSet\":{\"id\": \"RHqFlB1Wm4d\"}}]}" )
+                .content( HttpStatus.OK );
+
+        response = GET( "/optionSets/{uid}?fields=options[id,sortOrder]", "RHqFlB1Wm4d" ).content();
+        assertEquals( 2, response.getObject( "options" ).size() );
+        assertEquals( 1, response.getNumber( "options[0].sortOrder" ).intValue() );
+        // sortOrder 20 should be saved as 2.
+        assertEquals( "Uh4HvjK6zg3", response.getString( "options[1].id" ).string() );
+        assertEquals( 2, response.getNumber( "options[1].sortOrder" ).intValue() );
+    }
+}


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12828

### Issue
- By default, if we update an OptionSet with Option's sortOrder gaps then Hibernate will auto re-organizes the sortOrders. However, Hibernate can't do that if we execute the update from _Option side of the association_.  Means that we only update Option without touching its OptionSet.

### Fix
- I think the best way to solve this for the metadata import service is to remove and add the updating Option again to OptionSet. 
- Then at then end of the import process when we call `session.flush()` the OptionSet will be updated and all sortOrders will be re-organized.
- This is already handled for create new Option. Currently issue only happens with updating.

Example: [1,2,null,null,null,9] will be re-organized by Hibernate to [1,2,3]

### Test
- Added controller test
