### PR TITLE
feat: render GeoJSON attribute values as JSON when individually requested [DHIS2-13323]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/DataType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/DataType.java
@@ -40,11 +40,11 @@ public enum DataType
 
     public static DataType fromValueType( ValueType valueType )
     {
-        if ( ValueType.NUMERIC_TYPES.contains( valueType ) )
+        if ( valueType != null && valueType.isNumeric() )
         {
             return DataType.NUMERIC;
         }
-        else if ( ValueType.BOOLEAN_TYPES.contains( valueType ) )
+        else if ( valueType != null && valueType.isBoolean() )
         {
             return DataType.BOOLEAN;
         }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -32,6 +32,8 @@ import static java.util.stream.Collectors.toSet;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.geotools.geojson.GeoJSON;
 import org.hisp.dhis.analytics.AggregationType;
@@ -40,7 +42,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.opengis.geometry.primitive.Point;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Lars Helge Overland
@@ -76,29 +77,33 @@ public enum ValueType
     IMAGE( String.class, false, FileTypeValueOptions.class ),
     GEOJSON( GeoJSON.class, false );
 
-    public static final Set<ValueType> INTEGER_TYPES = ImmutableSet.of(
+    private static final Set<ValueType> INTEGER_TYPES = Set.of(
         INTEGER, INTEGER_POSITIVE, INTEGER_NEGATIVE, INTEGER_ZERO_OR_POSITIVE );
 
-    public static final Set<ValueType> DECIMAL_TYPES = ImmutableSet.of(
+    private static final Set<ValueType> DECIMAL_TYPES = Set.of(
         NUMBER, UNIT_INTERVAL, PERCENTAGE );
 
-    public static final Set<ValueType> BOOLEAN_TYPES = ImmutableSet.of(
+    private static final Set<ValueType> BOOLEAN_TYPES = Set.of(
         BOOLEAN, TRUE_ONLY );
 
-    public static final Set<ValueType> TEXT_TYPES = ImmutableSet.of(
+    public static final Set<ValueType> TEXT_TYPES = Set.of(
         TEXT, LONG_TEXT, LETTER, TIME, USERNAME, EMAIL, PHONE_NUMBER, URL );
 
-    public static final Set<ValueType> DATE_TYPES = ImmutableSet.of(
+    public static final Set<ValueType> DATE_TYPES = Set.of(
         DATE, DATETIME, AGE );
 
-    public static final Set<ValueType> FILE_TYPES = ImmutableSet.of(
+    private static final Set<ValueType> FILE_TYPES = Set.of(
         FILE_RESOURCE, IMAGE );
 
-    public static final Set<ValueType> GEO_TYPES = ImmutableSet.of(
+    private static final Set<ValueType> GEO_TYPES = Set.of(
         COORDINATE, GEOJSON );
 
-    public static final Set<ValueType> NUMERIC_TYPES = ImmutableSet.<ValueType> builder().addAll(
-        INTEGER_TYPES ).addAll( DECIMAL_TYPES ).build();
+    private static final Set<ValueType> JSON_TYPES = Set.of(
+        GEOJSON );
+
+    public static final Set<ValueType> NUMERIC_TYPES = Stream.concat( INTEGER_TYPES.stream(), DECIMAL_TYPES.stream() )
+        .collect(
+            Collectors.toUnmodifiableSet() );
 
     @Deprecated
     private final Class<?> javaClass;
@@ -181,6 +186,11 @@ public enum ValueType
     public boolean isNumeric()
     {
         return NUMERIC_TYPES.contains( this );
+    }
+
+    public boolean isJson()
+    {
+        return JSON_TYPES.contains( this );
     }
 
     public boolean isAggregatable()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -54,13 +54,13 @@ import java.util.TreeMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.gist.GistQuery.Comparison;
@@ -107,6 +107,19 @@ final class GistBuilder
     private static final String GIST_PATH = "/gist";
 
     /**
+     * Defines the functions the builder needs to be able to run that depend on
+     * other parts of the system.
+     */
+    interface GistBuilderSupport
+    {
+        List<String> getUserGroupIdsByUserId( String userId );
+
+        Attribute getAttributeById( String attributeId );
+
+        Object getTypedAttributeValue( Attribute attribute, String value );
+    }
+
+    /**
      * HQL does not allow plain "null" in select columns list as the type is
      * unknown. Therefore we just cast it to some simple type. Which is not
      * important as the value will be {@code null} anyway.
@@ -122,15 +135,15 @@ final class GistBuilder
     private static final String ATTRIBUTES_PROPERTY = "attributeValues";
 
     static GistBuilder createFetchBuilder( GistQuery query, RelativePropertyContext context, GistAccessControl access,
-        Function<String, List<String>> userGroupsByUserId )
+        GistBuilderSupport support )
     {
-        return new GistBuilder( access, addSupportFields( query, context ), context, userGroupsByUserId );
+        return new GistBuilder( access, addSupportFields( query, context ), context, support );
     }
 
     static GistBuilder createCountBuilder( GistQuery query, RelativePropertyContext context, GistAccessControl access,
-        Function<String, List<String>> userGroupsByUserId )
+        GistBuilderSupport support )
     {
-        return new GistBuilder( access, query, context, userGroupsByUserId );
+        return new GistBuilder( access, query, context, support );
     }
 
     private final GistAccessControl access;
@@ -139,7 +152,7 @@ final class GistBuilder
 
     private final RelativePropertyContext context;
 
-    private final Function<String, List<String>> userGroupsByUserId;
+    private final GistBuilderSupport support;
 
     private final List<Consumer<Object[]>> fieldResultTransformers = new ArrayList<>();
 
@@ -263,7 +276,7 @@ final class GistBuilder
         fieldResultTransformers.add( transformer );
     }
 
-    private Object attributeValue( String attributeUid, Object attributeValues )
+    private Object attributeValue( String attributeUid, Object attributeValues, Attribute attribute )
     {
         @SuppressWarnings( "unchecked" )
         Set<AttributeValue> values = (Set<AttributeValue>) attributeValues;
@@ -271,7 +284,9 @@ final class GistBuilder
         {
             if ( attributeUid.equals( v.getAttribute().getUid() ) )
             {
-                return v.getValue();
+                return attribute != null
+                    ? support.getTypedAttributeValue( attribute, v.getValue() )
+                    : v.getValue();
             }
         }
         return null;
@@ -392,12 +407,18 @@ final class GistBuilder
         }
         if ( field.isAttribute() )
         {
+            Attribute attribute = query.isTypedAttributeValues() ? support.getAttributeById( path ) : null;
             if ( field.getTransformation() == Transform.PLUCK )
             {
+                if ( attribute != null )
+                {
+                    addTransformer(
+                        row -> row[index] = support.getTypedAttributeValue( attribute, (String) row[index] ) );
+                }
                 return "jsonb_extract_path_text(e.attributeValues, '" + field.getPropertyPath() + "', 'value')";
             }
             int attrValuesFieldIndex = getSameParentFieldIndex( "", ATTRIBUTES_PROPERTY );
-            addTransformer( row -> row[index] = attributeValue( path, row[attrValuesFieldIndex] ) );
+            addTransformer( row -> row[index] = attributeValue( path, row[attrValuesFieldIndex], attribute ) );
             return HQL_NULL;
         }
         Property property = context.resolveMandatory( path );
@@ -855,7 +876,7 @@ final class GistBuilder
     {
         String userId = filter.getValue()[0];
         return JpaQueryUtils.generateHqlQueryForSharingCheck( tableName, getAccessPattern( filter ), userId,
-            userGroupsByUserId.apply( userId ) );
+            support.getUserGroupIdsByUserId( userId ) );
     }
 
     private String getAccessPattern( Filter filter )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistQuery.java
@@ -169,6 +169,8 @@ public final class GistQuery
     @JsonProperty
     private final boolean references;
 
+    private final boolean typedAttributeValues;
+
     /**
      * The extend to which fields are included by default
      */

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/dataanalysis/MinMaxOutlierAnalysisService.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.datavalue.DeflatedDataValue;
 import org.hisp.dhis.jdbc.batchhandler.MinMaxDataElementBatchHandler;
@@ -90,7 +89,7 @@ public class MinMaxOutlierAnalysisService
         Collection<DataElement> dataElements, Collection<Period> periods, Double stdDevFactor, Date from )
     {
         Set<DataElement> elements = dataElements.stream()
-            .filter( de -> ValueType.NUMERIC_TYPES.contains( de.getValueType() ) )
+            .filter( de -> de.getValueType().isNumeric() )
             .collect( Collectors.toSet() );
         Set<CategoryOptionCombo> categoryOptionCombos = new HashSet<>();
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -708,7 +708,7 @@ public class ValidationUtils
      */
     public static String normalizeBoolean( String bool, ValueType valueType )
     {
-        if ( ValueType.BOOLEAN_TYPES.contains( valueType ) )
+        if ( valueType != null && valueType.isBoolean() )
         {
             if ( BOOL_FALSE_VARIANTS.contains( bool ) && valueType != ValueType.TRUE_ONLY )
             {

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GeoJsonImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GeoJsonImportControllerTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.webapi.controller;
 import static java.lang.String.format;
 import static org.hisp.dhis.webapi.utils.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -44,7 +43,6 @@ import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonNumber;
 import org.hisp.dhis.jsontree.JsonObject;
-import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonImportConflict;
 import org.hisp.dhis.webapi.json.domain.JsonImportCount;
@@ -380,10 +378,10 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         JsonObject unit = GET( "/organisationUnits/{uid}/gist?fields=geometry,{attr}~rename(geo2)", uid, attributeId )
             .content();
-        String geometry = unit.getString( "geo2" ).string();
-        assertNotNull( geometry, uid + " has no geometry" );
+        JsonObject geometry = unit.getObject( "geo2" );
+        assertTrue( geometry.exists() && geometry.isObject(), uid + " has no geometry" );
         // need to un-quote the value to make it into a JSON document
-        assertIsGeometryValue( JsonValue.of( geometry.replace( "\\\"", "\"" ) ).asObject() );
+        assertIsGeometryValue( geometry );
         assertTrue( unit.getObject( "geometry" ).isUndefined(),
             "unit should not have a geometry value set when an attribute is used" );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -110,7 +110,8 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
         throws IOException
     {
         gistToCsvResponse( response, createGistQuery( request, getEntityClass(), GistAutoType.L )
-            .withFilter( new Filter( "id", Comparison.EQ, uid ) ) );
+            .withFilter( new Filter( "id", Comparison.EQ, uid ) )
+            .toBuilder().typedAttributeValues( false ).build() );
     }
 
     @GetMapping( value = "/gist", produces = APPLICATION_JSON_VALUE )
@@ -125,7 +126,8 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
     public void getObjectListGistAsCsv( HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
-        gistToCsvResponse( response, createGistQuery( request, getEntityClass(), GistAutoType.S ) );
+        gistToCsvResponse( response, createGistQuery( request, getEntityClass(), GistAutoType.S )
+            .toBuilder().typedAttributeValues( false ).build() );
     }
 
     @GetMapping( value = "/{uid}/{property}/gist", produces = APPLICATION_JSON_VALUE )
@@ -164,7 +166,8 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
         {
             throw new BadRequestException( "No such property: " + property );
         }
-        gistToCsvResponse( response, createPropertyQuery( uid, property, request, objProperty ) );
+        gistToCsvResponse( response, createPropertyQuery( uid, property, request, objProperty )
+            .toBuilder().typedAttributeValues( false ).build() );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -191,6 +194,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
             .autoType( params.getEnum( "auto", autoDefault ) )
             .contextRoot( ContextUtils.getRootPath( request ) )
             .translationLocale( translationLocale )
+            .typedAttributeValues( true )
             .build()
             .with( params );
     }


### PR DESCRIPTION
### Summary
When a attribute of value type `GEOJSON` (or any JSON type) is requested explicitly by its ID in the `fields` list, the value is rendered as JSON instead of being a string (which is rendered as escaped JSON string).

After having implemented this for individual attributes I opted to not also implement this in general when all attribute values are included as the overhead both on server and client side can be significant as GeoJSON data can be a quite large object graph.

### Automatic Testing
Added tests for Gist API that test both extraction from the deserialised `Set<AttributeValue>` as well as the direct extraction from database using JSONB functions.

### Manual Testing
* create a new attribute of type `GEOJSON` and make it usable for e.g. user groups
* create or edit a user group and add a value for the new attribute, a minimal valid GeoJSON value could be
```json
{"type":"MultiPolygon", "coordinates": [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }
```
* check that the different API endpoint render the value as JSON tree and not as single string value containing the escaped JSON
  * `/api/userGroups?fields=id,name,{attr}`
  * `/api/userGroups/gist?fields=id,name,{attr}`
  * `/api/userGroups/gist?fields=id,name,{attr}::pluck`
  * `/api/userGroups/{uid}?fields=id,name,{attr}`
  * `/api/userGroups/{uid}/gist?fields=id,name,{attr}`
  * `/api/userGroups/{uid}/gist?fields=id,name,{attr}::pluck`

`{attr}` = UID of the `GEOJSON` attribute