### PR TITLE
chore: simplify TrackerErrorReport/WarningReport DHIS2-12519

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
@@ -30,9 +30,9 @@ package org.hisp.dhis.tracker.report;
 import java.text.DateFormat;
 import java.text.MessageFormat;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOption;
@@ -61,11 +61,6 @@ class MessageFormatter
         // not meant to be inherited from
     }
 
-    protected static List<String> buildArgumentList( TrackerIdSchemeParams params, List<Object> arguments )
-    {
-        return arguments.stream().map( arg -> parseArgs( params, arg ) ).collect( Collectors.toList() );
-    }
-
     /**
      *
      * @param idSchemes
@@ -73,13 +68,23 @@ class MessageFormatter
      * @param arguments
      * @return
      */
-    protected static String format( TrackerIdSchemeParams idSchemes, String messagePattern, List<Object> arguments )
+    protected static String format( TrackerIdSchemeParams idSchemes, String messagePattern, Object... arguments )
     {
-        return MessageFormat.format( messagePattern,
-            buildArgumentList( idSchemes, arguments ).toArray( new Object[0] ) );
+        List<String> args = buildArgumentList( idSchemes, arguments );
+        return MessageFormat.format( messagePattern, args.toArray( new Object[0] ) );
     }
 
-    private static String parseArgs( TrackerIdSchemeParams idSchemeParams, Object argument )
+    protected static List<String> buildArgumentList( TrackerIdSchemeParams idSchemes, Object... arguments )
+    {
+        List<String> args = new ArrayList<>();
+        for ( Object arg : arguments )
+        {
+            args.add( parseArgs( idSchemes, arg ) );
+        }
+        return args;
+    }
+
+    private static String parseArgs( TrackerIdSchemeParams idSchemes, Object argument )
     {
         if ( String.class.isAssignableFrom( ObjectUtils.firstNonNull( argument, "NULL" ).getClass() ) )
         {
@@ -91,36 +96,36 @@ class MessageFormatter
         }
         else if ( CategoryOptionCombo.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (CategoryOptionCombo) argument ),
+            return getIdAndName( idSchemes.toMetadataIdentifier( (CategoryOptionCombo) argument ),
                 (CategoryOptionCombo) argument );
         }
         else if ( CategoryOption.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (CategoryOption) argument ),
+            return getIdAndName( idSchemes.toMetadataIdentifier( (CategoryOption) argument ),
                 (CategoryOption) argument );
         }
         else if ( DataElement.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (DataElement) argument ),
+            return getIdAndName( idSchemes.toMetadataIdentifier( (DataElement) argument ),
                 (DataElement) argument );
         }
         else if ( OrganisationUnit.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (OrganisationUnit) argument ),
+            return getIdAndName( idSchemes.toMetadataIdentifier( (OrganisationUnit) argument ),
                 (OrganisationUnit) argument );
         }
         else if ( Program.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (Program) argument ), (Program) argument );
+            return getIdAndName( idSchemes.toMetadataIdentifier( (Program) argument ), (Program) argument );
         }
         else if ( ProgramStage.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (ProgramStage) argument ),
