### PR TITLE
feat: data integrity checks provide issues ID type information [DHIS2-13321]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheck.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheck.java
@@ -75,6 +75,9 @@ public final class DataIntegrityCheck implements Serializable
     @JsonProperty
     private final String recommendation;
 
+    @JsonProperty
+    private final String issuesIdType;
+
     private final transient Function<DataIntegrityCheck, DataIntegritySummary> runSummaryCheck;
 
     private final transient Function<DataIntegrityCheck, DataIntegrityDetails> runDetailsCheck;

--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
+      <artifactId>dhis-service-schema</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-system</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
@@ -79,6 +79,9 @@ class DataIntegrityYamlReader
         @JsonProperty( "details_sql" )
         String detailsSql;
 
+        @JsonProperty( "details_id_type" )
+        String detailsIdType;
+
         @JsonProperty
         String introduction;
 
@@ -122,6 +125,7 @@ class DataIntegrityYamlReader
                     .description( info.apply( name + ".description", trim( e.description ) ) )
                     .introduction( info.apply( name + ".introduction", trim( e.introduction ) ) )
                     .recommendation( info.apply( name + ".recommendation", trim( e.recommendation ) ) )
+                    .issuesIdType( trim( e.detailsIdType ) )
                     .section( trim( e.section ) )
                     .severity( e.severity )
                     .runSummaryCheck( sqlToSummary.apply( sanitiseSQL( e.summarySql ) ) )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_no_options.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_no_options.yaml
@@ -39,6 +39,7 @@ details_sql: >-
     where categoryid
     not in (select distinct categoryid from categories_categoryoptions)
     ORDER BY name;
+details_id_type: categories
 severity: WARNING
 introduction: >
     Categories should always have at least a single category options.

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category.yaml
@@ -35,6 +35,7 @@ details_sql: >-
   SELECT uid, name FROM dataelementcategory
   WHERE name = 'default' AND uid != 'GLevLNI9wkl'
   ORDER BY categoryid;
+details_id_type: categories
 severity: SEVERE
 introduction: >
   There should only exist one category with name and code "default".

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_combo.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_combo.yaml
@@ -35,6 +35,7 @@ details_sql: >-
   SELECT uid, name FROM categorycombo
   WHERE name = 'default' AND uid != 'bjDvmb4bfuf'
   ORDER BY categorycomboid;
+details_id_type: categoryCombos
 severity: SEVERE
 introduction: >
   There should only exist one category combo with name and code "default".

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option.yaml
@@ -35,6 +35,7 @@ details_sql: >-
   SELECT uid, name FROM dataelementcategoryoption
   WHERE name = 'default' AND uid != 'xYerKDKCefk'
   ORDER BY categoryoptionid;
+details_id_type: categoryOptions
 severity: SEVERE
 introduction: >
   There should only exist one category option with name and code "default".

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option_combo.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_one_default_category_option_combo.yaml
@@ -35,6 +35,7 @@ details_sql: >-
   SELECT uid, name FROM categoryoptioncombo
   WHERE name = 'default' AND uid != 'HllvX50cXC0'
   ORDER BY categoryoptioncomboid;
+details_id_type: categoryOptionCombos
 severity: SEVERE
 introduction: >
   There should only exist one category option with name and code "default".

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_unique_category_combo.yaml
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/resources/data-integrity-checks/categories/categories_unique_category_combo.yaml
@@ -59,6 +59,7 @@ details_sql: >-
   from combo_sets a
   left join categorycombo cca on a.id = cca.categorycomboid
   where exists (select 1 from combo_sets c where c.id != a.id and c.cats @> a.cats and a.cats @> c.cats)
+details_id_type: categoryCombos
 severity: SEVERE
 introduction: >
   A category combo should be a unique combination of categories

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -96,6 +96,7 @@ import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.random.BeanRandomizer;
+import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.validation.ValidationRuleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -218,7 +219,7 @@ class DataIntegrityServiceTest
             programRuleVariableService, dataElementService, indicatorService, dataSetService,
             organisationUnitService, organisationUnitGroupService, validationRuleService, expressionService,
             dataEntryFormService, categoryService, periodService, programIndicatorService,
-            mock( CacheProvider.class ), mock( DataIntegrityStore.class ) );
+            mock( CacheProvider.class ), mock( DataIntegrityStore.class ), mock( SchemaService.class ) );
         setUpFixtures();
     }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -59,6 +59,7 @@ class DataIntegrityYamlReaderTest
         assertEquals( "categories_no_options", check.getName() );
         assertEquals( "Categories with no category options", check.getDescription() );
         assertEquals( "Categories", check.getSection() );
+        assertEquals( "categories", check.getIssuesIdType() );
         assertEquals( DataIntegritySeverity.WARNING, check.getSeverity() );
         assertEquals( "Categories should always have at least a single category options.", check.getIntroduction() );
         assertEquals( "Any categories without category options should either be removed from the"

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityCheck.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityCheck.java
@@ -76,4 +76,8 @@ public interface JsonDataIntegrityCheck extends JsonObject
         return getString( "recommendation" ).string();
     }
 
+    default String getIssuesIdType()
+    {
+        return getString( "issuesIdType" ).string();
+    }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
@@ -75,5 +75,6 @@ class DataIntegrityDetailsControllerTest extends AbstractDataIntegrityController
         assertEquals( 1, issues.size() );
         assertEquals( uid, issues.get( 0 ).getId() );
         assertEquals( "CatDog", issues.get( 0 ).getName() );
+        assertEquals( "categories", details.getIssuesIdType() );
     }
 }


### PR DESCRIPTION
### Summary
Adds a new field `issuesIdType` to the data integrity check information. 
The field gives the type of details `issues[*].id` values in form of their plural name, for example `categories` in case the `id` of an issue is a `Category` UID.

The proper type was added to all existing data integrity checks.

### Automatic Testing
Existing tests were adjusted to also check for the new field.

### Manual Testing
Check `/api/dataIntegrity` and look for the `issuesIdType` property. It should have a value in almost all cases. It is correct that few do not have that information as they do not point to an existing object type but some scope, like for example periods with a similar start date of same type.

### Documentation
https://github.com/dhis2/dhis2-docs/pull/1007