### PR TITLE
fix: complete data set registration sync strategy [DHIS2-13249]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeService.java
@@ -642,7 +642,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             {
                 // CDSR already exists
 
-                if ( strategy.isCreateAndUpdate() || strategy.isUpdate() )
+                if ( strategy.isCreateAndUpdate() || strategy.isUpdate() || strategy.isSync() )
                 {
                     // Update existing CDSR
 
@@ -671,7 +671,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             {
                 // CDSR does not already exist
 
-                if ( strategy.isCreateAndUpdate() || strategy.isCreate() )
+                if ( strategy.isCreateAndUpdate() || strategy.isCreate() || strategy.isSync() )
                 {
                     if ( existingCdsr != null )
                     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
@@ -132,7 +132,7 @@ public class CompleteDataSetRegistrationSynchronization implements DataSynchroni
 
         if ( objectsToSynchronize != 0 )
         {
-            SystemInstance instance = SyncUtils.getRemoteInstanceWithSyncImportStrategy( settings,
+            SystemInstance instance = SyncUtils.getRemoteInstance( settings,
                 SyncEndpoint.COMPLETE_DATA_SET_REGISTRATIONS );
 
             return new CompleteDataSetRegistrationSynchronizationContext( skipChangedBefore, objectsToSynchronize,


### PR DESCRIPTION
### Create And Update
I opted to address this in two ways: the sync does no longer add the `SYNC` strategy parameter. That alone should fix the synchronization. 

However, the `SYNC` strategy is still a valid value for `strategy` parameter. Therefore the `isSync()` is also added to the guards for the create and update blocks in the import effectively making it equal to the `isCreateAndUpdate()` strategy. 

### Deletion
 `isSync()` was not added to the guard of the delete block. For an object that does not have soft-deletion flag an import either create or updates its items or deletes them. Both at the same time does not make sense.

A comment in the deletion path also wonders:

    // TODO Does 'delete' even make sense for CDSR?

For the `CompleteDataSetRegistration` synchronisation it surely will not as the list send to the central instance is what exists on the local instances. This set does not contain what might have been removed on any local instance and therefore would never be able to have individual items of the imported set cause their deletion in the central instance. While such a feature might be useful it was certainly never implemented.