+            return getIdAndName( idSchemes.toMetadataIdentifier( (ProgramStage) argument ),
                 (ProgramStage) argument );
         }
         else if ( IdentifiableObject.class.isAssignableFrom( argument.getClass() ) )
         {
-            return getIdAndName( idSchemeParams.toMetadataIdentifier( (IdentifiableObject) argument ),
+            return getIdAndName( idSchemes.toMetadataIdentifier( (IdentifiableObject) argument ),
                 (IdentifiableObject) argument );
         }
         else if ( Date.class.isAssignableFrom( argument.getClass() ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
@@ -52,10 +52,10 @@ import org.hisp.dhis.util.ObjectUtils;
 /**
  * @author Luciano Fiandesio
  */
-class TrackerReportUtils
+class MessageFormatter
 {
 
-    private TrackerReportUtils()
+    private MessageFormatter()
     {
         // not meant to be inherited from
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
@@ -62,29 +62,36 @@ class MessageFormatter
     }
 
     /**
+     * Creates an interpolated string using given {@code messagePattern}
+     * ({@link MessageFormat}) and {@code arguments}. {@code arguments} are
+     * pre-processed to be rendered in a type specific manner. For example
+     * {@link Instant} are displayed in ISO 8601, without any TZ info.
+     * Identifiers for {@link IdentifiableObject} are displayed in the user
+     * chosen idScheme ({@code idSchemes}).
      *
-     * @param idSchemes
-     * @param messagePattern
-     * @param arguments
-     * @return
+     * @param idSchemes idSchemes to use when rendering identifiers
+     * @param messagePattern message format pattern
+     * @param arguments arguments representing format elements in the message
+     *        pattern
+     * @return interpolated string of given message pattern and arguments
      */
     protected static String format( TrackerIdSchemeParams idSchemes, String messagePattern, Object... arguments )
     {
-        List<String> args = buildArgumentList( idSchemes, arguments );
+        List<String> args = formatArguments( idSchemes, arguments );
         return MessageFormat.format( messagePattern, args.toArray( new Object[0] ) );
     }
 
-    protected static List<String> buildArgumentList( TrackerIdSchemeParams idSchemes, Object... arguments )
+    protected static List<String> formatArguments( TrackerIdSchemeParams idSchemes, Object... arguments )
     {
         List<String> args = new ArrayList<>();
         for ( Object arg : arguments )
         {
-            args.add( parseArgs( idSchemes, arg ) );
+            args.add( formatArgument( idSchemes, arg ) );
         }
         return args;
     }
 
-    private static String parseArgs( TrackerIdSchemeParams idSchemes, Object argument )
+    private static String formatArgument( TrackerIdSchemeParams idSchemes, Object argument )
     {
         if ( String.class.isAssignableFrom( ObjectUtils.firstNonNull( argument, "NULL" ).getClass() ) )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/MessageFormatter.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.report;
 
 import java.text.DateFormat;
+import java.text.MessageFormat;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -63,6 +64,19 @@ class MessageFormatter
     protected static List<String> buildArgumentList( TrackerIdSchemeParams params, List<Object> arguments )
     {
         return arguments.stream().map( arg -> parseArgs( params, arg ) ).collect( Collectors.toList() );
+    }
+
+    /**
+     *
+     * @param idSchemes
+     * @param messagePattern
+     * @param arguments
+     * @return
+     */
+    protected static String format( TrackerIdSchemeParams idSchemes, String messagePattern, List<Object> arguments )
+    {
+        return MessageFormat.format( messagePattern,
+            buildArgumentList( idSchemes, arguments ).toArray( new Object[0] ) );
     }
 
     private static String parseArgs( TrackerIdSchemeParams idSchemeParams, Object argument )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import static org.hisp.dhis.tracker.report.MessageFormatter.buildArgumentList;
-
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -112,16 +109,9 @@ public class TrackerErrorReport
 
         public TrackerErrorReport build( TrackerIdSchemeParams idSchemes )
         {
-            return new TrackerErrorReport(
-                MessageFormat.format( errorCode.getMessage(),
-                    buildArgumentList( idSchemes, arguments ).toArray( new Object[0] ) ),
+            return new TrackerErrorReport( MessageFormatter.format( idSchemes, errorCode.getMessage(), arguments ),
                 this.errorCode, this.trackerType, this.uid );
         }
-    }
-
-    public static TrackerErrorReportBuilder newReport( TrackerErrorCode errorCode )
-    {
-        return builder().errorCode( errorCode );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -27,14 +27,9 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import lombok.Builder;
 import lombok.Value;
 
-import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -89,29 +84,6 @@ public class TrackerErrorReport
     public String getUid()
     {
         return uid;
-    }
-
-    public static class TrackerErrorReportBuilder
-    {
-        private final List<Object> arguments = new ArrayList<>();
-
-        public TrackerErrorReportBuilder addArg( Object arg )
-        {
-            this.arguments.add( arg );
-            return this;
-        }
-
-        public TrackerErrorReportBuilder addArgs( Object... args )
-        {
-            this.arguments.addAll( Arrays.asList( args ) );
-            return this;
-        }
-
-        public TrackerErrorReport build( TrackerIdSchemeParams idSchemes )
-        {
-            return new TrackerErrorReport( MessageFormatter.format( idSchemes, errorCode.getMessage(), arguments ),
-                this.errorCode, this.trackerType, this.uid );
-        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorReport.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import static org.hisp.dhis.tracker.report.TrackerReportUtils.buildArgumentList;
+import static org.hisp.dhis.tracker.report.MessageFormatter.buildArgumentList;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import static org.hisp.dhis.tracker.report.MessageFormatter.buildArgumentList;
-
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -111,15 +108,9 @@ public class TrackerWarningReport
 
         public TrackerWarningReport build( TrackerIdSchemeParams idSchemes )
         {
-            return new TrackerWarningReport( MessageFormat.format( warningCode.getMessage(),
-                buildArgumentList( idSchemes, arguments ).toArray( new Object[0] ) ), this.warningCode, trackerType,
-                uid );
+            return new TrackerWarningReport( MessageFormatter.format( idSchemes, warningCode.getMessage(), arguments ),
+                this.warningCode, trackerType, uid );
         }
-    }
-
-    public static TrackerWarningReportBuilder newWarningReport( TrackerErrorCode errorCode )
-    {
-        return builder().warningCode( errorCode );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import static org.hisp.dhis.tracker.report.TrackerReportUtils.buildArgumentList;
+import static org.hisp.dhis.tracker.report.MessageFormatter.buildArgumentList;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerWarningReport.java
@@ -27,14 +27,9 @@
  */
 package org.hisp.dhis.tracker.report;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import lombok.Builder;
 import lombok.Value;
 
-import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -88,29 +83,6 @@ public class TrackerWarningReport
     public String getUid()
     {
         return uid;
-    }
-
-    public static class TrackerWarningReportBuilder
-    {
-        private final List<Object> arguments = new ArrayList<>();
-
-        public TrackerWarningReportBuilder addArg( Object arg )
-        {
-            this.arguments.add( arg );
-            return this;
-        }
-
-        public TrackerWarningReportBuilder addArgs( Object... args )
-        {
-            this.arguments.addAll( Arrays.asList( args ) );
-            return this;
-        }
-
-        public TrackerWarningReport build( TrackerIdSchemeParams idSchemes )
-        {
-            return new TrackerWarningReport( MessageFormatter.format( idSchemes, warningCode.getMessage(), arguments ),
-                this.warningCode, trackerType, uid );
-        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -123,13 +123,8 @@ public class ValidationErrorReporter
 
     public void addError( TrackerDto dto, TrackerErrorCode code, Object... args )
     {
-        TrackerErrorReport error = TrackerErrorReport.builder()
-            .uid( dto.getUid() )
-            .trackerType( dto.getTrackerType() )
-            .errorCode( code )
-            .addArgs( args )
-            .build( idSchemes );
-        addError( error );
+        addError( new TrackerErrorReport( MessageFormatter.format( idSchemes, code.getMessage(), args ),
+            code, dto.getTrackerType(), dto.getUid() ) );
     }
 
     public void addError( TrackerErrorReport error )
@@ -164,13 +159,8 @@ public class ValidationErrorReporter
 
     public void addWarning( TrackerDto dto, TrackerErrorCode code, Object... args )
     {
-        TrackerWarningReport warn = TrackerWarningReport.builder()
-            .uid( dto.getUid() )
-            .trackerType( dto.getTrackerType() )
-            .warningCode( code )
-            .addArgs( args )
-            .build( idSchemes );
-        addWarning( warn );
+        addWarning( new TrackerWarningReport( MessageFormatter.format( idSchemes, code.getMessage(), args ),
+            code, dto.getTrackerType(), dto.getUid() ) );
     }
 
     public void addWarningIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -162,8 +162,7 @@ public class ValidationErrorReporter
         return this.isInvalid( dto.getTrackerType(), dto.getUid() );
     }
 
-    public void addWarning( TrackerDto dto, TrackerErrorCode code,
-        Object... args )
+    public void addWarning( TrackerDto dto, TrackerErrorCode code, Object... args )
     {
         TrackerWarningReport warn = TrackerWarningReport.builder()
             .uid( dto.getUid() )
@@ -174,8 +173,7 @@ public class ValidationErrorReporter
         addWarning( warn );
     }
 
-    public void addWarningIf( BooleanSupplier expression, TrackerDto dto,
-        TrackerErrorCode code, Object... args )
+    public void addWarningIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
     {
         if ( expression.getAsBoolean() )
         {
@@ -183,8 +181,7 @@ public class ValidationErrorReporter
         }
     }
 
-    public void addErrorIf( BooleanSupplier expression, TrackerDto dto,
-        TrackerErrorCode code, Object... args )
+    public void addErrorIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
     {
         if ( expression.getAsBoolean() )
         {
@@ -192,9 +189,7 @@ public class ValidationErrorReporter
         }
     }
 
-    public void addErrorIfNull( Object object, TrackerDto dto,
-        TrackerErrorCode code,
-        Object... args )
+    public void addErrorIfNull( Object object, TrackerDto dto, TrackerErrorCode code, Object... args )
     {
         if ( object == null )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
@@ -33,7 +33,6 @@ import static org.hamcrest.Matchers.is;
 
 import java.text.DateFormat;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -90,8 +89,8 @@ class MessageFormatterTest
         CategoryOption co = new CategoryOption();
         co.setAttributeValues( attributeValues( "y0Yxr50hAbP", "red" ) );
 
-        List<String> args = MessageFormatter.buildArgumentList( params,
-            Arrays.asList( relationshipType, program, programStage, orgUnit, dataElement, coc, co ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, relationshipType, program, programStage,
+            orgUnit, dataElement, coc, co );
 
         assertThat( args,
             contains( "RelationshipType (WTTYiPQDqh1)",
@@ -120,7 +119,7 @@ class MessageFormatterTest
     {
         final Instant now = Instant.now();
 
-        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList( now ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, Instant.now() );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateUtils.getIso8601NoTz( DateUtils.fromInstant( now ) ) ) );
@@ -131,7 +130,7 @@ class MessageFormatterTest
     {
         final Date now = Date.from( Instant.now() );
 
-        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList( now ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, now );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateFormat.getInstance().format( now ) ) );
@@ -140,7 +139,7 @@ class MessageFormatterTest
     @Test
     void buildArgumentListShouldTurnStringsIntoArguments()
     {
-        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList( "foo", "faa" ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, "foo", "faa" );
 
         assertThat( args, contains( "foo", "faa" ) );
     }
@@ -148,8 +147,8 @@ class MessageFormatterTest
     @Test
     void buildArgumentListShouldTurnMetadataIdentifierIntoArguments()
     {
-        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList(
-            MetadataIdentifier.ofUid( "iB8AZpf681V" ), MetadataIdentifier.ofAttribute( "zwccdzhk5zc", "GREEN" ) ) );
+        List<String> args = MessageFormatter.buildArgumentList( params,
+            MetadataIdentifier.ofUid( "iB8AZpf681V" ), MetadataIdentifier.ofAttribute( "zwccdzhk5zc", "GREEN" ) );
 
         assertThat( args, contains( "iB8AZpf681V", "GREEN" ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
@@ -54,7 +54,7 @@ import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class TrackerReportUtilsTest
+class MessageFormatterTest
 {
 
     private TrackerIdSchemeParams params;
@@ -90,7 +90,7 @@ class TrackerReportUtilsTest
         CategoryOption co = new CategoryOption();
         co.setAttributeValues( attributeValues( "y0Yxr50hAbP", "red" ) );
 
-        List<String> args = TrackerReportUtils.buildArgumentList( params,
+        List<String> args = MessageFormatter.buildArgumentList( params,
             Arrays.asList( relationshipType, program, programStage, orgUnit, dataElement, coc, co ) );
 
         assertThat( args,
@@ -120,7 +120,7 @@ class TrackerReportUtilsTest
     {
         final Instant now = Instant.now();
 
-        List<String> args = TrackerReportUtils.buildArgumentList( params, Arrays.asList( now ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList( now ) );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateUtils.getIso8601NoTz( DateUtils.fromInstant( now ) ) ) );
@@ -131,7 +131,7 @@ class TrackerReportUtilsTest
     {
         final Date now = Date.from( Instant.now() );
 
-        List<String> args = TrackerReportUtils.buildArgumentList( params, Arrays.asList( now ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList( now ) );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateFormat.getInstance().format( now ) ) );
@@ -140,7 +140,7 @@ class TrackerReportUtilsTest
     @Test
     void buildArgumentListShouldTurnStringsIntoArguments()
     {
-        List<String> args = TrackerReportUtils.buildArgumentList( params, Arrays.asList( "foo", "faa" ) );
+        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList( "foo", "faa" ) );
 
         assertThat( args, contains( "foo", "faa" ) );
     }
@@ -148,7 +148,7 @@ class TrackerReportUtilsTest
     @Test
     void buildArgumentListShouldTurnMetadataIdentifierIntoArguments()
     {
-        List<String> args = TrackerReportUtils.buildArgumentList( params, Arrays.asList(
+        List<String> args = MessageFormatter.buildArgumentList( params, Arrays.asList(
             MetadataIdentifier.ofUid( "iB8AZpf681V" ), MetadataIdentifier.ofAttribute( "zwccdzhk5zc", "GREEN" ) ) );
 
         assertThat( args, contains( "iB8AZpf681V", "GREEN" ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
@@ -30,9 +30,11 @@ package org.hisp.dhis.tracker.report;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.DateFormat;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -48,7 +50,10 @@ import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,18 +61,34 @@ import org.junit.jupiter.api.Test;
 class MessageFormatterTest
 {
 
-    private TrackerIdSchemeParams params;
+    private TrackerIdSchemeParams idSchemes;
 
     @BeforeEach
     void setUp()
     {
-        params = TrackerIdSchemeParams.builder().build();
+        idSchemes = TrackerIdSchemeParams.builder().build();
     }
 
     @Test
-    void buildArgumentListShouldTurnIdentifiableObjectIntoArgument()
+    void format()
     {
-        TrackerIdSchemeParams params = TrackerIdSchemeParams.builder()
+
+        assertEquals( "User: `Snow`, has no write access to OrganisationUnit: `ward`.", MessageFormatter
+            .format( idSchemes, "User: `{0}`, has no write access to OrganisationUnit: `{1}`.", "Snow", "ward" ) );
+    }
+
+    @Test
+    void formatWithoutArgs()
+    {
+
+        assertEquals( "User has no write access to OrganisationUnit.",
+            MessageFormatter.format( idSchemes, "User has no write access to OrganisationUnit." ) );
+    }
+
+    @Test
+    void formatArgumentsShouldTurnIdentifiableObjectIntoArgument()
+    {
+        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder()
             .idScheme( TrackerIdSchemeParam.UID )
             .programIdScheme( TrackerIdSchemeParam.NAME )
             .programStageIdScheme( TrackerIdSchemeParam.NAME )
@@ -89,7 +110,7 @@ class MessageFormatterTest
         CategoryOption co = new CategoryOption();
         co.setAttributeValues( attributeValues( "y0Yxr50hAbP", "red" ) );
 
-        List<String> args = MessageFormatter.buildArgumentList( params, relationshipType, program, programStage,
+        List<String> args = MessageFormatter.formatArguments( idSchemes, relationshipType, program, programStage,
             orgUnit, dataElement, coc, co );
 
         assertThat( args,
@@ -115,41 +136,80 @@ class MessageFormatterTest
     }
 
     @Test
-    void buildArgumentListShouldTurnInstantIntoArgument()
+    void formatArgumentsShouldTurnInstantIntoArgument()
     {
         final Instant now = Instant.now();
 
-        List<String> args = MessageFormatter.buildArgumentList( params, Instant.now() );
+        List<String> args = MessageFormatter.formatArguments( idSchemes, Instant.now() );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateUtils.getIso8601NoTz( DateUtils.fromInstant( now ) ) ) );
     }
 
     @Test
-    void buildArgumentListShouldTurnDateIntoArgument()
+    void formatArgumentsShouldTurnDateIntoArgument()
     {
         final Date now = Date.from( Instant.now() );
 
-        List<String> args = MessageFormatter.buildArgumentList( params, now );
+        List<String> args = MessageFormatter.formatArguments( idSchemes, now );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateFormat.getInstance().format( now ) ) );
     }
 
     @Test
-    void buildArgumentListShouldTurnStringsIntoArguments()
+    void formatArgumentsShouldTurnStringsIntoArguments()
     {
-        List<String> args = MessageFormatter.buildArgumentList( params, "foo", "faa" );
+        List<String> args = MessageFormatter.formatArguments( idSchemes, "foo", "faa" );
 
         assertThat( args, contains( "foo", "faa" ) );
     }
 
     @Test
-    void buildArgumentListShouldTurnMetadataIdentifierIntoArguments()
+    void formatArgumentsShouldTurnMetadataIdentifierIntoArguments()
     {
-        List<String> args = MessageFormatter.buildArgumentList( params,
+        List<String> args = MessageFormatter.formatArguments( idSchemes,
             MetadataIdentifier.ofUid( "iB8AZpf681V" ), MetadataIdentifier.ofAttribute( "zwccdzhk5zc", "GREEN" ) );
 
         assertThat( args, contains( "iB8AZpf681V", "GREEN" ) );
+    }
+
+    @Test
+    void formatArgumentsShouldTurnTrackedEntityIntoArguments()
+    {
+        List<String> args = MessageFormatter.formatArguments( idSchemes,
+            TrackedEntity.builder().trackedEntity( "zwccdzhk5zc" ).build() );
+
+        assertThat( args, contains( "TrackedEntity (zwccdzhk5zc)" ) );
+    }
+
+    @Test
+    void formatArgumentsShouldTurnEnrollmentIntoArguments()
+    {
+        List<String> args = MessageFormatter.formatArguments( idSchemes,
+            Enrollment.builder().enrollment( "zwccdzhk5zc" ).build() );
+
+        assertThat( args, contains( "Enrollment (zwccdzhk5zc)" ) );
+    }
+
+    @Test
+    void formatArgumentsShouldTurnEventIntoArguments()
+    {
+        List<String> args = MessageFormatter.formatArguments( idSchemes,
+            Event.builder().event( "zwccdzhk5zc" ).build() );
+
+        assertThat( args, contains( "Event (zwccdzhk5zc)" ) );
+    }
+
+    @Test
+    void formatArgumentsWithNumber()
+    {
+        assertEquals( List.of( "" ), MessageFormatter.formatArguments( idSchemes, 2 ) );
+    }
+
+    @Test
+    void formatArgumentsWithoutArgument()
+    {
+        assertEquals( Collections.emptyList(), MessageFormatter.formatArguments( idSchemes ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/ValidationErrorReporterTest.java
@@ -41,13 +41,8 @@ class ValidationErrorReporterTest
     void hasErrorReportFound()
     {
 
-        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
-        TrackerErrorReport error = TrackerErrorReport.builder()
-            .errorCode( TrackerErrorCode.E1000 )
-            .trackerType( TrackerType.EVENT )
-            .build( idSchemes );
-        reporter.getReportList().add( error );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter.addError( eventError() );
 
         assertTrue( reporter.hasErrorReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
     }
@@ -56,13 +51,8 @@ class ValidationErrorReporterTest
     void hasErrorReportNotFound()
     {
 
-        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
-        TrackerErrorReport error = TrackerErrorReport.builder()
-            .errorCode( TrackerErrorCode.E1000 )
-            .trackerType( TrackerType.EVENT )
-            .build( idSchemes );
-        reporter.getReportList().add( error );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter.addError( eventError() );
 
         assertFalse( reporter.hasErrorReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
     }
@@ -71,13 +61,8 @@ class ValidationErrorReporterTest
     void hasWarningReportFound()
     {
 
-        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
-        TrackerWarningReport warning = TrackerWarningReport.builder()
-            .warningCode( TrackerErrorCode.E1000 )
-            .trackerType( TrackerType.EVENT )
-            .build( idSchemes );
-        reporter.getWarningsReportList().add( warning );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter.addWarning( eventWarning() );
 
         assertTrue( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
     }
@@ -86,14 +71,19 @@ class ValidationErrorReporterTest
     void hasWarningReportNotFound()
     {
 
-        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        ValidationErrorReporter reporter = new ValidationErrorReporter( idSchemes );
-        TrackerWarningReport warning = TrackerWarningReport.builder()
-            .warningCode( TrackerErrorCode.E1000 )
-            .trackerType( TrackerType.EVENT )
-            .build( idSchemes );
-        reporter.getWarningsReportList().add( warning );
+        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter.addWarning( eventWarning() );
 
         assertFalse( reporter.hasWarningReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
+    }
+
+    private TrackerErrorReport eventError()
+    {
+        return new TrackerErrorReport( "some error", TrackerErrorCode.E1000, TrackerType.EVENT, "JgDfHAGzzfS" );
+    }
+
+    private TrackerWarningReport eventWarning()
+    {
+        return new TrackerWarningReport( "some warning", TrackerErrorCode.E1000, TrackerType.EVENT, "JgDfHAGzzfS" );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -378,12 +378,8 @@ class RelationshipsValidationHookTest
             .to( trackedEntityRelationshipItem( "notValidTrackedEntity" ) )
             .relationshipType( MetadataIdentifier.ofUid( relType.getUid() ) )
             .build();
-        TrackerErrorReport error = TrackerErrorReport.builder()
-            .uid( relationship.getTo().getTrackedEntity() )
-            .trackerType( TRACKED_ENTITY )
-            .errorCode( TrackerErrorCode.E9999 )
-            .build( TrackerIdSchemeParams.builder().build() );
-        reporter.addError( error );
+        reporter.addError( new TrackerErrorReport( "some error", TrackerErrorCode.E9999, TRACKED_ENTITY,
+            relationship.getTo().getTrackedEntity() ) );
 
         validationHook.validateRelationship( reporter, bundle, relationship );
 
@@ -407,12 +403,8 @@ class RelationshipsValidationHookTest
             .to( trackedEntityRelationshipItem( "anotherValidTrackedEntity" ) )
             .relationshipType( MetadataIdentifier.ofUid( relType.getUid() ) )
             .build();
-        TrackerErrorReport error = TrackerErrorReport.builder()
-            .uid( "notValidTrackedEntity" )
-            .trackerType( TRACKED_ENTITY )
-            .errorCode( TrackerErrorCode.E9999 )
-            .build( TrackerIdSchemeParams.builder().build() );
-        reporter.addError( error );
+        reporter.addError(
+            new TrackerErrorReport( "some error", TrackerErrorCode.E9999, TRACKED_ENTITY, "notValidTrackedEntity" ) );
 
         validationHook.validateRelationship( reporter, bundle, relationship );
 


### PR DESCRIPTION
* ReportUtils (now MessageFormatter) is actually responsible for formatting the report message. Thus, name it MessageFormatter (`report` context is already part of the package).
* TrackerErrorReport/WarningReport do not need builders. All their fields are required. So it should only have an all args constructor. Builders are great with lots of optional fields.
* TrackerErrorReport/WarningReport do not need to depend on idSchemes. The ValidationErrorReporter is already idScheme aware. ValidationErrorReporter can instantiate the TrackerErrorReport using a MessageFormatter formatted message.
* add docs and tests to MessageFormatter