### PR TITLE
fix: remove OU from category options when OU is deleted [DHIS2-13152]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionDeletionHandler.java
@@ -60,6 +60,16 @@ public class CategoryOptionDeletionHandler
     }
 
     @Override
+    public void deleteOrganisationUnit( OrganisationUnit unit )
+    {
+        for ( CategoryOption option : unit.getCategoryOptions() )
+        {
+            option.getOrganisationUnits().remove( unit );
+            idObjectManager.updateNoAcl( option );
+        }
+    }
+
+    @Override
     public void deleteCategory( Category category )
     {
         for ( CategoryOption categoryOption : category.getCategoryOptions() )


### PR DESCRIPTION
Backport of #10615 which uses same solution but as deletion handlers work by inheritance in 2.36 the body of the added method was copied over manually. 