### PR TITLE
fix: collect TrackedEntity/RelationshipType from payload

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdentifierCollector.java
@@ -73,23 +73,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TrackerIdentifierCollector
 {
-    public static final String ID_WILDCARD = "*";
-
     private final ProgramRuleService programRuleService;
 
     public Map<Class<?>, Set<String>> collect( TrackerImportParams params )
     {
         final Map<Class<?>, Set<String>> identifiers = new HashMap<>();
-
         collectTrackedEntities( identifiers, params.getTrackedEntities() );
         collectEnrollments( identifiers, params.getEnrollments() );
         collectEvents( identifiers, params.getEvents() );
         collectRelationships( identifiers, params.getRelationships() );
-        // Using "*" signals that all the entities of the given type have to be
-        // preloaded in the Preheat
-        identifiers.put( TrackedEntityType.class, Set.of( ID_WILDCARD ) );
-        identifiers.put( RelationshipType.class, Set.of( ID_WILDCARD ) );
-
         collectProgramRulesFields( identifiers );
         return identifiers;
     }
@@ -122,6 +114,7 @@ public class TrackerIdentifierCollector
     {
         trackedEntities.forEach( trackedEntity -> {
             addIdentifier( identifiers, TrackedEntity.class, trackedEntity.getTrackedEntity() );
+            addIdentifier( identifiers, TrackedEntityType.class, trackedEntity.getTrackedEntityType() );
             addIdentifier( identifiers, OrganisationUnit.class, trackedEntity.getOrgUnit() );
 
             collectEnrollments( identifiers, trackedEntity.getEnrollments() );
@@ -185,6 +178,7 @@ public class TrackerIdentifierCollector
         relationships.forEach( relationship -> {
 
             addIdentifier( identifiers, Relationship.class, relationship.getRelationship() );
+            addIdentifier( identifiers, RelationshipType.class, relationship.getRelationshipType() );
 
             if ( Objects.nonNull( relationship.getFrom() ) )
             {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
@@ -41,8 +41,6 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.programrule.ProgramRuleService;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.junit.jupiter.api.BeforeEach;
@@ -90,8 +88,6 @@ class TrackerIdentifierCollectorTest
         assertContainsOnly( ids.get( Enrollment.class ), enrollment.getUid() );
         assertContainsOnly( ids.get( Program.class ), "sunshine" );
         assertContainsOnly( ids.get( OrganisationUnit.class ), orgUnit.getUid() );
-        assertContainsOnly( ids.get( TrackedEntityType.class ), "*" );
-        assertContainsOnly( ids.get( RelationshipType.class ), "*" );
     }
 
     @Test
@@ -111,8 +107,6 @@ class TrackerIdentifierCollectorTest
 
         assertNotNull( ids );
         assertContainsOnly( ids.get( Enrollment.class ), enrollment.getUid() );
-        assertContainsOnly( ids.get( TrackedEntityType.class ), "*" );
-        assertContainsOnly( ids.get( RelationshipType.class ), "*" );
     }
 
     private AttributeValue attributeValue( String value )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatServiceTest.java
@@ -41,8 +41,6 @@ import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.relationship.RelationshipType;
-import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -71,16 +69,6 @@ class TrackerPreheatServiceTest extends TrackerTest
     @Override
     protected void initTest()
     {
-    }
-
-    @Test
-    void testCollectIdentifiersSimple()
-    {
-        TrackerImportParams params = new TrackerImportParams();
-        Map<Class<?>, Set<String>> collectedMap = identifierCollector.collect( params );
-        assertEquals( 2, collectedMap.keySet().size() );
-        assertTrue( collectedMap.containsKey( TrackedEntityType.class ) );
-        assertTrue( collectedMap.containsKey( RelationshipType.class ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/strategy/AbstractSchemaStrategyCachingTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.preheat.supplier.strategy;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hisp.dhis.tracker.TrackerIdentifierCollector.ID_WILDCARD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,28 +38,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.CodeGenerator;
-import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.query.Query;
 import org.hisp.dhis.query.QueryService;
 import org.hisp.dhis.random.BeanRandomizer;
-import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.schema.descriptors.ProgramSchemaDescriptor;
-import org.hisp.dhis.schema.descriptors.RelationshipTypeSchemaDescriptor;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.cache.PreheatCacheService;
 import org.hisp.dhis.tracker.preheat.mappers.CopyMapper;
 import org.hisp.dhis.tracker.preheat.mappers.ProgramMapper;
-import org.hisp.dhis.tracker.preheat.mappers.RelationshipTypeMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -94,31 +87,6 @@ class AbstractSchemaStrategyCachingTest
     public void setUp()
     {
         preheat = new TrackerPreheat();
-    }
-
-    @Test
-    void verifyFetchWildcardObjectsFromDbAndPutInCache()
-    {
-        // Given
-        final Schema schema = new RelationshipTypeSchemaDescriptor().getSchema();
-
-        when( manager.getAll( (Class<IdentifiableObject>) schema.getKlass() ) )
-            .thenReturn( (List<IdentifiableObject>) rnd.objects( schema.getKlass(), 5 )
-                .collect( Collectors.toList() ) );
-
-        RelationshipTypeStrategy strategy = new RelationshipTypeStrategy( schemaService, queryService,
-            manager, cache );
-
-        // When
-        strategy.queryForIdentifiableObjects( preheat, schema, TrackerIdSchemeParam.UID,
-            singletonList( singletonList( ID_WILDCARD ) ), RelationshipTypeMapper.class );
-
-        // Then
-        assertThat( preheat.getAll( RelationshipType.class ), hasSize( 5 ) );
-
-        verify( cache, times( 1 ) ).hasKey( "RelationshipType" );
-
-        verify( cache, times( 5 ) ).put( eq( "RelationshipType" ), anyString(), any(), eq( 10 ), eq( 10L ) );
     }
 
     @Test


### PR DESCRIPTION
so we fetch them with attributes and values in case the idScheme is
ATTRIBUTE. Otherwise, idScheme ATTRIBUTE will not work for these
metadata types.

Caching is currently disabled entirely, so we will not have any
performance penalty. When caching is fixed it should be with idSchemes
in mind.