### PR TITLE
fix: predictor unique short name - drop constriant before adding it [DHIS2-10688]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_7__Add_unique_and_not_null_to_predictor_shortName.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.39/V2_39_7__Add_unique_and_not_null_to_predictor_shortName.sql
@@ -1,2 +1,3 @@
 alter table predictor alter column shortname set not null;
+alter table predictor drop constraint if exists predictor_unique_shortname;
 alter table predictor add constraint predictor_unique_shortname unique (shortname);


### PR DESCRIPTION
To be safe we need to drop the constraint should it already exist. 

The modified flyway script is not yet released so changing it only affects development in master.