### PR TITLE
fix: Delete user with multiple roles DHIS2-13336

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -263,7 +264,7 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
         userGroupService.removeUserFromGroups( user, getUids( groups ) );
 
         Set<UserRole> userRoles = user.getUserRoles();
-        for ( UserRole userRole : userRoles )
+        for ( UserRole userRole : new ArrayList<>( userRoles ) )
         {
             userRole.removeUser( user );
             sessionFactory.getCurrentSession().update( userRole );


### PR DESCRIPTION
See [DHIS2-13336](https://jira.dhis2.org/browse/DHIS2-13336). Trying to delete a user with multiple roles resulted in an error. This is because `UserObjectBundleHook#removeUserFromGroups` was iterating through the Set of `userRoles` and removing each one. During the iterations it called `userRole.removeUser( user );` which removed the role from the Set being iterated through, causing the error.

The error was presumably occurring also on users with just one role, but by the time the error occurred, the role had been successfully removed.

The fix was just to make a new collection of the roles, then they could be removed from the original collection.