### PR TITLE
chore: ValidationErrorReporter does not need the bunlde DHIS2-12519

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -38,8 +38,6 @@ import lombok.Value;
 
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.ValidationMode;
-import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.validation.ValidationFailFastException;
 
@@ -66,16 +64,7 @@ public class ValidationErrorReporter
      * A map that keep tracks of all the invalid Tracker objects encountered
      * during the validation process
      */
-    private Map<TrackerType, List<String>> invalidDTOs;
-
-    public ValidationErrorReporter( TrackerBundle bundle )
-    {
-        this.reportList = new ArrayList<>();
-        this.warningsReportList = new ArrayList<>();
-        this.isFailFast = bundle.getValidationMode() == ValidationMode.FAIL_FAST;
-        this.idSchemes = bundle.getPreheat().getIdSchemes();
-        this.invalidDTOs = new HashMap<>();
-    }
+    private final Map<TrackerType, List<String>> invalidDTOs;
 
     /**
      * Create a {@link ValidationErrorReporter} reporting all errors and

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -60,8 +60,6 @@ public class ValidationErrorReporter
 
     private final boolean isFailFast;
 
-    private final TrackerBundle bundle;
-
     private final TrackerIdSchemeParams idSchemes;
 
     /*
@@ -70,29 +68,48 @@ public class ValidationErrorReporter
      */
     private Map<TrackerType, List<String>> invalidDTOs;
 
-    public static ValidationErrorReporter emptyReporter()
-    {
-        return new ValidationErrorReporter();
-    }
-
-    private ValidationErrorReporter()
-    {
-        this.warningsReportList = new ArrayList<>();
-        this.reportList = new ArrayList<>();
-        this.isFailFast = false;
-        this.bundle = null;
-        this.idSchemes = TrackerIdSchemeParams.builder().build();
-        this.invalidDTOs = new HashMap<>();
-    }
-
     public ValidationErrorReporter( TrackerBundle bundle )
     {
         this.reportList = new ArrayList<>();
         this.warningsReportList = new ArrayList<>();
         this.isFailFast = bundle.getValidationMode() == ValidationMode.FAIL_FAST;
-        this.bundle = bundle;
         this.idSchemes = bundle.getPreheat().getIdSchemes();
         this.invalidDTOs = new HashMap<>();
+    }
+
+    /**
+     * Create a {@link ValidationErrorReporter} reporting all errors and
+     * warnings with identifiers in given idSchemes.
+     * {@link #addError(TrackerErrorReport)} will only throw a
+     * {@link ValidationFailFastException} if {@code failFast} true is given.
+     *
+     * @param idSchemes idSchemes in which to report errors and warnings
+     * @param failFast
+     */
+    public ValidationErrorReporter( TrackerIdSchemeParams idSchemes, boolean failFast )
+    {
+        this.reportList = new ArrayList<>();
+        this.warningsReportList = new ArrayList<>();
+        this.invalidDTOs = new HashMap<>();
+        this.idSchemes = idSchemes;
+        this.isFailFast = failFast;
+    }
+
+    /**
+     * Create a {@link ValidationErrorReporter} reporting all errors and
+     * warnings ({@link #isFailFast} = false) with identifiers in given
+     * idSchemes. {@link #addError(TrackerErrorReport)} will not throw a
+     * {@link ValidationFailFastException}.
+     *
+     * @param idSchemes idSchemes in which to report errors and warnings
+     */
+    public ValidationErrorReporter( TrackerIdSchemeParams idSchemes )
+    {
+        this.reportList = new ArrayList<>();
+        this.warningsReportList = new ArrayList<>();
+        this.invalidDTOs = new HashMap<>();
+        this.idSchemes = idSchemes;
+        this.isFailFast = false;
     }
 
     public boolean hasErrors()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -86,7 +86,8 @@ public class DefaultTrackerValidationService
 
         // Note that the bundle gets cloned internally, so the original bundle
         // is always available
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle.getPreheat().getIdSchemes(),
+            bundle.getValidationMode() == ValidationMode.FAIL_FAST );
 
         try
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
@@ -67,7 +67,8 @@ public abstract class AbstractTrackerDtoValidationHook
         .<TrackerType, TriConsumer<ValidationErrorReporter, TrackerBundle, TrackerDto>> builder()
         .put( TrackerType.TRACKED_ENTITY,
             ( report, bundle, dto ) -> validateTrackedEntity( report, bundle, (TrackedEntity) dto ) )
-        .put( TrackerType.ENROLLMENT, ( report, bundle, dto ) -> validateEnrollment( report, (Enrollment) dto ) )
+        .put( TrackerType.ENROLLMENT,
+            ( report, bundle, dto ) -> validateEnrollment( report, bundle, (Enrollment) dto ) )
         .put( TrackerType.EVENT, ( report, bundle, dto ) -> validateEvent( report, bundle, (Event) dto ) )
         .put( TrackerType.RELATIONSHIP,
             ( report, bundle, dto ) -> validateRelationship( report, bundle, (Relationship) dto ) )
@@ -97,9 +98,10 @@ public abstract class AbstractTrackerDtoValidationHook
      * dtoTypeClass == null
      *
      * @param reporter ValidationErrorReporter instance
+     * @param bundle tracker bundle
      * @param enrollment entity to validate
      */
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
@@ -66,7 +66,7 @@ public abstract class AbstractTrackerDtoValidationHook
     private final Map<TrackerType, TriConsumer<ValidationErrorReporter, TrackerBundle, TrackerDto>> validationMap = ImmutableMap
         .<TrackerType, TriConsumer<ValidationErrorReporter, TrackerBundle, TrackerDto>> builder()
         .put( TrackerType.TRACKED_ENTITY,
-            ( report, bundle, dto ) -> validateTrackedEntity( report, (TrackedEntity) dto ) )
+            ( report, bundle, dto ) -> validateTrackedEntity( report, bundle, (TrackedEntity) dto ) )
         .put( TrackerType.ENROLLMENT, ( report, bundle, dto ) -> validateEnrollment( report, (Enrollment) dto ) )
         .put( TrackerType.EVENT, ( report, bundle, dto ) -> validateEvent( report, bundle, (Event) dto ) )
         .put( TrackerType.RELATIONSHIP, ( report, bundle, dto ) -> validateRelationship( report, (Relationship) dto ) )
@@ -118,9 +118,10 @@ public abstract class AbstractTrackerDtoValidationHook
      * dtoTypeClass == null
      *
      * @param reporter ValidationErrorReporter instance
+     * @param bundle tracker bundle
      * @param tei entity to validate
      */
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity tei )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity tei )
     {
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AbstractTrackerDtoValidationHook.java
@@ -69,7 +69,8 @@ public abstract class AbstractTrackerDtoValidationHook
             ( report, bundle, dto ) -> validateTrackedEntity( report, bundle, (TrackedEntity) dto ) )
         .put( TrackerType.ENROLLMENT, ( report, bundle, dto ) -> validateEnrollment( report, (Enrollment) dto ) )
         .put( TrackerType.EVENT, ( report, bundle, dto ) -> validateEvent( report, bundle, (Event) dto ) )
-        .put( TrackerType.RELATIONSHIP, ( report, bundle, dto ) -> validateRelationship( report, (Relationship) dto ) )
+        .put( TrackerType.RELATIONSHIP,
+            ( report, bundle, dto ) -> validateRelationship( report, bundle, (Relationship) dto ) )
         .build();
 
     /**
@@ -107,9 +108,11 @@ public abstract class AbstractTrackerDtoValidationHook
      * dtoTypeClass == null
      *
      * @param reporter ValidationErrorReporter instance
+     * @param bundle tracker bundle
      * @param relationship entity to validate
      */
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
 
@@ -46,32 +47,29 @@ public class AssignedUserValidationHook
     {
         if ( event.getAssignedUser() != null && !event.getAssignedUser().isEmpty() )
         {
-            if ( assignedUserNotPresentInPreheat( reporter, event ) )
+            if ( assignedUserNotPresentInPreheat( bundle.getPreheat(), event ) )
             {
                 reporter.addError( event, E1118, event.getAssignedUser().toString() );
             }
-            if ( isNotEnabledUserAssignment( reporter, event ) )
+            if ( isNotEnabledUserAssignment( bundle.getPreheat(), event ) )
             {
                 reporter.addWarning( event, E1120, event.getProgramStage() );
             }
         }
     }
 
-    private Boolean isNotEnabledUserAssignment( ValidationErrorReporter reporter, Event event )
+    private Boolean isNotEnabledUserAssignment( TrackerPreheat preheat, Event event )
     {
-        Boolean userAssignmentEnabled = reporter.getBundle().getPreheat()
-            .getProgramStage( event.getProgramStage() )
-            .isEnableUserAssignment();
+        Boolean userAssignmentEnabled = preheat.getProgramStage( event.getProgramStage() ).isEnableUserAssignment();
 
         return !Optional.ofNullable( userAssignmentEnabled )
             .orElse( false );
     }
 
