### PR TITLE
fix: report ids or attribute value for MetadataIdentifiers DHIS2-12519

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
+@Value
 @Builder
 public class TrackerErrorReport
 {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerReportUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerReportUtils.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
@@ -66,6 +67,10 @@ class TrackerReportUtils
         if ( String.class.isAssignableFrom( ObjectUtils.firstNonNull( argument, "NULL" ).getClass() ) )
         {
             return ObjectUtils.firstNonNull( argument, "NULL" ).toString();
+        }
+        else if ( MetadataIdentifier.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return ((MetadataIdentifier) argument).getIdentifierOrAttributeValue();
         }
         else if ( IdentifiableObject.class.isAssignableFrom( argument.getClass() ) )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -46,13 +46,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Enrico Colasante
  */
-@Data
+@Value
 @Builder
 public class TrackerWarningReport
 {
     private final String warningMessage;
 
-    private TrackerErrorCode warningCode;
+    private final TrackerErrorCode warningCode;
 
     private final TrackerType trackerType;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
-import lombok.Data;
+import lombok.Value;
 
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
@@ -48,7 +48,7 @@ import org.hisp.dhis.tracker.validation.ValidationFailFastException;
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-@Data
+@Value
 // TODO: should this be "ValidationReporter" since it does not only report
 // errors ?
 public class ValidationErrorReporter

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -132,14 +132,12 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         if ( optionalTrackedAttr.isPresent() )
         {
             reporter.addErrorIfNull( attribute.getValue(), enrollment, E1076,
-                TrackedEntityAttribute.class.getSimpleName(),
-                attribute.getAttribute().getIdentifierOrAttributeValue() );
+                TrackedEntityAttribute.class.getSimpleName(), attribute.getAttribute() );
         }
 
         TrackedEntityAttribute teAttribute = reporter.getBundle().getPreheat()
             .getTrackedEntityAttribute( attribute.getAttribute() );
-        reporter.addErrorIfNull( teAttribute, enrollment, E1006,
-            attribute.getAttribute().getIdentifierOrAttributeValue() );
+        reporter.addErrorIfNull( teAttribute, enrollment, E1006, attribute.getAttribute() );
     }
 
     private void validateMandatoryAttributes( ValidationErrorReporter reporter,
@@ -175,17 +173,14 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             .map( Map.Entry::getKey )
             .forEach( mandatoryProgramAttribute -> reporter.addErrorIf(
                 () -> !mergedAttributes.contains( mandatoryProgramAttribute ),
-                enrollment, E1018,
-                mandatoryProgramAttribute.getIdentifierOrAttributeValue(), program.getUid(),
-                enrollment.getEnrollment() ) );
+                enrollment, E1018, mandatoryProgramAttribute, program.getUid(), enrollment.getEnrollment() ) );
 
         // enrollment must not contain any attribute which is not defined in
         // program
         enrollmentNonEmptyAttributes
             .forEach(
                 ( attrId, attrVal ) -> reporter.addErrorIf( () -> !programAttributesMap.containsKey( attrId ),
-                    enrollment, E1019,
-                    attrId.getIdentifierOrAttributeValue() + "=" + attrVal ) );
+                    enrollment, E1019, attrId.getIdentifierOrAttributeValue() + "=" + attrVal ) );
     }
 
     private Set<MetadataIdentifier> buildTeiAttributes( ValidationErrorReporter reporter,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -105,7 +105,7 @@ public class EventDataValuesValidationHook
         List<MetadataIdentifier> missingDataValue = validateMandatoryDataValue( programStage, event,
             mandatoryDataElements );
         missingDataValue
-            .forEach( de -> reporter.addError( event, E1303, de.getIdentifierOrAttributeValue() ) );
+            .forEach( de -> reporter.addError( event, E1303, de ) );
     }
 
     private void validateDataValue( ValidationErrorReporter reporter, DataElement dataElement,
@@ -184,8 +184,7 @@ public class EventDataValuesValidationHook
         {
             if ( !dataElements.contains( payloadDataElement ) )
             {
-                reporter.addError( event, TrackerErrorCode.E1305, payloadDataElement.getIdentifierOrAttributeValue(),
-                    programStage.getUid() );
+                reporter.addError( event, TrackerErrorCode.E1305, payloadDataElement, programStage.getUid() );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -229,7 +229,7 @@ public class PreCheckDataRelationsValidationHook
         {
             if ( preheat.getCategoryOption( id ) == null )
             {
-                reporter.addError( event, E1116, id.getIdentifierOrAttributeValue() );
+                reporter.addError( event, E1116, id );
                 allCOsExist = false;
             }
         }
@@ -291,8 +291,8 @@ public class PreCheckDataRelationsValidationHook
             .getCategoryOptionCombo( event.getAttributeOptionCombo() );
         if ( !program.getCategoryCombo().equals( aoc.getCategoryCombo() ) )
         {
-            reporter.addError( event, TrackerErrorCode.E1054,
-                event.getAttributeOptionCombo().getIdentifierOrAttributeValue(), program.getCategoryCombo() );
+            reporter.addError( event, TrackerErrorCode.E1054, event.getAttributeOptionCombo(),
+                program.getCategoryCombo() );
             return false;
         }
 
@@ -374,7 +374,7 @@ public class PreCheckDataRelationsValidationHook
         else
         {
             reporter.addError( event, TrackerErrorCode.E1117,
-                event.getAttributeOptionCombo().getIdentifierOrAttributeValue(),
+                event.getAttributeOptionCombo(),
                 event.getAttributeCategoryOptions().stream().map( MetadataIdentifier::getIdentifierOrAttributeValue )
                     .collect( Collectors.toSet() ).toString() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -83,7 +83,7 @@ public class PreCheckMetaValidationHook
         reporter.addErrorIfNull( organisationUnit, enrollment, E1070, enrollment.getOrgUnit() );
 
         Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
-        reporter.addErrorIfNull( program, enrollment, E1069, enrollment.getProgram().getIdentifierOrAttributeValue() );
+        reporter.addErrorIfNull( program, enrollment, E1069, enrollment.getProgram() );
 
         reporter.addErrorIf( () -> !trackedEntityInstanceExist( reporter.getBundle(), enrollment.getTrackedEntity() ),
             enrollment,
@@ -97,8 +97,7 @@ public class PreCheckMetaValidationHook
         reporter.addErrorIfNull( organisationUnit, event, E1011, event.getOrgUnit() );
 
         Program program = reporter.getBundle().getPreheat().getProgram( event.getProgram() );
-        reporter.addErrorIfNull( program, event, E1010,
-            event.getProgram().getIdentifierOrAttributeValue() );
+        reporter.addErrorIfNull( program, event, E1010, event.getProgram() );
 
         ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
         reporter.addErrorIfNull( programStage, event, E1013, event.getProgramStage() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -185,10 +185,8 @@ public class RelationshipsValidationHook
 
                             if ( !type.isEqualTo( constraint.getTrackedEntityType() ) )
                             {
-                                reporter.addError( relationship,
-                                    TrackerErrorCode.E4014, relSide,
-                                    type.identifierOf( constraint.getTrackedEntityType() ),
-                                    type.getIdentifierOrAttributeValue() );
+                                reporter.addError( relationship, TrackerErrorCode.E4014, relSide,
+                                    type.identifierOf( constraint.getTrackedEntityType() ), type );
                             }
 
                         } );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -73,8 +73,7 @@ public class RepeatedEventsValidationHook
             {
                 for ( Event event : mapEntry.getValue() )
                 {
-                    reporter.addError( event, TrackerErrorCode.E1039,
-                        mapEntry.getKey().getLeft().getIdentifierOrAttributeValue() );
+                    reporter.addError( event, TrackerErrorCode.E1039, mapEntry.getKey().getLeft() );
                 }
             }
         }
@@ -95,7 +94,7 @@ public class RepeatedEventsValidationHook
             && reporter.getBundle().getPreheat().hasProgramStageWithEvents( event.getProgramStage(),
                 event.getEnrollment() ) )
         {
-            reporter.addError( event, TrackerErrorCode.E1039, event.getProgramStage().getIdentifierOrAttributeValue() );
+            reporter.addError( event, TrackerErrorCode.E1039, event.getProgramStage() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -140,7 +140,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
 
             if ( tea == null )
             {
-                reporter.addError( trackedEntity, E1006, attribute.getAttribute().getIdentifierOrAttributeValue() );
+                reporter.addError( trackedEntity, E1006, attribute.getAttribute() );
                 continue;
             }
 
@@ -155,7 +155,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
 
                 if ( optionalTea.isPresent() )
                     reporter.addError( trackedEntity, E1076, TrackedEntityAttribute.class.getSimpleName(),
-                        attribute.getAttribute().getIdentifierOrAttributeValue() );
+                        attribute.getAttribute() );
 
                 continue;
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerReportUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerReportUtilsTest.java
@@ -58,7 +58,9 @@ class TrackerReportUtilsTest
     void buildArgumentListShouldTurnInstantIntoArgument()
     {
         final Instant now = Instant.now();
+
         List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList( now ) );
+
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateUtils.getIso8601NoTz( DateUtils.fromInstant( now ) ) ) );
     }
@@ -67,7 +69,9 @@ class TrackerReportUtilsTest
     void buildArgumentListShouldTurnDateIntoArgument()
     {
         final Date now = Date.from( Instant.now() );
+
         List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList( now ) );
+
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateFormat.getInstance().format( now ) ) );
     }
