### PR TITLE
chore: Clean up user management in tracker tests [TECH-890]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/hibernate/HibernateRelationshipStore.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.relationship.hibernate;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -40,6 +41,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Subquery;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -272,6 +274,11 @@ public class HibernateRelationshipStore extends SoftDeleteHibernateObjectStore<R
     @Override
     public List<String> getUidsByRelationshipKeys( List<String> relationshipKeyList )
     {
+        if ( CollectionUtils.isEmpty( relationshipKeyList ) )
+        {
+            return Collections.emptyList();
+        }
+
         List<Object> c = getSession().createNativeQuery( new StringBuilder().append( "SELECT R.uid " )
             .append( "FROM relationship R " )
             .append( "INNER JOIN relationshiptype RT ON RT.relationshiptypeid = R.relationshiptypeid " )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -63,7 +63,6 @@ import org.springframework.core.io.ClassPathResource;
 @Slf4j
 public abstract class TrackerTest extends TransactionalIntegrationTest
 {
-
     @Autowired
     protected IdentifiableObjectManager manager;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.validation.AbstractImportValidationTest.ADMIN_USER_UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,14 +48,11 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
-import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 class LastUpdateImportTest extends TrackerTest
 {
-
     @Autowired
     private TrackerImportService trackerImportService;
 
@@ -66,21 +62,18 @@ class LastUpdateImportTest extends TrackerTest
     @Autowired
     private TrackedEntityInstanceService trackedEntityInstanceService;
 
-    private static User superuser;
-
-    private static TrackedEntity trackedEntity;
+    private TrackedEntity trackedEntity;
 
     @Override
-    @Transactional
     protected void initTest()
         throws IOException
     {
         setUpMetadata( "tracker/simple_metadata.json" );
-        superuser = userService.getUser( "M5zQapPyTZI" );
-        TrackerImportParams trackerImportParams = fromJson( "tracker/single_tei.json", superuser.getUid() );
+        injectAdminUser();
+        TrackerImportParams trackerImportParams = fromJson( "tracker/single_tei.json" );
         assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
         trackedEntity = trackerImportParams.getTrackedEntities().get( 0 );
-        TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json", superuser.getUid() );
+        TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json" );
         assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
         manager.flush();
     }
@@ -89,7 +82,7 @@ class LastUpdateImportTest extends TrackerTest
     void shouldUpdateTeiIfTeiIsUpdated()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/single_tei.json", superuser.getUid() );
+        TrackerImportParams trackerImportParams = fromJson( "tracker/single_tei.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.UPDATE );
         Attribute attribute = Attribute.builder()
             .attribute( MetadataIdentifier.ofUid( "toUpdate000" ) )
@@ -107,8 +100,7 @@ class LastUpdateImportTest extends TrackerTest
     void shouldUpdateTeiIfEventIsUpdated()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json" );
         Date lastUpdateBefore = trackedEntityInstanceService
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() ).getLastUpdated();
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
@@ -126,7 +118,7 @@ class LastUpdateImportTest extends TrackerTest
     void shouldUpdateTeiIfEnrollmentIsUpdated()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/single_enrollment.json", superuser.getUid() );
+        TrackerImportParams trackerImportParams = fromJson( "tracker/single_enrollment.json" );
         Date lastUpdateBefore = trackedEntityInstanceService
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() ).getLastUpdated();
         Enrollment enrollment = trackerImportParams.getEnrollments().get( 0 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.validation.AbstractImportValidationTest.ADMIN_USER_UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,7 +46,6 @@ import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
-import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -65,9 +63,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         throws IOException
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
-        dbmsManager.clearSession();
-        TrackerImportParams params = fromJson( "tracker/tracker_basic_data_before_deletion.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        injectAdminUser();
+        TrackerImportParams params = fromJson( "tracker/tracker_basic_data_before_deletion.json" );
         assertEquals( 13, params.getTrackedEntities().size() );
         assertEquals( 2, params.getEnrollments().size() );
         assertEquals( 2, params.getEvents().size() );
@@ -81,22 +78,19 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         assertEquals( 6, manager.getAll( ProgramInstance.class ).size() );
         assertEquals( bundleReport.getTypeReportMap().get( TrackerType.EVENT ).getStats().getCreated(),
             manager.getAll( ProgramStageInstance.class ).size() );
+
+        dbmsManager.clearSession();
     }
 
     @Test
     void testTrackedEntityInstanceDeletion()
         throws IOException
     {
-        dbmsManager.clearSession();
-        User superUser = userService.getUser( ADMIN_USER_UID );
-        injectSecurityContext( superUser );
-
-        TrackerImportParams params = fromJson( "tracker/tracked_entity_basic_data_for_deletion.json", superUser );
+        TrackerImportParams params = fromJson( "tracker/tracked_entity_basic_data_for_deletion.json" );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
         assertEquals( 9, params.getTrackedEntities().size() );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         assertDeletedObjects( 9, trackerImportReport.getBundleReport(), TrackerType.TRACKED_ENTITY );
         // remaining
@@ -108,11 +102,8 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
     void testEnrollmentDeletion()
         throws IOException
     {
-        dbmsManager.clearSession();
-        User superUser = userService.getUser( ADMIN_USER_UID );
-        injectSecurityContext( superUser );
         assertEquals( 2, manager.getAll( ProgramStageInstance.class ).size() );
-        TrackerImportParams params = fromJson( "tracker/enrollment_basic_data_for_deletion.json", superUser );
+        TrackerImportParams params = fromJson( "tracker/enrollment_basic_data_for_deletion.json" );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
@@ -129,8 +120,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
     void testEventDeletion()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/event_basic_data_for_deletion.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams params = fromJson( "tracker/event_basic_data_for_deletion.json" );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
@@ -145,8 +135,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
     void testNonExistentEnrollment()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/non_existent_enrollment_basic_data_for_deletion.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams params = fromJson( "tracker/non_existent_enrollment_basic_data_for_deletion.json" );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport importReport = trackerImportService.importTracker( params );
@@ -161,8 +150,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
     void testDeleteMultipleEntities()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/tracker_data_for_deletion.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams params = fromJson( "tracker/tracker_data_for_deletion.json" );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.validation.AbstractImportValidationTest.ADMIN_USER_UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -48,7 +47,6 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
-import org.hisp.dhis.user.CurrentUserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -68,9 +66,6 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
     private IdentifiableObjectManager manager;
 
     @Autowired
-    private CurrentUserService currentUserService;
-
-    @Autowired
     private TrackedEntityAttributeValueAuditService attributeValueAuditService;
 
     @Override
@@ -78,6 +73,7 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         throws IOException
     {
         setUpMetadata( "tracker/te_program_with_tea_allow_audit_metadata.json" );
+        injectAdminUser();
     }
 
     @Test
@@ -85,7 +81,6 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
-        trackerImportParams.setUser( userService.getUser( ADMIN_USER_UID ) );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         logTrackerErrors( trackerImportReport );
@@ -108,7 +103,6 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
-        trackerImportParams.setUser( userService.getUser( ADMIN_USER_UID ) );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
@@ -117,7 +111,6 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         List<TrackedEntityAttribute> attributes1 = attributeValues1.stream()
             .map( TrackedEntityAttributeValue::getAttribute ).collect( Collectors.toList() );
         trackerImportParams = fromJson( "tracker/te_program_with_tea_null_data.json" );
-        trackerImportParams.setUser( userService.getUser( ADMIN_USER_UID ) );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.validation.AbstractImportValidationTest.ADMIN_USER_UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -74,6 +73,7 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
         throws IOException
     {
         setUpMetadata( "tracker/simple_metadata.json" );
+        injectAdminUser();
     }
 
     @Test
@@ -81,21 +81,18 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_and_enrollment_with_data_values.json" );
-        trackerImportParams.setUser( userService.getUser( ADMIN_USER_UID ) );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         logTrackerErrors( trackerImportReport );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
 
         trackerImportParams = fromJson( "tracker/event_with_data_values_for_update_audit.json" );
-        trackerImportParams.setUser( userService.getUser( ADMIN_USER_UID ) );
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         logTrackerErrors( trackerImportReport );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
 
         trackerImportParams = fromJson( "tracker/event_with_data_values_for_delete_audit.json" );
-        trackerImportParams.setUser( userService.getUser( ADMIN_USER_UID ) );
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         logTrackerErrors( trackerImportReport );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
@@ -28,40 +28,30 @@
 package org.hisp.dhis.tracker.bundle;
 
 import static org.awaitility.Awaitility.await;
-import static org.hisp.dhis.tracker.validation.AbstractImportValidationTest.ADMIN_USER_UID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.hisp.dhis.TransactionalIntegrationTest;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
-import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
+import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * @author Zubair Asghar
  */
-class TrackerSideEffectHandlerServiceTest extends TransactionalIntegrationTest
+class TrackerSideEffectHandlerServiceTest extends TrackerTest
 {
 
     @Autowired
@@ -83,22 +73,11 @@ class TrackerSideEffectHandlerServiceTest extends TransactionalIntegrationTest
     private IdentifiableObjectManager manager;
 
     @Override
-    protected void setUpTest()
+    protected void initTest()
         throws IOException
     {
-        renderService = _renderService;
-        userService = _userService;
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
-            new ClassPathResource( "tracker/tracker_metadata_with_program_rules.json" ).getInputStream(),
-            RenderFormat.JSON );
-        ObjectBundleParams params = new ObjectBundleParams();
-        params.setObjectBundleMode( ObjectBundleMode.COMMIT );
-        params.setImportStrategy( ImportStrategy.CREATE );
-        params.setObjects( metadata );
-        ObjectBundle bundle = objectBundleService.create( params );
-        ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertFalse( validationReport.hasErrorReports() );
-        objectBundleService.commit( bundle );
+        setUpMetadata( "tracker/tracker_metadata_with_program_rules.json" );
+        injectAdminUser();
     }
 
     @Test
@@ -106,15 +85,14 @@ class TrackerSideEffectHandlerServiceTest extends TransactionalIntegrationTest
     void testRuleEngineSideEffectHandlerService()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = renderService.fromJson(
-            new ClassPathResource( "tracker/enrollment_data_with_program_rule_side_effects.json" ).getInputStream(),
-            TrackerImportParams.class );
+        TrackerImportParams trackerImportParams = fromJson(
+            "tracker/enrollment_data_with_program_rule_side_effects.json" );
         assertEquals( 0, trackerImportParams.getEvents().size() );
         assertEquals( 1, trackerImportParams.getTrackedEntities().size() );
         TrackerImportParams params = TrackerImportParams.builder().events( trackerImportParams.getEvents() )
             .enrollments( trackerImportParams.getEnrollments() )
             .trackedEntities( trackerImportParams.getTrackedEntities() ).build();
-        params.setUserId( ADMIN_USER_UID );
+
         trackerImportService.importTracker( params );
         await().atMost( 2, TimeUnit.SECONDS )
             .until( () -> manager.getAll( ProgramNotificationInstance.class ).size() > 0 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleVariableIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleVariableIntegrationTest.java
@@ -47,7 +47,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * @author Zubair Asghar
  */
-public class ProgramRuleVariableIntegrationTest extends TrackerTest
+class ProgramRuleVariableIntegrationTest extends TrackerTest
 {
     @Autowired
     private ProgramRuleVariableService programRuleVariableService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleVariableIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleVariableIntegrationTest.java
@@ -28,78 +28,41 @@
 package org.hisp.dhis.tracker.programrule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
-import org.hisp.dhis.TransactionalIntegrationTest;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
-import org.hisp.dhis.render.RenderFormat;
-import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
-import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.tracker.TrackerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * @author Zubair Asghar
  */
-public class ProgramRuleVariableIntegrationTest extends TransactionalIntegrationTest
+public class ProgramRuleVariableIntegrationTest extends TrackerTest
 {
     @Autowired
-    private RenderService _renderService;
-
-    @Autowired
-    private UserService _userService;
-
-    @Autowired
     private ProgramRuleVariableService programRuleVariableService;
-
-    @Autowired
-    private ObjectBundleService objectBundleService;
 
     @Autowired
     private ProgramService programService;
 
     @Autowired
-    private ObjectBundleValidationService objectBundleValidationService;
-
-    @Autowired
     private TrackedEntityAttributeService trackedEntityAttributeService;
 
     @Override
-    public void setUpTest()
-        throws Exception
+    public void initTest()
+        throws IOException
     {
-        renderService = _renderService;
-        userService = _userService;
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
-            new ClassPathResource( "tracker/tracker_metadata_with_program_rules_variables.json" ).getInputStream(),
-            RenderFormat.JSON );
-        ObjectBundleParams params = new ObjectBundleParams();
-        params.setObjectBundleMode( ObjectBundleMode.COMMIT );
-        params.setImportStrategy( ImportStrategy.CREATE );
-        params.setObjects( metadata );
-        ObjectBundle bundle = objectBundleService.create( params );
-        ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertFalse( validationReport.hasErrorReports() );
-        objectBundleService.commit( bundle );
+        setUpMetadata( "tracker/tracker_metadata_with_program_rules_variables.json" );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
@@ -36,42 +36,35 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.List;
 
-import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
-import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-class EnrollmentAttrValidationTest extends AbstractImportValidationTest
+class EnrollmentAttrValidationTest extends TrackerTest
 {
-
     @Autowired
     protected TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Autowired
     private TrackerImportService trackerImportService;
 
-    @Autowired
-    private TrackedEntityAttributeService trackedEntityAttributeService;
-
     @Override
     protected void initTest()
         throws IOException
     {
         setUpMetadata( "tracker/tracker_basic_metadata_mandatory_attr.json" );
-        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data_2.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        User currentUser = currentUserService.getCurrentUser();
+        injectAdminUser();
+        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data_2.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         List<TrackerErrorReport> errors = trackerImportReport.getValidationReport().getErrors();
         errors.forEach( error -> {
@@ -87,10 +80,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void failValidationWhenTrackedEntityAttributeHasWrongOptionValue()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_with_invalid_option_value.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_with_invalid_option_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -101,9 +92,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void successValidationWhenTrackedEntityAttributeHasValidOptionValue()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_with_valid_option_value.json", userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_with_valid_option_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
@@ -112,9 +102,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesMissingUid()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_attr-missing-uuid.json", userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_attr-missing-uuid.json" );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
@@ -127,9 +116,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesMissingValues()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_attr-missing-value.json", userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_attr-missing-value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -140,8 +128,7 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesMissingTeA()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson( "tracker/validations/enrollments_te_attr-non-existing.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_attr-non-existing.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -152,9 +139,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesMissingMandatory()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_attr-missing-mandatory.json", userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_attr-missing-mandatory.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -165,9 +151,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesUniquenessInSameTei()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_unique_attr_same_tei.json", userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
@@ -176,23 +161,18 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesUniquenessAlreadyInDB()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
         manager.clear();
-        params = createBundleFromJson( "tracker/validations/enrollments_te_unique_attr_same_tei.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        params = fromJson( "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
         trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         manager.flush();
         manager.clear();
-        params = createBundleFromJson( "tracker/validations/enrollments_te_unique_attr_in_db.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        params = fromJson( "tracker/validations/enrollments_te_unique_attr_in_db.json" );
         trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -203,16 +183,13 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesUniquenessInDifferentTeis()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json",
-            userService.getUser( ADMIN_USER_UID ) );
+        TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
         manager.flush();
         manager.clear();
-        params = createBundleFromJson( "tracker/validations/enrollments_te_unique_attr.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        params = fromJson( "tracker/validations/enrollments_te_unique_attr.json" );
 
         trackerImportReport = trackerImportService.importTracker( params );
 
@@ -225,9 +202,8 @@ class EnrollmentAttrValidationTest extends AbstractImportValidationTest
     void testAttributesOnlyProgramAttrAllowed()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
-            "tracker/validations/enrollments_te_attr-only-program-attr.json", userService.getUser( ADMIN_USER_UID ) );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson(
+            "tracker/validations/enrollments_te_attr-only-program-attr.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -35,8 +35,10 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Every.everyItem;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.UPDATE;
+import static org.hisp.dhis.tracker.validation.Users.ADMIN_USER_UID;
+import static org.hisp.dhis.tracker.validation.Users.USER_2;
+import static org.hisp.dhis.tracker.validation.Users.USER_6;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -52,47 +54,30 @@ import java.util.stream.Stream;
 import lombok.SneakyThrows;
 
 import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleMode;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleParams;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleCommitReport;
-import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationReport;
-import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.render.RenderFormat;
-import org.hisp.dhis.render.RenderService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-class EventImportValidationTest extends AbstractImportValidationTest
+class EventImportValidationTest extends TrackerTest
 {
-
     @Autowired
     protected TrackedEntityInstanceService trackedEntityInstanceService;
-
-    @Autowired
-    private RenderService _renderService;
-
-    @Autowired
-    private UserService _userService;
 
     @Autowired
     private ProgramStageInstanceService programStageServiceInstance;
@@ -107,35 +92,19 @@ class EventImportValidationTest extends AbstractImportValidationTest
     }
 
     @Override
-    protected void setUpTest()
+    protected void initTest()
         throws IOException
     {
-        renderService = _renderService;
-        userService = _userService;
-        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
-            new ClassPathResource( "tracker/tracker_basic_metadata.json" ).getInputStream(), RenderFormat.JSON );
-        ObjectBundleParams params = new ObjectBundleParams();
-        params.setObjectBundleMode( ObjectBundleMode.COMMIT );
-        params.setImportStrategy( ImportStrategy.CREATE );
-        params.setObjects( metadata );
-        ObjectBundle bundle = objectBundleService.create( params );
-        ObjectBundleValidationReport validationReport = objectBundleValidationService.validate( bundle );
-        assertFalse( validationReport.hasErrorReports() );
-        ObjectBundleCommitReport commit = objectBundleService.commit( bundle );
-        assertFalse( commit.hasErrorReports() );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        setUpMetadata( "tracker/tracker_basic_metadata.json" );
+        injectAdminUser();
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/enrollments_te_te-data.json" );
-        User user = userService.getUser( ADMIN_USER_UID );
-        injectSecurityContext( user );
 
-        trackerImportParams.setUser( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        trackerImportParams = renderService.fromJson(
-            new ClassPathResource( "tracker/validations/enrollments_te_enrollments-data.json" ).getInputStream(),
-            TrackerImportParams.class );
-        trackerImportParams.setUser( user );
+        trackerImportParams = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
+
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
@@ -145,9 +114,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void failValidationWhenTrackedEntityAttributeHasWrongOptionValue()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson(
+        TrackerImportParams params = fromJson(
             "tracker/validations/events-with_invalid_option_value.json" );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -158,8 +126,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void successWhenTrackedEntityAttributeHasValidOptionValue()
         throws IOException
     {
-        TrackerImportParams params = createBundleFromJson( "tracker/validations/events-with_valid_option_value.json" );
-        params.setImportStrategy( TrackerImportStrategy.CREATE );
+        TrackerImportParams params = fromJson( "tracker/validations/events-with_valid_option_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
     }
@@ -168,10 +135,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testEventValidationOkAll()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
-            "tracker/validations/events-with-registration.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
-
+        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/events-with-registration.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
@@ -182,9 +146,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testEventValidationOkWithoutAttributeOptionCombo()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-without-attribute-option-combo.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -196,10 +159,9 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testTrackerAndProgramEventUpdateSuccess()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/program_and_tracker_events.json" );
 
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
@@ -216,11 +178,10 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testCantWriteAccessCatCombo()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/events-cat-write-access.json" );
         User user = userService.getUser( USER_6 );
         trackerImportParams.setUser( user );
-        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -237,11 +198,10 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testNoWriteAccessToOrg()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-with-registration.json" );
         User user = userService.getUser( USER_2 );
         trackerBundleParams.setUser( user );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -253,14 +213,10 @@ class EventImportValidationTest extends AbstractImportValidationTest
         throws IOException
     {
         TrackerImportParams trackerImportParams = fromJson(
-            "tracker/validations/events_non-repeatable-programstage_part1.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE );
+            "tracker/validations/events_non-repeatable-programstage_part1.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        trackerImportParams = fromJson( "tracker/validations/events_non-repeatable-programstage_part2.json",
-            userService.getUser( ADMIN_USER_UID ) );
-        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE );
+        trackerImportParams = fromJson( "tracker/validations/events_non-repeatable-programstage_part2.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -271,16 +227,15 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testWrongScheduledDateString()
     {
         assertThrows( IOException.class,
-            () -> createBundleFromJson( "tracker/validations/events_error-no-wrong-date.json" ) );
+            () -> fromJson( "tracker/validations/events_error-no-wrong-date.json" ) );
     }
 
     @Test
     void testEventProgramHasNonDefaultCategoryCombo()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_non-default-combo.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -293,9 +248,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testCategoryOptionComboNotFound()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_cant-find-cat-opt-combo.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -308,9 +262,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testCategoryOptionComboNotFoundGivenSubsetOfCategoryOptions()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_cant-find-aoc-with-subset-of-cos.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -323,9 +276,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testCOFoundButAOCNotFound()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_cant-find-aoc-but-co-exists.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -338,9 +290,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testCategoryOptionsNotFound()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_cant-find-cat-option.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -353,9 +304,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testAttributeCategoryOptionNotInProgramCC()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-aoc-not-in-program-cc.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -368,9 +318,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testAttributeCategoryOptionAndCODoNotMatch()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-aoc-and-co-dont-match.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -383,9 +332,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testAttributeCategoryOptionCannotBeFoundForEventProgramCCAndGivenCategoryOption()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -398,9 +346,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testWrongDatesInCatCombo()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_combo-date-wrong.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -464,7 +411,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
     }
 
     @Test
-    void testInserDeleteEventFails()
+    void testInsertDeleteEventFails()
     {
         testDeletedEventFails( CREATE_AND_UPDATE );
     }
@@ -478,7 +425,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
         assertNotNull( event );
         // When -> Soft-delete the event
         programStageServiceInstance.deleteProgramStageInstance( event );
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-with-notes-data.json" );
         trackerBundleParams.setImportStrategy( importStrategy );
         // When
@@ -492,9 +439,8 @@ class EventImportValidationTest extends AbstractImportValidationTest
     void testEventDeleteOk()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events-with-registration.json" );
-        trackerBundleParams.setImportStrategy( TrackerImportStrategy.CREATE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
@@ -504,7 +450,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
         manager.flush();
         manager.clear();
 
-        TrackerImportParams paramsDelete = createBundleFromJson(
+        TrackerImportParams paramsDelete = fromJson(
             "tracker/validations/event-data-delete.json" );
         paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
 
@@ -518,7 +464,7 @@ class EventImportValidationTest extends AbstractImportValidationTest
         throws IOException
     {
         // Given
-        TrackerImportParams trackerBundleParams = createBundleFromJson( jsonPayload );
+        TrackerImportParams trackerBundleParams = fromJson( jsonPayload );
         trackerBundleParams.setImportStrategy( CREATE_AND_UPDATE );
         // When
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Every.everyItem;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.UPDATE;
-import static org.hisp.dhis.tracker.validation.Users.ADMIN_USER_UID;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.validation.Users.USER_6;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -31,7 +31,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.hisp.dhis.tracker.validation.Users.ADMIN_USER_UID;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.validation.Users.USER_5;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -31,6 +31,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.validation.Users.ADMIN_USER_UID;
+import static org.hisp.dhis.tracker.validation.Users.USER_3;
+import static org.hisp.dhis.tracker.validation.Users.USER_4;
+import static org.hisp.dhis.tracker.validation.Users.USER_5;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -62,18 +66,18 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-class EventSecurityImportValidationTest extends AbstractImportValidationTest
+class EventSecurityImportValidationTest extends TrackerTest
 {
 
     @Autowired
@@ -135,17 +139,13 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         throws IOException
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        injectAdminUser();
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/enrollments_te_te-data.json" );
-        User user = userService.getUser( "M5zQapPyTZI" );
-        trackerBundleParams.setUser( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        trackerBundleParams = renderService.fromJson(
-            new ClassPathResource( "tracker/validations/enrollments_te_enrollments-data.json" ).getInputStream(),
-            TrackerImportParams.class );
-        trackerBundleParams.setUser( user );
+        trackerBundleParams = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
@@ -237,7 +237,7 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         throws IOException
     {
         setupMetadata();
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_error-no-programStage-access.json" );
         User user = userService.getUser( USER_3 );
         trackerBundleParams.setUser( user );
@@ -256,7 +256,7 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         throws IOException
     {
         setupMetadata();
-        TrackerImportParams params = createBundleFromJson( "tracker/validations/events_error-no-uncomplete.json" );
+        TrackerImportParams params = fromJson( "tracker/validations/events_error-no-uncomplete.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
         assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
@@ -265,7 +265,7 @@ class EventSecurityImportValidationTest extends AbstractImportValidationTest
         ProgramStageInstance zwwuwNp6gVd = programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" );
         zwwuwNp6gVd.setStatus( EventStatus.COMPLETED );
         manager.update( zwwuwNp6gVd );
-        TrackerImportParams trackerBundleParams = createBundleFromJson(
+        TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/events_error-no-uncomplete.json" );
         programA.setPublicAccess( AccessStringHelper.FULL );
         manager.update( programA );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.core.Every.everyItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.hisp.dhis.config.H2DhisConfigurationProvider;
+import org.hisp.dhis.encryption.EncryptionStatus;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.tracker.TrackerImportParams;
+import org.hisp.dhis.tracker.TrackerImportService;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerTest;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.hisp.dhis.tracker.report.TrackerStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TeTaEncryptionValidationTest extends TrackerTest
+{
+
+    @Autowired
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Autowired
+    private TrackerImportService trackerImportService;
+
+    @Override
+    protected void initTest()
+        throws IOException
+    {
+        setUpMetadata( "tracker/validations/te-program_with_tea_encryption_metadata.json" );
+        injectAdminUser();
+    }
+
+    @Test
+    void testEncryptedAttrFail()
+        throws IOException
+    {
+        TrackerImportParams trackerImportParams = fromJson(
+            "tracker/validations/te-program_with_tea_encryption_data.json" );
+        H2DhisConfigurationProvider dhisConfigurationProvider = (H2DhisConfigurationProvider) this.dhisConfigurationProvider;
+        dhisConfigurationProvider.setEncryptionStatus( EncryptionStatus.MISSING_ENCRYPTION_PASSWORD );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
+            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1112 ) ) ) );
+    }
+
+    @Test
+    void testUniqueFailInOrgUnit()
+        throws IOException
+    {
+        TrackerImportParams trackerImportParams = fromJson(
+            "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+
+        trackerImportParams = fromJson(
+            "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
+        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
+        trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        trackerImportParams = fromJson(
+            "tracker/validations/te-program_with_tea_unique_data_in_region.json" );
+        trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+    }
+
+    @Test
+    void testUniqueFail()
+        throws IOException
+    {
+        TrackerImportParams trackerImportParams = fromJson(
+            "tracker/validations/te-program_with_tea_unique_data.json" );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+
+        trackerImportParams = fromJson( "tracker/validations/te-program_with_tea_unique_data2.json" );
+        trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertThat( trackerImportReport.getValidationReport().getErrors(),
+            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
@@ -41,9 +41,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.config.H2DhisConfigurationProvider;
-import org.hisp.dhis.encryption.EncryptionStatus;
-import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceService;
@@ -52,23 +49,17 @@ import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-class TeTaValidationTest extends AbstractImportValidationTest
+class TeTaValidationTest extends TrackerTest
 {
-
-    @Autowired
-    private DhisConfigurationProvider dhisConfigurationProvider;
-
     @Autowired
     private TrackerImportService trackerImportService;
 
@@ -81,18 +72,25 @@ class TeTaValidationTest extends AbstractImportValidationTest
     @Autowired
     private FileResourceService fileResourceService;
 
+    @Override
+    protected void initTest()
+        throws IOException
+    {
+        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
+        injectAdminUser();
+    }
+
     @Test
     void testTrackedEntityProgramAttributeFileResourceValue()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
         FileResource fileResource = new FileResource( "test.pdf", "application/pdf", 0,
             "d41d8cd98f00b204e9800998ecf8427e", FileResourceDomain.DOCUMENT );
         fileResource.setUid( "Jzf6hHNP7jx" );
         File file = File.createTempFile( "file-resource", "test" );
         fileResourceService.saveFileResource( fileResource, file );
         assertFalse( fileResource.isAssigned() );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_fileresource_data.json" );
         trackerImportService.importTracker( trackerImportParams );
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
@@ -109,14 +107,13 @@ class TeTaValidationTest extends AbstractImportValidationTest
     void testFileAlreadyAssign()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
         FileResource fileResource = new FileResource( "test.pdf", "application/pdf", 0,
             "d41d8cd98f00b204e9800998ecf8427e", FileResourceDomain.DOCUMENT );
         fileResource.setUid( "Jzf6hHNP7jx" );
         File file = File.createTempFile( "file-resource", "test" );
         fileResourceService.saveFileResource( fileResource, file );
         assertFalse( fileResource.isAssigned() );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_fileresource_data.json" );
         trackerImportService.importTracker( trackerImportParams );
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
@@ -127,7 +124,7 @@ class TeTaValidationTest extends AbstractImportValidationTest
         assertEquals( 1, attributeValues.size() );
         fileResource = fileResourceService.getFileResource( fileResource.getUid() );
         assertTrue( fileResource.isAssigned() );
-        trackerImportParams = createBundleFromJson( "tracker/validations/te-program_with_tea_fileresource_data2.json" );
+        trackerImportParams = fromJson( "tracker/validations/te-program_with_tea_fileresource_data2.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -138,15 +135,9 @@ class TeTaValidationTest extends AbstractImportValidationTest
     void testNoFileRef()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_fileresource_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-
-        List<TrackerErrorReport> errors = trackerImportReport.getValidationReport().getErrors();
-        errors.forEach( error -> {
-            error.getMessage();
-        } );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -159,8 +150,7 @@ class TeTaValidationTest extends AbstractImportValidationTest
     void testTeaMaxTextValueLength()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_too_long_text_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
@@ -169,63 +159,10 @@ class TeTaValidationTest extends AbstractImportValidationTest
     }
 
     @Test
-    void testEncryptedAttrFail()
-        throws IOException
-    {
-        List<User> allUsers = userService.getAllUsers();
-        User currentUser = currentUserService.getCurrentUser();
-
-        setUpMetadata( "tracker/validations/te-program_with_tea_encryption_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
-            "tracker/validations/te-program_with_tea_encryption_data.json" );
-        H2DhisConfigurationProvider dhisConfigurationProvider = (H2DhisConfigurationProvider) this.dhisConfigurationProvider;
-        dhisConfigurationProvider.setEncryptionStatus( EncryptionStatus.MISSING_ENCRYPTION_PASSWORD );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1112 ) ) ) );
-    }
-
-    @Test
-    void testUniqueFailInOrgUnit()
-        throws IOException
-    {
-        setUpMetadata( "tracker/validations/te-program_with_tea_encryption_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
-            "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
-        trackerImportService.importTracker( trackerImportParams );
-        trackerImportParams = createBundleFromJson(
-            "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
-        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        trackerImportParams = createBundleFromJson(
-            "tracker/validations/te-program_with_tea_unique_data_in_region.json" );
-        trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-    }
-
-    @Test
-    void testUniqueFail()
-        throws IOException
-    {
-        setUpMetadata( "tracker/validations/te-program_with_tea_encryption_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
-            "tracker/validations/te-program_with_tea_unique_data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        trackerImportParams = createBundleFromJson( "tracker/validations/te-program_with_tea_unique_data2.json" );
-        trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
-    }
-
-    @Test
     void testTeaInvalidFormat()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_invalid_format_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
@@ -237,8 +174,7 @@ class TeTaValidationTest extends AbstractImportValidationTest
     void testTeaInvalidImage()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program_with_tea_fileresource_metadata.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_invalid_image_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
@@ -252,8 +188,7 @@ class TeTaValidationTest extends AbstractImportValidationTest
     void testTeaIsNull()
         throws IOException
     {
-        setUpMetadata( "tracker/validations/te-program-with-tea-mandatory-image.json" );
-        TrackerImportParams trackerImportParams = createBundleFromJson(
+        TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_invalid_value_isnull.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/Users.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/Users.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.tracker.validation;
 
 public class Users
 {
-    public static final String ADMIN_USER_UID = "M5zQapPyTZI";
-
     public static final String USER_1 = "oZZ43IHxuUM";
 
     public static final String USER_2 = "MbkW4Bhfw7o";

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/Users.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/Users.java
@@ -27,33 +27,8 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import java.io.IOException;
-
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleService;
-import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundleValidationService;
-import org.hisp.dhis.tracker.TrackerImportParams;
-import org.hisp.dhis.tracker.TrackerTest;
-import org.hisp.dhis.tracker.bundle.TrackerBundleService;
-import org.hisp.dhis.user.User;
-import org.springframework.beans.factory.annotation.Autowired;
-
-/**
- * @author Morten Svanæs <msvanaes@dhis2.org>
- */
-public abstract class AbstractImportValidationTest extends TrackerTest
+public class Users
 {
-    @Autowired
-    protected TrackerBundleService trackerBundleService;
-
-    @Autowired
-    protected ObjectBundleService objectBundleService;
-
-    @Autowired
-    protected ObjectBundleValidationService objectBundleValidationService;
-
-    @Autowired
-    protected DefaultTrackerValidationService trackerValidationService;
-
     public static final String ADMIN_USER_UID = "M5zQapPyTZI";
 
     public static final String USER_1 = "oZZ43IHxuUM";
@@ -71,25 +46,4 @@ public abstract class AbstractImportValidationTest extends TrackerTest
     public static final String USER_7 = "E5AiPnHG3t5";
 
     public static final String USER_8 = "xbgFeL0l3Ap";
-
-    protected TrackerImportParams createBundleFromJson( String jsonFile )
-        throws IOException
-    {
-        return createBundleFromJson( jsonFile, userService.getUser( ADMIN_USER_UID ) );
-    }
-
-    protected TrackerImportParams createBundleFromJson( String jsonFile, User user )
-        throws IOException
-    {
-        TrackerImportParams params = _fromJson( jsonFile );
-        params.setUser( user );
-
-        return params;
-    }
-
-    @Override
-    protected void initTest()
-        throws IOException
-    {
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_metadata.json
@@ -309,6 +309,39 @@
       "trackedEntityTypeAttributes": [
         {
           "lastUpdated": "2020-02-25T10:54:34.965",
+          "id": "fOV8XA0v4IM",
+          "created": "2020-02-10T09:12:52.050",
+          "name": "Person Attribute_Image",
+          "displayName": "Person Attribute_Image",
+          "displayShortName": "null Attribute_Image",
+          "mandatory": true,
+          "externalAccess": false,
+          "valueType": "DATE",
+          "searchable": true,
+          "displayInList": true,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "trackedEntityAttribute": {
+            "id": "ccccc5ttttt"
+          },
+          "trackedEntityType": {
+            "id": "KrYIdvLxkMb"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2020-02-25T10:54:34.965",
           "id": "fOV8XA0v4ep",
           "created": "2020-02-10T09:12:52.050",
           "name": "Person Attribute_Date",
@@ -576,6 +609,36 @@
         "id": "M5zQapPyTZI"
       },
       "programTrackedEntityAttributes": [
+        {
+          "lastUpdated": "2020-02-20T12:08:40.006",
+          "id": "OQeqChgVcIM",
+          "created": "2020-02-12T15:07:06.260",
+          "name": "Program Attribute_Identifier_Image",
+          "displayName": "Program Attribute_Identifier_Image",
+          "mandatory": true,
+          "displayShortName": "Program Attribute_Identifier_Image",
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "valueType": "IMAGE",
+          "searchable": false,
+          "displayInList": true,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "program": {
+            "id": "hJUBNVQWl4e"
+          },
+          "trackedEntityAttribute": {
+            "id": "ccccc5ttttt"
+          }
+        },
         {
           "lastUpdated": "2020-02-20T12:08:40.006",
           "id": "OQeqChgVcMi",

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_fileresource_metadata.json
@@ -55,6 +55,33 @@
     },
     {
       "lastUpdated": "2020-02-10T10:08:27.188",
+      "id": "ccccc5tttXX",
+      "created": "2020-02-10T09:12:11.348",
+      "name": "Attribute_Image_Mandatory",
+      "shortName": "Attribute_Image_Mandatory",
+      "publicAccess": "rw------",
+      "aggregationType": "COUNT",
+      "skipSynchronization": false,
+      "generated": false,
+      "valueType": "IMAGE",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    },
+    {
+      "lastUpdated": "2020-02-10T10:08:27.188",
       "id": "tTttt5ttttt",
       "created": "2020-02-10T09:12:11.348",
       "name": "Attribute_Generated",
@@ -314,9 +341,9 @@
           "name": "Person Attribute_Image",
           "displayName": "Person Attribute_Image",
           "displayShortName": "null Attribute_Image",
-          "mandatory": true,
+          "mandatory": false,
           "externalAccess": false,
-          "valueType": "DATE",
+          "valueType": "IMAGE",
           "searchable": true,
           "displayInList": true,
           "favorite": false,
@@ -504,6 +531,63 @@
       ],
       "translations": [],
       "userAccesses": []
+    },
+    {
+      "created": "2020-02-10T09:09:22.093",
+      "lastUpdated": "2020-02-25T10:54:34.963",
+      "name": "Person2",
+      "id": "KrYIdvLxkMC",
+      "publicAccess": "rwrw----",
+      "maxTeiCountToReturn": 0,
+      "allowAuditLog": false,
+      "featureType": "NONE",
+      "minAttributesRequiredToSearch": 1,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "style": {},
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "trackedEntityTypeAttributes": [
+        {
+          "lastUpdated": "2020-02-25T10:54:34.965",
+          "id": "fOV8XA0v4XX",
+          "created": "2020-02-10T09:12:52.050",
+          "name": "Person Attribute",
+          "displayName": "Person Attribute",
+          "displayShortName": "null Attribute_Image",
+          "mandatory": true,
+          "externalAccess": false,
+          "valueType": "IMAGE",
+          "searchable": true,
+          "displayInList": true,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "trackedEntityAttribute": {
+            "id": "ccccc5tttXX"
+          },
+          "trackedEntityType": {
+            "id": "KrYIdvLxkMC"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        }
+      ],
+      "translations": [],
+      "userAccesses": []
     }
   ],
   "categoryOptions": [
@@ -615,7 +699,7 @@
           "created": "2020-02-12T15:07:06.260",
           "name": "Program Attribute_Identifier_Image",
           "displayName": "Program Attribute_Identifier_Image",
-          "mandatory": true,
+          "mandatory": false,
           "displayShortName": "Program Attribute_Identifier_Image",
           "externalAccess": false,
           "renderOptionsAsRadio": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_invalid_value_isnull.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/validations/te-program_with_tea_invalid_value_isnull.json
@@ -35,7 +35,7 @@
       "trackedEntity": "cNEZTkdAvre",
       "trackedEntityType": {
         "idScheme": "UID",
-        "identifier": "KrYIdvLxkMb"
+        "identifier": "KrYIdvLxkMC"
       },
       "createdAtClient": "2020-02-20T12:09:21.844",
       "orgUnit": {
@@ -50,7 +50,7 @@
         {
           "attribute": {
             "idScheme": "UID",
-            "identifier": "ccccc5ttttt"
+            "identifier": "ccccc5tttXX"
           },
           "displayName": "Attribute_Image",
           "storedBy": "admin"

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -230,6 +230,8 @@ public abstract class DhisConvenienceTest
 
     private static final String EXT_TEST_DIR = System.getProperty( "user.home" ) + File.separator + "dhis2_test_dir";
 
+    public static final String ADMIN_USER_UID = "M5zQapPyTZI";
+
     public static final String DEFAULT_ADMIN_PASSWORD = "district";
 
     public static final String DEFAULT_USERNAME = "admin";
@@ -2573,7 +2575,7 @@ public abstract class DhisConvenienceTest
 
     protected void injectAdminUser()
     {
-        injectSecurityContext( userService.getUser( "M5zQapPyTZI" ) );
+        injectSecurityContext( userService.getUser( ADMIN_USER_UID ) );
     }
 
     protected void injectSecurityContext( User user )

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2543,7 +2543,7 @@ public abstract class DhisConvenienceTest
 
         User user = createUser( username );
         user.setUuid( UUID.fromString( "6507f586-f154-4ec1-a25e-d7aa51de5216" ) );
-        user.setUid( "M5zQapPyTZI" );
+        user.setUid( ADMIN_USER_UID );
         user.setName( "Admin" );
         user.setUsername( username );
         user.setPassword( password );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -2528,6 +2528,11 @@ public abstract class DhisConvenienceTest
         return user;
     }
 
+    protected void injectAdminUser()
+    {
+        injectSecurityContext( userService.getUser( "M5zQapPyTZI" ) );
+    }
+
     protected void injectSecurityContext( User user )
     {
         if ( user == null )


### PR DESCRIPTION
This PR is just cleaning up a little bit the tests in tracker module fundamentally doing 2 things:

- Removing `AbstractImportValidationTest` as it was just an indirection for `TrackerTest` injecting admin user in tracker params. Now admin user is explicitly injected in the setup using `injectAdminUser()` method.
- Make some remaining tests extends TrackerTest in order to remove redundant code