-    private boolean assignedUserNotPresentInPreheat( ValidationErrorReporter reporter, Event event )
+    private boolean assignedUserNotPresentInPreheat( TrackerPreheat preheat, Event event )
     {
         return event.getAssignedUser().getUsername() == null ||
-            reporter.getBundle().getPreheat()
-                .getUserByUsername( event.getAssignedUser().getUsername() ).isEmpty();
+            preheat.getUserByUsername( event.getAssignedUser().getUsername() ).isEmpty();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1120;
 
 import java.util.Optional;
 
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -41,7 +42,7 @@ public class AssignedUserValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         if ( event.getAssignedUser() != null && !event.getAssignedUser().isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.TrackerDto;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -58,7 +59,8 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
         this.teAttrService = teAttrService;
     }
 
-    protected void validateAttrValueType( ValidationErrorReporter reporter, TrackerDto dto, Attribute attr,
+    protected void validateAttrValueType( ValidationErrorReporter reporter, TrackerPreheat preheat, TrackerDto dto,
+        Attribute attr,
         TrackedEntityAttribute teAttr )
     {
         checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
@@ -70,13 +72,13 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
 
         if ( valueType.equals( ValueType.ORGANISATION_UNIT ) )
         {
-            error = reporter.getBundle().getPreheat().getOrganisationUnit( attr.getValue() ) == null
+            error = preheat.getOrganisationUnit( attr.getValue() ) == null
                 ? " Value " + attr.getValue() + " is not a valid org unit value"
                 : null;
         }
         else if ( valueType.equals( ValueType.USERNAME ) )
         {
-            error = reporter.getBundle().getPreheat().getUserByUsername( attr.getValue() ).isPresent() ? null
+            error = preheat.getUserByUsername( attr.getValue() ).isPresent() ? null
                 : " Value " + attr.getValue() + " is not a valid username value";
         }
         else
@@ -102,7 +104,7 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
     }
 
     protected void validateAttributeUniqueness( ValidationErrorReporter reporter,
-        TrackerDto dto,
+        TrackerPreheat preheat, TrackerDto dto,
         String value,
         TrackedEntityAttribute trackedEntityAttribute,
         TrackedEntityInstance trackedEntityInstance,
@@ -113,8 +115,7 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
         if ( Boolean.FALSE.equals( trackedEntityAttribute.isUnique() ) )
             return;
 
-        List<UniqueAttributeValue> uniqueAttributeValues = reporter
-            .getBundle().getPreheat().getUniqueAttributeValues();
+        List<UniqueAttributeValue> uniqueAttributeValues = preheat.getUniqueAttributeValues();
 
         for ( UniqueAttributeValue uniqueAttributeValue : uniqueAttributeValues )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -74,9 +74,8 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        TrackerBundle bundle = reporter.getBundle();
         TrackerPreheat preheat = bundle.getPreheat();
         Program program = preheat.getProgram( enrollment.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
@@ -40,6 +40,7 @@ import java.time.ZoneOffset;
 import java.util.Objects;
 
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -52,7 +53,7 @@ public class EnrollmentDateValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         validateMandatoryDates( reporter, enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHook.java
@@ -57,7 +57,7 @@ public class EnrollmentDateValidationHook
     {
         validateMandatoryDates( reporter, enrollment );
 
-        Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
+        Program program = bundle.getPreheat().getProgram( enrollment.getProgram() );
 
         validateEnrollmentDatesNotInFuture( reporter, program, enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
@@ -45,7 +45,7 @@ public class EnrollmentGeoValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
+        Program program = bundle.getPreheat().getProgram( enrollment.getProgram() );
 
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHook.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -42,7 +43,7 @@ public class EnrollmentGeoValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -45,6 +45,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -58,7 +59,7 @@ public class EnrollmentInExistingValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         checkNotNull( enrollment, ENROLLMENT_CANT_BE_NULL );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -68,7 +68,7 @@ public class EnrollmentInExistingValidationHook
             return;
         }
 
-        Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
+        Program program = bundle.getPreheat().getProgram( enrollment.getProgram() );
 
         checkNotNull( program, PROGRAM_CANT_BE_NULL );
 
@@ -78,17 +78,17 @@ public class EnrollmentInExistingValidationHook
             return;
         }
 
-        validateTeiNotEnrolledAlready( reporter, enrollment, program );
+        validateTeiNotEnrolledAlready( reporter, bundle, enrollment, program );
     }
 
-    private void validateTeiNotEnrolledAlready( ValidationErrorReporter reporter,
+    private void validateTeiNotEnrolledAlready( ValidationErrorReporter reporter, TrackerBundle bundle,
         Enrollment enrollment, Program program )
     {
         checkNotNull( enrollment.getTrackedEntity(), TRACKED_ENTITY_INSTANCE_CANT_BE_NULL );
 
-        TrackedEntityInstance tei = getTrackedEntityInstance( reporter, enrollment.getTrackedEntity() );
+        TrackedEntityInstance tei = getTrackedEntityInstance( bundle, enrollment.getTrackedEntity() );
 
-        Set<Enrollment> payloadEnrollment = reporter.getBundle().getEnrollments()
+        Set<Enrollment> payloadEnrollment = bundle.getEnrollments()
             .stream().filter( Objects::nonNull )
             .filter( pi -> pi.getProgram().isEqualTo( program ) )
             .filter( pi -> pi.getTrackedEntity().equals( tei.getUid() )
@@ -96,7 +96,7 @@ public class EnrollmentInExistingValidationHook
             .filter( pi -> EnrollmentStatus.ACTIVE == pi.getStatus() || EnrollmentStatus.COMPLETED == pi.getStatus() )
             .collect( Collectors.toSet() );
 
-        Set<Enrollment> dbEnrollment = reporter.getBundle().getPreheat()
+        Set<Enrollment> dbEnrollment = bundle.getPreheat()
             .getTrackedEntityToProgramInstanceMap().getOrDefault( enrollment.getTrackedEntity(), new ArrayList<>() )
             .stream()
             .filter( Objects::nonNull )
@@ -142,11 +142,11 @@ public class EnrollmentInExistingValidationHook
         return enrollment;
     }
 
-    private TrackedEntityInstance getTrackedEntityInstance( ValidationErrorReporter reporter, String uid )
+    private TrackedEntityInstance getTrackedEntityInstance( TrackerBundle bundle, String uid )
     {
-        TrackedEntityInstance tei = reporter.getBundle().getTrackedEntityInstance( uid );
+        TrackedEntityInstance tei = bundle.getTrackedEntityInstance( uid );
 
-        if ( tei == null && reporter.getBundle().getPreheat().getReference( uid ).isPresent() )
+        if ( tei == null && bundle.getPreheat().getReference( uid ).isPresent() )
         {
             tei = new TrackedEntityInstance();
             tei.setUid( uid );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
@@ -41,7 +41,7 @@ public class EnrollmentNoteValidationHook extends AbstractTrackerDtoValidationHo
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        enrollment.setNotes( ValidationUtils.validateNotes( reporter, enrollment,
+        enrollment.setNotes( ValidationUtils.validateNotes( reporter, bundle.getPreheat(), enrollment,
             enrollment.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHook.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -38,7 +39,7 @@ import org.springframework.stereotype.Component;
 public class EnrollmentNoteValidationHook extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         enrollment.setNotes( ValidationUtils.validateNotes( reporter, enrollment,
             enrollment.getNotes() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
@@ -57,7 +58,7 @@ public class EnrollmentRuleValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -62,7 +62,7 @@ public class EnrollmentRuleValidationHook
     {
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()
-            .flatMap( v -> v.validateEnrollments( reporter.getBundle() )
+            .flatMap( v -> v.validateEnrollments( bundle )
                 .getOrDefault( enrollment.getEnrollment(), Lists.newArrayList() ).stream() )
             .collect( Collectors.toList() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -65,7 +66,7 @@ public class EventCategoryOptValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         Program program = reporter.getBundle().getPreheat().getProgram( event.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHook.java
@@ -68,13 +68,13 @@ public class EventCategoryOptValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        Program program = reporter.getBundle().getPreheat().getProgram( event.getProgram() );
+        Program program = bundle.getPreheat().getProgram( event.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
-        checkNotNull( reporter.getBundle().getUser(), TrackerImporterAssertErrors.USER_CANT_BE_NULL );
+        checkNotNull( bundle.getUser(), TrackerImporterAssertErrors.USER_CANT_BE_NULL );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
         checkNotNull( event, TrackerImporterAssertErrors.EVENT_CANT_BE_NULL );
 
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
+        TrackerPreheat preheat = bundle.getPreheat();
         CategoryOptionCombo categoryOptionCombo;
         if ( program.getCategoryCombo().isDefault() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageDataElement;
 import org.hisp.dhis.system.util.ValidationUtils;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -62,7 +63,7 @@ public class EventDataValuesValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHook.java
@@ -65,7 +65,7 @@ public class EventDataValuesValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
 
         checkNotNull( programStage, TrackerImporterAssertErrors.PROGRAM_STAGE_CANT_BE_NULL );
 
@@ -73,7 +73,7 @@ public class EventDataValuesValidationHook
         {
             // event dates (createdAt, updatedAt) are ignored and set by the
             // system
-            TrackerPreheat preheat = reporter.getBundle().getPreheat();
+            TrackerPreheat preheat = bundle.getPreheat();
             DataElement dataElement = preheat.getDataElement( dataValue.getDataElement() );
 
             if ( dataElement == null )
@@ -82,22 +82,22 @@ public class EventDataValuesValidationHook
                 continue;
             }
 
-            validateDataValue( reporter, dataElement, dataValue, programStage, event );
+            validateDataValue( reporter, bundle, dataElement, dataValue, programStage, event );
         }
 
-        validateMandatoryDataValues( event, reporter );
-        validateDataValueDataElementIsConnectedToProgramStage( reporter, event, programStage );
+        validateMandatoryDataValues( reporter, bundle, event );
+        validateDataValueDataElementIsConnectedToProgramStage( reporter, bundle, event, programStage );
     }
 
-    private void validateMandatoryDataValues( Event event, ValidationErrorReporter reporter )
+    private void validateMandatoryDataValues( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         if ( event.getProgramStage().isBlank() )
         {
             return;
         }
 
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
-        ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
+        TrackerPreheat preheat = bundle.getPreheat();
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         final List<MetadataIdentifier> mandatoryDataElements = programStage.getProgramStageDataElements()
             .stream()
             .filter( ProgramStageDataElement::isCompulsory )
@@ -109,7 +109,7 @@ public class EventDataValuesValidationHook
             .forEach( de -> reporter.addError( event, E1303, de ) );
     }
 
-    private void validateDataValue( ValidationErrorReporter reporter, DataElement dataElement,
+    private void validateDataValue( ValidationErrorReporter reporter, TrackerBundle bundle, DataElement dataElement,
         DataValue dataValue, ProgramStage programStage, Event event )
     {
         String status = null;
@@ -125,11 +125,11 @@ public class EventDataValuesValidationHook
         }
         else if ( dataElement.getValueType().isFile() )
         {
-            validateFileNotAlreadyAssigned( reporter, event, dataValue, dataElement );
+            validateFileNotAlreadyAssigned( reporter, bundle, event, dataValue, dataElement );
         }
         else if ( dataElement.getValueType().isOrganisationUnit() )
         {
-            validateOrgUnitValueType( reporter, event, dataValue, dataElement );
+            validateOrgUnitValueType( reporter, bundle, event, dataValue, dataElement );
         }
         else
         {
@@ -168,10 +168,11 @@ public class EventDataValuesValidationHook
         }
     }
 
-    private void validateDataValueDataElementIsConnectedToProgramStage( ValidationErrorReporter reporter, Event event,
+    private void validateDataValueDataElementIsConnectedToProgramStage( ValidationErrorReporter reporter,
+        TrackerBundle bundle, Event event,
         ProgramStage programStage )
     {
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
+        TrackerPreheat preheat = bundle.getPreheat();
         final Set<MetadataIdentifier> dataElements = programStage.getProgramStageDataElements()
             .stream()
             .map( de -> preheat.getIdSchemes().toMetadataIdentifier( de.getDataElement() ) )
@@ -190,7 +191,8 @@ public class EventDataValuesValidationHook
         }
     }
 
-    private void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, Event event, DataValue dataValue,
+    private void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+        DataValue dataValue,
         DataElement dataElement )
     {
         boolean isFile = dataElement.getValueType() != null && dataElement.getValueType().isFile();
@@ -200,19 +202,20 @@ public class EventDataValuesValidationHook
             return;
         }
 
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
+        TrackerPreheat preheat = bundle.getPreheat();
         FileResource fileResource = preheat.get( FileResource.class, dataValue.getValue() );
 
         reporter.addErrorIfNull( fileResource, event, E1084, dataValue.getValue() );
 
-        if ( reporter.getBundle().getStrategy( event ).isCreate() )
+        if ( bundle.getStrategy( event ).isCreate() )
         {
             reporter.addErrorIf( () -> fileResource != null && fileResource.isAssigned(), event,
                 E1009, dataValue.getValue() );
         }
     }
 
-    private void validateOrgUnitValueType( ValidationErrorReporter reporter, Event event, DataValue dataValue,
+    private void validateOrgUnitValueType( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+        DataValue dataValue,
         DataElement dataElement )
     {
         boolean isOrgUnit = dataElement.getValueType() != null && dataElement.getValueType().isOrganisationUnit();
@@ -222,7 +225,7 @@ public class EventDataValuesValidationHook
             return;
         }
 
-        reporter.addErrorIfNull( reporter.getBundle().getPreheat().getOrganisationUnit( dataValue.getValue() ),
+        reporter.addErrorIfNull( bundle.getPreheat().getOrganisationUnit( dataValue.getValue() ),
             event, E1007, dataValue.getValue() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -63,7 +63,7 @@ public class EventDateValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
+        TrackerPreheat preheat = bundle.getPreheat();
 
         Program program = preheat.getProgram( event.getProgram() );
 
@@ -79,13 +79,14 @@ public class EventDateValidationHook
             return;
         }
 
-        validateExpiryDays( reporter, event, program );
+        validateExpiryDays( reporter, bundle, event, program );
         validatePeriodType( reporter, event, program );
     }
 
-    private void validateExpiryDays( ValidationErrorReporter reporter, Event event, Program program )
+    private void validateExpiryDays( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+        Program program )
     {
-        User actingUser = reporter.getBundle().getUser();
+        User actingUser = bundle.getUser();
 
         checkNotNull( actingUser, TrackerImporterAssertErrors.USER_CANT_BE_NULL );
         checkNotNull( event, TrackerImporterAssertErrors.EVENT_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHook.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.security.Authorities;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
@@ -60,7 +61,7 @@ public class EventDateValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         TrackerPreheat preheat = reporter.getBundle().getPreheat();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -42,7 +43,7 @@ public class EventGeoValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
         checkNotNull( programStage, TrackerImporterAssertErrors.PROGRAM_STAGE_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHook.java
@@ -45,7 +45,7 @@ public class EventGeoValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         checkNotNull( programStage, TrackerImporterAssertErrors.PROGRAM_STAGE_CANT_BE_NULL );
 
         if ( event.getGeometry() != null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.stereotype.Component;
@@ -38,7 +39,7 @@ import org.springframework.stereotype.Component;
 public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         event
             .setNotes( ValidationUtils.validateNotes( reporter, event, event.getNotes() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHook.java
@@ -42,6 +42,6 @@ public class EventNoteValidationHook extends AbstractTrackerDtoValidationHook
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         event
-            .setNotes( ValidationUtils.validateNotes( reporter, event, event.getNotes() ) );
+            .setNotes( ValidationUtils.validateNotes( reporter, bundle.getPreheat(), event, event.getNotes() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
@@ -57,7 +58,7 @@ public class EventRuleValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
@@ -63,7 +63,7 @@ public class EventRuleValidationHook
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()
             .flatMap(
-                v -> v.validateEvents( reporter.getBundle() )
+                v -> v.validateEvents( bundle )
                     .getOrDefault( event.getEvent(), Lists.newArrayList() ).stream() )
             .collect( Collectors.toList() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -115,7 +115,7 @@ public class PreCheckDataRelationsValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
         OrganisationUnit organisationUnit = reporter.getBundle().getPreheat().getOrganisationUnit( event.getOrgUnit() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -84,7 +84,7 @@ public class PreCheckDataRelationsValidationHook
 {
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter,
-        TrackedEntity trackedEntity )
+        TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         // NOTHING TO DO HERE
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -454,7 +454,8 @@ public class PreCheckDataRelationsValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         validateRelationshipReference( reporter, relationship, relationship.getFrom() );
         validateRelationshipReference( reporter, relationship, relationship.getTo() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -90,7 +90,7 @@ public class PreCheckDataRelationsValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
         OrganisationUnit organisationUnit = reporter.getBundle().getPreheat()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -134,7 +134,8 @@ public class PreCheckExistenceValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
 
         org.hisp.dhis.relationship.Relationship existingRelationship = reporter.getBundle()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -44,6 +44,7 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -108,7 +109,7 @@ public class PreCheckExistenceValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( event );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -63,10 +63,9 @@ public class PreCheckExistenceValidationHook
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
         TrackedEntity trackedEntity )
     {
-        TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( trackedEntity );
+        TrackerImportStrategy importStrategy = bundle.getStrategy( trackedEntity );
 
-        TrackedEntityInstance existingTe = reporter.getBundle()
-            .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+        TrackedEntityInstance existingTe = bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
 
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingTe != null && existingTe.isDeleted() )
@@ -88,9 +87,9 @@ public class PreCheckExistenceValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( enrollment );
+        TrackerImportStrategy importStrategy = bundle.getStrategy( enrollment );
 
-        ProgramInstance existingPi = reporter.getBundle().getProgramInstance( enrollment.getEnrollment() );
+        ProgramInstance existingPi = bundle.getProgramInstance( enrollment.getEnrollment() );
 
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingPi != null && existingPi.isDeleted() )
@@ -112,9 +111,9 @@ public class PreCheckExistenceValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( event );
+        TrackerImportStrategy importStrategy = bundle.getStrategy( event );
 
-        ProgramStageInstance existingPsi = reporter.getBundle().getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance existingPsi = bundle.getProgramStageInstance( event.getEvent() );
 
         // If the event is soft-deleted no operation is allowed
         if ( existingPsi != null && existingPsi.isDeleted() )
@@ -138,9 +137,9 @@ public class PreCheckExistenceValidationHook
         Relationship relationship )
     {
 
-        org.hisp.dhis.relationship.Relationship existingRelationship = reporter.getBundle()
+        org.hisp.dhis.relationship.Relationship existingRelationship = bundle
             .getRelationship( relationship.getRelationship() );
-        TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( relationship );
+        TrackerImportStrategy importStrategy = bundle.getStrategy( relationship );
 
         validateRelationshipNotDeleted( reporter, existingRelationship, relationship );
         validateRelationshipNotUpdated( reporter, existingRelationship, relationship, importStrategy );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -60,7 +60,8 @@ public class PreCheckExistenceValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity trackedEntity )
     {
         TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( trackedEntity );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -86,7 +86,7 @@ public class PreCheckExistenceValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         TrackerImportStrategy importStrategy = reporter.getBundle().getStrategy( enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -77,7 +77,7 @@ public class PreCheckMandatoryFieldsValidationHook
         reporter.addErrorIf( () -> event.getProgramStage().isBlank(), event, E1123, "programStage" );
 
         // TODO remove if once metadata import is fixed
-        ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         if ( programStage != null )
         {
             // Program stages should always have a program! Due to how metadata

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -53,7 +53,8 @@ public class PreCheckMandatoryFieldsValidationHook
     private static final String ORG_UNIT = "orgUnit";
 
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity trackedEntity )
     {
         reporter.addErrorIf( () -> trackedEntity.getTrackedEntityType().isBlank(), trackedEntity, E1121,
             "trackedEntityType" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -62,7 +62,7 @@ public class PreCheckMandatoryFieldsValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         reporter.addErrorIf( () -> enrollment.getOrgUnit().isBlank(), enrollment, E1122, ORG_UNIT );
         reporter.addErrorIf( () -> enrollment.getProgram().isBlank(), enrollment, E1122, "program" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -35,6 +35,7 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1124;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -69,7 +70,7 @@ public class PreCheckMandatoryFieldsValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         reporter.addErrorIf( () -> event.getOrgUnit().isBlank(), event, E1123, ORG_UNIT );
         reporter.addErrorIf( () -> event.getProgramStage().isBlank(), event, E1123, "programStage" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHook.java
@@ -99,7 +99,8 @@ public class PreCheckMandatoryFieldsValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         reporter.addErrorIfNull( relationship.getFrom(), relationship, E1124, "from" );
         reporter.addErrorIfNull( relationship.getTo(), relationship, E1124, "to" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -91,7 +92,7 @@ public class PreCheckMetaValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         OrganisationUnit organisationUnit = reporter.getBundle().getPreheat().getOrganisationUnit( event.getOrgUnit() );
         reporter.addErrorIfNull( organisationUnit, event, E1011, event.getOrgUnit() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -60,7 +60,7 @@ public class PreCheckMetaValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity tei )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity tei )
     {
         OrganisationUnit organisationUnit = reporter.getBundle().getPreheat().getOrganisationUnit( tei.getOrgUnit() );
         if ( organisationUnit == null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -105,7 +105,8 @@ public class PreCheckMetaValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         TrackerPreheat preheat = reporter.getBundle().getPreheat();
         RelationshipType relationshipType = preheat.getRelationshipType( relationship.getRelationshipType() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -62,14 +62,13 @@ public class PreCheckMetaValidationHook
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity tei )
     {
-        OrganisationUnit organisationUnit = reporter.getBundle().getPreheat().getOrganisationUnit( tei.getOrgUnit() );
+        OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( tei.getOrgUnit() );
         if ( organisationUnit == null )
         {
             reporter.addError( tei, TrackerErrorCode.E1049, tei.getOrgUnit() );
         }
 
-        TrackedEntityType entityType = reporter.getBundle().getPreheat()
-            .getTrackedEntityType( tei.getTrackedEntityType() );
+        TrackedEntityType entityType = bundle.getPreheat().getTrackedEntityType( tei.getTrackedEntityType() );
         if ( entityType == null )
         {
             reporter.addError( tei, E1005, tei.getTrackedEntityType() );
@@ -79,14 +78,13 @@ public class PreCheckMetaValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        OrganisationUnit organisationUnit = reporter.getBundle().getPreheat()
-            .getOrganisationUnit( enrollment.getOrgUnit() );
+        OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( enrollment.getOrgUnit() );
         reporter.addErrorIfNull( organisationUnit, enrollment, E1070, enrollment.getOrgUnit() );
 
-        Program program = reporter.getBundle().getPreheat().getProgram( enrollment.getProgram() );
+        Program program = bundle.getPreheat().getProgram( enrollment.getProgram() );
         reporter.addErrorIfNull( program, enrollment, E1069, enrollment.getProgram() );
 
-        reporter.addErrorIf( () -> !trackedEntityInstanceExist( reporter.getBundle(), enrollment.getTrackedEntity() ),
+        reporter.addErrorIf( () -> !trackedEntityInstanceExist( bundle, enrollment.getTrackedEntity() ),
             enrollment,
             E1068, enrollment.getTrackedEntity() );
     }
@@ -94,13 +92,13 @@ public class PreCheckMetaValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        OrganisationUnit organisationUnit = reporter.getBundle().getPreheat().getOrganisationUnit( event.getOrgUnit() );
+        OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( event.getOrgUnit() );
         reporter.addErrorIfNull( organisationUnit, event, E1011, event.getOrgUnit() );
 
-        Program program = reporter.getBundle().getPreheat().getProgram( event.getProgram() );
+        Program program = bundle.getPreheat().getProgram( event.getProgram() );
         reporter.addErrorIfNull( program, event, E1010, event.getProgram() );
 
-        ProgramStage programStage = reporter.getBundle().getPreheat().getProgramStage( event.getProgramStage() );
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         reporter.addErrorIfNull( programStage, event, E1013, event.getProgramStage() );
     }
 
@@ -108,7 +106,7 @@ public class PreCheckMetaValidationHook
     public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
+        TrackerPreheat preheat = bundle.getPreheat();
         RelationshipType relationshipType = preheat.getRelationshipType( relationship.getRelationshipType() );
 
         reporter.addErrorIfNull( relationshipType, relationship, E4006, relationship.getRelationshipType() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHook.java
@@ -77,7 +77,7 @@ public class PreCheckMetaValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         OrganisationUnit organisationUnit = reporter.getBundle().getPreheat()
             .getOrganisationUnit( enrollment.getOrgUnit() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -246,10 +246,9 @@ public class PreCheckSecurityOwnershipValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         TrackerImportStrategy strategy = reporter.getBundle().getStrategy( event );
-        TrackerBundle bundle = reporter.getBundle();
         TrackerPreheat preheat = bundle.getPreheat();
         User user = bundle.getUser();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -314,7 +314,8 @@ public class PreCheckSecurityOwnershipValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         // NOTHING TO DO HERE
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -97,10 +97,10 @@ public class PreCheckSecurityOwnershipValidationHook
     private static final String ORG_UNIT_NO_USER_ASSIGNED = " has no organisation unit assigned, so we skip user validation";
 
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity trackedEntity )
     {
         TrackerImportStrategy strategy = reporter.getBundle().getStrategy( trackedEntity );
-        TrackerBundle bundle = reporter.getBundle();
         User user = bundle.getUser();
 
         checkNotNull( user, USER_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -160,10 +160,9 @@ public class PreCheckSecurityOwnershipValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         TrackerImportStrategy strategy = reporter.getBundle().getStrategy( enrollment );
-        TrackerBundle bundle = reporter.getBundle();
         TrackerPreheat preheat = bundle.getPreheat();
         User user = bundle.getUser();
         Program program = strategy.isUpdateOrDelete()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 import java.util.List;
 
 import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
@@ -63,7 +64,7 @@ public class PreCheckUidValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         checkUidFormat( event.getEvent(), reporter, event, event, event.getEvent() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
@@ -57,7 +57,7 @@ public class PreCheckUidValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         checkUidFormat( enrollment.getEnrollment(), reporter, enrollment, enrollment, enrollment.getEnrollment() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
@@ -73,7 +73,8 @@ public class PreCheckUidValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         checkUidFormat( relationship.getRelationship(), reporter, relationship, relationship,
             relationship.getRelationship() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHook.java
@@ -49,7 +49,8 @@ public class PreCheckUidValidationHook
     extends AbstractTrackerDtoValidationHook
 {
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity trackedEntity )
     {
         checkUidFormat( trackedEntity.getTrackedEntity(), reporter, trackedEntity, trackedEntity,
             trackedEntity.getTrackedEntity() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -57,7 +57,7 @@ public class PreCheckUpdatableFieldsValidationHook
 {
     @Override
     public void validateTrackedEntity( ValidationErrorReporter reporter,
-        TrackedEntity trackedEntity )
+        TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         TrackedEntityInstance trackedEntityInstance = reporter.getBundle()
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -101,7 +101,8 @@ public class PreCheckUpdatableFieldsValidationHook
     }
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         // Nothing to do
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -68,7 +68,7 @@ public class PreCheckUpdatableFieldsValidationHook
     }
 
     @Override
-    public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+    public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         ProgramInstance pi = reporter.getBundle().getProgramInstance( enrollment.getEnrollment() );
         Program program = pi.getProgram();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -80,7 +81,7 @@ public class PreCheckUpdatableFieldsValidationHook
     }
 
     @Override
-    public void validateEvent( ValidationErrorReporter reporter, Event event )
+    public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStageInstance programStageInstance = reporter.getBundle().getProgramStageInstance( event.getEvent() );
         ProgramStage programStage = programStageInstance.getProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -59,7 +59,7 @@ public class PreCheckUpdatableFieldsValidationHook
     public void validateTrackedEntity( ValidationErrorReporter reporter,
         TrackerBundle bundle, TrackedEntity trackedEntity )
     {
-        TrackedEntityInstance trackedEntityInstance = reporter.getBundle()
+        TrackedEntityInstance trackedEntityInstance = bundle
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
 
         reporter.addErrorIf(
@@ -70,7 +70,7 @@ public class PreCheckUpdatableFieldsValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        ProgramInstance pi = reporter.getBundle().getProgramInstance( enrollment.getEnrollment() );
+        ProgramInstance pi = bundle.getProgramInstance( enrollment.getEnrollment() );
         Program program = pi.getProgram();
         TrackedEntityInstance trackedEntityInstance = pi.getEntityInstance();
 
@@ -83,7 +83,7 @@ public class PreCheckUpdatableFieldsValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        ProgramStageInstance programStageInstance = reporter.getBundle().getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance programStageInstance = bundle.getProgramStageInstance( event.getEvent() );
         ProgramStage programStage = programStageInstance.getProgramStage();
         ProgramInstance programInstance = programStageInstance.getProgramInstance();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -78,7 +78,7 @@ public class RelationshipsValidationHook
         if ( isValid )
         {
             validateRelationshipLinkToOneEntity( reporter, relationship );
-            validateRelationshipConstraint( reporter, relationship, bundle );
+            validateRelationshipConstraint( reporter, bundle, relationship );
 
             validateAutoRelationship( reporter, relationship );
 
@@ -115,14 +115,14 @@ public class RelationshipsValidationHook
             relationship, E4001, "to", relationship.getRelationship() );
     }
 
-    private void validateRelationshipConstraint( ValidationErrorReporter reporter, Relationship relationship,
-        TrackerBundle bundle )
+    private void validateRelationshipConstraint( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
         getRelationshipType( bundle.getPreheat().getAll( RelationshipType.class ),
             relationship.getRelationshipType() ).ifPresent( relationshipType -> {
-                validateRelationshipConstraint( reporter, relationship, "from", relationship.getFrom(),
+                validateRelationshipConstraint( reporter, bundle, relationship, "from", relationship.getFrom(),
                     relationshipType.getFromConstraint() );
-                validateRelationshipConstraint( reporter, relationship, "to", relationship.getTo(),
+                validateRelationshipConstraint( reporter, bundle, relationship, "to", relationship.getTo(),
                     relationshipType.getToConstraint() );
             } );
     }
@@ -153,7 +153,8 @@ public class RelationshipsValidationHook
         }
     }
 
-    private void validateRelationshipConstraint( ValidationErrorReporter reporter, Relationship relationship,
+    private void validateRelationshipConstraint( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship,
         String relSide,
         RelationshipItem item,
         RelationshipConstraint constraint )
@@ -178,7 +179,7 @@ public class RelationshipsValidationHook
                 // Check tracked entity type matches the type specified in the
                 // constraint
                 //
-                getRelationshipTypeUidFromTrackedEntity( reporter.getBundle(),
+                getRelationshipTypeUidFromTrackedEntity( bundle,
                     item.getTrackedEntity() )
                         .ifPresent( type -> {
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -67,10 +67,9 @@ public class RelationshipsValidationHook
 {
 
     @Override
-    public void validateRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    public void validateRelationship( ValidationErrorReporter reporter, TrackerBundle bundle,
+        Relationship relationship )
     {
-        TrackerBundle bundle = reporter.getBundle();
-
         boolean isValid = validateMandatoryData( reporter, relationship,
             bundle.getPreheat().getAll( RelationshipType.class ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -91,7 +91,7 @@ public class RepeatedEventsValidationHook
 
         if ( strategy == TrackerImportStrategy.CREATE && programStage != null && programInstance != null
             && !programStage.getRepeatable()
-            && reporter.getBundle().getPreheat().hasProgramStageWithEvents( event.getProgramStage(),
+            && bundle.getPreheat().hasProgramStageWithEvents( event.getProgramStage(),
                 event.getEnrollment() ) )
         {
             reporter.addError( event, TrackerErrorCode.E1039, event.getProgramStage() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -85,18 +85,19 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
     public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
         TrackedEntity trackedEntity )
     {
-        TrackedEntityType trackedEntityType = reporter.getBundle().getPreheat()
+        TrackedEntityType trackedEntityType = bundle.getPreheat()
             .getTrackedEntityType( trackedEntity.getTrackedEntityType() );
 
-        TrackedEntityInstance tei = reporter.getBundle().getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
-        OrganisationUnit organisationUnit = reporter.getBundle().getPreheat()
+        TrackedEntityInstance tei = bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+        OrganisationUnit organisationUnit = bundle.getPreheat()
             .getOrganisationUnit( trackedEntity.getOrgUnit() );
 
-        validateMandatoryAttributes( reporter, trackedEntity, trackedEntityType );
-        validateAttributes( reporter, trackedEntity, tei, organisationUnit, trackedEntityType );
+        validateMandatoryAttributes( reporter, bundle, trackedEntity, trackedEntityType );
+        validateAttributes( reporter, bundle, trackedEntity, tei, organisationUnit, trackedEntityType );
     }
 
-    private void validateMandatoryAttributes( ValidationErrorReporter reporter, TrackedEntity trackedEntity,
+    private void validateMandatoryAttributes( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity trackedEntity,
         TrackedEntityType trackedEntityType )
     {
         if ( trackedEntityType != null )
@@ -106,7 +107,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
                 .map( Attribute::getAttribute )
                 .collect( Collectors.toSet() );
 
-            TrackerIdSchemeParams idSchemes = reporter.getBundle().getPreheat().getIdSchemes();
+            TrackerIdSchemeParams idSchemes = bundle.getPreheat().getIdSchemes();
             trackedEntityType.getTrackedEntityTypeAttributes()
                 .stream()
                 .filter( trackedEntityTypeAttribute -> Boolean.TRUE.equals( trackedEntityTypeAttribute.isMandatory() ) )
@@ -120,16 +121,17 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
     }
 
     protected void validateAttributes( ValidationErrorReporter reporter,
-        TrackedEntity trackedEntity, TrackedEntityInstance tei, OrganisationUnit orgUnit,
+        TrackerBundle bundle, TrackedEntity trackedEntity, TrackedEntityInstance tei, OrganisationUnit orgUnit,
         TrackedEntityType trackedEntityType )
     {
         checkNotNull( trackedEntity, TrackerImporterAssertErrors.TRACKED_ENTITY_CANT_BE_NULL );
         checkNotNull( trackedEntityType, TrackerImporterAssertErrors.TRACKED_ENTITY_TYPE_CANT_BE_NULL );
 
+        TrackerPreheat preheat = bundle.getPreheat();
         Map<MetadataIdentifier, TrackedEntityAttributeValue> valueMap = new HashMap<>();
         if ( tei != null )
         {
-            TrackerIdSchemeParams idSchemes = reporter.getBundle().getPreheat().getIdSchemes();
+            TrackerIdSchemeParams idSchemes = preheat.getIdSchemes();
             valueMap = tei.getTrackedEntityAttributeValues()
                 .stream()
                 .collect( Collectors.toMap( v -> idSchemes.toMetadataIdentifier( v.getAttribute() ), v -> v ) );
@@ -137,8 +139,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
 
         for ( Attribute attribute : trackedEntity.getAttributes() )
         {
-            TrackedEntityAttribute tea = reporter.getBundle().getPreheat()
-                .getTrackedEntityAttribute( attribute.getAttribute() );
+            TrackedEntityAttribute tea = preheat.getTrackedEntityAttribute( attribute.getAttribute() );
 
             if ( tea == null )
             {
@@ -163,13 +164,12 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
             }
 
             validateAttributeValue( reporter, trackedEntity, tea, attribute.getValue() );
-            validateAttrValueType( reporter, trackedEntity, attribute, tea );
-            validateOptionSet( reporter, trackedEntity, tea,
-                attribute.getValue() );
+            validateAttrValueType( reporter, preheat, trackedEntity, attribute, tea );
+            validateOptionSet( reporter, trackedEntity, tea, attribute.getValue() );
 
-            validateAttributeUniqueness( reporter, trackedEntity, attribute.getValue(), tea, tei, orgUnit );
+            validateAttributeUniqueness( reporter, preheat, trackedEntity, attribute.getValue(), tea, tei, orgUnit );
 
-            validateFileNotAlreadyAssigned( reporter, trackedEntity, attribute, valueMap );
+            validateFileNotAlreadyAssigned( reporter, bundle, trackedEntity, attribute, valueMap );
         }
     }
 
@@ -197,7 +197,8 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
         reporter.addErrorIf( () -> result != null, te, E1085, tea, result );
     }
 
-    protected void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, TrackedEntity te,
+    protected void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity te,
         Attribute attr, Map<MetadataIdentifier, TrackedEntityAttributeValue> valueMap )
     {
         checkNotNull( attr, ATTRIBUTE_CANT_BE_NULL );
@@ -217,12 +218,11 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
             return;
         }
 
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
-        FileResource fileResource = preheat.get( FileResource.class, attr.getValue() );
+        FileResource fileResource = bundle.getPreheat().get( FileResource.class, attr.getValue() );
 
         reporter.addErrorIfNull( fileResource, te, E1084, attr.getValue() );
 
-        if ( reporter.getBundle().getStrategy( te ).isCreate() )
+        if ( bundle.getStrategy( te ).isCreate() )
         {
             reporter.addErrorIf( () -> fileResource != null && fileResource.isAssigned(), te, E1009, attr.getValue() );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
@@ -81,7 +82,8 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
     }
 
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
+    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
+        TrackedEntity trackedEntity )
     {
         TrackedEntityType trackedEntityType = reporter.getBundle().getPreheat()
             .getTrackedEntityType( trackedEntity.getTrackedEntityType() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -80,11 +80,9 @@ public class ValidationUtils
         }
     }
 
-    protected static List<Note> validateNotes( ValidationErrorReporter reporter, TrackerDto dto,
+    protected static List<Note> validateNotes( ValidationErrorReporter reporter, TrackerPreheat preheat, TrackerDto dto,
         List<Note> notesToCheck )
     {
-        TrackerPreheat preheat = reporter.getBundle().getPreheat();
-
         final List<Note> notes = new ArrayList<>();
         for ( Note note : notesToCheck )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
@@ -41,8 +41,8 @@ class ValidationErrorReporterTest
     void hasErrorReportFound()
     {
 
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
         TrackerErrorReport error = TrackerErrorReport.builder()
             .errorCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
@@ -56,8 +56,8 @@ class ValidationErrorReporterTest
     void hasErrorReportNotFound()
     {
 
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
         TrackerErrorReport error = TrackerErrorReport.builder()
             .errorCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
@@ -71,8 +71,8 @@ class ValidationErrorReporterTest
     void hasWarningReportFound()
     {
 
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
         TrackerWarningReport warning = TrackerWarningReport.builder()
             .warningCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )
@@ -86,8 +86,8 @@ class ValidationErrorReporterTest
     void hasWarningReportNotFound()
     {
 
-        ValidationErrorReporter reporter = ValidationErrorReporter.emptyReporter();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
         TrackerWarningReport warning = TrackerWarningReport.builder()
             .warningCode( TrackerErrorCode.E1000 )
             .trackerType( TrackerType.EVENT )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -156,7 +156,7 @@ class DefaultTrackerValidationServiceTest
         }
 
         @Override
-        public void validateEvent( ValidationErrorReporter reporter, Event event )
+        public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
         {
             if ( this.validateEvent != null )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -138,7 +138,8 @@ class DefaultTrackerValidationServiceTest
         private BiConsumer<ValidationErrorReporter, Event> validateEvent;
 
         @Override
-        public void validateTrackedEntity( ValidationErrorReporter reporter, TrackedEntity trackedEntity )
+        public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
+            TrackedEntity trackedEntity )
         {
             if ( this.validateTrackedEntity != null )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -148,7 +148,7 @@ class DefaultTrackerValidationServiceTest
         }
 
         @Override
-        public void validateEnrollment( ValidationErrorReporter reporter, Enrollment enrollment )
+        public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
         {
             if ( this.validateEnrollment != null )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -102,7 +102,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -119,7 +119,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -136,7 +136,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -154,7 +154,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1118, TrackerType.EVENT, event.getUid() );
@@ -175,7 +175,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         bundle = TrackerBundle.builder().preheat( preheat ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1118, TrackerType.EVENT, event.getUid() );
@@ -195,7 +195,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         // when
         programStage.setEnableUserAssignment( false );
 
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -219,7 +219,7 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         // when
         programStage.setEnableUserAssignment( null );
 
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidationHookTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
@@ -67,6 +68,8 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     private ProgramStage programStage;
 
     private static final User VALID_USER = User.builder().username( USER_NAME ).build();
@@ -89,6 +92,9 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         programStage.setUid( PROGRAM_STAGE );
         programStage.setEnableUserAssignment( true );
         preheat.put( programStage );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -98,8 +104,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setAssignedUser( VALID_USER );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -116,8 +120,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         event.setAssignedUser( null );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
 
@@ -132,8 +134,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setAssignedUser( User.builder().build() );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -150,8 +150,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( INVALID_USER );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -173,7 +171,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         TrackerPreheat preheat = new TrackerPreheat();
         preheat.put( programStage );
         bundle = TrackerBundle.builder().preheat( preheat ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         this.hookToTest.validateEvent( reporter, bundle, event );
 
@@ -189,8 +186,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( VALID_USER );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         programStage.setEnableUserAssignment( false );
@@ -213,8 +208,6 @@ class AssignedUserValidationHookTest extends DhisConvenienceTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setAssignedUser( VALID_USER );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         programStage.setEnableUserAssignment( null );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -152,7 +152,7 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
@@ -182,7 +182,7 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
@@ -210,7 +210,7 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
         hasTrackerError( reporter, TrackerErrorCode.E1018, TrackerType.ENROLLMENT, enrollment.getUid() );
@@ -236,7 +236,7 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( trackedEntityInstance );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         hasTrackerError( reporter,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -97,6 +97,8 @@ class EnrollmentAttributeValidationHookTest
 
     private TrackedEntityAttribute trackedEntityAttribute1;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -126,6 +128,9 @@ class EnrollmentAttributeValidationHookTest
         bundle = TrackerBundle.builder()
             .preheat( preheat )
             .build();
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -151,7 +156,6 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
@@ -181,7 +185,6 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 0 ) );
@@ -209,7 +212,6 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
@@ -235,7 +237,6 @@ class EnrollmentAttributeValidationHookTest
         when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
             .thenReturn( trackedEntityInstance );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -41,6 +41,7 @@ import java.time.Instant;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -66,6 +67,8 @@ class EnrollmentDateValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -74,6 +77,9 @@ class EnrollmentDateValidationHookTest
         bundle = TrackerBundle.builder()
             .preheat( preheat )
             .build();
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -84,8 +90,6 @@ class EnrollmentDateValidationHookTest
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .occurredAt( Instant.now() )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
@@ -104,8 +108,6 @@ class EnrollmentDateValidationHookTest
             .occurredAt( dateInTheFuture )
             .enrolledAt( dateInTheFuture )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
@@ -126,8 +128,6 @@ class EnrollmentDateValidationHookTest
             .enrolledAt( today )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
         this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
@@ -145,8 +145,6 @@ class EnrollmentDateValidationHookTest
             .occurredAt( dateInTheFuture )
             .enrolledAt( dateInTheFuture )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Program program = new Program();
         program.setSelectEnrollmentDatesInFuture( true );
@@ -166,8 +164,6 @@ class EnrollmentDateValidationHookTest
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .enrolledAt( Instant.now() )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         Program program = new Program();
         program.setDisplayIncidentDate( true );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidationHookTest.java
@@ -89,7 +89,7 @@ class EnrollmentDateValidationHookTest
 
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1025, ENROLLMENT, enrollment.getUid() );
     }
@@ -109,7 +109,7 @@ class EnrollmentDateValidationHookTest
 
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1020, ENROLLMENT, enrollment.getUid() );
         hasTrackerError( reporter, E1021, ENROLLMENT, enrollment.getUid() );
@@ -130,7 +130,7 @@ class EnrollmentDateValidationHookTest
 
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( new Program() );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -153,7 +153,7 @@ class EnrollmentDateValidationHookTest
         program.setSelectIncidentDatesInFuture( true );
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( program );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -173,7 +173,7 @@ class EnrollmentDateValidationHookTest
         program.setDisplayIncidentDate( true );
         when( preheat.getProgram( enrollment.getProgram() ) ).thenReturn( program );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1023, ENROLLMENT, enrollment.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -69,6 +70,8 @@ class EnrollmentGeoValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -81,6 +84,9 @@ class EnrollmentGeoValidationHookTest
         Program program = new Program();
         program.setFeatureType( FeatureType.POINT );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM ) ) ).thenReturn( program );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -91,8 +97,6 @@ class EnrollmentGeoValidationHookTest
             .program( MetadataIdentifier.ofUid( PROGRAM ) )
             .geometry( new GeometryFactory().createPoint() )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
@@ -109,8 +113,6 @@ class EnrollmentGeoValidationHookTest
         enrollment.setProgram( null );
         enrollment.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         assertThrows( NullPointerException.class,
             () -> this.hookToTest.validateEnrollment( reporter, bundle, enrollment ) );
     }
@@ -124,8 +126,6 @@ class EnrollmentGeoValidationHookTest
             .program( MetadataIdentifier.ofUid( PROGRAM ) )
             .geometry( new GeometryFactory().createPoint() )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         Program program = new Program();
@@ -147,8 +147,6 @@ class EnrollmentGeoValidationHookTest
             .geometry( new GeometryFactory().createPoint() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         Program program = new Program();
         program.setFeatureType( FeatureType.NONE );
@@ -169,8 +167,6 @@ class EnrollmentGeoValidationHookTest
             .program( MetadataIdentifier.ofUid( PROGRAM ) )
             .geometry( new GeometryFactory().createPoint() )
             .build();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         Program program = new Program();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidationHookTest.java
@@ -95,7 +95,7 @@ class EnrollmentGeoValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -111,7 +111,8 @@ class EnrollmentGeoValidationHookTest
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
-        assertThrows( NullPointerException.class, () -> this.hookToTest.validateEnrollment( reporter, enrollment ) );
+        assertThrows( NullPointerException.class,
+            () -> this.hookToTest.validateEnrollment( reporter, bundle, enrollment ) );
     }
 
     @Test
@@ -130,7 +131,7 @@ class EnrollmentGeoValidationHookTest
         Program program = new Program();
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM ) ) ).thenReturn( program );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1074, ENROLLMENT, enrollment.getUid() );
@@ -153,7 +154,7 @@ class EnrollmentGeoValidationHookTest
         program.setFeatureType( FeatureType.NONE );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM ) ) ).thenReturn( program );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1012, ENROLLMENT, enrollment.getUid() );
@@ -176,7 +177,7 @@ class EnrollmentGeoValidationHookTest
         program.setFeatureType( FeatureType.MULTI_POLYGON );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM ) ) ).thenReturn( program );
 
-        this.hookToTest.validateEnrollment( reporter, enrollment );
+        this.hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1012, ENROLLMENT, enrollment.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -117,7 +117,7 @@ class EnrollmentInExistingValidationHookTest
     void shouldExitCancelledStatus()
     {
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.CANCELLED );
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         verify( preheat, times( 0 ) ).getProgram( programUid );
     }
@@ -127,7 +127,7 @@ class EnrollmentInExistingValidationHookTest
     {
         when( enrollment.getProgram() ).thenReturn( null );
         assertThrows( NullPointerException.class,
-            () -> hookToTest.validateEnrollment( reporter, enrollment ) );
+            () -> hookToTest.validateEnrollment( reporter, bundle, enrollment ) );
     }
 
     @Test
@@ -138,7 +138,7 @@ class EnrollmentInExistingValidationHookTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( programUid ) ) ).thenReturn( program );
         when( enrollment.getStatus() ).thenReturn( EnrollmentStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -153,7 +153,7 @@ class EnrollmentInExistingValidationHookTest
 
         when( enrollment.getTrackedEntity() ).thenReturn( null );
         assertThrows( NullPointerException.class,
-            () -> hookToTest.validateEnrollment( reporter, enrollment ) );
+            () -> hookToTest.validateEnrollment( reporter, bundle, enrollment ) );
     }
 
     @Test
@@ -164,7 +164,7 @@ class EnrollmentInExistingValidationHookTest
 
         when( preheat.getProgram( MetadataIdentifier.ofUid( programUid ) ) ).thenReturn( program );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -174,7 +174,7 @@ class EnrollmentInExistingValidationHookTest
     {
         setEnrollmentInPayload( EnrollmentStatus.ACTIVE );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
@@ -192,7 +192,7 @@ class EnrollmentInExistingValidationHookTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( programUid ) ) ).thenReturn( program );
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
@@ -205,7 +205,7 @@ class EnrollmentInExistingValidationHookTest
     {
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -215,7 +215,7 @@ class EnrollmentInExistingValidationHookTest
     {
         setTeiInDb();
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
@@ -233,7 +233,7 @@ class EnrollmentInExistingValidationHookTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( programUid ) ) ).thenReturn( program );
         setTeiInDb( ProgramStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
@@ -245,7 +245,7 @@ class EnrollmentInExistingValidationHookTest
     {
         setTeiInDb( ProgramStatus.COMPLETED );
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -261,7 +261,7 @@ class EnrollmentInExistingValidationHookTest
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
         setTeiInDb();
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getReportList().size() );
@@ -279,7 +279,7 @@ class EnrollmentInExistingValidationHookTest
         setEnrollmentInPayload( EnrollmentStatus.COMPLETED );
         setTeiInDb();
 
-        hookToTest.validateEnrollment( reporter, enrollment );
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -110,7 +110,9 @@ class EnrollmentInExistingValidationHookTest
         program.setUid( programUid );
 
         when( preheat.getProgram( MetadataIdentifier.ofUid( programUid ) ) ).thenReturn( program );
-        reporter = new ValidationErrorReporter( bundle );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
-import org.hisp.dhis.tracker.ValidationMode;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Note;
@@ -72,6 +72,8 @@ class EnrollmentNoteValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -80,8 +82,10 @@ class EnrollmentNoteValidationHookTest
 
         preheat = mock( TrackerPreheat.class );
         bundle = mock( TrackerBundle.class );
-        when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( bundle.getPreheat() ).thenReturn( preheat );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -92,7 +96,6 @@ class EnrollmentNoteValidationHookTest
 
         when( preheat.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
         enrollment.setNotes( Collections.singletonList( note ) );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // When
         this.hook.validateEnrollment( reporter, bundle, enrollment );
@@ -111,7 +114,6 @@ class EnrollmentNoteValidationHookTest
         // Given
         final Note note = rnd.nextObject( Note.class );
         note.setValue( null );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         enrollment.setNotes( Collections.singletonList( note ) );
 
@@ -128,7 +130,6 @@ class EnrollmentNoteValidationHookTest
     {
         // Given
         final List<Note> notes = rnd.objects( Note.class, 5 ).collect( Collectors.toList() );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         enrollment.setNotes( notes );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidationHookTest.java
@@ -95,7 +95,7 @@ class EnrollmentNoteValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // When
-        this.hook.validateEnrollment( reporter, enrollment );
+        this.hook.validateEnrollment( reporter, bundle, enrollment );
 
         // Then
         assertTrue( reporter.hasWarnings() );
@@ -116,7 +116,7 @@ class EnrollmentNoteValidationHookTest
         enrollment.setNotes( Collections.singletonList( note ) );
 
         // When
-        this.hook.validateEnrollment( reporter, enrollment );
+        this.hook.validateEnrollment( reporter, bundle, enrollment );
 
         // Then
         assertFalse( reporter.hasErrors() );
@@ -133,7 +133,7 @@ class EnrollmentNoteValidationHookTest
         enrollment.setNotes( notes );
 
         // When
-        this.hook.validateEnrollment( reporter, enrollment );
+        this.hook.validateEnrollment( reporter, bundle, enrollment );
 
         // Then
         assertFalse( reporter.hasErrors() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.mock.MockI18nFormat;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -148,7 +149,8 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
             .thenReturn( program );
         when( i18nManager.getI18nFormat() ).thenReturn( I18N_FORMAT );
 
-        reporter = new ValidationErrorReporter( bundle );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidationHookTest.java
@@ -74,6 +74,8 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     @Mock
     private TrackerPreheat preheat;
 
+    private TrackerBundle bundle;
+
     private static final I18nFormat I18N_FORMAT = new MockI18nFormat();
 
     private EventCategoryOptValidationHook hook;
@@ -137,7 +139,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
 
         User user = makeUser( "A" );
 
-        TrackerBundle bundle = TrackerBundle.builder()
+        bundle = TrackerBundle.builder()
             .user( user )
             .preheat( preheat )
             .build();
@@ -155,7 +157,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         when( preheat.getDefault( CategoryOptionCombo.class ) ).thenReturn( defaultCatOptionCombo );
         program.setCategoryCombo( defaultCatCombo );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -165,7 +167,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
     {
         when( preheat.getCategoryOptionCombo( event.getAttributeOptionCombo() ) ).thenReturn( attOptionCombo );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -177,7 +179,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         catOption.setStartDate( ONE_YEAR_BEFORE_EVENT );
         catOption.setEndDate( ONE_YEAR_AFTER_EVENT );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -188,7 +190,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOptionCombo( event.getAttributeOptionCombo() ) ).thenReturn( attOptionCombo );
         catOption.setStartDate( ONE_YEAR_AFTER_EVENT );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1056, EVENT, event.getUid() );
     }
@@ -199,7 +201,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         when( preheat.getCategoryOptionCombo( event.getAttributeOptionCombo() ) ).thenReturn( attOptionCombo );
         catOption.setEndDate( ONE_YEAR_BEFORE_EVENT );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1057, EVENT, event.getUid() );
     }
@@ -211,7 +213,7 @@ class EventCategoryOptValidationHookTest extends DhisConvenienceTest
         catOption.setEndDate( ONE_YEAR_BEFORE_EVENT );
         program.setOpenDaysAfterCoEndDate( 400 );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -112,7 +112,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -138,7 +138,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -164,7 +164,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -188,7 +188,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1304, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -225,7 +225,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( dataValue() ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1303, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -262,7 +262,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue() ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -295,7 +295,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( dataValue ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -333,7 +333,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue(), notPresentDataValue ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1305, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -367,7 +367,7 @@ class EventDataValuesValidationHookTest
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue ) ).build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -393,7 +393,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( dataValue() ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -424,7 +424,7 @@ class EventDataValuesValidationHookTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1084, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -452,7 +452,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -479,7 +479,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -508,7 +508,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -537,7 +537,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -566,7 +566,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -594,7 +594,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -622,7 +622,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -649,7 +649,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -676,7 +676,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -707,7 +707,7 @@ class EventDataValuesValidationHookTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1009, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -716,7 +716,7 @@ class EventDataValuesValidationHookTest
 
         ValidationErrorReporter updateReporter = new ValidationErrorReporter( bundle );
 
-        hook.validateEvent( updateReporter, event );
+        hook.validateEvent( updateReporter, bundle, event );
 
         assertThat( updateReporter.getReportList(), hasSize( 0 ) );
     }
@@ -770,7 +770,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue, nullDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -806,7 +806,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList(), hasSize( 1 ) );
@@ -837,7 +837,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( invalidDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1007, reporter.getReportList().get( 0 ).getErrorCode() );
@@ -868,7 +868,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -895,7 +895,7 @@ class EventDataValuesValidationHookTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -85,19 +85,25 @@ class EventDataValuesValidationHookTest
     @Mock
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
+    private TrackerIdSchemeParams idSchemes;
+
     @BeforeEach
     public void setUp()
     {
         hook = new EventDataValuesValidationHook();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
+
+        idSchemes = TrackerIdSchemeParams.builder().build();
+        when( preheat.getIdSchemes() ).thenReturn( idSchemes );
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
     void successValidationWhenDataElementIsValid()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
@@ -105,10 +111,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -120,8 +124,6 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenCreatedAtIsNull()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
@@ -129,12 +131,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setCreatedAt( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) ).build();
 
@@ -146,8 +146,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenUpdatedAtIsNull()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
@@ -155,12 +153,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setUpdatedAt( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) ).build();
 
@@ -172,8 +168,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsInvalid()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( null );
 
@@ -181,10 +175,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -197,8 +189,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenAMandatoryDataElementIsMissing()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
@@ -218,10 +208,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -234,8 +222,6 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsWhenMandatoryDataElementIsNotPresentButMandatoryValidationIsNotNeeded()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
@@ -255,10 +241,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue() ) ).build();
 
@@ -286,12 +270,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue dataValue = dataValue();
         dataValue.setDataElement( MetadataIdentifier.ofCode( "DE_424050" ) );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( dataValue ) ).build();
 
@@ -303,8 +285,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementIsNotPresentInProgramStage()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( dataElement );
 
@@ -324,12 +304,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue notPresentDataValue = dataValue();
         notPresentDataValue.setDataElement( MetadataIdentifier.ofUid( "de_not_present_in_program_stage" ) );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue(), notPresentDataValue ) ).build();
 
@@ -358,12 +336,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue dataValue = dataValue();
         dataValue.setDataElement( MetadataIdentifier.ofCode( "DE_424050" ) );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( dataValue ) ).build();
 
@@ -375,8 +351,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenDataElementValueTypeIsNull()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement dataElement = dataElement();
         DataElement invalidDataElement = dataElement( null );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( invalidDataElement );
@@ -385,10 +359,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( dataValue() ) )
             .build();
@@ -402,8 +374,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsNull()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -414,10 +384,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -433,8 +401,6 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenFileResourceValueIsNullAndDataElementIsNotCompulsory()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -442,12 +408,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -460,8 +424,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceValueIsNullAndDataElementIsCompulsory()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -469,12 +431,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -488,8 +448,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnActiveEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -498,12 +456,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -517,8 +473,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueNullAndValidationStrategyOnUpdate()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -527,12 +481,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -546,8 +498,6 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnActiveEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -556,12 +506,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -574,8 +522,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failsOnCompletedEventWithDataElementValueIsNullAndValidationStrategyOnComplete()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -584,12 +530,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -603,8 +547,6 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnScheduledEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -612,12 +554,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SCHEDULE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -630,8 +570,6 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsOnSkippedEventWithDataElementValueIsNullAndEventStatusSkippedOrScheduled()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -639,12 +577,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -657,8 +593,6 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationWhenDataElementIsNullAndDataElementIsNotCompulsory()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement();
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -666,12 +600,10 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setValue( null );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.COMPLETED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -684,8 +616,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenFileResourceIsAlreadyAssigned()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement validDataElement = dataElement( ValueType.FILE_RESOURCE );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
 
@@ -693,14 +623,12 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         FileResource fileResource = new FileResource();
         fileResource.setAssigned( true );
         DataValue validDataValue = dataValue( "QX4LpiTZmUH" );
         when( preheat.get( FileResource.class, validDataValue.getValue() ) ).thenReturn( fileResource );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -714,11 +642,11 @@ class EventDataValuesValidationHookTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter updateReporter = new ValidationErrorReporter( bundle );
+        reporter = new ValidationErrorReporter( idSchemes );
 
-        hook.validateEvent( updateReporter, bundle, event );
+        hook.validateEvent( reporter, bundle, event );
 
-        assertThat( updateReporter.getReportList(), hasSize( 0 ) );
+        assertThat( reporter.getReportList(), hasSize( 0 ) );
     }
 
     @Test
@@ -742,7 +670,6 @@ class EventDataValuesValidationHookTest
     @Test
     void successValidationDataElementOptionValueIsValid()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataValue validDataValue = dataValue( "CODE" );
         DataValue nullDataValue = dataValue( null );
@@ -762,10 +689,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue, nullDataValue ) )
             .build();
@@ -778,7 +703,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationDataElementOptionValueIsInValid()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataValue validDataValue = dataValue( "value" );
         validDataValue.setDataElement( MetadataIdentifier.ofUid( dataElementUid ) );
@@ -798,10 +722,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -817,7 +739,6 @@ class EventDataValuesValidationHookTest
     @Test
     void failValidationWhenOrgUnitValueIsInvalid()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.ORGANISATION_UNIT );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
@@ -829,10 +750,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( invalidDataValue ) )
             .build();
@@ -846,7 +765,6 @@ class EventDataValuesValidationHookTest
     @Test
     void succeedsValidationWhenOrgUnitValueIsValid()
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
 
         DataElement validDataElement = dataElement( ValueType.ORGANISATION_UNIT );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( validDataElement );
@@ -860,10 +778,8 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.ACTIVE )
             .dataValues( Set.of( validDataValue ) )
             .build();
@@ -875,8 +791,6 @@ class EventDataValuesValidationHookTest
 
     private void runAndAssertValidationForDataValue( ValueType valueType, String value )
     {
-        TrackerIdSchemeParams params = setUpIdentifiers();
-
         DataElement invalidDataElement = dataElement( valueType );
         when( preheat.getDataElement( MetadataIdentifier.ofUid( dataElementUid ) ) ).thenReturn( invalidDataElement );
 
@@ -884,33 +798,20 @@ class EventDataValuesValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStageUid ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         DataValue validDataValue = dataValue();
         validDataValue.setDataElement( MetadataIdentifier.ofUid( dataElementUid ) );
         validDataValue.setValue( value );
         Event event = Event.builder()
-            .programStage( params.toMetadataIdentifier( programStage ) )
+            .programStage( idSchemes.toMetadataIdentifier( programStage ) )
             .status( EventStatus.SKIPPED )
             .dataValues( Set.of( validDataValue ) )
             .build();
 
+        reporter = new ValidationErrorReporter( idSchemes );
         hook.validateEvent( reporter, bundle, event );
 
         assertThat( reporter.getReportList(), hasSize( 1 ) );
         assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
-    }
-
-    private TrackerIdSchemeParams setUpIdentifiers()
-    {
-        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
-            .idScheme( TrackerIdSchemeParam.UID )
-            .programIdScheme( TrackerIdSchemeParam.UID )
-            .programStageIdScheme( TrackerIdSchemeParam.UID )
-            .dataElementIdScheme( TrackerIdSchemeParam.UID )
-            .build();
-        when( preheat.getIdSchemes() ).thenReturn( params );
-        return params;
     }
 
     private DataElement dataElement( ValueType type )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.security.Authorities;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -86,6 +87,8 @@ class EventDateValidationHookTest extends DhisConvenienceTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -102,6 +105,9 @@ class EventDateValidationHookTest extends DhisConvenienceTest
             .thenReturn( getProgramWithRegistration() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION_ID ) ) )
             .thenReturn( getProgramWithoutRegistration() );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -117,7 +123,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
             .user( getEditExpiredUser() )
             .preheat( preheat )
             .build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -133,8 +138,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         Event event = new Event();
         event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITHOUT_REGISTRATION_ID ) );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -152,8 +155,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION_ID ) );
         event.setStatus( EventStatus.ACTIVE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
 
@@ -169,8 +170,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION_ID ) );
         event.setStatus( EventStatus.COMPLETED );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -189,8 +188,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setOccurredAt( Instant.now() );
         event.setStatus( EventStatus.SCHEDULE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
 
@@ -207,8 +204,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION_ID ) );
         event.setOccurredAt( now() );
         event.setStatus( EventStatus.COMPLETED );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -228,8 +223,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setCompletedAt( sevenDaysAgo() );
         event.setStatus( EventStatus.COMPLETED );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
 
@@ -248,8 +241,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setScheduledAt( null );
         event.setStatus( EventStatus.SKIPPED );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
 
@@ -266,8 +257,6 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         event.setProgram( MetadataIdentifier.ofUid( PROGRAM_WITH_REGISTRATION_ID ) );
         event.setOccurredAt( sevenDaysAgo() );
         event.setStatus( EventStatus.ACTIVE );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidationHookTest.java
@@ -120,7 +120,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -137,7 +137,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1031, EVENT, event.getUid() );
@@ -155,7 +155,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1031, EVENT, event.getUid() );
@@ -173,7 +173,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1031, EVENT, event.getUid() );
@@ -192,7 +192,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1050, EVENT, event.getUid() );
@@ -211,7 +211,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1042, EVENT, event.getUid() );
@@ -231,7 +231,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1043, EVENT, event.getUid() );
@@ -251,7 +251,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1046, EVENT, event.getUid() );
@@ -270,7 +270,7 @@ class EventDateValidationHookTest extends DhisConvenienceTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1047, EVENT, event.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.organisationunit.FeatureType;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
@@ -71,6 +72,8 @@ class EventGeoValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -84,6 +87,9 @@ class EventGeoValidationHookTest
         programStage.setFeatureType( FeatureType.POINT );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) ) )
             .thenReturn( programStage );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -93,8 +99,6 @@ class EventGeoValidationHookTest
         Event event = new Event();
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         this.hookToTest.validateEvent( reporter, bundle, event );
@@ -111,8 +115,6 @@ class EventGeoValidationHookTest
         event.setProgramStage( null );
         event.setGeometry( new GeometryFactory().createPoint() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         assertThrows( NullPointerException.class, () -> this.hookToTest.validateEvent( reporter, bundle, event ) );
     }