@@ -76,6 +80,7 @@ class TrackerReportUtilsTest
     void buildArgumentListShouldTurnStringsIntoArguments()
     {
         List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList( "foo", "faa" ) );
+
         assertThat( args, contains( "foo", "faa" ) );
     }
 
@@ -84,6 +89,7 @@ class TrackerReportUtilsTest
     {
         List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList(
             MetadataIdentifier.ofUid( "iB8AZpf681V" ), MetadataIdentifier.ofAttribute( "zwccdzhk5zc", "GREEN" ) ) );
+
         assertThat( args, contains( "iB8AZpf681V", "GREEN" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerReportUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerReportUtilsTest.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,5 +77,13 @@ class TrackerReportUtilsTest
     {
         List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList( "foo", "faa" ) );
         assertThat( args, contains( "foo", "faa" ) );
+    }
+
+    @Test
+    void buildArgumentListShouldTurnMetadataIdentifierIntoArguments()
+    {
+        List<String> args = TrackerReportUtils.buildArgumentList( bundle, Arrays.asList(
+            MetadataIdentifier.ofUid( "iB8AZpf681V" ), MetadataIdentifier.ofAttribute( "zwccdzhk5zc", "GREEN" ) ) );
+        assertThat( args, contains( "iB8AZpf681V", "GREEN" ) );
     }
 }


### PR DESCRIPTION
which will already be in the user defined idScheme.

This way we do not have to remember calling `.getIdentifierOrAttributeValue()` when adding error/warning reports.