### PR TITLE
chore: ValidationErrorReporter only needs idSchemes DHIS2-12519

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java
@@ -94,12 +94,6 @@ public class TrackerIdSchemeParam
         throw new RuntimeException( "Unhandled identifier type." );
     }
 
-    public <T extends IdentifiableObject> String getIdAndName( T object )
-    {
-        String identifier = getIdentifier( object );
-        return object.getClass().getSimpleName() + " (" + identifier + ")";
-    }
-
     /**
      * Creates an identifier for given {@code metadata} using this idScheme
      * parameter. This means the metadata identifier will have the this

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.FlushMode;
-import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
@@ -81,12 +80,6 @@ public class TrackerBundle
      */
     @Builder.Default
     private TrackerBundleMode importMode = TrackerBundleMode.COMMIT;
-
-    /**
-     * What identifiers to match on.
-     */
-    @Builder.Default
-    private TrackerIdScheme identifier = TrackerIdScheme.UID;
 
     /**
      * Sets import strategy (create, update, etc).

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -37,8 +37,8 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -110,11 +110,11 @@ public class TrackerErrorReport
             return this;
         }
 
-        public TrackerErrorReport build( TrackerBundle bundle )
+        public TrackerErrorReport build( TrackerIdSchemeParams idSchemes )
         {
             return new TrackerErrorReport(
                 MessageFormat.format( errorCode.getMessage(),
-                    buildArgumentList( bundle, arguments ).toArray( new Object[0] ) ),
+                    buildArgumentList( idSchemes, arguments ).toArray( new Object[0] ) ),
                 this.errorCode, this.trackerType, this.uid );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerReportUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerReportUtils.java
@@ -34,9 +34,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObject;
-import org.hisp.dhis.tracker.TrackerIdSchemeParam;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -55,14 +60,12 @@ class TrackerReportUtils
         // not meant to be inherited from
     }
 
-    protected static List<String> buildArgumentList( TrackerBundle bundle, List<Object> arguments )
+    protected static List<String> buildArgumentList( TrackerIdSchemeParams params, List<Object> arguments )
     {
-        final TrackerIdSchemeParam idSchemeParam = TrackerIdSchemeParam.builder().idScheme( bundle.getIdentifier() )
-            .build();
-        return arguments.stream().map( arg -> parseArgs( idSchemeParam, arg ) ).collect( Collectors.toList() );
+        return arguments.stream().map( arg -> parseArgs( params, arg ) ).collect( Collectors.toList() );
     }
 
-    private static String parseArgs( TrackerIdSchemeParam idSchemeParam, Object argument )
+    private static String parseArgs( TrackerIdSchemeParams idSchemeParams, Object argument )
     {
         if ( String.class.isAssignableFrom( ObjectUtils.firstNonNull( argument, "NULL" ).getClass() ) )
         {
@@ -72,9 +75,39 @@ class TrackerReportUtils
         {
             return ((MetadataIdentifier) argument).getIdentifierOrAttributeValue();
         }
+        else if ( CategoryOptionCombo.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (CategoryOptionCombo) argument ),
+                (CategoryOptionCombo) argument );
+        }
+        else if ( CategoryOption.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (CategoryOption) argument ),
+                (CategoryOption) argument );
+        }
+        else if ( DataElement.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (DataElement) argument ),
+                (DataElement) argument );
+        }
+        else if ( OrganisationUnit.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (OrganisationUnit) argument ),
+                (OrganisationUnit) argument );
+        }
+        else if ( Program.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (Program) argument ), (Program) argument );
+        }
+        else if ( ProgramStage.class.isAssignableFrom( argument.getClass() ) )
+        {
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (ProgramStage) argument ),
+                (ProgramStage) argument );
+        }
         else if ( IdentifiableObject.class.isAssignableFrom( argument.getClass() ) )
         {
-            return idSchemeParam.getIdAndName( (IdentifiableObject) argument );
+            return getIdAndName( idSchemeParams.toMetadataIdentifier( (IdentifiableObject) argument ),
+                (IdentifiableObject) argument );
         }
         else if ( Date.class.isAssignableFrom( argument.getClass() ) )
         {
@@ -102,4 +135,10 @@ class TrackerReportUtils
 
         return StringUtils.EMPTY;
     }
+
+    private static <T extends IdentifiableObject> String getIdAndName( MetadataIdentifier identifier, T object )
+    {
+        return object.getClass().getSimpleName() + " (" + identifier.getIdentifierOrAttributeValue() + ")";
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
@@ -37,8 +37,8 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Value;
 
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -109,10 +109,11 @@ public class TrackerWarningReport
             return this;
         }
 
-        public TrackerWarningReport build( TrackerBundle bundle )
+        public TrackerWarningReport build( TrackerIdSchemeParams idSchemes )
         {
             return new TrackerWarningReport( MessageFormat.format( warningCode.getMessage(),
-                buildArgumentList( bundle, arguments ).toArray( new Object[0] ) ), this.warningCode, trackerType, uid );
+                buildArgumentList( idSchemes, arguments ).toArray( new Object[0] ) ), this.warningCode, trackerType,
+                uid );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -36,6 +36,7 @@ import java.util.function.Predicate;
 
 import lombok.Value;
 
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -61,6 +62,8 @@ public class ValidationErrorReporter
 
     private final TrackerBundle bundle;
 
+    private final TrackerIdSchemeParams idSchemes;
+
     /*
      * A map that keep tracks of all the invalid Tracker objects encountered
      * during the validation process
@@ -78,6 +81,7 @@ public class ValidationErrorReporter
         this.reportList = new ArrayList<>();
         this.isFailFast = false;
         this.bundle = null;
+        this.idSchemes = TrackerIdSchemeParams.builder().build();
         this.invalidDTOs = new HashMap<>();
     }
 
@@ -87,6 +91,7 @@ public class ValidationErrorReporter
         this.warningsReportList = new ArrayList<>();
         this.isFailFast = bundle.getValidationMode() == ValidationMode.FAIL_FAST;
         this.bundle = bundle;
+        this.idSchemes = bundle.getPreheat().getIdSchemes();
         this.invalidDTOs = new HashMap<>();
     }
 
@@ -117,7 +122,7 @@ public class ValidationErrorReporter
             .trackerType( dto.getTrackerType() )
             .errorCode( code )
             .addArgs( args )
-            .build( bundle );
+            .build( idSchemes );
         addError( error );
     }
 
@@ -159,7 +164,7 @@ public class ValidationErrorReporter
             .trackerType( dto.getTrackerType() )
             .warningCode( code )
             .addArgs( args )
-            .build( bundle );
+            .build( idSchemes );
         addWarning( warn );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -38,12 +38,10 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 
@@ -99,15 +97,7 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
 
         if ( error != null )
         {
-            TrackerBundle bundle = reporter.getBundle();
-            TrackerErrorReport err = TrackerErrorReport.builder()
-                .uid( dto.getUid() )
-                .trackerType( dto.getTrackerType() )
-                .errorCode( TrackerErrorCode.E1007 )
-                .addArg( valueType.toString() )
-                .addArg( error )
-                .build( bundle );
-            reporter.addError( err );
+            reporter.addError( dto, TrackerErrorCode.E1007, valueType, error );
         }
     }
 
@@ -142,15 +132,7 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
                 && hasTheSameValue
                 && isNotSameTei )
             {
-                TrackerBundle bundle = reporter.getBundle();
-                TrackerErrorReport err = TrackerErrorReport.builder()
-                    .uid( dto.getUid() )
-                    .trackerType( dto.getTrackerType() )
-                    .errorCode( TrackerErrorCode.E1064 )
-                    .addArg( value )
-                    .addArg( trackedEntityAttribute.getUid() )
-                    .build( bundle );
-                reporter.addError( err );
+                reporter.addError( dto, TrackerErrorCode.E1064, value, trackedEntityAttribute );
                 return;
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -63,7 +63,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
-import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -72,7 +71,6 @@ import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
@@ -143,10 +141,10 @@ public class PreCheckSecurityOwnershipValidationHook
             }
         }
 
-        checkTeiTypeWriteAccess( reporter, trackedEntity.getUid(), trackedEntityType );
+        checkTeiTypeWriteAccess( reporter, trackedEntity, trackedEntityType );
     }
 
-    private void checkTeiTypeWriteAccess( ValidationErrorReporter reporter, String teUid,
+    private void checkTeiTypeWriteAccess( ValidationErrorReporter reporter, TrackedEntity trackedEntity,
         TrackedEntityType trackedEntityType )
     {
         TrackerBundle bundle = reporter.getBundle();
@@ -157,14 +155,7 @@ public class PreCheckSecurityOwnershipValidationHook
 
         if ( !aclService.canDataWrite( user, trackedEntityType ) )
         {
-            TrackerErrorReport error = TrackerErrorReport.builder()
-                .uid( teUid )
-                .trackerType( TrackerType.TRACKED_ENTITY )
-                .errorCode( TrackerErrorCode.E1001 )
-                .addArg( user )
-                .addArg( trackedEntityType )
-                .build( bundle.getPreheat().getIdSchemes() );
-            reporter.addError( error );
+            reporter.addError( trackedEntity, TrackerErrorCode.E1001, user, trackedEntityType );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -51,8 +51,6 @@ import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
-import org.hisp.dhis.tracker.report.TrackerWarningReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.locationtech.jts.geom.Geometry;
 
@@ -70,12 +68,7 @@ public class ValidationUtils
 
         if ( featureType == null )
         {
-            TrackerErrorReport error = TrackerErrorReport.builder()
-                .uid( dto.getUid() )
-                .trackerType( dto.getTrackerType() )
-                .errorCode( TrackerErrorCode.E1074 )
-                .build( reporter.getBundle() );
-            reporter.addError( error );
+            reporter.addError( dto, TrackerErrorCode.E1074 );
             return;
         }
 
@@ -83,13 +76,7 @@ public class ValidationUtils
 
         if ( FeatureType.NONE == featureType || featureType != typeFromName )
         {
-            TrackerErrorReport error = TrackerErrorReport.builder()
-                .uid( dto.getUid() )
-                .trackerType( dto.getTrackerType() )
-                .errorCode( TrackerErrorCode.E1012 )
-                .addArg( featureType.name() )
-                .build( reporter.getBundle() );
-            reporter.addError( error );
+            reporter.addError( dto, TrackerErrorCode.E1012, featureType.name() );
         }
     }
 
@@ -107,13 +94,7 @@ public class ValidationUtils
                 // warning, ignore the note and continue
                 if ( isNotEmpty( note.getNote() ) && preheat.getNote( note.getNote() ).isPresent() )
                 {
-                    TrackerWarningReport warning = TrackerWarningReport.builder()
-                        .uid( dto.getUid() )
-                        .trackerType( dto.getTrackerType() )
-                        .warningCode( TrackerErrorCode.E1119 )
-                        .addArg( note.getNote() )
-                        .build( reporter.getBundle() );
-                    reporter.addWarning( warning );
+                    reporter.addWarning( dto, TrackerErrorCode.E1119, note.getNote() );
                 }
                 else
                 {
@@ -175,13 +156,7 @@ public class ValidationUtils
             .forEach( issue -> {
                 List<String> args = Lists.newArrayList( issue.getRuleUid() );
                 args.addAll( issue.getArgs() );
-                TrackerErrorReport error = TrackerErrorReport.builder()
-                    .uid( dto.getUid() )
-                    .trackerType( dto.getTrackerType() )
-                    .errorCode( issue.getIssueCode() )
-                    .addArgs( args.toArray() )
-                    .build( reporter.getBundle() );
-                reporter.addError( error );
+                reporter.addError( dto, issue.getIssueCode(), args.toArray() );
             } );
 
         programRuleIssues
@@ -191,13 +166,7 @@ public class ValidationUtils
                 issue -> {
                     List<String> args = Lists.newArrayList( issue.getRuleUid() );
                     args.addAll( issue.getArgs() );
-                    TrackerWarningReport warning = TrackerWarningReport.builder()
-                        .uid( dto.getUid() )
-                        .trackerType( dto.getTrackerType() )
-                        .warningCode( issue.getIssueCode() )
-                        .addArgs( args.toArray() )
-                        .build( reporter.getBundle() );
-                    reporter.addWarning( warning );
+                    reporter.addWarning( dto, issue.getIssueCode(), args.toArray() );
                 } );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
@@ -29,10 +29,9 @@ package org.hisp.dhis.tracker.report;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.junit.jupiter.api.Test;
 
 class ValidationErrorReporterTest
@@ -43,11 +42,11 @@ class ValidationErrorReporterTest
     {
 
         ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
-        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         TrackerErrorReport error = TrackerErrorReport.builder()
             .errorCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
-            .build( bundle );
+            .build( idSchemes );
         reporter.getReportList().add( error );
 
         assertTrue( reporter.hasErrorReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
@@ -58,11 +57,11 @@ class ValidationErrorReporterTest
     {
 
         ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
-        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         TrackerErrorReport error = TrackerErrorReport.builder()
             .errorCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
-            .build( bundle );
+            .build( idSchemes );
         reporter.getReportList().add( error );
 
         assertFalse( reporter.hasErrorReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
@@ -73,11 +72,11 @@ class ValidationErrorReporterTest
     {
 
         ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
-        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         TrackerWarningReport warning = TrackerWarningReport.builder()
             .warningCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
-            .build( bundle );
+            .build( idSchemes );
         reporter.getWarningsReportList().add( warning );
 
         assertTrue( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
@@ -88,11 +87,11 @@ class ValidationErrorReporterTest
     {
 
         ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
-        TrackerBundle bundle = mock( TrackerBundle.class );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         TrackerWarningReport warning = TrackerWarningReport.builder()
             .warningCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
-            .build( bundle );
+            .build( idSchemes );
         reporter.getWarningsReportList().add( warning );
 
         assertFalse( reporter.hasWarningReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceConfigOrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceConfigOrderTest.java
@@ -34,10 +34,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 
 import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.bundle.TrackerBundleMode;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +63,10 @@ class DefaultTrackerValidationServiceConfigOrderTest extends DhisSpringTest
 
         Event event = new Event();
         event.setEvent( "invalidUid" );
+        TrackerPreheat preheat = new TrackerPreheat();
+        preheat.setIdSchemes( TrackerIdSchemeParams.builder().build() );
         TrackerBundle bundle = TrackerBundle.builder()
+            .preheat( preheat )
             .importMode( TrackerBundleMode.VALIDATE )
             .validationMode( ValidationMode.FAIL_FAST )
             .skipRuleEngine( true )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -49,12 +49,14 @@ import java.util.function.BiConsumer;
 import lombok.Builder;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -488,6 +490,8 @@ class DefaultTrackerValidationServiceTest
 
     private TrackerBundle.TrackerBundleBuilder newBundle()
     {
-        return TrackerBundle.builder().skipRuleEngine( true );
+        TrackerPreheat preheat = new TrackerPreheat();
+        preheat.setIdSchemes( TrackerIdSchemeParams.builder().build() );
+        return TrackerBundle.builder().preheat( preheat ).skipRuleEngine( true );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
@@ -94,7 +94,7 @@ class EnrollmentInExistingValidationHookTest
         hookToTest = new EnrollmentInExistingValidationHook();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( enrollment.getProgram() ).thenReturn( MetadataIdentifier.ofUid( programUid ) );
         when( enrollment.getTrackedEntity() ).thenReturn( trackedEntity );
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.ACTIVE );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -58,6 +58,7 @@ import org.hisp.dhis.relationship.RelationshipEntity;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -114,6 +115,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         hook = new PreCheckDataRelationsValidationHook();
 
         bundle = TrackerBundle.builder().preheat( preheat ).build();
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         reporter = new ValidationErrorReporter( bundle );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -61,7 +62,9 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -100,7 +103,18 @@ class PreCheckExistenceValidationHookTest
     @Mock
     private TrackerBundle bundle;
 
+    @Mock
+    private TrackerPreheat preheat;
+
     private PreCheckExistenceValidationHook validationHook = new PreCheckExistenceValidationHook();
+
+    @BeforeEach
+    void setUp()
+    {
+
+        when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+    }
 
     @Test
     void verifyTrackedEntityValidationSuccessWhenIsCreateAndTeiIsNotPresent()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -61,7 +61,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityProgramOwnerOrgUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackerOwnershipManager;
-import org.hisp.dhis.tracker.TrackerIdScheme;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
@@ -162,7 +162,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
-        when( preheat.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -183,6 +183,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
 
@@ -207,7 +208,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
-        when( preheat.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -230,7 +231,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
-        when( preheat.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -251,6 +252,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
 
@@ -273,6 +275,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithDeleteProgramInstances() );
 
@@ -295,6 +298,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getUser() ).thenReturn( deleteTeiAuthorisedUser() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
@@ -318,8 +323,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -342,10 +349,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
-        when( preheat.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -368,10 +375,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
-        when( preheat.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -392,10 +399,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
-        when( preheat.getTrackedEntityType( TEI_TYPE_ID ) ).thenReturn( trackedEntityType );
+        when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( false );
@@ -609,7 +616,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() ).thenReturn( Collections.emptyList() );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -633,7 +640,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() )
             .thenReturn( Collections.singletonList( enrollment.getEnrollment() ) );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
@@ -662,7 +669,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( false );
@@ -689,7 +696,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
@@ -869,7 +876,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
@@ -939,7 +946,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
@@ -970,7 +977,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
@@ -1001,7 +1008,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( bundle.getIdentifier() ).thenReturn( TrackerIdScheme.UID );
+        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.tracker.validation.hooks.AssertValidationErrorReport
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -43,6 +44,7 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -64,7 +66,9 @@ class PreCheckUidValidationHookTest
     @BeforeEach
     void setUp()
     {
-        bundle = TrackerBundle.builder().build();
+        TrackerPreheat preheat = new TrackerPreheat();
+        preheat.setIdSchemes( TrackerIdSchemeParams.builder().build() );
+        bundle = TrackerBundle.builder().preheat( preheat ).build();
 
         validationHook = new PreCheckUidValidationHook();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -46,12 +46,14 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +88,8 @@ class PreCheckUpdatableFieldsValidationHookTest
     @Mock
     private TrackerBundle bundle;
 
+    private TrackerPreheat preheat;
+
     @BeforeEach
     public void setUp()
     {
@@ -100,6 +104,10 @@ class PreCheckUpdatableFieldsValidationHookTest
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_ID ) ).thenReturn( trackedEntityInstance() );
         when( bundle.getProgramInstance( ENROLLMENT_ID ) ).thenReturn( programInstance() );
         when( bundle.getProgramStageInstance( EVENT_ID ) ).thenReturn( programStageInstance() );
+
+        preheat = new TrackerPreheat();
+        preheat.setIdSchemes( TrackerIdSchemeParams.builder().build() );
+        when( bundle.getPreheat() ).thenReturn( preheat );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -392,7 +392,7 @@ class RelationshipsValidationHookTest
             .uid( relationship.getTo().getTrackedEntity() )
             .trackerType( TRACKED_ENTITY )
             .errorCode( TrackerErrorCode.E9999 )
-            .build( bundle );
+            .build( TrackerIdSchemeParams.builder().build() );
         reporter.addError( error );
 
         validationHook.validateRelationship( reporter, relationship );
@@ -422,7 +422,7 @@ class RelationshipsValidationHookTest
             .uid( "notValidTrackedEntity" )
             .trackerType( TRACKED_ENTITY )
             .errorCode( TrackerErrorCode.E9999 )
-            .build( bundle );
+            .build( TrackerIdSchemeParams.builder().build() );
         reporter.addError( error );
 
         validationHook.validateRelationship( reporter, relationship );


### PR DESCRIPTION
* TrackerErrorReport/TrackerWarningReport/ValidationErrorReporter only needs idSchemes to add a new error. Not the entire TrackerBundle. First step in decoupling ValidationErrorReporter from the TrackerBundle. Later PR will look into removing its dependency on it.

* removed unused TrackerBundle.identifier which was always UID and did not reflect the actual idSchemes set by the user. Using it in TrackerReportUtils lead to reports always being in idScheme UID instead of user defined one.