@@ -125,8 +127,6 @@ class EventGeoValidationHookTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( new ProgramStage() );
@@ -145,8 +145,6 @@ class EventGeoValidationHookTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         ProgramStage programStage = new ProgramStage();
@@ -167,8 +165,6 @@ class EventGeoValidationHookTest
         event.setEvent( CodeGenerator.generateUid() );
         event.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE ) );
         event.setGeometry( new GeometryFactory().createPoint() );
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         ProgramStage programStage = new ProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidationHookTest.java
@@ -97,7 +97,7 @@ class EventGeoValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -114,7 +114,7 @@ class EventGeoValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        assertThrows( NullPointerException.class, () -> this.hookToTest.validateEvent( reporter, event ) );
+        assertThrows( NullPointerException.class, () -> this.hookToTest.validateEvent( reporter, bundle, event ) );
     }
 
     @Test
@@ -131,7 +131,7 @@ class EventGeoValidationHookTest
         // when
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( new ProgramStage() );
 
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1074, EVENT, event.getUid() );
@@ -153,7 +153,7 @@ class EventGeoValidationHookTest
         programStage.setFeatureType( NONE );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
 
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1012, EVENT, event.getUid() );
@@ -175,7 +175,7 @@ class EventGeoValidationHookTest
         programStage.setFeatureType( MULTI_POLYGON );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
 
