### PR TITLE
chore: cleanup geneic object store

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GenericDimensionalObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GenericDimensionalObjectStore.java
@@ -52,4 +52,5 @@ public interface GenericDimensionalObjectStore<T>
      * @return a List of objects.
      */
     List<T> getByDataDimensionNoAcl( boolean dataDimension );
+
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
@@ -226,6 +226,15 @@ public interface IdentifiableObjectStore<T>
     List<T> getById( Collection<Long> ids );
 
     /**
+     * Retrieves a list of objects referenced by the given collection of ids.
+     *
+     * @param ids a collection of ids.
+     * @param user the {@link User} for sharing restrictions
+     * @return a list of objects.
+     */
+    List<T> getById( Collection<Long> ids, User user );
+
+    /**
      * Retrieves a list of objects referenced by the given collection of uids.
      *
      * @param uids a collection of uids.
@@ -239,6 +248,7 @@ public interface IdentifiableObjectStore<T>
      * Objects which are soft-deleted (deleted=true) are filtered out
      *
      * @param uids a collection of uids.
+     * @param user the {@link User} for sharing restrictions
      * @return a list of objects.
      */
     List<T> getByUid( Collection<String> uids, User user );
@@ -255,6 +265,7 @@ public interface IdentifiableObjectStore<T>
      * Retrieves a list of objects referenced by the given collection of codes.
      *
      * @param codes a collection of codes.
+     * @param user the {@link User} for sharing restrictions
      * @return a list of objects.
      */
     List<T> getByCode( Collection<String> codes, User user );
@@ -271,6 +282,7 @@ public interface IdentifiableObjectStore<T>
      * Retrieves a list of objects referenced by the given collection of names.
      *
      * @param names a collection of names.
+     * @param user the {@link User} for sharing restrictions
      * @return a list of objects.
      */
     List<T> getByName( Collection<String> names, User user );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserService.java
@@ -129,14 +129,7 @@ public class CurrentUserService
 
     public CurrentUserGroupInfo getCurrentUserGroupsInfo()
     {
-        User currentUser = getCurrentUser();
-        if ( currentUser == null )
-        {
-            return null;
-        }
-
-        return currentUserGroupInfoCache
-            .get( currentUser.getUsername(), this::getCurrentUserGroupsInfo );
+        return getCurrentUserGroupsInfo( getCurrentUser() );
     }
 
     public CurrentUserGroupInfo getCurrentUserGroupsInfo( User user )


### PR DESCRIPTION
Working on DHIS2-7171 I noticed a bit of code duplication in the `HibernateIdentifiableObjectStore` that goes back to having the same code once with and again without a user. This only had effect on the sharing filters added. If no user was supplied the current user would be fetched within the `getSharingPredicates` which would do `CurrentUserService#getCurrentUser()`. If we lift that out and do it on the outside the methods without users can simply call the ones with users passing the current user.

In addition I improved the code to build the `in` clause queries so they can reuse the same code as well as handling partitioned lookups.