### PR TITLE
chore: orgUnitName is unused in tracker domain DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/EventTrackerConverterService.java
@@ -121,7 +121,6 @@ public class EventTrackerConverterService
             if ( ou != null )
             {
                 event.setOrgUnit( MetadataIdentifier.ofUid( ou ) );
-                event.setOrgUnitName( ou.getName() );
             }
 
             event.setEnrollment( psi.getProgramInstance().getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Enrollment.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Enrollment.java
@@ -79,9 +79,6 @@ public class Enrollment
     private MetadataIdentifier orgUnit;
 
     @JsonProperty
-    private String orgUnitName;
-
-    @JsonProperty
     private Instant enrolledAt;
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Event.java
@@ -75,9 +75,6 @@ public class Event
     private MetadataIdentifier orgUnit;
 
     @JsonProperty
-    private String orgUnitName;
-
-    @JsonProperty
     @Builder.Default
     private List<Relationship> relationships = new ArrayList<>();
 


### PR DESCRIPTION
its a field exposed in our view on export. It has also no influence on an import as orgUnits are not created within tracker