-        this.hookToTest.validateEvent( reporter, event );
+        this.hookToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1012, EVENT, event.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -41,8 +41,8 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.random.BeanRandomizer;
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
-import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
@@ -72,6 +72,8 @@ class EventNoteValidationHookTest
 
     private TrackerPreheat preheat;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -80,8 +82,10 @@ class EventNoteValidationHookTest
 
         bundle = mock( TrackerBundle.class );
         preheat = mock( TrackerPreheat.class );
-        when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( bundle.getPreheat() ).thenReturn( preheat );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -90,7 +94,6 @@ class EventNoteValidationHookTest
         // Given
         final Note note = rnd.nextObject( Note.class );
         when( preheat.getNote( note.getNote() ) ).thenReturn( Optional.of( new TrackedEntityComment() ) );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         event.setNotes( Collections.singletonList( note ) );
 
@@ -111,7 +114,6 @@ class EventNoteValidationHookTest
         // Given
         final Note note = rnd.nextObject( Note.class );
         note.setValue( null );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         event.setNotes( Collections.singletonList( note ) );
 
@@ -128,7 +130,6 @@ class EventNoteValidationHookTest
     {
         // Given
         final List<Note> notes = rnd.objects( Note.class, 5 ).collect( Collectors.toList() );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         event.setNotes( notes );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidationHookTest.java
@@ -95,7 +95,7 @@ class EventNoteValidationHookTest
         event.setNotes( Collections.singletonList( note ) );
 
         // When
-        this.hook.validateEvent( reporter, event );
+        this.hook.validateEvent( reporter, bundle, event );
 
         // Then
         assertTrue( reporter.hasWarnings() );
@@ -116,7 +116,7 @@ class EventNoteValidationHookTest
         event.setNotes( Collections.singletonList( note ) );
 
         // When
-        this.hook.validateEvent( reporter, event );
+        this.hook.validateEvent( reporter, bundle, event );
 
         // Then
         assertFalse( reporter.hasErrors() );
@@ -133,7 +133,7 @@ class EventNoteValidationHookTest
         event.setNotes( notes );
 
         // When
-        this.hook.validateEvent( reporter, event );
+        this.hook.validateEvent( reporter, bundle, event );
 
         // Then
         assertFalse( reporter.hasErrors() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -115,8 +115,8 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         hook = new PreCheckDataRelationsValidationHook();
 
         bundle = TrackerBundle.builder().preheat( preheat ).build();
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
-        reporter = new ValidationErrorReporter( bundle );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -928,7 +928,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .relationshipType( MetadataIdentifier.ofUid( relType.getUid() ) )
             .build();
 
-        hook.validateRelationship( reporter, relationship );
+        hook.validateRelationship( reporter, bundle, relationship );
 
         assertTrue( reporter.hasErrors() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E4012 ) );
@@ -962,7 +962,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .relationshipType( MetadataIdentifier.ofUid( relType.getUid() ) )
             .build();
 
-        hook.validateRelationship( reporter, relationship );
+        hook.validateRelationship( reporter, bundle, relationship );
 
         assertFalse( reporter.hasErrors() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -276,7 +276,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .enrollment( ENROLLMENT_ID )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -308,7 +308,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.EMPTY_UID )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1089 ) );
     }
