### PR TITLE
chore: docs, improve APIs DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -212,7 +212,7 @@ public class EventTrackerConverterService
 
     private ProgramStageInstance from( TrackerPreheat preheat, Event event, ProgramStageInstance programStageInstance )
     {
-        ProgramStage programStage = preheat.get( ProgramStage.class, event.getProgramStage() );
+        ProgramStage programStage = preheat.getProgramStage( event.getProgramStage() );
         Program program = preheat.getProgram( event.getProgram() );
         OrganisationUnit organisationUnit = preheat.getOrganisationUnit( event.getOrgUnit() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -239,7 +239,7 @@ public class EventTrackerConverterService
         programStageInstance.setExecutionDate( DateUtils.fromInstant( event.getOccurredAt() ) );
         programStageInstance.setDueDate( DateUtils.fromInstant( event.getScheduledAt() ) );
 
-        if ( !event.getAttributeOptionCombo().isBlank() )
+        if ( event.getAttributeOptionCombo().isNotBlank() )
         {
             programStageInstance.setAttributeOptionCombo(
                 preheat.getCategoryOptionCombo( event.getAttributeOptionCombo() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.relationship.RelationshipKey;
-import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
@@ -119,7 +118,7 @@ public class RelationshipTrackerConverterService
         org.hisp.dhis.relationship.Relationship toRelationship )
     {
         org.hisp.dhis.relationship.RelationshipType relationshipType = preheat
-            .get( RelationshipType.class, fromRelationship.getRelationshipType() );
+            .getRelationshipType( fromRelationship.getRelationshipType() );
         org.hisp.dhis.relationship.RelationshipItem fromItem = new org.hisp.dhis.relationship.RelationshipItem();
         org.hisp.dhis.relationship.RelationshipItem toItem = new org.hisp.dhis.relationship.RelationshipItem();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/TrackedEntityTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/TrackedEntityTrackerConverterService.java
@@ -93,10 +93,8 @@ public class TrackedEntityTrackerConverterService
 
     private TrackedEntityInstance from( TrackerPreheat preheat, TrackedEntity te, TrackedEntityInstance tei )
     {
-        OrganisationUnit organisationUnit = preheat.get( OrganisationUnit.class,
-            te.getOrgUnit() );
-        TrackedEntityType trackedEntityType = preheat.get( TrackedEntityType.class,
-            te.getTrackedEntityType() );
+        OrganisationUnit organisationUnit = preheat.getOrganisationUnit( te.getOrgUnit() );
+        TrackedEntityType trackedEntityType = preheat.getTrackedEntityType( te.getTrackedEntityType() );
 
         Date now = new Date();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/MetadataIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/MetadataIdentifier.java
@@ -43,8 +43,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * MetadataIdentifier represents an immutable idScheme aware identifier of
- * metadata.
- *
+ * metadata. <br>
+ * <p>
+ * Tracker allows imports to use identifiers in idScheme {@code UID},
+ * {@code CODE} {@code NAME} and {@code ATTRIBUTE}. Any matching of metadata
+ * like "does the {@code orgUnit} given in the import exist?" has to respect the
+ * user chosen idScheme. To reduce the risk of falsely declaring metadata as for
+ * example not found {@code MetadataIdentifier} wraps the idScheme with the
+ * identifier value.
+ * </p>
+ * <br>
+ * <p>
+ * Compare a {@link MetadataIdentifier} to an {@link IdentifiableObject} using
+ * {@link #isEqualTo(IdentifiableObject)}. {@link MetadataIdentifier} can be
+ * compared to {@link MetadataIdentifier} using {@link #equals(Object)}. If you
+ * must access the actual identifier like the {@code UID} use
+ * {@link #getIdentifier()}. Exercise caution when you do, as you should of
+ * course only compare the UID to another UID.
+ * </p>
+ * <br>
  * idScheme=ATTRIBUTE uses the {@link #identifier} and {@link #attributeValue}
  * to identify metadata while the other idSchemes only rely on the
  * {@link #identifier} (UID, CODE, NAME).

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/MetadataIdentifier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/MetadataIdentifier.java
@@ -292,4 +292,15 @@ public class MetadataIdentifier
     {
         return StringUtils.isBlank( this.getIdentifierOrAttributeValue() );
     }
+
+    /**
+     * Determines whether this metadata identifier is not blank. Complement of
+     * {@link #isBlank()}.
+     *
+     * @return true if identifier is not blank
+     */
+    public boolean isNotBlank()
+    {
+        return !this.isBlank();
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramStageInstanceProgramStageMapSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramStageInstanceProgramStageMapSupplier.java
@@ -82,7 +82,7 @@ public class ProgramStageInstanceProgramStageMapSupplier
         List<String> notRepeatableProgramStageUids = params.getEvents().stream()
             .map( Event::getProgramStage )
             .filter( Objects::nonNull )
-            .map( ps -> (ProgramStage) preheat.get( ProgramStage.class, ps ) )
+            .map( ps -> preheat.getProgramStage( ps ) )
             .filter( Objects::nonNull )
             .filter( ps -> !ps.getRepeatable() )
             .map( ProgramStage::getUid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramStageInstanceProgramStageMapSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramStageInstanceProgramStageMapSupplier.java
@@ -82,7 +82,7 @@ public class ProgramStageInstanceProgramStageMapSupplier
         List<String> notRepeatableProgramStageUids = params.getEvents().stream()
             .map( Event::getProgramStage )
             .filter( Objects::nonNull )
-            .map( ps -> preheat.getProgramStage( ps ) )
+            .map( preheat::getProgramStage )
             .filter( Objects::nonNull )
             .filter( ps -> !ps.getRepeatable() )
             .map( ProgramStage::getUid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BidirectionalRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/BidirectionalRelationshipsPreProcessor.java
@@ -47,8 +47,7 @@ public class BidirectionalRelationshipsPreProcessor
     {
         bundle.getRelationships()
             .forEach( rel -> {
-                RelationshipType relType = bundle.getPreheat()
-                    .get( RelationshipType.class, rel.getRelationshipType() );
+                RelationshipType relType = bundle.getPreheat().getRelationshipType( rel.getRelationshipType() );
                 if ( relType != null )
                 {
                     rel.setBidirectional( relType.isBidirectional() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/DuplicateRelationshipsPreProcessor.java
@@ -111,7 +111,7 @@ public class DuplicateRelationshipsPreProcessor implements BundlePreProcessor
     public void process( TrackerBundle bundle )
     {
         Predicate<Relationship> validRelationship = rel -> StringUtils.isNotEmpty( rel.getRelationship() )
-            && !rel.getRelationshipType().isBlank() &&
+            && rel.getRelationshipType().isNotBlank() &&
             rel.getFrom() != null && rel.getTo() != null
             && bundle.getPreheat().getRelationshipType( rel.getRelationshipType() ) != null;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessor.java
@@ -61,7 +61,7 @@ public class EventProgramPreProcessor
         for ( Event event : eventsToPreprocess )
         {
             // Extract program from program stage
-            if ( !event.getProgramStage().isBlank() )
+            if ( event.getProgramStage().isNotBlank() )
             {
                 ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
                 if ( Objects.nonNull( programStage ) )
@@ -92,7 +92,7 @@ public class EventProgramPreProcessor
                 }
             }
             // If it is a program event, extract program stage from program
-            else if ( !event.getProgram().isBlank() )
+            else if ( event.getProgram().isNotBlank() )
             {
                 Program program = bundle.getPreheat().getProgram( event.getProgram() );
                 if ( Objects.nonNull( program ) && program.isWithoutRegistration() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
@@ -51,7 +51,7 @@ public class EventWithoutRegistrationPreProcessor
         {
             if ( event.getProgramStage().isNotBlank() )
             {
-                ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
+                ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
 
                 if ( programStage != null )
                 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preprocess/EventWithoutRegistrationPreProcessor.java
@@ -49,7 +49,7 @@ public class EventWithoutRegistrationPreProcessor
     {
         for ( Event event : bundle.getEvents() )
         {
-            if ( !event.getProgramStage().isBlank() )
+            if ( event.getProgramStage().isNotBlank() )
             {
                 ProgramStage programStage = bundle.getPreheat().get( ProgramStage.class, event.getProgramStage() );
 
@@ -78,7 +78,7 @@ public class EventWithoutRegistrationPreProcessor
                     setEnrollment( bundle, programStage.getProgram().getUid(), event );
                 }
             }
-            else if ( !event.getProgram().isBlank() )
+            else if ( event.getProgram().isNotBlank() )
             {
                 Program program = bundle.getPreheat().getProgram( event.getProgram() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -95,7 +95,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             TrackedEntityAttribute teAttribute = reporter.getBundle().getPreheat()
                 .getTrackedEntityAttribute( attribute.getAttribute() );
 
-            if ( !attribute.getAttribute().isBlank() && attribute.getValue() != null && teAttribute != null )
+            if ( attribute.getAttribute().isNotBlank() && attribute.getValue() != null && teAttribute != null )
             {
 
                 attributeValueMap.put( attribute.getAttribute(), attribute.getValue() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -43,7 +43,6 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.fileresource.FileResource;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.system.util.ValidationUtils;
@@ -223,7 +222,7 @@ public class EventDataValuesValidationHook
             return;
         }
 
-        reporter.addErrorIfNull( reporter.getBundle().getPreheat().get( OrganisationUnit.class, dataValue.getValue() ),
+        reporter.addErrorIfNull( reporter.getBundle().getPreheat().getOrganisationUnit( dataValue.getValue() ),
             event, E1007, dataValue.getValue() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -108,7 +108,7 @@ public class PreCheckMetaValidationHook
     public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
     {
         TrackerPreheat preheat = reporter.getBundle().getPreheat();
-        RelationshipType relationshipType = preheat.get( RelationshipType.class, relationship.getRelationshipType() );
+        RelationshipType relationshipType = preheat.getRelationshipType( relationship.getRelationshipType() );
 
         reporter.addErrorIfNull( relationshipType, relationship, E4006, relationship.getRelationshipType() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -321,7 +321,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
     private void setUpMocks()
     {
         when( preheat.getUser() ).thenReturn( user );
-        when( preheat.get( ProgramStage.class, MetadataIdentifier.ofUid( programStage ) ) )
+        when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage ) ) )
             .thenReturn( programStage );
         when( preheat.getProgram( MetadataIdentifier.ofUid( program ) ) ).thenReturn( program );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( organisationUnit ) ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preprocess/EventProgramPreProcessorTest.java
@@ -131,8 +131,8 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        verify( preheat, never() ).get( Program.class, PROGRAM_WITH_REGISTRATION );
-        verify( preheat, never() ).get( ProgramStage.class, PROGRAM_STAGE_WITH_REGISTRATION );
+        verify( preheat, never() ).getProgram( PROGRAM_WITH_REGISTRATION );
+        verify( preheat, never() ).getProgramStage( PROGRAM_STAGE_WITH_REGISTRATION );
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION ),
             bundle.getEvents().get( 0 ).getProgram() );
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITH_REGISTRATION ),
@@ -144,7 +144,7 @@ class EventProgramPreProcessorTest
     {
         ProgramStage programStage = new ProgramStage();
         programStage.setUid( "LGSWs20XFvy" );
-        when( preheat.get( ProgramStage.class, "LGSWs20XFvy" ) ).thenReturn( programStage );
+        when( preheat.getProgramStage( "LGSWs20XFvy" ) ).thenReturn( programStage );
 
         Event event = Event.builder()
             .program( MetadataIdentifier.EMPTY_UID )
@@ -209,8 +209,8 @@ class EventProgramPreProcessorTest
 
         preprocessor.process( bundle );
 
-        verify( preheat, never() ).get( Program.class, PROGRAM_WITHOUT_REGISTRATION );
-        verify( preheat, never() ).get( ProgramStage.class, PROGRAM_STAGE_WITHOUT_REGISTRATION );
+        verify( preheat, never() ).getProgram( PROGRAM_WITHOUT_REGISTRATION );
+        verify( preheat, never() ).getProgramStage( PROGRAM_STAGE_WITHOUT_REGISTRATION );
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION ),
             bundle.getEvents().get( 0 ).getProgram() );
         assertEquals( MetadataIdentifier.ofUid( PROGRAM_STAGE_WITHOUT_REGISTRATION ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -823,7 +823,7 @@ class EventDataValuesValidationHookTest
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
         DataValue invalidDataValue = dataValue( "invlaid_org_unit" );
-        when( preheat.get( OrganisationUnit.class, invalidDataValue.getValue() ) ).thenReturn( null );
+        when( preheat.getOrganisationUnit( invalidDataValue.getValue() ) ).thenReturn( null );
 
         ProgramStage programStage = programStage( validDataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
@@ -854,7 +854,7 @@ class EventDataValuesValidationHookTest
         OrganisationUnit validOrgUnit = organisationUnit();
 
         DataValue validDataValue = dataValue( validOrgUnit.getUid() );
-        when( preheat.get( OrganisationUnit.class, validDataValue.getValue() ) ).thenReturn( validOrgUnit );
+        when( preheat.getOrganisationUnit( validDataValue.getValue() ) ).thenReturn( validOrgUnit );
 
         ProgramStage programStage = programStage( validDataElement );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -115,7 +115,8 @@ class PreCheckMetaValidationHookTest
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
-        when( preheat.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) ).thenReturn( new TrackedEntityType() );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TRACKED_ENTITY_TYPE_UID ) ) )
+            .thenReturn( new TrackedEntityType() );
 
         validatorToTest.validateTrackedEntity( reporter, tei );
 
@@ -132,7 +133,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) ).thenReturn( new TrackedEntityType() );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TRACKED_ENTITY_TYPE_UID ) ) )
+            .thenReturn( new TrackedEntityType() );
 
         validatorToTest.validateTrackedEntity( reporter, tei );
 
@@ -343,7 +345,8 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        when( preheat.get( RelationshipType.class, RELATIONSHIP_TYPE_UID ) ).thenReturn( new RelationshipType() );
+        when( preheat.getRelationshipType( MetadataIdentifier.ofUid( RELATIONSHIP_TYPE_UID ) ) )
+            .thenReturn( new RelationshipType() );
 
         validatorToTest.validateRelationship( reporter, relationship );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/package-info.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Export mappers translate from {@link org.hisp.dhis} to the JSON payloads
+ * ({@link org.hisp.dhis.webapi.controller.tracker.view}) tracker exposes to its
+ * users.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/package-info.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Import mappers translate JSON payloads
+ * ({@link org.hisp.dhis.webapi.controller.tracker.view}) to the
+ * {@link org.hisp.dhis.tracker.domain} which is used internally.
+ */
+package org.hisp.dhis.webapi.controller.tracker.imports;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/package-info.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Contains the view (JSON) models of tracker. Imports and exports share the
+ * same model. Import mappers in
+ * {@link org.hisp.dhis.webapi.controller.tracker.imports} translate JSON
+ * payloads (view models) to the {@link org.hisp.dhis.tracker.domain} which is
+ * used internally. Export mappers in
+ * {@link org.hisp.dhis.webapi.controller.tracker.export} translate from
+ * {@link org.hisp.dhis} to the JSON payloads (view models) tracker exposes to
+ * its users.
+ */
+package org.hisp.dhis.webapi.controller.tracker.view;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -29,12 +29,10 @@ package org.hisp.dhis.webapi.controller.tracker.imports;
 
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -56,8 +54,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromDataElement( "RiNIt1yJoge", params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), id );
     }
 
     @Test
@@ -71,9 +68,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromDataElement( "clouds", params );
 
-        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
-        assertEquals( "clouds", id.getAttributeValue() );
+        assertEquals( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ), id );
     }
 
     @Test
@@ -86,8 +81,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromDataElement( null, params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertNull( id.getIdentifier() );
+        assertEquals( MetadataIdentifier.EMPTY_UID, id );
     }
 
     @Test
@@ -100,8 +94,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromProgram( "RiNIt1yJoge", params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), id );
     }
 
     @Test
@@ -115,9 +108,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromProgram( "clouds", params );
 
-        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
-        assertEquals( "clouds", id.getAttributeValue() );
+        assertEquals( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ), id );
     }
 
     @Test
@@ -130,8 +121,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromProgram( null, params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertNull( id.getIdentifier() );
+        assertEquals( MetadataIdentifier.EMPTY_UID, id );
     }
 
     @Test
@@ -144,8 +134,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromProgramStage( "RiNIt1yJoge", params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), id );
     }
 
     @Test
@@ -159,9 +148,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromProgramStage( "clouds", params );
 
-        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
-        assertEquals( "clouds", id.getAttributeValue() );
+        assertEquals( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ), id );
     }
 
     @Test
@@ -174,8 +161,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromProgramStage( null, params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertNull( id.getIdentifier() );
+        assertEquals( MetadataIdentifier.EMPTY_UID, id );
     }
 
     @Test
@@ -188,8 +174,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromOrgUnit( "RiNIt1yJoge", params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), id );
     }
 
     @Test
@@ -203,9 +188,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromOrgUnit( "clouds", params );
 
-        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
-        assertEquals( "clouds", id.getAttributeValue() );
+        assertEquals( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ), id );
     }
 
     @Test
@@ -218,8 +201,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromOrgUnit( null, params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertNull( id.getIdentifier() );
+        assertEquals( MetadataIdentifier.EMPTY_UID, id );
     }
 
     @Test
@@ -232,8 +214,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromAttributeOptionCombo( "RiNIt1yJoge", params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), id );
     }
 
     @Test
@@ -247,9 +228,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromAttributeOptionCombo( "clouds", params );
 
-        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
-        assertEquals( "clouds", id.getAttributeValue() );
+        assertEquals( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ), id );
     }
 
     @Test
