### PR TITLE
feat: GeoJSON import - delete with null geometry [DHIS2-7171]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/GeoJsonService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/GeoJsonService.java
@@ -30,10 +30,19 @@ package org.hisp.dhis.dxf2.geojson;
 import java.io.InputStream;
 
 /**
+ * Service for handling import/export of GeoJSON.
  *
  * @author Jan Bernitt
  */
 public interface GeoJsonService
 {
+    /**
+     * Imports the data provided as {@link InputStream}.
+     *
+     * @param params on how to process and match the data to organisation units
+     * @param geoJsonData expected to be a GeoJSON feature-collection root
+     *        object
+     * @return a report with statistics and conflicts
+     */
     GeoJsonImportReport importGeoData( GeoJsonImportParams params, InputStream geoJsonData );
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/GeoJsonImportController.java
@@ -60,6 +60,7 @@ import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -140,6 +141,16 @@ public class GeoJsonImportController
         return toWebMessage( geoJsonService.importGeoData( params,
             toInputStream( format( "{\"features\":[{\"id\":\"%s\",\"geometry\":%s}]}", ou, geometry ),
                 StandardCharsets.UTF_8 ) ) );
+    }
+
+    @DeleteMapping( value = "/{uid}/geometry" )
+    public WebMessage deleteImportSingle(
+        @PathVariable( "uid" ) String ou,
+        @RequestParam( required = false ) String attributeId,
+        @RequestParam( required = false ) boolean dryRun,
+        @CurrentUser User currentUser )
+    {
+        return postImportSingle( ou, attributeId, dryRun, "null", currentUser );
     }
 
     private WebMessage toWebMessage( GeoJsonImportReport report )


### PR DESCRIPTION
### Summary
After a chat with Björn we concluded that using JSON `null` value for the `geometry` of a GeoJSON feature node should effectively delete the geometry present. This is either setting `geometry` of the organisation unit to `null` or removes the attribute of the provided ID.

API wise deletion can also be done by using HTTP `DELETE` 

    DELETE /api/organisationUnits/{uid}/geometry

### Automatic Testing
New test scenarios were added to test deletion.
One scenario tests geometry property deletion, another one attribute deletion.
As these use the HTTP DELETE path this also tests single delete with `null` as body.
As single update is just turned into a bulk update with one entry internally this also tests bulk deletetion.
