### PR TITLE
fix: map all idScheme related fields DHIS2-12563

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/AttributeValueMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/AttributeValueMapper.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
+import java.util.Set;
+
 import org.hisp.dhis.attribute.AttributeValue;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
@@ -42,4 +44,6 @@ public interface AttributeValueMapper extends PreheatMapper<AttributeValue>
     @Mapping( target = "attribute" )
     @Mapping( target = "value" )
     AttributeValue map( AttributeValue attributeValue );
+
+    Set<AttributeValue> mapAttributeValues( Set<AttributeValue> attributeValues );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryComboMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryComboMapper.java
@@ -33,7 +33,10 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = DebugMapper.class )
+@Mapper( uses = {
+    DebugMapper.class,
+    AttributeValueMapper.class
+} )
 public interface CategoryComboMapper
     extends PreheatMapper<CategoryCombo>
 {
@@ -44,5 +47,6 @@ public interface CategoryComboMapper
     @Mapping( target = "uid" )
     @Mapping( target = "name" )
     @Mapping( target = "code" )
+    @Mapping( target = "attributeValues" )
     CategoryCombo map( CategoryCombo categoryCombo );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryMapper.java
@@ -33,7 +33,10 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = DebugMapper.class )
+@Mapper( uses = {
+    DebugMapper.class,
+    AttributeValueMapper.class
+} )
 public interface CategoryMapper
     extends PreheatMapper<Category>
 {
@@ -44,6 +47,7 @@ public interface CategoryMapper
     @Mapping( target = "uid" )
     @Mapping( target = "name" )
     @Mapping( target = "code" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "sharing" )
     Category map( Category category );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionComboMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionComboMapper.java
@@ -37,7 +37,12 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, CategoryOptionMapper.class, CategoryComboMapper.class } )
+@Mapper( uses = {
+    DebugMapper.class,
+    CategoryOptionMapper.class,
+    CategoryComboMapper.class,
+    AttributeValueMapper.class
+} )
 public interface CategoryOptionComboMapper
     extends PreheatMapper<CategoryOptionCombo>
 {
@@ -48,6 +53,7 @@ public interface CategoryOptionComboMapper
     @Mapping( target = "uid" )
     @Mapping( target = "name" )
     @Mapping( target = "code" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "categoryOptions", qualifiedByName = "categoryOptions" )
     @Mapping( target = "categoryCombo" )
     CategoryOptionCombo map( CategoryOptionCombo categoryOptionCombo );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/CategoryOptionMapper.java
@@ -31,7 +31,10 @@ import org.hisp.dhis.category.CategoryOption;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = DebugMapper.class )
+@Mapper( uses = {
+    DebugMapper.class,
+    AttributeValueMapper.class
+} )
 public interface CategoryOptionMapper extends PreheatMapper<CategoryOption>
 {
     CategoryOptionMapper INSTANCE = Mappers.getMapper( CategoryOptionMapper.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/DataElementMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/DataElementMapper.java
@@ -33,7 +33,11 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, OptionSetMapper.class } )
+@Mapper( uses = {
+    DebugMapper.class,
+    OptionSetMapper.class,
+    AttributeValueMapper.class
+} )
 public interface DataElementMapper extends PreheatMapper<DataElement>
 {
     DataElementMapper INSTANCE = Mappers.getMapper( DataElementMapper.class );
@@ -43,6 +47,7 @@ public interface DataElementMapper extends PreheatMapper<DataElement>
     @Mapping( target = "uid" )
     @Mapping( target = "code" )
     @Mapping( target = "name" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "valueType" )
     @Mapping( target = "optionSet" )
     DataElement map( DataElement dataElement );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapper.java
@@ -34,7 +34,9 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( )
+@Mapper( uses = {
+    AttributeValueMapper.class
+} )
 public interface OrganisationUnitMapper
     extends PreheatMapper<OrganisationUnit>
 {
@@ -46,6 +48,7 @@ public interface OrganisationUnitMapper
     @Mapping( target = "uid" )
     @Mapping( target = "code" )
     @Mapping( target = "name" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "user" )
     @Mapping( target = "publicAccess" )
     @Mapping( target = "externalAccess" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapper.java
@@ -39,8 +39,14 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, UserGroupAccessMapper.class, UserAccessMapper.class, ProgramMapper.class,
-    TrackedEntityInstanceMapper.class, OrganisationUnitMapper.class } )
+@Mapper( uses = {
+    DebugMapper.class,
+    UserGroupAccessMapper.class,
+    UserAccessMapper.class,
+    TrackedEntityInstanceMapper.class,
+    OrganisationUnitMapper.class,
+    AttributeValueMapper.class
+} )
 public interface ProgramInstanceMapper extends PreheatMapper<ProgramInstance>
 {
     ProgramInstanceMapper INSTANCE = Mappers.getMapper( ProgramInstanceMapper.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapper.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.preheat.mappers;
 
 import java.util.Set;
 
-import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.user.UserAccess;
@@ -39,8 +38,15 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, OrganisationUnitMapper.class, UserGroupAccessMapper.class,
-    UserAccessMapper.class, CategoryComboMapper.class, TrackedEntityTypeMapper.class, ProgramStageMapper.class,
+@Mapper( uses = {
+    DebugMapper.class,
+    OrganisationUnitMapper.class,
+    UserGroupAccessMapper.class,
+    UserAccessMapper.class,
+    CategoryComboMapper.class,
+    TrackedEntityTypeMapper.class,
+    ProgramStageMapper.class,
+    ProgramTrackedEntityAttributeMapper.class,
     AttributeValueMapper.class
 } )
 public interface ProgramMapper extends PreheatMapper<Program>
@@ -80,6 +86,4 @@ public interface ProgramMapper extends PreheatMapper<Program>
     Set<UserAccess> mapUserAccessProgramInstanceProgram( Set<UserAccess> userAccesses );
 
     Set<ProgramStage> mapProgramStages( Set<ProgramStage> programStages );
-
-    Set<AttributeValue> mapAttributeValues( Set<AttributeValue> attributeValues );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageInstanceMapper.java
@@ -37,8 +37,14 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, UserGroupAccessMapper.class, UserAccessMapper.class, ProgramStageMapper.class,
-    OrganisationUnitMapper.class, ProgramInstanceMapper.class } )
+@Mapper( uses = {
+    DebugMapper.class,
+    UserGroupAccessMapper.class,
+    UserAccessMapper.class,
+    ProgramStageMapper.class,
+    OrganisationUnitMapper.class,
+    ProgramInstanceMapper.class
+} )
 public interface ProgramStageInstanceMapper extends PreheatMapper<ProgramStageInstance>
 {
     ProgramStageInstanceMapper INSTANCE = Mappers.getMapper( ProgramStageInstanceMapper.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapper.java
@@ -39,8 +39,12 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, UserGroupAccessMapper.class, UserGroupAccessMapper.class,
-    TrackedEntityTypeMapper.class } )
+@Mapper( uses = {
+    DebugMapper.class,
+    UserGroupAccessMapper.class,
+    TrackedEntityTypeMapper.class,
+    AttributeValueMapper.class
+} )
 public interface ProgramStageMapper extends PreheatMapper<ProgramStage>
 {
     ProgramStageMapper INSTANCE = Mappers.getMapper( ProgramStageMapper.class );
@@ -50,6 +54,7 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage>
     @Mapping( target = "uid" )
     @Mapping( target = "code" )
     @Mapping( target = "name" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "user" )
     @Mapping( target = "publicAccess" )
     @Mapping( target = "externalAccess" )
@@ -75,6 +80,7 @@ public interface ProgramStageMapper extends PreheatMapper<ProgramStage>
     @Mapping( target = "uid" )
     @Mapping( target = "code" )
     @Mapping( target = "name" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "trackedEntityType" )
     @Mapping( target = "programType" )
     @Mapping( target = "categoryCombo" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramTrackedEntityAttributeMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/ProgramTrackedEntityAttributeMapper.java
@@ -29,8 +29,7 @@ package org.hisp.dhis.tracker.preheat.mappers;
 
 import java.util.List;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
+import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -38,25 +37,17 @@ import org.mapstruct.factory.Mappers;
 
 @Mapper( uses = {
     DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
+    TrackedEntityAttributeMapper.class
 } )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+public interface ProgramTrackedEntityAttributeMapper extends PreheatMapper<ProgramTrackedEntityAttribute>
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
+    ProgramTrackedEntityAttributeMapper INSTANCE = Mappers.getMapper( ProgramTrackedEntityAttributeMapper.class );
 
     @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+    @Mapping( target = "mandatory" )
+    @Mapping( target = "attribute" )
+    ProgramTrackedEntityAttribute map( ProgramTrackedEntityAttribute programTrackedEntityAttribute );
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+    List<ProgramTrackedEntityAttribute> mapProgramAttributes(
+        List<ProgramTrackedEntityAttribute> programTrackedEntityAttributes );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipMapper.java
@@ -35,7 +35,10 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = DebugMapper.class )
+@Mapper( uses = {
+    DebugMapper.class,
+    AttributeValueMapper.class
+} )
 public interface RelationshipMapper extends PreheatMapper<Relationship>
 {
     RelationshipMapper INSTANCE = Mappers.getMapper( RelationshipMapper.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipTypeMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipTypeMapper.java
@@ -35,7 +35,10 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = DebugMapper.class )
+@Mapper( uses = {
+    DebugMapper.class,
+    AttributeValueMapper.class
+} )
 public interface RelationshipTypeMapper extends PreheatMapper<RelationshipType>
 {
     RelationshipTypeMapper INSTANCE = Mappers.getMapper( RelationshipTypeMapper.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityAttributeMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityAttributeMapper.java
@@ -33,7 +33,11 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = { DebugMapper.class, OptionSetMapper.class } )
+@Mapper( uses = {
+    DebugMapper.class,
+    OptionSetMapper.class,
+    AttributeValueMapper.class
+} )
 public interface TrackedEntityAttributeMapper extends PreheatMapper<TrackedEntityAttribute>
 {
     TrackedEntityAttributeMapper INSTANCE = Mappers.getMapper( TrackedEntityAttributeMapper.class );
@@ -43,6 +47,8 @@ public interface TrackedEntityAttributeMapper extends PreheatMapper<TrackedEntit
     @Mapping( target = "id" )
     @Mapping( target = "uid" )
     @Mapping( target = "code" )
+    @Mapping( target = "name" )
+    @Mapping( target = "attributeValues" )
     @Mapping( target = "confidential" )
     @Mapping( target = "unique" )
     @Mapping( target = "generated" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityInstanceMapper.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityInstanceMapper.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.preheat.mappers;
 
 import java.util.Set;
 
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.user.UserAccess;
 import org.hisp.dhis.user.UserGroupAccess;
@@ -38,7 +39,11 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
-@Mapper( uses = DebugMapper.class )
+@Mapper( uses = {
+    DebugMapper.class,
+    TrackedEntityTypeMapper.class,
+    AttributeValueMapper.class
+} )
 public interface TrackedEntityInstanceMapper extends PreheatMapper<TrackedEntityInstance>
 {
     TrackedEntityInstanceMapper INSTANCE = Mappers.getMapper( TrackedEntityInstanceMapper.class );
@@ -52,7 +57,7 @@ public interface TrackedEntityInstanceMapper extends PreheatMapper<TrackedEntity
     @Mapping( target = "externalAccess" )
     @Mapping( target = "userGroupAccesses", qualifiedByName = "userGroupAccesses" )
     @Mapping( target = "userAccesses", qualifiedByName = "userAccesses" )
-    @Mapping( target = "organisationUnit" )
+    @Mapping( target = "organisationUnit", qualifiedByName = "organisationUnit" )
     @Mapping( target = "trackedEntityType" )
     @Mapping( target = "inactive" )
     @Mapping( target = "programInstances" )
@@ -69,4 +74,17 @@ public interface TrackedEntityInstanceMapper extends PreheatMapper<TrackedEntity
     @Named( "userAccesses" )
     Set<UserAccess> mapUserAccessProgramInstance( Set<UserAccess> userAccesses );
 
+    @Named( "organisationUnit" )
+    @BeanMapping( ignoreByDefault = true )
+    @Mapping( target = "id" )
+    @Mapping( target = "uid" )
+    @Mapping( target = "code" )
+    @Mapping( target = "name" )
+    @Mapping( target = "attributeValues" )
+    @Mapping( target = "user" )
+    @Mapping( target = "publicAccess" )
+    @Mapping( target = "externalAccess" )
+    @Mapping( target = "userGroupAccesses" )
+    @Mapping( target = "userAccesses" )
+    OrganisationUnit map( OrganisationUnit organisationUnit );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/AttributeCreator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/AttributeCreator.java
@@ -27,36 +27,39 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import java.util.Set;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.BaseIdentifiableObject;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class AttributeCreator
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
+    static Set<AttributeValue> attributeValues( String uid, String value )
+    {
+        return Set.of( attributeValue( uid, value ) );
+    }
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+    static AttributeValue attributeValue( String uid, String value )
+    {
+        return new AttributeValue( attribute( uid ), value );
+    }
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+    static Attribute attribute( String attributeUid )
+    {
+        Attribute att = new Attribute();
+        att.setUid( attributeUid );
+        return att;
+    }
+
+    static <T extends BaseIdentifiableObject> T setIdSchemeFields( T identifiable, String uid, String name, String code,
+        Set<AttributeValue> attributeValues )
+    {
+        identifiable.setUid( uid );
+        identifiable.setName( name );
+        identifiable.setCode( code );
+        identifiable.setAttributeValues( attributeValues );
+        return identifiable;
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapperTest.java
@@ -27,36 +27,33 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValue;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValues;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.junit.jupiter.api.Test;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class OrganisationUnitMapperTest
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
+    @Test
+    void testIdSchemeRelatedFieldsAreMapped()
+    {
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+        OrganisationUnit orgUnit = setIdSchemeFields(
+            new OrganisationUnit(),
+            "HpSAvRWtdDR",
+            "meet",
+            "green",
+            attributeValues( "m0GpPuMUfFW", "purple" ) );
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+        OrganisationUnit mapped = OrganisationUnitMapper.INSTANCE.map( orgUnit );
+
+        assertEquals( "HpSAvRWtdDR", mapped.getUid() );
+        assertEquals( "meet", mapped.getName() );
+        assertEquals( "green", mapped.getCode() );
+        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapperTest.java
@@ -27,36 +27,37 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValue;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValues;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
+import org.junit.jupiter.api.Test;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class ProgramInstanceMapperTest
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+    @Test
+    void testIdSchemeRelatedFieldsAreMapped()
+    {
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+        Program program = setIdSchemeFields(
+            new Program(),
+            "WTTYiPQDqh1",
+            "friendship",
+            "red",
+            attributeValues( "m0GpPuMUfFW", "yellow" ) );
+        ProgramInstance programInstance = new ProgramInstance();
+        programInstance.setProgram( program );
+
+        ProgramInstance mapped = ProgramInstanceMapper.INSTANCE.map( programInstance );
+
+        assertEquals( "WTTYiPQDqh1", mapped.getProgram().getUid() );
+        assertEquals( "friendship", mapped.getProgram().getName() );
+        assertEquals( "red", mapped.getProgram().getCode() );
+        assertContainsOnly( mapped.getProgram().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapperTest.java
@@ -32,21 +32,20 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeVa
 import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
-import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
-import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageDataElement;
 import org.junit.jupiter.api.Test;
 
-class ProgramMapperTest extends DhisConvenienceTest
+class ProgramStageMapperTest
 {
+
     @Test
     void testIdSchemeRelatedFieldsAreMapped()
     {
@@ -58,58 +57,42 @@ class ProgramMapperTest extends DhisConvenienceTest
             "red",
             attributeValues( "m0GpPuMUfFW", "yellow" ) );
 
-        TrackedEntityAttribute attribute = setIdSchemeFields(
-            new TrackedEntityAttribute(),
+        DataElement dataElement = setIdSchemeFields(
+            new DataElement(),
             "khBzbxTLo8k",
             "clouds",
             "orange",
             attributeValues( "m0GpPuMUfFW", "purple" ) );
-        ProgramTrackedEntityAttribute programAttribute = new ProgramTrackedEntityAttribute();
-        programAttribute.setAttribute( attribute );
-        program.setProgramAttributes( List.of( programAttribute ) );
+        ProgramStageDataElement programStageDataElement = new ProgramStageDataElement();
+        programStageDataElement.setDataElement( dataElement );
 
-        Program mapped = ProgramMapper.INSTANCE.map( program );
+        ProgramStage programStage = setIdSchemeFields(
+            new ProgramStage(),
+            "HpSAvRWtdDR",
+            "meet",
+            "green",
+            attributeValues( "m0GpPuMUfFW", "purple" ) );
+        programStage.setProgram( program );
+        programStage.setProgramStageDataElements( Set.of( programStageDataElement ) );
 
-        assertEquals( "WTTYiPQDqh1", mapped.getUid() );
-        assertEquals( "friendship", mapped.getName() );
-        assertEquals( "red", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        ProgramStage mapped = ProgramStageMapper.INSTANCE.map( programStage );
 
-        Optional<ProgramTrackedEntityAttribute> actual = mapped.getProgramAttributes().stream().findFirst();
+        assertEquals( "HpSAvRWtdDR", mapped.getUid() );
+        assertEquals( "meet", mapped.getName() );
+        assertEquals( "green", mapped.getCode() );
+        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+
+        assertEquals( "WTTYiPQDqh1", mapped.getProgram().getUid() );
+        assertEquals( "friendship", mapped.getProgram().getName() );
+        assertEquals( "red", mapped.getProgram().getCode() );
+        assertContainsOnly( mapped.getProgram().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+
+        Optional<ProgramStageDataElement> actual = mapped.getProgramStageDataElements().stream().findFirst();
         assertTrue( actual.isPresent() );
-        ProgramTrackedEntityAttribute value = actual.get();
-        assertEquals( "khBzbxTLo8k", value.getAttribute().getUid() );
-        assertEquals( "clouds", value.getAttribute().getName() );
-        assertEquals( "orange", value.getAttribute().getCode() );
-        assertContainsOnly( value.getAttribute().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
-    }
-
-    @Test
-    void testCategoryComboIsSetForDefaultCategoryCombos()
-    {
-
-        Program program = new Program();
-        CategoryCombo cc = createCategoryCombo( 'A' );
-        cc.setName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME );
-        assertTrue( cc.isDefault(), "tests rely on this CC being the default one" );
-        program.setCategoryCombo( cc );
-
-        Program mappedProgram = ProgramMapper.INSTANCE.map( program );
-
-        assertEquals( cc, mappedProgram.getCategoryCombo() );
-    }
-
-    @Test
-    void testCategoryComboIsSetForNonDefaultCategoryCombos()
-    {
-
-        Program program = new Program();
-        CategoryCombo cc = createCategoryCombo( 'A' );
-        assertFalse( cc.isDefault(), "tests rely on this CC NOT being the default one" );
-        program.setCategoryCombo( cc );
-
-        Program mappedProgram = ProgramMapper.INSTANCE.map( program );
-
-        assertEquals( cc, mappedProgram.getCategoryCombo() );
+        ProgramStageDataElement value = actual.get();
+        assertEquals( "khBzbxTLo8k", value.getDataElement().getUid() );
+        assertEquals( "clouds", value.getDataElement().getName() );
+        assertEquals( "orange", value.getDataElement().getCode() );
+        assertContainsOnly( value.getDataElement().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipMapperTest.java
@@ -27,36 +27,39 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValue;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValues;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.hisp.dhis.relationship.Relationship;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.junit.jupiter.api.Test;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class RelationshipMapperTest
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
+    @Test
+    void testIdSchemeRelatedFieldsAreMapped()
+    {
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+        RelationshipType relationshipType = setIdSchemeFields(
+            new RelationshipType(),
+            "WTTYiPQDqh1",
+            "friendship",
+            "red",
+            attributeValues( "m0GpPuMUfFW", "yellow" ) );
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+        Relationship relationship = new Relationship();
+        relationship.setRelationshipType( relationshipType );
+
+        Relationship mapped = RelationshipMapper.INSTANCE.map( relationship );
+
+        assertEquals( "WTTYiPQDqh1", mapped.getRelationshipType().getUid() );
+        assertEquals( "friendship", mapped.getRelationshipType().getName() );
+        assertEquals( "red", mapped.getRelationshipType().getCode() );
+        assertContainsOnly( mapped.getRelationshipType().getAttributeValues(),
+            attributeValue( "m0GpPuMUfFW", "yellow" ) );
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipTypeMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipTypeMapperTest.java
@@ -27,36 +27,34 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValue;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValues;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.hisp.dhis.relationship.RelationshipType;
+import org.junit.jupiter.api.Test;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class RelationshipTypeMapperTest
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
+    @Test
+    void testIdSchemeRelatedFieldsAreMapped()
+    {
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+        RelationshipType relationshipType = setIdSchemeFields(
+            new RelationshipType(),
+            "WTTYiPQDqh1",
+            "friendship",
+            "red",
+            attributeValues( "m0GpPuMUfFW", "yellow" ) );
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+        RelationshipType mapped = RelationshipTypeMapper.INSTANCE.map( relationshipType );
+
+        assertEquals( "WTTYiPQDqh1", mapped.getUid() );
+        assertEquals( "friendship", mapped.getName() );
+        assertEquals( "red", mapped.getCode() );
+        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+    }
+
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityAttributeMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityAttributeMapperTest.java
@@ -27,36 +27,34 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValue;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValues;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.junit.jupiter.api.Test;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class TrackedEntityAttributeMapperTest
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+    @Test
+    void testIdSchemeRelatedFieldsAreMapped()
+    {
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+        TrackedEntityAttribute trackedEntityAttribute = setIdSchemeFields(
+            new TrackedEntityAttribute(),
+            "HpSAvRWtdDR",
+            "meet",
+            "green",
+            attributeValues( "m0GpPuMUfFW", "purple" ) );
+
+        TrackedEntityAttribute mapped = TrackedEntityAttributeMapper.INSTANCE.map( trackedEntityAttribute );
+
+        assertEquals( "HpSAvRWtdDR", mapped.getUid() );
+        assertEquals( "meet", mapped.getName() );
+        assertEquals( "green", mapped.getCode() );
+        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityInstanceMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityInstanceMapperTest.java
@@ -32,31 +32,37 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeVa
 import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
-import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.category.CategoryCombo;
-import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.junit.jupiter.api.Test;
 
-class ProgramMapperTest extends DhisConvenienceTest
+class TrackedEntityInstanceMapperTest
 {
     @Test
     void testIdSchemeRelatedFieldsAreMapped()
     {
 
-        Program program = setIdSchemeFields(
-            new Program(),
+        TrackedEntityType trackedEntityType = setIdSchemeFields(
+            new TrackedEntityType(),
             "WTTYiPQDqh1",
             "friendship",
             "red",
             attributeValues( "m0GpPuMUfFW", "yellow" ) );
+
+        OrganisationUnit orgUnit = setIdSchemeFields(
+            new OrganisationUnit(),
+            "HpSAvRWtdDR",
+            "meet",
+            "green",
+            attributeValues( "m0GpPuMUfFW", "purple" ) );
 
         TrackedEntityAttribute attribute = setIdSchemeFields(
             new TrackedEntityAttribute(),
@@ -64,52 +70,35 @@ class ProgramMapperTest extends DhisConvenienceTest
             "clouds",
             "orange",
             attributeValues( "m0GpPuMUfFW", "purple" ) );
-        ProgramTrackedEntityAttribute programAttribute = new ProgramTrackedEntityAttribute();
-        programAttribute.setAttribute( attribute );
-        program.setProgramAttributes( List.of( programAttribute ) );
+        TrackedEntityAttributeValue attributeValue = new TrackedEntityAttributeValue();
+        attributeValue.setAttribute( attribute );
 
-        Program mapped = ProgramMapper.INSTANCE.map( program );
+        TrackedEntityInstance tei = new TrackedEntityInstance();
+        tei.setTrackedEntityType( trackedEntityType );
+        tei.setOrganisationUnit( orgUnit );
+        tei.setTrackedEntityAttributeValues( Set.of( attributeValue ) );
 
-        assertEquals( "WTTYiPQDqh1", mapped.getUid() );
-        assertEquals( "friendship", mapped.getName() );
-        assertEquals( "red", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        TrackedEntityInstance mapped = TrackedEntityInstanceMapper.INSTANCE.map( tei );
 
-        Optional<ProgramTrackedEntityAttribute> actual = mapped.getProgramAttributes().stream().findFirst();
+        assertEquals( "WTTYiPQDqh1", mapped.getTrackedEntityType().getUid() );
+        assertEquals( "friendship", mapped.getTrackedEntityType().getName() );
+        assertEquals( "red", mapped.getTrackedEntityType().getCode() );
+        assertContainsOnly( mapped.getTrackedEntityType().getAttributeValues(),
+            attributeValue( "m0GpPuMUfFW", "yellow" ) );
+
+        assertEquals( "HpSAvRWtdDR", mapped.getOrganisationUnit().getUid() );
+        assertEquals( "meet", mapped.getOrganisationUnit().getName() );
+        assertEquals( "green", mapped.getOrganisationUnit().getCode() );
+        assertContainsOnly( mapped.getOrganisationUnit().getAttributeValues(),
+            attributeValue( "m0GpPuMUfFW", "purple" ) );
+
+        Optional<TrackedEntityAttributeValue> actual = mapped.getTrackedEntityAttributeValues().stream().findFirst();
         assertTrue( actual.isPresent() );
-        ProgramTrackedEntityAttribute value = actual.get();
+        TrackedEntityAttributeValue value = actual.get();
         assertEquals( "khBzbxTLo8k", value.getAttribute().getUid() );
         assertEquals( "clouds", value.getAttribute().getName() );
         assertEquals( "orange", value.getAttribute().getCode() );
         assertContainsOnly( value.getAttribute().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
     }
 
-    @Test
-    void testCategoryComboIsSetForDefaultCategoryCombos()
-    {
-
-        Program program = new Program();
-        CategoryCombo cc = createCategoryCombo( 'A' );
-        cc.setName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME );
-        assertTrue( cc.isDefault(), "tests rely on this CC being the default one" );
-        program.setCategoryCombo( cc );
-
-        Program mappedProgram = ProgramMapper.INSTANCE.map( program );
-
-        assertEquals( cc, mappedProgram.getCategoryCombo() );
-    }
-
-    @Test
-    void testCategoryComboIsSetForNonDefaultCategoryCombos()
-    {
-
-        Program program = new Program();
-        CategoryCombo cc = createCategoryCombo( 'A' );
-        assertFalse( cc.isDefault(), "tests rely on this CC NOT being the default one" );
-        program.setCategoryCombo( cc );
-
-        Program mappedProgram = ProgramMapper.INSTANCE.map( program );
-
-        assertEquals( cc, mappedProgram.getCategoryCombo() );
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityTypeMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityTypeMapperTest.java
@@ -27,36 +27,34 @@
  */
 package org.hisp.dhis.tracker.preheat.mappers;
 
-import java.util.List;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValue;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.attributeValues;
+import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdSchemeFields;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.trackedentity.TrackedEntityType;
-import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+import org.junit.jupiter.api.Test;
 
-@Mapper( uses = {
-    DebugMapper.class,
-    TrackedEntityTypeAttributeMapper.class,
-    AttributeValueMapper.class
-} )
-public interface TrackedEntityTypeMapper
-    extends PreheatMapper<TrackedEntityType>
+class TrackedEntityTypeMapperTest
 {
-    TrackedEntityTypeMapper INSTANCE = Mappers.getMapper( TrackedEntityTypeMapper.class );
 
-    @BeanMapping( ignoreByDefault = true )
-    @Mapping( target = "id" )
-    @Mapping( target = "uid" )
-    @Mapping( target = "name" )
-    @Mapping( target = "code" )
-    @Mapping( target = "attributeValues" )
-    @Mapping( target = "featureType" )
-    @Mapping( target = "sharing" )
-    @Mapping( target = "trackedEntityTypeAttributes" )
-    @Mapping( target = "allowAuditLog" )
-    TrackedEntityType map( TrackedEntityType trackedEntityType );
+    @Test
+    void testIdSchemeRelatedFieldsAreMapped()
+    {
 
-    List<TrackedEntityTypeAttribute> map( List<TrackedEntityTypeAttribute> trackedEntityTypeAttributes );
+        TrackedEntityType trackedEntityType = setIdSchemeFields(
+            new TrackedEntityType(),
+            "HpSAvRWtdDR",
+            "meet",
+            "green",
+            attributeValues( "m0GpPuMUfFW", "purple" ) );
+
+        TrackedEntityType mapped = TrackedEntityTypeMapper.INSTANCE.map( trackedEntityType );
+
+        assertEquals( "HpSAvRWtdDR", mapped.getUid() );
+        assertEquals( "meet", mapped.getName() );
+        assertEquals( "green", mapped.getCode() );
+        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+    }
 }


### PR DESCRIPTION
## Why

When comparing metadata from the preheat to metadata in the payload like in

https://github.com/dhis2/dhis2-core/blob/336a4c206938a264d27dd3eb67dc75df83483f30/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java#L128-L129

we need to ensure that metadata in the preheat has fields uid, code, name, attributeValues mapped. This is needed to support all 4 idSchemes for matching metadata (UID, CODE, NAME, ATTRIBUTE).

Not mapping them would lead to false `metadata not found` errors or other errors.

## What

* add reusable mapper of Set<AttributeValue> to AttributeValueMapper
* mapping attributeValues field in preheat mappers for metadata fields that are used in the tracker domain. The best I could 😓 We might still need to add a few mappings to get idScheme ATTRIBUTE working for all metadata types.
* ProgramInstanceMapper used ProgramMapper but also mapped directly within the ProgramInstanceMapper; use direct mapping with only necessary fields


The following is my checklist; if it does not help you it might be worth as a future reference.

## Checklist for all the metadata (idScheme related) fields

All metadata identifiers in the tracker domain

* Event.orgUnit ✅ 
* Event.program  ✅ 
* Event.programStage  ✅ 
* Event.attributeOptionCombo  ✅ 
* Enrollment.program  ✅ 
* Enrollment.orgUnit  ✅ 
* TrackedEntity.orgUnit  ✅ 
* Event.attributeCategoryOptions  ✅ 
* Relationship.relationshipType  ✅ 
* TrackedEntity.trackedEntityType  ✅ 
* TrackedEntity.Attribute.attribute ✅
* Event.DataValue.dataElement ✅

Why I think they are done/how they are mapped:

left of the => is the tracker domain metadata field
right of the => is the corresponding field in the org.hisp.dhis domain

OrganistationUnit
* OrganistationUnitMapper has uid, code, name, attributes mapped
* Event.orgUnit => ProgramStageInstance.orgUnit ; done via use of OrganistationUnitMapper in ProgramStageInstanceMapper
* Enrollment.orgUnit => ProgramInstance.orgUnit; done via use of OrganistationUnitMapper in ProgramInstanceMapper
* TrackedEntity.orgUnit => TrackedEntityInstance.orgUnit; done via explicit mapper in TrackedEntityInstanceMapper

Program
* ProgramMapper has uid, code, name, attributes mapped
* Event.program => field does not exist in ProgramStageInstance so its not mapped in ProgramStageInstanceMapper
* Enrollment.program => ProgramInstance.program ; done via explicit mapper in ProgramInstanceMapper

ProgramStage
* ProgramStageMapper has uid, code, name, attributes mapped
* Event.programStage => ProgramStageInstance.programStage ; done via use of ProgramStageMapper in ProgramStageInstanceMapper

AttributeOptionCombo
* CategoryOptionComboMapper has uid, code, name, attributes mapped
* Event.attributeOptionCombo => ; field is not mapped in ProgramStageInstanceMapper

CategoryOption
* CategoryOptionMapper has uid, code, name, attributes mapped
* Event.attributeCategoryOptions => field does not exist in ProgramStageInstance so its not mapped in ProgramStageInstanceMapper

AttributeCategoryOption

CategoryCombo
* CategoryComboMapper has uid, code, name, attributes mapped

Category
* CategoryMapper has uid, code, name, attributes mapped

DataElement
* DataElementMapper has uid, code, name, attributes mapped
* Event.DataValue.dataElement =>  ProgramStageInstanceMapper does not use a custom mapper for eventDataValues, so its attributeValues will be lazy-loaded (hibernate proxy). I could not find any references to eventDataValues

RelationshipType
* RelationshipTypeMapper has uid, code, name, attributes mapped
* Relationship.relationshipType => Relationship.relationshipType ; done via explicit mapper in RelationshipMapper

TrackedEntityType
* TrackedEntityTypeMapper has uid, code, name, attributes mapped
* TrackedEntityInstance.trackedEntityType ; done via use of TrackedEntityTypeMapper in TrackedEntityInstanceMapper

TrackedEntityAttribute
* TrackedEntityAttributeMapper has uid, code, name, attributes mapped
* TrackedEntity.Attribute.attribute => TrackedEntityInstance.trackedEntityAttributeValues ; TrackedEntityInstanceMapper does not use a custom mapper for trackedEntityAttributeValues, so its attributeValues will be lazy-loaded (hibernate proxy). We will have to follow up with a mapper/mapping.