@@ -339,7 +339,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.EMPTY_UID )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1033 ) );
@@ -375,7 +375,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .enrollment( ENROLLMENT_ID )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1079 ) );
@@ -412,7 +412,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .enrollment( ENROLLMENT_ID )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1029 ) );
@@ -428,7 +428,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         Event event = eventBuilder()
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1055 ) );
@@ -449,7 +449,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
@@ -475,7 +475,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( defaultCO ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -498,7 +498,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
@@ -521,7 +521,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
@@ -544,7 +544,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -565,7 +565,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -584,7 +584,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
@@ -604,7 +604,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( UNKNOWN_AOC_ID ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
@@ -624,7 +624,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1054 &&
@@ -647,7 +647,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( defaultAOC ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1055 ) );
@@ -667,7 +667,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeOptionCombo( MetadataIdentifier.ofUid( aoc ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1054 &&
@@ -696,7 +696,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( defaultCO ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -719,7 +719,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -743,7 +743,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
@@ -769,7 +769,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1055 ) );
@@ -794,7 +794,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( UNKNOWN_CO_ID ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1116 ) );
@@ -825,7 +825,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
                 MetadataIdentifier.ofUid( co ), MetadataIdentifier.ofUid( UNKNOWN_CO_ID2 ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 3, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
@@ -854,7 +854,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( eventCO ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
@@ -882,7 +882,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co1 ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
@@ -908,7 +908,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .attributeCategoryOptions( Set.of( MetadataIdentifier.ofUid( co1 ) ) )
             .build();
 
-        hook.validateEvent( reporter, event );
+        hook.validateEvent( reporter, bundle, event );
 
         assertEquals( 1, reporter.getReportList().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -140,7 +140,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .build();
 
-        hook.validateEnrollment( reporter, enrollment );
+        hook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -162,7 +162,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .program( MetadataIdentifier.ofUid( PROGRAM_UID ) )
             .build();
 
-        hook.validateEnrollment( reporter, enrollment );
+        hook.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1014 ) );
     }
@@ -186,7 +186,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .orgUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) )
             .build();
 
