### PR TITLE
fix: complete data set registration sync strategy [DHIS2-13249] (2.38)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/dataset/DefaultCompleteDataSetRegistrationExchangeService.java
@@ -637,7 +637,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             {
                 // CDSR already exists
 
-                if ( strategy.isCreateAndUpdate() || strategy.isUpdate() )
+                if ( strategy.isCreateAndUpdate() || strategy.isUpdate() || strategy.isSync() )
                 {
                     // Update existing CDSR
 
@@ -666,7 +666,7 @@ public class DefaultCompleteDataSetRegistrationExchangeService
             {
                 // CDSR does not already exist
 
-                if ( strategy.isCreateAndUpdate() || strategy.isCreate() )
+                if ( strategy.isCreateAndUpdate() || strategy.isCreate() || strategy.isSync() )
                 {
                     if ( existingCdsr != null )
                     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/sync/CompleteDataSetRegistrationSynchronization.java
@@ -129,7 +129,7 @@ public class CompleteDataSetRegistrationSynchronization extends DataSynchronizat
 
         if ( objectsToSynchronize != 0 )
         {
-            instance = SyncUtils.getRemoteInstanceWithSyncImportStrategy( systemSettingManager,
+            instance = SyncUtils.getRemoteInstance( systemSettingManager,
                 SyncEndpoint.COMPLETE_DATA_SET_REGISTRATIONS );
 
             log.info( objectsToSynchronize + " completed data set registrations to synchronize were found." );


### PR DESCRIPTION
backport of #10880

Not from cherry-pick as that wanted to draw in more changes and it was easier to just change the 3 lines again.