@@ -262,8 +241,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromAttributeOptionCombo( null, params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertNull( id.getIdentifier() );
+        assertEquals( MetadataIdentifier.EMPTY_UID, id );
     }
 
     @Test
@@ -330,8 +308,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromStringIdentifier( "RiNIt1yJoge", params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
+        assertEquals( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), id );
     }
 
     @Test
@@ -344,9 +321,7 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromStringIdentifier( "clouds", params );
 
-        assertEquals( TrackerIdScheme.ATTRIBUTE, id.getIdScheme() );
-        assertEquals( "RiNIt1yJoge", id.getIdentifier() );
-        assertEquals( "clouds", id.getAttributeValue() );
+        assertEquals( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ), id );
     }
 
     @Test
@@ -359,7 +334,6 @@ class MetadataIdentifierMapperTest
 
         MetadataIdentifier id = MAPPER.fromStringIdentifier( null, params );
 
-        assertEquals( TrackerIdScheme.UID, id.getIdScheme() );
-        assertNull( id.getIdentifier() );
+        assertEquals( MetadataIdentifier.EMPTY_UID, id );
     }
 }


### PR DESCRIPTION
cleanups like
* use higher level preheat APIs like `preheat.getOrganisationUnit( id );` instead of `preheat.get( OrganisationUnit.class, id );`
* add javadocs to MetadataIdentifier, view, import, export packages; so we know why they exist
* !MetadataIdentifier.isBlank is used often enough for us to add complement MetadataIdentifier.isNotBlank
* improve assertions in MetadataIdentifierTest (thereby also testing lombok `@EqualsAndHashCode` is setup)