-        hook.validateEnrollment( reporter, enrollment );
+        hook.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1041 ) );
     }
@@ -212,7 +212,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .build();
 
-        hook.validateEnrollment( reporter, enrollment );
+        hook.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1022 ) );
     }
@@ -242,7 +242,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .trackedEntity( TEI_ID )
             .build();
 
-        hook.validateEnrollment( reporter, enrollment );
+        hook.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1022 ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -306,7 +306,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -320,7 +320,7 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -335,7 +335,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -350,7 +350,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramStageInstance( SOFT_DELETED_EVENT_UID ) ).thenReturn( getSoftDeletedEvent() );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1082, EVENT, event.getUid() );
     }
@@ -366,7 +366,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1030, EVENT, event.getUid() );
     }
@@ -381,7 +381,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1032, EVENT, event.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -126,7 +126,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -140,7 +140,7 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -155,7 +155,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getTrackedEntityInstance( TEI_UID ) ).thenReturn( getTei() );
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -170,7 +170,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getTrackedEntityInstance( SOFT_DELETED_TEI_UID ) ).thenReturn( getSoftDeletedTei() );
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1114, TRACKED_ENTITY, trackedEntity.getUid() );
     }
@@ -186,7 +186,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1002, TRACKED_ENTITY, trackedEntity.getUid() );
     }
@@ -201,7 +201,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1063, TRACKED_ENTITY, trackedEntity.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -108,12 +108,13 @@ class PreCheckExistenceValidationHookTest
 
     private PreCheckExistenceValidationHook validationHook = new PreCheckExistenceValidationHook();
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     void setUp()
     {
-
-        when( bundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -125,7 +126,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -139,7 +139,6 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -154,7 +153,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getTrackedEntityInstance( TEI_UID ) ).thenReturn( getTei() );
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -169,7 +167,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getTrackedEntityInstance( SOFT_DELETED_TEI_UID ) ).thenReturn( getSoftDeletedTei() );
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1114, TRACKED_ENTITY, trackedEntity.getUid() );
@@ -185,7 +182,6 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getTrackedEntityInstance( TEI_UID ) ).thenReturn( getTei() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1002, TRACKED_ENTITY, trackedEntity.getUid() );
@@ -200,7 +196,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1063, TRACKED_ENTITY, trackedEntity.getUid() );
@@ -215,7 +210,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
@@ -229,7 +223,6 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
@@ -244,7 +237,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
@@ -259,7 +251,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getProgramInstance( SOFT_DELETED_ENROLLMENT_UID ) ).thenReturn( getSoftDeletedEnrollment() );
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1113, ENROLLMENT, enrollment.getUid() );
@@ -275,7 +266,6 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1080, ENROLLMENT, enrollment.getUid() );
@@ -290,7 +280,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1081, ENROLLMENT, enrollment.getUid() );
@@ -305,7 +294,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
@@ -319,7 +307,6 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
@@ -334,7 +321,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
@@ -349,7 +335,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getProgramStageInstance( SOFT_DELETED_EVENT_UID ) ).thenReturn( getSoftDeletedEvent() );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1082, EVENT, event.getUid() );
@@ -365,7 +350,6 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1030, EVENT, event.getUid() );
@@ -380,7 +364,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1032, EVENT, event.getUid() );
@@ -395,7 +378,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.CREATE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, rel );
 
         assertFalse( reporter.hasErrors() );
@@ -410,7 +392,6 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.UPDATE );
         when( bundle.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, rel );
 
         assertFalse( reporter.hasErrors() );
@@ -427,7 +408,6 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( bundle.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4015, RELATIONSHIP, rel.getUid() );
@@ -442,7 +422,6 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.DELETE );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4016, RELATIONSHIP, rel.getUid() );
@@ -456,7 +435,6 @@ class PreCheckExistenceValidationHookTest
             .build();
 
         when( bundle.getRelationship( SOFT_DELETED_RELATIONSHIP_UID ) ).thenReturn( softDeletedRelationship() );
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4017, RELATIONSHIP, rel.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -396,7 +396,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, rel );
+        validationHook.validateRelationship( reporter, bundle, rel );
 
         assertFalse( reporter.hasErrors() );
         assertThat( reporter.getWarningsReportList(), empty() );
@@ -411,7 +411,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, rel );
+        validationHook.validateRelationship( reporter, bundle, rel );
 
         assertFalse( reporter.hasErrors() );
         assertTrue( reporter.hasWarningReport( r -> E4015.equals( r.getWarningCode() ) &&
@@ -428,7 +428,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, rel );
+        validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4015, RELATIONSHIP, rel.getUid() );
     }
@@ -443,7 +443,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.DELETE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, rel );
+        validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4016, RELATIONSHIP, rel.getUid() );
     }
@@ -457,7 +457,7 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getRelationship( SOFT_DELETED_RELATIONSHIP_UID ) ).thenReturn( softDeletedRelationship() );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, rel );
+        validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4017, RELATIONSHIP, rel.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -216,7 +216,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -230,7 +230,7 @@ class PreCheckExistenceValidationHookTest
 
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -245,7 +245,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -260,7 +260,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getProgramInstance( SOFT_DELETED_ENROLLMENT_UID ) ).thenReturn( getSoftDeletedEnrollment() );
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1113, ENROLLMENT, enrollment.getUid() );
     }
@@ -276,7 +276,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1080, ENROLLMENT, enrollment.getUid() );
     }
@@ -291,7 +291,7 @@ class PreCheckExistenceValidationHookTest
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1081, ENROLLMENT, enrollment.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -209,7 +209,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -225,7 +225,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "program" );
     }
@@ -244,7 +244,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .thenReturn( programStage );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList(), hasSize( 1 ) );
@@ -262,7 +262,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "programStage" );
     }
@@ -278,7 +278,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "orgUnit" );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -298,7 +298,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -315,7 +315,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "from" );
     }
@@ -332,7 +332,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "to" );
     }
@@ -352,7 +352,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "relationshipType" );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -145,7 +145,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -161,7 +161,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "trackedEntity" );
     }
@@ -177,7 +177,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "program" );
     }
@@ -193,7 +193,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "orgUnit" );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.when;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
@@ -79,6 +80,8 @@ class PreCheckMandatoryFieldsValidationHookTest
     @Mock
     private TrackerPreheat preheat;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -87,6 +90,9 @@ class PreCheckMandatoryFieldsValidationHookTest
         when( bundle.getImportStrategy() ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( bundle.getPreheat() ).thenReturn( preheat );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -98,7 +104,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -113,7 +118,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .orgUnit( MetadataIdentifier.EMPTY_UID )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "orgUnit" );
@@ -128,7 +132,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "trackedEntityType" );
@@ -144,7 +147,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
@@ -160,7 +162,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( null )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "trackedEntity" );
@@ -176,7 +177,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "program" );
@@ -192,7 +192,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         assertMissingPropertyForEnrollment( reporter, enrollment.getUid(), "orgUnit" );
@@ -208,7 +207,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
@@ -224,7 +222,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( MetadataIdentifier.EMPTY_UID )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "program" );
@@ -243,7 +240,6 @@ class PreCheckMandatoryFieldsValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( programStage ) ) )
             .thenReturn( programStage );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertTrue( reporter.hasErrors() );
@@ -261,7 +257,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "programStage" );
@@ -277,7 +272,6 @@ class PreCheckMandatoryFieldsValidationHookTest
             .program( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         assertMissingPropertyForEvent( reporter, event.getUid(), "orgUnit" );
@@ -297,7 +291,6 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertFalse( reporter.hasErrors() );
@@ -314,7 +307,6 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "from" );
@@ -331,7 +323,6 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "to" );
@@ -351,7 +342,6 @@ class PreCheckMandatoryFieldsValidationHookTest
                 .build() )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertMissingPropertyForRelationship( reporter, relationship.getUid(), "relationshipType" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -99,7 +99,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -114,7 +114,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "orgUnit" );
     }
@@ -129,7 +129,7 @@ class PreCheckMandatoryFieldsValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertMissingPropertyForTrackedEntity( reporter, trackedEntity.getUid(), "trackedEntityType" );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -53,6 +53,7 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -94,6 +95,8 @@ class PreCheckMetaValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -102,6 +105,9 @@ class PreCheckMetaValidationHookTest
         bundle = TrackerBundle.builder()
             .preheat( preheat )
             .build();
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -109,8 +115,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         TrackedEntity tei = validTei();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
@@ -130,8 +134,6 @@ class PreCheckMetaValidationHookTest
         // given
         TrackedEntity tei = validTei();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TRACKED_ENTITY_TYPE_UID ) ) )
             .thenReturn( new TrackedEntityType() );
@@ -148,8 +150,6 @@ class PreCheckMetaValidationHookTest
         // given
         TrackedEntity tei = validTei();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
@@ -165,8 +165,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         Enrollment enrollment = validEnrollment();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
@@ -185,8 +183,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         Enrollment enrollment = validEnrollment();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getReference( TRACKED_ENTITY_UID ) )
@@ -207,8 +203,6 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
@@ -224,8 +218,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         Enrollment enrollment = validEnrollment();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
@@ -244,8 +236,6 @@ class PreCheckMetaValidationHookTest
         // given
         Enrollment enrollment = validEnrollment();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
@@ -262,8 +252,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         Event event = validEvent();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
@@ -284,8 +272,6 @@ class PreCheckMetaValidationHookTest
         // given
         Event event = validEvent();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
@@ -304,8 +290,6 @@ class PreCheckMetaValidationHookTest
         // given
         Event event = validEvent();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
@@ -322,8 +306,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         Event event = validEvent();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
@@ -342,8 +324,6 @@ class PreCheckMetaValidationHookTest
         // given
         Relationship relationship = validRelationship();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-
         // when
         when( preheat.getRelationshipType( MetadataIdentifier.ofUid( RELATIONSHIP_TYPE_UID ) ) )
             .thenReturn( new RelationshipType() );
@@ -359,8 +339,6 @@ class PreCheckMetaValidationHookTest
     {
         // given
         Relationship relationship = validRelationship();
-
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
         validatorToTest.validateRelationship( reporter, bundle, relationship );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -174,7 +174,7 @@ class PreCheckMetaValidationHookTest
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -195,7 +195,7 @@ class PreCheckMetaValidationHookTest
             .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -213,7 +213,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1070, ENROLLMENT, enrollment.getUid() );
@@ -232,7 +232,7 @@ class PreCheckMetaValidationHookTest
             .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1068, ENROLLMENT, enrollment.getUid() );
@@ -251,7 +251,7 @@ class PreCheckMetaValidationHookTest
             .thenReturn( new OrganisationUnit() );
         when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1069, ENROLLMENT, enrollment.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -348,7 +348,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getRelationshipType( MetadataIdentifier.ofUid( RELATIONSHIP_TYPE_UID ) ) )
             .thenReturn( new RelationshipType() );
 
-        validatorToTest.validateRelationship( reporter, relationship );
+        validatorToTest.validateRelationship( reporter, bundle, relationship );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -363,7 +363,7 @@ class PreCheckMetaValidationHookTest
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         // when
-        validatorToTest.validateRelationship( reporter, relationship );
+        validatorToTest.validateRelationship( reporter, bundle, relationship );
 
         // then
         hasTrackerError( reporter, E4006, RELATIONSHIP, relationship.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -272,7 +272,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
             .thenReturn( new ProgramStage() );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -292,7 +292,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
             .thenReturn( new ProgramStage() );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1010, EVENT, event.getUid() );
@@ -311,7 +311,7 @@ class PreCheckMetaValidationHookTest
             .thenReturn( new OrganisationUnit() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1013, EVENT, event.getUid() );
@@ -330,7 +330,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_UID ) ) )
             .thenReturn( new ProgramStage() );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1011, EVENT, event.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -118,7 +118,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TRACKED_ENTITY_TYPE_UID ) ) )
             .thenReturn( new TrackedEntityType() );
 
-        validatorToTest.validateTrackedEntity( reporter, tei );
+        validatorToTest.validateTrackedEntity( reporter, bundle, tei );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -136,7 +136,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TRACKED_ENTITY_TYPE_UID ) ) )
             .thenReturn( new TrackedEntityType() );
 
-        validatorToTest.validateTrackedEntity( reporter, tei );
+        validatorToTest.validateTrackedEntity( reporter, bundle, tei );
 
         // then
         hasTrackerError( reporter, E1049, TRACKED_ENTITY, tei.getUid() );
@@ -154,7 +154,7 @@ class PreCheckMetaValidationHookTest
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
 
-        validatorToTest.validateTrackedEntity( reporter, tei );
+        validatorToTest.validateTrackedEntity( reporter, bundle, tei );
 
         // then
         hasTrackerError( reporter, E1005, TRACKED_ENTITY, tei.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -433,14 +433,14 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
         verify( organisationUnitService, times( 0 ) ).isInUserHierarchyCached( user, organisationUnit );
 
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
         verify( organisationUnitService, times( 0 ) ).isInUserHierarchyCached( user, organisationUnit );
@@ -463,7 +463,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -488,7 +488,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -514,7 +514,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -540,7 +540,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -566,7 +566,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -594,7 +594,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -621,7 +621,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1000, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
@@ -649,7 +649,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1103, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
@@ -676,7 +676,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1091, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
@@ -703,7 +703,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEnrollment( reporter, enrollment );
+        validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
         hasTrackerError( reporter, E1104, TrackerType.ENROLLMENT, enrollment.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -737,7 +737,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -768,7 +768,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -796,7 +796,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -824,7 +824,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -855,7 +855,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -891,13 +891,13 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
         when( ownershipAccessManager.hasAccess( user, TEI_ID, organisationUnit, program ) ).thenReturn( false );
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, TrackerErrorCode.E1102, TrackerType.EVENT, event.getUid() );
 
         when( ownershipAccessManager.hasAccess( user, TEI_ID, organisationUnit, program ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
         assertFalse( reporter.hasErrors() );
     }
 
@@ -928,7 +928,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -958,7 +958,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1000, TrackerType.EVENT, event.getUid() );
     }
@@ -989,7 +989,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1000, TrackerType.EVENT, event.getUid() );
     }
@@ -1020,7 +1020,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, E1083, TrackerType.EVENT, event.getUid() );
     }
@@ -1055,7 +1055,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateEvent( reporter, event );
+        validatorToTest.validateEvent( reporter, bundle, event );
 
         verify( organisationUnitService, times( 0 ) ).isInUserHierarchyCached( user, organisationUnit );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -169,7 +169,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -192,7 +192,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -215,7 +215,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -238,7 +238,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -261,7 +261,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -284,7 +284,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -309,7 +309,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
     }
@@ -334,7 +334,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1100, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
@@ -358,9 +358,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
-
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1000, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
@@ -384,7 +382,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1003, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }
@@ -408,7 +406,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( false );
         reporter = new ValidationErrorReporter( bundle );
 
-        validatorToTest.validateTrackedEntity( reporter, trackedEntity );
+        validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         hasTrackerError( reporter, E1001, TrackerType.TRACKED_ENTITY, trackedEntity.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -128,6 +128,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
     private ProgramStage programStage;
 
+    private TrackerIdSchemeParams idSchemes;
+
     @BeforeEach
     public void setUp()
     {
@@ -146,6 +148,9 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         programStage = createProgramStage( 'A', program );
         programStage.setUid( PS_ID );
+
+        idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
 
         validatorToTest = new PreCheckSecurityOwnershipValidationHook( aclService, ownershipAccessManager,
             organisationUnitService );
@@ -167,7 +172,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -183,14 +187,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
-        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -213,7 +215,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -236,7 +237,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -252,14 +252,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
-        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -275,14 +273,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
-        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithDeleteProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -298,8 +294,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
-        when( bundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getUser() ).thenReturn( deleteTeiAuthorisedUser() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
@@ -307,7 +301,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -323,16 +316,11 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .trackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) )
             .build();
 
-        when( bundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
-
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -349,14 +337,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -373,14 +359,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -397,14 +381,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getPreheat() ).thenReturn( preheat );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( preheat.getTrackedEntityType( MetadataIdentifier.ofUid( TEI_TYPE_ID ) ) ).thenReturn( trackedEntityType );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( false );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -431,7 +413,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( programInstance );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -461,7 +442,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -486,7 +466,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -512,7 +491,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -538,7 +516,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -564,7 +541,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -592,7 +568,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -614,12 +589,10 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() ).thenReturn( Collections.emptyList() );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -638,7 +611,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() )
             .thenReturn( Collections.singletonList( enrollment.getEnrollment() ) );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
@@ -647,7 +619,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -667,14 +638,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -694,14 +663,12 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( false );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -733,7 +700,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -764,8 +730,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .thenReturn( true );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
 
-        reporter = new ValidationErrorReporter( bundle );
-
         validatorToTest.validateEvent( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );
@@ -792,7 +756,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -820,7 +783,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -851,7 +813,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -874,7 +835,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
@@ -887,15 +847,17 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
+
         when( ownershipAccessManager.hasAccess( user, TEI_ID, organisationUnit, program ) ).thenReturn( false );
         validatorToTest.validateEvent( reporter, bundle, event );
 
         hasTrackerError( reporter, TrackerErrorCode.E1102, TrackerType.EVENT, event.getUid() );
 
         when( ownershipAccessManager.hasAccess( user, TEI_ID, organisationUnit, program ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
+
+        reporter = new ValidationErrorReporter( idSchemes );
         validatorToTest.validateEvent( reporter, bundle, event );
+
         assertFalse( reporter.hasErrors() );
     }
 
@@ -924,7 +886,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -944,7 +905,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
@@ -954,7 +914,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -975,7 +934,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
         when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
@@ -985,7 +943,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -1006,7 +963,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
@@ -1016,7 +972,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 
@@ -1050,8 +1005,6 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
         when( aclService.canDataWrite( user, programStage ) ).thenReturn( true );
-
-        reporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validateEvent( reporter, bundle, event );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -145,7 +145,7 @@ class PreCheckUidValidationHookTest
         Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
         Event event = Event.builder().event( CodeGenerator.generateUid() ).notes( Lists.newArrayList( note ) ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
         // then
         assertFalse( reporter.hasErrors() );
     }
@@ -156,7 +156,7 @@ class PreCheckUidValidationHookTest
         // given
         Event event = Event.builder().event( INVALID_UID ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
         // then
         hasTrackerError( reporter, E1048, EVENT, event.getUid() );
     }
@@ -168,7 +168,7 @@ class PreCheckUidValidationHookTest
         Note note = Note.builder().note( INVALID_UID ).build();
         Event event = Event.builder().event( CodeGenerator.generateUid() ).notes( Lists.newArrayList( note ) ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
         // then
         hasTrackerError( reporter, E1048, EVENT, event.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -179,7 +179,7 @@ class PreCheckUidValidationHookTest
         // given
         Relationship relationship = Relationship.builder().relationship( CodeGenerator.generateUid() ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
         // then
         assertFalse( reporter.hasErrors() );
     }
@@ -190,7 +190,7 @@ class PreCheckUidValidationHookTest
         // given
         Relationship relationship = Relationship.builder().relationship( INVALID_UID ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
         // then
         hasTrackerError( reporter, E1048, RELATIONSHIP, relationship.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -63,11 +63,15 @@ class PreCheckUidValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     void setUp()
     {
         TrackerPreheat preheat = new TrackerPreheat();
-        preheat.setIdSchemes( TrackerIdSchemeParams.builder().build() );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        preheat.setIdSchemes( idSchemes );
+        reporter = new ValidationErrorReporter( idSchemes );
         bundle = TrackerBundle.builder().preheat( preheat ).build();
 
         validationHook = new PreCheckUidValidationHook();
@@ -81,7 +85,6 @@ class PreCheckUidValidationHookTest
             .trackedEntity( CodeGenerator.generateUid() )
             .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
         assertFalse( reporter.hasErrors() );
     }
@@ -95,7 +98,6 @@ class PreCheckUidValidationHookTest
             .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
         // then
         hasTrackerError( reporter, E1048, TRACKED_ENTITY, trackedEntity.getUid() );
@@ -108,7 +110,6 @@ class PreCheckUidValidationHookTest
         Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
         Enrollment enrollment = Enrollment.builder().enrollment( CodeGenerator.generateUid() )
             .notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
         // then
         assertFalse( reporter.hasErrors() );
@@ -119,7 +120,6 @@ class PreCheckUidValidationHookTest
     {
         // given
         Enrollment enrollment = Enrollment.builder().enrollment( INVALID_UID ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
         // then
         hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
@@ -132,7 +132,6 @@ class PreCheckUidValidationHookTest
         Note note = Note.builder().note( INVALID_UID ).build();
         Enrollment enrollment = Enrollment.builder().enrollment( CodeGenerator.generateUid() )
             .notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
         // then
         hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
@@ -144,7 +143,6 @@ class PreCheckUidValidationHookTest
         // given
         Note note = Note.builder().note( CodeGenerator.generateUid() ).build();
         Event event = Event.builder().event( CodeGenerator.generateUid() ).notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
         // then
         assertFalse( reporter.hasErrors() );
@@ -155,7 +153,6 @@ class PreCheckUidValidationHookTest
     {
         // given
         Event event = Event.builder().event( INVALID_UID ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
         // then
         hasTrackerError( reporter, E1048, EVENT, event.getUid() );
@@ -167,7 +164,6 @@ class PreCheckUidValidationHookTest
         // given
         Note note = Note.builder().note( INVALID_UID ).build();
         Event event = Event.builder().event( CodeGenerator.generateUid() ).notes( Lists.newArrayList( note ) ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
         // then
         hasTrackerError( reporter, E1048, EVENT, event.getUid() );
@@ -178,7 +174,6 @@ class PreCheckUidValidationHookTest
     {
         // given
         Relationship relationship = Relationship.builder().relationship( CodeGenerator.generateUid() ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
         // then
         assertFalse( reporter.hasErrors() );
@@ -189,7 +184,6 @@ class PreCheckUidValidationHookTest
     {
         // given
         Relationship relationship = Relationship.builder().relationship( INVALID_UID ).build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
         // then
         hasTrackerError( reporter, E1048, RELATIONSHIP, relationship.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -82,7 +82,7 @@ class PreCheckUidValidationHookTest
             .orgUnit( MetadataIdentifier.ofUid( CodeGenerator.generateUid() ) )
             .build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
         assertFalse( reporter.hasErrors() );
     }
 
@@ -96,7 +96,7 @@ class PreCheckUidValidationHookTest
             .build();
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
         // then
         hasTrackerError( reporter, E1048, TRACKED_ENTITY, trackedEntity.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUidValidationHookTest.java
@@ -109,7 +109,7 @@ class PreCheckUidValidationHookTest
         Enrollment enrollment = Enrollment.builder().enrollment( CodeGenerator.generateUid() )
             .notes( Lists.newArrayList( note ) ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
         // then
         assertFalse( reporter.hasErrors() );
     }
@@ -120,7 +120,7 @@ class PreCheckUidValidationHookTest
         // given
         Enrollment enrollment = Enrollment.builder().enrollment( INVALID_UID ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
         // then
         hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
     }
@@ -133,7 +133,7 @@ class PreCheckUidValidationHookTest
         Enrollment enrollment = Enrollment.builder().enrollment( CodeGenerator.generateUid() )
             .notes( Lists.newArrayList( note ) ).build();
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
         // then
         hasTrackerError( reporter, E1048, ENROLLMENT, enrollment.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -192,7 +192,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -207,7 +207,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1128, EVENT, event.getUid() );
@@ -223,7 +223,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEvent( reporter, event );
+        validationHook.validateEvent( reporter, bundle, event );
 
         // then
         hasTrackerError( reporter, E1128, EVENT, event.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -90,6 +90,8 @@ class PreCheckUpdatableFieldsValidationHookTest
 
     private TrackerPreheat preheat;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -106,7 +108,9 @@ class PreCheckUpdatableFieldsValidationHookTest
         when( bundle.getProgramStageInstance( EVENT_ID ) ).thenReturn( programStageInstance() );
 
         preheat = new TrackerPreheat();
-        preheat.setIdSchemes( TrackerIdSchemeParams.builder().build() );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        preheat.setIdSchemes( idSchemes );
+        reporter = new ValidationErrorReporter( idSchemes );
         when( bundle.getPreheat() ).thenReturn( preheat );
     }
 
@@ -117,7 +121,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         TrackedEntity trackedEntity = validTei();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         // then
@@ -132,7 +135,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         trackedEntity.setTrackedEntityType( MetadataIdentifier.ofUid( "NewTrackedEntityTypeId" ) );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         // then
@@ -146,7 +148,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         Enrollment enrollment = validEnrollment();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         // then
@@ -160,7 +161,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         Enrollment enrollment = validEnrollment( "NewProgramId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         // then
@@ -176,7 +176,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         enrollment.setTrackedEntity( "NewTrackedEntityId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         // then
@@ -191,7 +190,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         Event event = validEvent();
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         // then
@@ -206,7 +204,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         event.setProgramStage( MetadataIdentifier.ofUid( "NewProgramStageId" ) );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         // then
@@ -222,7 +219,6 @@ class PreCheckUpdatableFieldsValidationHookTest
         event.setEnrollment( "NewEnrollmentId" );
 
         // when
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         validationHook.validateEvent( reporter, bundle, event );
 
         // then

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -147,7 +147,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -161,7 +161,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1127, ENROLLMENT, enrollment.getUid() );
@@ -177,7 +177,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateEnrollment( reporter, enrollment );
+        validationHook.validateEnrollment( reporter, bundle, enrollment );
 
         // then
         hasTrackerError( reporter, E1127, ENROLLMENT, enrollment.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -118,7 +118,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         // then
         assertFalse( reporter.hasErrors() );
@@ -133,7 +133,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // when
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateTrackedEntity( reporter, trackedEntity );
+        validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
         // then
         hasTrackerError( reporter, E1126, TRACKED_ENTITY, trackedEntity.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -113,7 +113,7 @@ class RelationshipsValidationHookTest
             .build();
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4009, RELATIONSHIP, relationship.getUid() );
     }
@@ -143,7 +143,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertTrue( reporter.hasErrors() );
         assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4001 ) );
@@ -173,7 +173,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4013, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
@@ -205,7 +205,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relationshipType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4001, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
@@ -228,7 +228,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
@@ -251,7 +251,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
@@ -276,7 +276,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
@@ -328,7 +328,7 @@ class RelationshipsValidationHookTest
 
         reporter = new ValidationErrorReporter( bundle );
 
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
@@ -366,7 +366,7 @@ class RelationshipsValidationHookTest
         when( bundle.getTrackedEntities() ).thenReturn( trackedEntities );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
@@ -395,7 +395,7 @@ class RelationshipsValidationHookTest
             .build( TrackerIdSchemeParams.builder().build() );
         reporter.addError( error );
 
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, TrackerErrorCode.E4011, RELATIONSHIP, relationship.getUid() );
         assertThat(
@@ -425,7 +425,7 @@ class RelationshipsValidationHookTest
             .build( TrackerIdSchemeParams.builder().build() );
         reporter.addError( error );
 
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertTrue( reporter.hasErrors() );
         assertThat(
@@ -449,7 +449,7 @@ class RelationshipsValidationHookTest
             .thenReturn( Collections.singletonList( relType ) );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4000, RELATIONSHIP, relationship.getUid() );
         assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
@@ -473,7 +473,7 @@ class RelationshipsValidationHookTest
         when( preheat.isDuplicate( relationship ) ).thenReturn( true );
 
         reporter = new ValidationErrorReporter( bundle );
-        validationHook.validateRelationship( reporter, relationship );
+        validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4018, RELATIONSHIP, relationship.getUid() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -60,7 +60,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
-import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Relationship;
@@ -98,8 +97,10 @@ class RelationshipsValidationHookTest
     {
         validationHook = new RelationshipsValidationHook();
 
-        when( bundle.getValidationMode() ).thenReturn( ValidationMode.FULL );
         when( bundle.getPreheat() ).thenReturn( preheat );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        reporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -112,7 +113,6 @@ class RelationshipsValidationHookTest
             .to( trackedEntityRelationshipItem() )
             .build();
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4009, RELATIONSHIP, relationship.getUid() );
@@ -142,7 +142,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertTrue( reporter.hasErrors() );
@@ -172,7 +171,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4013, RELATIONSHIP, relationship.getUid() );
@@ -204,7 +202,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relationshipType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4001, RELATIONSHIP, relationship.getUid() );
@@ -227,7 +224,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
@@ -250,7 +246,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
@@ -275,7 +270,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
@@ -326,8 +320,6 @@ class RelationshipsValidationHookTest
 
         when( bundle.getTrackedEntityInstance( trackedEntityUid ) ).thenReturn( trackedEntityInstance );
 
-        reporter = new ValidationErrorReporter( bundle );
-
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
@@ -365,7 +357,6 @@ class RelationshipsValidationHookTest
 
         when( bundle.getTrackedEntities() ).thenReturn( trackedEntities );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
@@ -381,7 +372,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
@@ -411,7 +401,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         Relationship relationship = Relationship.builder()
             .relationship( CodeGenerator.generateUid() )
             .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
@@ -448,7 +437,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) )
             .thenReturn( Collections.singletonList( relType ) );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4000, RELATIONSHIP, relationship.getUid() );
@@ -472,7 +460,6 @@ class RelationshipsValidationHookTest
         when( preheat.getAll( RelationshipType.class ) ).thenReturn( Collections.singletonList( relType ) );
         when( preheat.isDuplicate( relationship ) ).thenReturn( true );
 
-        reporter = new ValidationErrorReporter( bundle );
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4018, RELATIONSHIP, relationship.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
@@ -99,7 +100,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -171,7 +172,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( repeatableEvent( "A" ), repeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -187,7 +188,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = errorReporter();
         errorReporter.getInvalidDTOs().put( EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
 
         validatorToTest.validate( errorReporter, bundle );
@@ -206,7 +207,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( eventEnrollmentA, eventEnrollmentB );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -223,7 +224,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( eventProgramA, eventProgramB );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = ValidationErrorReporter.emptyReporter();
+        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -300,5 +301,11 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         event.setEnrollment( ENROLLMENT_A );
         event.setProgramStage( MetadataIdentifier.ofUid( REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION ) );
         return event;
+    }
+
+    private ValidationErrorReporter errorReporter()
+    {
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        return new ValidationErrorReporter( idSchemes );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -83,6 +83,8 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     @Mock
     private TrackerPreheat preheat;
 
+    private ValidationErrorReporter errorReporter;
+
     @BeforeEach
     public void setUp()
     {
@@ -90,6 +92,9 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         bundle = TrackerBundle.builder().build();
         bundle.setPreheat( preheat );
+
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        errorReporter = new ValidationErrorReporter( idSchemes );
     }
 
     @Test
@@ -100,7 +105,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -123,7 +127,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
         when( preheat.hasProgramStageWithEvents( event.getProgramStage(), event.getEnrollment() ) ).thenReturn( true );
         bundle.setEvents( Lists.newArrayList( event ) );
-        ValidationErrorReporter errorReporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -145,7 +148,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( notRepeatableEvent( "A" ), notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = new ValidationErrorReporter( bundle );
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -172,7 +174,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( repeatableEvent( "A" ), repeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -188,7 +189,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = errorReporter();
         errorReporter.getInvalidDTOs().put( EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
 
         validatorToTest.validate( errorReporter, bundle );
@@ -207,7 +207,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( eventEnrollmentA, eventEnrollmentB );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -224,7 +223,6 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( eventProgramA, eventProgramB );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        ValidationErrorReporter errorReporter = errorReporter();
 
         validatorToTest.validate( errorReporter, bundle );
 
@@ -301,11 +299,5 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         event.setEnrollment( ENROLLMENT_A );
         event.setProgramStage( MetadataIdentifier.ofUid( REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION ) );
         return event;
-    }
-
-    private ValidationErrorReporter errorReporter()
-    {
-        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        return new ValidationErrorReporter( idSchemes );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -114,7 +114,7 @@ class TrackedEntityAttributeValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -152,7 +152,7 @@ class TrackedEntityAttributeValidationHookTest
         when( preheat.getTrackedEntityAttribute( (MetadataIdentifier) any() ) ).thenReturn( contextAttribute );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
@@ -173,7 +173,7 @@ class TrackedEntityAttributeValidationHookTest
         when( preheat.getTrackedEntityType( (MetadataIdentifier) any() ) ).thenReturn( new TrackedEntityType() );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
@@ -209,7 +209,7 @@ class TrackedEntityAttributeValidationHookTest
             .thenReturn( trackedEntityAttribute );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
@@ -302,7 +302,7 @@ class TrackedEntityAttributeValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
@@ -327,7 +327,7 @@ class TrackedEntityAttributeValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -359,7 +359,7 @@ class TrackedEntityAttributeValidationHookTest
             .build();
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
@@ -393,7 +393,7 @@ class TrackedEntityAttributeValidationHookTest
         when( preheat.getTrackedEntityType( (MetadataIdentifier) any() ) ).thenReturn( trackedEntityType );
 
         ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter,
+        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -86,13 +86,17 @@ class TrackedEntityAttributeValidationHookTest
 
     private TrackerBundle bundle;
 
+    private ValidationErrorReporter reporter;
+
     @BeforeEach
     public void setUp()
     {
         bundle = TrackerBundle.builder()
             .preheat( preheat )
             .build();
-        when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
+        when( preheat.getIdSchemes() ).thenReturn( idSchemes );
+        reporter = new ValidationErrorReporter( idSchemes );
         when( dhisConfigurationProvider.getEncryptionStatus() ).thenReturn( EncryptionStatus.OK );
     }
 
@@ -113,7 +117,6 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -151,7 +154,6 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityAttribute( (MetadataIdentifier) any() ) ).thenReturn( contextAttribute );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -172,7 +174,6 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityType( (MetadataIdentifier) any() ) ).thenReturn( new TrackedEntityType() );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -208,7 +209,6 @@ class TrackedEntityAttributeValidationHookTest
         when( preheat.getTrackedEntityAttribute( MetadataIdentifier.ofUid( tea ) ) )
             .thenReturn( trackedEntityAttribute );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -221,7 +221,6 @@ class TrackedEntityAttributeValidationHookTest
     @Test
     void shouldFailValueTooLong()
     {
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.TEXT );
 
@@ -246,7 +245,6 @@ class TrackedEntityAttributeValidationHookTest
     @Test
     void shouldFailDataValueIsValid()
     {
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
 
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.NUMBER );
 
@@ -274,7 +272,6 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityAttribute( (MetadataIdentifier) any() ) ).thenReturn( trackedEntityAttribute );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
         trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
             trackedEntityAttribute, "value" );
@@ -301,7 +298,6 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -326,7 +322,6 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -358,7 +353,6 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 
@@ -392,7 +386,6 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityType( (MetadataIdentifier) any() ) ).thenReturn( trackedEntityType );
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle );
         trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
             trackedEntity );
 


### PR DESCRIPTION
ValidationErrorReporter does not need the bunlde to aggregate errors/warnings. ValidationErrorReporter only needs the validation mode and idSchemes.

This should be reflected in its dependencies.