### PR TITLE
fix: Prog. Ind. boolean as bool/number DHIS2-12657

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.expression;
 
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
-import static org.hisp.dhis.util.ObjectUtils.firstNonNull;
 
 import java.util.HashMap;
 import java.util.List;
@@ -188,6 +187,8 @@ public class ExpressionParams
 
     public DataType getDataType()
     {
-        return firstNonNull( dataType, parseType.getDataType() );
+        return (dataType != null)
+            ? dataType
+            : parseType.getDataType();
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicatorService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicatorService.java
@@ -31,6 +31,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.hisp.dhis.analytics.DataType;
+
 /**
  * @author Chau Thu Tran
  * @author Jim Grace
@@ -167,18 +169,21 @@ public interface ProgramIndicatorService
      * missing numeric values for data elements and attributes.
      *
      * @param expression the expression.
+     * @param dataType the data type to return.
      * @param programIndicator the program indicator to evaluate.
      * @param startDate the start date.
      * @param endDate the end date.
      * @return the SQL string.
      */
-    String getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate );
+    String getAnalyticsSql( String expression, DataType dataType, ProgramIndicator programIndicator,
+        Date startDate, Date endDate );
 
     /**
      * Gets the the analytics SQL clause of an expression. Does not ignore
      * missing numeric values for data elements and attributes.
      *
      * @param expression the expression.
+     * @param dataType the data type to return.
      * @param programIndicator the program indicator to evaluate.
      * @param startDate the start date.
      * @param endDate the end date.
@@ -187,8 +192,8 @@ public interface ProgramIndicatorService
      * @return the SQL string.
      */
 
-    String getAnalyticsSql( String expression, ProgramIndicator programIndicator, Date startDate, Date endDate,
-        String tableAlias );
+    String getAnalyticsSql( String expression, DataType dataType, ProgramIndicator programIndicator,
+        Date startDate, Date endDate, String tableAlias );
 
     /**
      * Returns a SQL clause which matches any value for the data elements and

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -35,6 +35,7 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
 import static org.hisp.dhis.analytics.SortOrder.ASC;
 import static org.hisp.dhis.analytics.SortOrder.DESC;
@@ -670,7 +671,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
             function = TextUtils.emptyIfEqual( function, AggregationType.CUSTOM.getValue() );
 
             String expression = programIndicatorService.getAnalyticsSql( params.getProgramIndicator().getExpression(),
-                params.getProgramIndicator(), params.getEarliestStartDate(), params.getLatestEndDate() );
+                NUMERIC, params.getProgramIndicator(), params.getEarliestStartDate(), params.getLatestEndDate() );
 
             return function + "(" + expression + ")";
         }
@@ -787,7 +788,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
         if ( item.isProgramIndicator() )
         {
             ProgramIndicator programIndicator = (ProgramIndicator) item.getItem();
-            return programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), programIndicator,
+            return programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
                 startDate, endDate );
         }
         else

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.encode;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
@@ -295,7 +296,7 @@ public class JdbcEnrollmentAnalyticsManager
         if ( params.hasProgramIndicatorDimension() && params.getProgramIndicator().hasFilter() )
         {
             String filter = programIndicatorService.getAnalyticsSql( params.getProgramIndicator().getFilter(),
-                params.getProgramIndicator(), params.getEarliestStartDate(), params.getLatestEndDate() );
+                BOOLEAN, params.getProgramIndicator(), params.getEarliestStartDate(), params.getLatestEndDate() );
 
             String sqlFilter = ExpressionUtils.asSql( filter );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.time.DateUtils.addYears;
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LATITUDE;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LONGITUDE;
 import static org.hisp.dhis.analytics.table.JdbcEventAnalyticsTableManager.OU_GEOMETRY_COL_SUFFIX;
@@ -501,7 +502,7 @@ public class JdbcEventAnalyticsManager
         if ( params.hasProgramIndicatorDimension() && params.getProgramIndicator().hasFilter() )
         {
             String filter = programIndicatorService.getAnalyticsSql( params.getProgramIndicator().getFilter(),
-                params.getProgramIndicator(), params.getEarliestStartDate(), params.getLatestEndDate() );
+                BOOLEAN, params.getProgramIndicator(), params.getEarliestStartDate(), params.getLatestEndDate() );
 
             String sqlFilter = ExpressionUtils.asSql( filter );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
@@ -29,10 +29,13 @@ package org.hisp.dhis.analytics.event.data.programindicator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 
 import java.util.Date;
 
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.analytics.event.ProgramIndicatorSubqueryBuilder;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.program.AnalyticsType;
@@ -103,8 +106,8 @@ public class DefaultProgramIndicatorSubqueryBuilder
             AggregationType.CUSTOM.getValue() );
 
         // Get sql construct from Program indicator expression //
-        String aggregateSql = getPrgIndSql( programIndicator.getExpression(), programIndicator, earliestStartDate,
-            latestDate );
+        String aggregateSql = getPrgIndSql( programIndicator.getExpression(), NUMERIC, programIndicator,
+            earliestStartDate, latestDate );
 
         // closes the function parenthesis ( avg( ... ) )
         aggregateSql += ")";
@@ -121,7 +124,8 @@ public class DefaultProgramIndicatorSubqueryBuilder
         if ( !Strings.isNullOrEmpty( programIndicator.getFilter() ) )
         {
             aggregateSql += (where.isBlank() ? " WHERE " : " AND ")
-                + getPrgIndSql( programIndicator.getFilter(), programIndicator, earliestStartDate, latestDate );
+                + getPrgIndSql( programIndicator.getFilter(), BOOLEAN, programIndicator, earliestStartDate,
+                    latestDate );
         }
 
         return "(SELECT " + function + " (" + aggregateSql + ")";
@@ -186,9 +190,10 @@ public class DefaultProgramIndicatorSubqueryBuilder
         return outerSqlEntity.equals( AnalyticsType.EVENT );
     }
 
-    private String getPrgIndSql( String expression, ProgramIndicator pi, Date earliestStartDate, Date latestDate )
+    private String getPrgIndSql( String expression, DataType dataType, ProgramIndicator pi, Date earliestStartDate,
+        Date latestDate )
     {
-        return this.programIndicatorService.getAnalyticsSql( expression, pi, earliestStartDate, latestDate,
+        return this.programIndicatorService.getAnalyticsSql( expression, dataType, pi, earliestStartDate, latestDate,
             SUBQUERY_TABLE_ALIAS );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManagerTest.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
 import static org.hisp.dhis.DhisConvenienceTest.getDate;
 import static org.hisp.dhis.analytics.AnalyticsAggregationType.fromAggregationType;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -135,8 +136,8 @@ class AbstractJdbcEventAnalyticsManagerTest extends
 
         subject.getSelectSql( new QueryFilter(), item, from, to );
 
-        verify( programIndicatorService ).getAnalyticsSql( programIndicator.getExpression(), programIndicator, from,
-            to );
+        verify( programIndicatorService ).getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
+            from, to );
     }
 
     @Test
@@ -254,7 +255,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
             .withProgramIndicator( programIndicator )
             .build();
 
-        when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), programIndicator,
+        when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
             params.getEarliestStartDate(), params.getLatestEndDate() ) )
                 .thenReturn( "select * from table" );
 
@@ -272,7 +273,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
         EventQueryParams params = new EventQueryParams.Builder( createRequestParams() )
             .withProgramIndicator( programIndicator ).build();
 
-        when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), programIndicator,
+        when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
             params.getEarliestStartDate(), params.getLatestEndDate() ) )
                 .thenReturn( "select * from table" );
 
@@ -290,7 +291,7 @@ class AbstractJdbcEventAnalyticsManagerTest extends
             .withProgramIndicator( programIndicator )
             .build();
 
-        when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), programIndicator,
+        when( programIndicatorService.getAnalyticsSql( programIndicator.getExpression(), NUMERIC, programIndicator,
             params.getEarliestStartDate(), params.getLatestEndDate() ) )
                 .thenReturn( "select * from table" );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
 import static org.hisp.dhis.DhisConvenienceTest.getDate;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
@@ -370,7 +371,7 @@ class EnrollmentAnalyticsManagerTest extends
             createRequestParams( programIndicatorA, relationshipTypeA ) ).withStartDate( startDate )
                 .withEndDate( endDate );
 
-        when( programIndicatorService.getAnalyticsSql( "", programIndicatorA, getDate( 2000, 1, 1 ),
+        when( programIndicatorService.getAnalyticsSql( "", NUMERIC, programIndicatorA, getDate( 2000, 1, 1 ),
             getDate( 2017, 4, 8 ), "subax" ) ).thenReturn( piSubquery );
 
         subject.getEnrollments( params.build(), new ListGrid(), 100 );
@@ -411,7 +412,7 @@ class EnrollmentAnalyticsManagerTest extends
             createRequestParams( programIndicatorA, relationshipTypeA ) ).withStartDate( startDate )
                 .withEndDate( endDate );
 
-        when( programIndicatorService.getAnalyticsSql( "", programIndicatorA, getDate( 2000, 1, 1 ),
+        when( programIndicatorService.getAnalyticsSql( "", NUMERIC, programIndicatorA, getDate( 2000, 1, 1 ),
             getDate( 2017, 4, 8 ), "subax" ) ).thenReturn( piSubquery );
 
         subject.getEnrollments( params.build(), new ListGrid(), 100 );
@@ -482,7 +483,7 @@ class EnrollmentAnalyticsManagerTest extends
             createRequestParams( programIndicatorA, relationshipTypeA ) ).withStartDate( startDate )
                 .withEndDate( endDate );
 
-        when( programIndicatorService.getAnalyticsSql( "", programIndicatorA, getDate( 2000, 1, 1 ),
+        when( programIndicatorService.getAnalyticsSql( "", NUMERIC, programIndicatorA, getDate( 2000, 1, 1 ),
             getDate( 2017, 4, 8 ), "subax" ) ).thenReturn( piSubquery );
 
         subject.getEnrollments( params.build(), new ListGrid(), 100 );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -32,6 +32,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hisp.dhis.DhisConvenienceTest.createProgram;
 import static org.hisp.dhis.DhisConvenienceTest.createProgramIndicator;
 import static org.hisp.dhis.DhisConvenienceTest.getDate;
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.mockito.Mockito.when;
 
 import java.util.Date;
@@ -87,7 +89,7 @@ class ProgramIndicatorSubqueryBuilderTest
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
 
-        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, pi, startDate, endDate, "subax" ) )
+        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, NUMERIC, pi, startDate, endDate, "subax" ) )
             .thenReturn( "distinct psi" );
 
         String sql = subject.getAggregateClauseForProgramIndicator( pi, AnalyticsType.ENROLLMENT, startDate, endDate );
@@ -106,7 +108,7 @@ class ProgramIndicatorSubqueryBuilderTest
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
         pi.setAggregationType( null );
 
-        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, pi, startDate, endDate, "subax" ) )
+        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, NUMERIC, pi, startDate, endDate, "subax" ) )
             .thenReturn( "distinct psi" );
 
         String sql = subject.getAggregateClauseForProgramIndicator( pi, AnalyticsType.EVENT, startDate, endDate );
@@ -120,7 +122,7 @@ class ProgramIndicatorSubqueryBuilderTest
     {
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
 
-        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, pi, startDate, endDate, "subax" ) )
+        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, NUMERIC, pi, startDate, endDate, "subax" ) )
             .thenReturn( "distinct psi" );
 
         String sql = subject.getAggregateClauseForProgramIndicator( pi, AnalyticsType.ENROLLMENT, startDate, endDate );
@@ -139,7 +141,7 @@ class ProgramIndicatorSubqueryBuilderTest
         relationshipType.getFromConstraint().setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
         relationshipType.getToConstraint().setRelationshipEntity( RelationshipEntity.TRACKED_ENTITY_INSTANCE );
 
-        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, pi, startDate, endDate, "subax" ) )
+        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, NUMERIC, pi, startDate, endDate, "subax" ) )
             .thenReturn( "distinct psi" );
 
         String sql = subject.getAggregateClauseForProgramIndicator( pi, relationshipType, AnalyticsType.ENROLLMENT,
@@ -161,10 +163,10 @@ class ProgramIndicatorSubqueryBuilderTest
         ProgramIndicator pi = createProgramIndicator( 'A', program, DUMMY_EXPRESSION, "" );
         pi.setFilter( DUMMY_FILTER_EXPRESSION );
 
-        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, pi, startDate, endDate, "subax" ) )
-            .thenReturn( "distinct psi" );
-        when( programIndicatorService.getAnalyticsSql( DUMMY_FILTER_EXPRESSION, pi, startDate, endDate, "subax" ) )
-            .thenReturn( "a = b" );
+        when( programIndicatorService.getAnalyticsSql( DUMMY_EXPRESSION, NUMERIC, pi, startDate, endDate,
+            "subax" ) ).thenReturn( "distinct psi" );
+        when( programIndicatorService.getAnalyticsSql( DUMMY_FILTER_EXPRESSION, BOOLEAN, pi, startDate, endDate,
+            "subax" ) ).thenReturn( "a = b" );
 
         String sql = subject.getAggregateClauseForProgramIndicator( pi, AnalyticsType.ENROLLMENT, startDate, endDate );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
@@ -57,6 +57,8 @@ import org.hisp.dhis.system.util.ValidationUtils;
 public abstract class ProgramExpressionItem
     implements ExpressionItem
 {
+    private final static String COALESCE = "coalesce(";
+
     @Override
     public final Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
     {
@@ -128,14 +130,14 @@ public abstract class ProgramExpressionItem
         {
             if ( visitor.getParams().getDataType() == DataType.BOOLEAN )
             {
-                return "coalesce(" + column + "::numeric!=0,false)";
+                return COALESCE + column + "::numeric!=0,false)";
             }
             else
             {
-                return "coalesce(" + column + "::numeric,0)";
+                return COALESCE + column + "::numeric,0)";
             }
         }
 
-        return "coalesce(" + column + ",'')";
+        return COALESCE + column + ",'')";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
@@ -27,8 +27,11 @@
  */
 package org.hisp.dhis.program;
 
+import static org.hisp.dhis.common.ValueType.BOOLEAN;
+import static org.hisp.dhis.common.ValueType.NUMBER;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
@@ -37,6 +40,7 @@ import org.hisp.dhis.program.dataitem.ProgramItemAttribute;
 import org.hisp.dhis.program.dataitem.ProgramItemPsEventdate;
 import org.hisp.dhis.program.dataitem.ProgramItemStageElement;
 import org.hisp.dhis.program.variable.ProgramVariableItem;
+import org.hisp.dhis.system.util.ValidationUtils;
 
 /**
  * Program indicator expression item
@@ -99,16 +103,39 @@ public abstract class ProgramExpressionItem
     }
 
     /**
+     * Get a null replacement value, but if the type is boolean get a number.
+     *
+     * @param valueType type to get a null replacement value for
+     * @return the replacement value
+     */
+    protected Object getNullReplacementValue( ValueType valueType )
+    {
+        return ValidationUtils.getNullReplacementValue( (valueType == BOOLEAN)
+            ? NUMBER
+            : valueType );
+    }
+
+    /**
      * Replace null SQL query values with 0 or '', depending on the value type.
      *
      * @param column the column (may be a subquery)
      * @param valueType the type of value that might be null
      * @return SQL to replace a null value with 0 or '' depending on type
      */
-    protected String replaceNullSqlValues( String column, ValueType valueType )
+    protected String replaceNullSqlValues( String column, CommonExpressionVisitor visitor, ValueType valueType )
     {
-        return valueType.isNumeric() || valueType.isBoolean()
-            ? "coalesce(" + column + "::numeric,0)"
-            : "coalesce(" + column + ",'')";
+        if ( valueType.isNumeric() || valueType.isBoolean() )
+        {
+            if ( visitor.getParams().getDataType() == DataType.BOOLEAN )
+            {
+                return "coalesce(" + column + "::numeric!=0,false)";
+            }
+            else
+            {
+                return "coalesce(" + column + "::numeric,0)";
+            }
+        }
+
+        return "coalesce(" + column + ",'')";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemAttribute.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.program.ProgramExpressionItem;
-import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 /**
@@ -58,7 +57,7 @@ public class ProgramItemAttribute
 
         visitor.getItemDescriptions().put( ctx.getText(), attribute.getDisplayName() );
 
-        return ValidationUtils.getNullReplacementValue( attribute.getValueType() );
+        return getNullReplacementValue( attribute.getValueType() );
     }
 
     @Override
@@ -79,7 +78,7 @@ public class ProgramItemAttribute
                     "Tracked entity attribute " + attributeId + " not found during SQL generation." );
             }
 
-            column = replaceNullSqlValues( column, attribute.getValueType() );
+            column = replaceNullSqlValues( column, visitor, attribute.getValueType() );
         }
 
         return column;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/dataitem/ProgramItemStageElement.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
 import org.hisp.dhis.system.util.SqlUtils;
-import org.hisp.dhis.system.util.ValidationUtils;
 
 /**
  * Program indicator expression data item ProgramItemStageElement
@@ -86,7 +85,7 @@ public class ProgramItemStageElement
 
         visitor.getItemDescriptions().put( ctx.getText(), description );
 
-        return ValidationUtils.getNullReplacementValue( dataElement.getValueType() );
+        return getNullReplacementValue( dataElement.getValueType() );
     }
 
     @Override
@@ -136,7 +135,7 @@ public class ProgramItemStageElement
                     "Data element " + dataElementId + " not found during SQL generation." );
             }
 
-            column = replaceNullSqlValues( column, dataElement.getValueType() );
+            column = replaceNullSqlValues( column, visitor, dataElement.getValueType() );
         }
 
         return column;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Condition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2Condition.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program.function;
 
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castClass;
 import static org.hisp.dhis.antlr.AntlrParserUtils.trimQuotes;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
@@ -66,7 +67,7 @@ public class D2Condition
 
         ProgramExpressionParams params = visitor.getProgParams();
 
-        String testSql = visitor.getProgramIndicatorService().getAnalyticsSql( testExpression,
+        String testSql = visitor.getProgramIndicatorService().getAnalyticsSql( testExpression, BOOLEAN,
             params.getProgramIndicator(), params.getReportingStartDate(),
             params.getReportingEndDate() );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfCondition.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/function/D2CountIfCondition.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program.function;
 
+import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 import static org.hisp.dhis.antlr.AntlrParserUtils.trimQuotes;
 import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
@@ -64,7 +65,7 @@ public class D2CountIfCondition
         ProgramExpressionParams params = visitor.getProgParams();
 
         String conditionSql = visitor.getProgramIndicatorService().getAnalyticsSql(
-            conditionExpression, params.getProgramIndicator(),
+            conditionExpression, BOOLEAN, params.getProgramIndicator(),
             params.getReportingStartDate(), params.getReportingEndDate() );
 
         return conditionSql.substring( 1 );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceD2FunctionTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.program;
 
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Calendar;
@@ -162,12 +163,12 @@ class ProgramIndicatorServiceD2FunctionTest extends DhisSpringTest
 
     private String getSql( String expression )
     {
-        return programIndicatorService.getAnalyticsSql( expression, piA, newDate, newDate );
+        return programIndicatorService.getAnalyticsSql( expression, NUMERIC, piA, newDate, newDate );
     }
 
     private String getSqlEnrollment( String expression )
     {
-        return programIndicatorService.getAnalyticsSql( expression, piB, newDate, newDate );
+        return programIndicatorService.getAnalyticsSql( expression, NUMERIC, piB, newDate, newDate );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.program;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -99,19 +100,19 @@ class ProgramIndicatorServiceVariableTest extends DhisSpringTest
     {
         piA.setExpression( expression );
 
-        return programIndicatorService.getAnalyticsSql( expression, piA, startDate, endDate );
+        return programIndicatorService.getAnalyticsSql( expression, NUMERIC, piA, startDate, endDate );
     }
 
     private String getSqlEnrollment( String expression )
     {
         piB.setExpression( expression );
 
-        return programIndicatorService.getAnalyticsSql( expression, piB, startDate, endDate );
+        return programIndicatorService.getAnalyticsSql( expression, NUMERIC, piB, startDate, endDate );
     }
 
     private String getSqlEnrollment( final String expression, final ProgramIndicator programIndicator )
     {
-        return programIndicatorService.getAnalyticsSql( expression, programIndicator, startDate, endDate );
+        return programIndicatorService.getAnalyticsSql( expression, NUMERIC, programIndicator, startDate, endDate );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.program;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
 import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIONS;
@@ -37,6 +38,7 @@ import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 import static org.hisp.dhis.program.variable.vEventCount.DEFAULT_COUNT_CONDITION;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -47,6 +49,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.AntlrExprLiteral;
 import org.hisp.dhis.antlr.Parser;
 import org.hisp.dhis.antlr.ParserException;
@@ -56,6 +59,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
@@ -89,6 +93,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     private DataElement dataElementC;
 
     private DataElement dataElementD;
+
+    private DataElement dataElementE;
 
     private ProgramStage programStageA;
 
@@ -137,6 +143,11 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
         dataElementD.setUid( "DataElmentD" );
         dataElementD.setValueType( ValueType.DATE );
 
+        dataElementE = createDataElement( 'E' );
+        dataElementE.setDomainType( DataElementDomain.TRACKER );
+        dataElementE.setUid( "DataElmentE" );
+        dataElementE.setValueType( ValueType.BOOLEAN );
+
         attributeA = createTrackedEntityAttribute( 'A', ValueType.NUMBER );
         attributeA.setUid( "Attribute0A" );
 
@@ -173,12 +184,38 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     {
         when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
-        when( programIndicatorService.getAnalyticsSql( anyString(), eq( programIndicator ), eq( startDate ),
-            eq( endDate ) ) )
-                .thenAnswer( i -> test( (String) i.getArguments()[0] ) );
+        when( programIndicatorService.getAnalyticsSql( anyString(), any( DataType.class ), eq( programIndicator ),
+            eq( startDate ), eq( endDate ) ) )
+                .thenAnswer( i -> test( (String) i.getArguments()[0], (DataType) i.getArguments()[1] ) );
 
         String sql = test( "d2:condition('#{ProgrmStagA.DataElmentA} > 3',10 + 5,3 * 2)" );
         assertThat( sql, is( "case when (coalesce(\"DataElmentA\"::numeric,0) > 3) then 10 + 5 else 3 * 2 end" ) );
+    }
+
+    @Test
+    void testConditionWithBooleanAsBoolean()
+    {
+        when( idObjectManager.get( DataElement.class, dataElementE.getUid() ) ).thenReturn( dataElementE );
+        when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
+        when( programIndicatorService.getAnalyticsSql( anyString(), any( DataType.class ), eq( programIndicator ),
+            eq( startDate ), eq( endDate ) ) )
+                .thenAnswer( i -> test( (String) i.getArguments()[0], (DataType) i.getArguments()[1] ) );
+
+        String sql = test( "d2:condition('#{ProgrmStagA.DataElmentE}',10 + 5,3 * 2)" );
+        assertThat( sql, is( "case when (coalesce(\"DataElmentE\"::numeric!=0,false)) then 10 + 5 else 3 * 2 end" ) );
+    }
+
+    @Test
+    void testConditionWithBooleanAsNumeric()
+    {
+        when( idObjectManager.get( DataElement.class, dataElementE.getUid() ) ).thenReturn( dataElementE );
+        when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
+        when( programIndicatorService.getAnalyticsSql( anyString(), any( DataType.class ), eq( programIndicator ),
+            eq( startDate ), eq( endDate ) ) )
+                .thenAnswer( i -> test( (String) i.getArguments()[0], (DataType) i.getArguments()[1] ) );
+
+        String sql = test( "d2:condition('#{ProgrmStagA.DataElmentE} > 0',10 + 5,3 * 2)" );
+        assertThat( sql, is( "case when (coalesce(\"DataElmentE\"::numeric,0) > 0) then 10 + 5 else 3 * 2 end" ) );
     }
 
     @Test
@@ -251,15 +288,36 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
     {
         when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
         when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
-        when( programIndicatorService.getAnalyticsSql( anyString(), eq( programIndicator ), eq( startDate ),
-            eq( endDate ) ) )
-                .thenAnswer( i -> test( (String) i.getArguments()[0] ) );
+        when( programIndicatorService.getAnalyticsSql( anyString(), any( DataType.class ), eq( programIndicator ),
+            eq( startDate ), eq( endDate ) ) )
+                .thenAnswer( i -> test( (String) i.getArguments()[0], (DataType) i.getArguments()[1] ) );
 
         String sql = test( "d2:countIfCondition(#{ProgrmStagA.DataElmentA},'>5')" );
         assertThat( sql, is( "(select count(\"DataElmentA\") " +
             "from analytics_event_Program000A " +
             "where analytics_event_Program000A.pi = ax.pi " +
             "and \"DataElmentA\" is not null and \"DataElmentA\" > 5 and ps = 'ProgrmStagA')" ) );
+    }
+
+    @Test
+    void testCountIfConditionWithBooleanAsNumeric()
+    {
+        // Note: A boolean within a comparison should be treated as numeric.
+        // PostgreSQL allows comparision of a text column with a numeric value.
+
+        when( programStageService.getProgramStage( programStageA.getUid() ) ).thenReturn( programStageA );
+        when( idObjectManager.get( DataElement.class, dataElementA.getUid() ) ).thenReturn( dataElementA );
+        when( idObjectManager.get( DataElement.class, dataElementE.getUid() ) ).thenReturn( dataElementE );
+        when( programIndicatorService.getAnalyticsSql( anyString(), any( DataType.class ), eq( programIndicator ),
+            eq( startDate ), eq( endDate ) ) )
+                .thenAnswer( i -> test( (String) i.getArguments()[0], (DataType) i.getArguments()[1] ) );
+
+        String sql = test( "d2:countIfCondition(#{ProgrmStagA.DataElmentA},'>#{ProgrmStagA.DataElmentE}')" );
+        assertThat( sql, is( "(select count(\"DataElmentA\") " +
+            "from analytics_event_Program000A " +
+            "where analytics_event_Program000A.pi = ax.pi " +
+            "and \"DataElmentA\" is not null and \"DataElmentA\" > coalesce(\"DataElmentE\"::numeric,0) " +
+            "and ps = 'ProgrmStagA')" ) );
     }
 
     @Test
@@ -580,20 +638,35 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
 
     private String test( String expression )
     {
-        test( expression, new DefaultLiteral(), ITEM_GET_DESCRIPTIONS );
+        return test( expression, NUMERIC );
+    }
 
-        return castString( test( expression, new SqlLiteral(), ITEM_GET_SQL ) );
+    private String test( String expression, DataType dataType )
+    {
+        test( expression, new DefaultLiteral(), ITEM_GET_DESCRIPTIONS, dataType );
+
+        return castString( test( expression, new SqlLiteral(), ITEM_GET_SQL, dataType ) );
     }
 
     private Object test( String expression, AntlrExprLiteral exprLiteral,
         ExpressionItemMethod itemMethod )
+    {
+        return test( expression, exprLiteral, itemMethod, NUMERIC );
+    }
+
+    private Object test( String expression, AntlrExprLiteral exprLiteral,
+        ExpressionItemMethod itemMethod, DataType dataType )
     {
         Set<String> dataElementsAndAttributesIdentifiers = new LinkedHashSet<>();
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "a" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        ProgramExpressionParams params = ProgramExpressionParams.builder()
+        ExpressionParams params = ExpressionParams.builder()
+            .dataType( dataType )
+            .build();
+
+        ProgramExpressionParams progParams = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
@@ -609,7 +682,8 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
             .i18n( new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )
-            .progParams( params )
+            .params( params )
+            .progParams( progParams )
             .build();
 
         visitor.setExpressionLiteral( exprLiteral );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.program;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
@@ -52,6 +53,7 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
@@ -234,7 +236,11 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        ProgramExpressionParams params = ProgramExpressionParams.builder()
+        ExpressionParams params = ExpressionParams.builder()
+            .dataType( NUMERIC )
+            .build();
+
+        ProgramExpressionParams progParams = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
@@ -251,7 +257,8 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
             .constantMap( constantMap )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )
-            .progParams( params )
+            .params( params )
+            .progParams( progParams )
             .build();
 
         visitor.setExpressionLiteral( exprLiteral );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.program;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
+import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
 import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
@@ -47,6 +48,7 @@ import org.hisp.dhis.antlr.ParserException;
 import org.hisp.dhis.antlr.literal.DefaultLiteral;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
@@ -303,7 +305,11 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "b" );
         dataElementsAndAttributesIdentifiers.add( BASE_UID + "c" );
 
-        ProgramExpressionParams params = ProgramExpressionParams.builder()
+        ExpressionParams params = ExpressionParams.builder()
+            .dataType( NUMERIC )
+            .build();
+
+        ProgramExpressionParams progParams = ProgramExpressionParams.builder()
             .programIndicator( programIndicator )
             .reportingStartDate( startDate )
             .reportingEndDate( endDate )
@@ -319,7 +325,8 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
             .i18n( new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( ITEM_GET_SQL )
-            .progParams( params )
+            .params( params )
+            .progParams( progParams )
             .build();
 
         subject.setExpressionLiteral( exprLiteral );

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -37,7 +37,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.hisp.dhis.analytics.DataType;
 import org.hisp.dhis.antlr.AntlrExpressionVisitor;
+import org.hisp.dhis.antlr.AntlrParserUtils;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryModifiers;
@@ -190,5 +192,36 @@ public class CommonExpressionVisitor
         state.setQueryMods( savedQueryMods );
 
         return result;
+    }
+
+    /**
+     * Visit a parse subtree to generate SQL with a request that boolean items
+     * should generate a boolean value.
+     */
+    public String sqlBooleanVisit( ExprContext ctx )
+    {
+        return AntlrParserUtils.castString( visitWithDataType( ctx, DataType.BOOLEAN ) );
+    }
+
+    /**
+     * Visit a parse subtree to generate SQL with a request that boolean items
+     * should generate a numeric value.
+     */
+    public String sqlNumericVisit( ExprContext ctx )
+    {
+        return AntlrParserUtils.castString( visitWithDataType( ctx, DataType.NUMERIC ) );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    private Object visitWithDataType( ExprContext ctx, DataType dataType )
+    {
+        ExpressionParams visitParams = params.toBuilder().dataType( dataType ).build();
+        CommonExpressionVisitor visitor = this.toBuilder().params( visitParams ).build();
+        visitor.setExpressionLiteral( this.expressionLiteral );
+
+        return visitor.visitExpr( ctx );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionIf.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionIf.java
@@ -65,11 +65,14 @@ public class FunctionIf
     {
         Boolean arg0 = visitor.castBooleanVisit( ctx.expr( 0 ) );
 
-        return arg0 == null
-            ? null
-            : arg0
-                ? visitor.visit( ctx.expr( 1 ) )
-                : visitor.visit( ctx.expr( 2 ) );
+        if ( arg0 == null )
+        {
+            return null;
+        }
+
+        return (arg0)
+            ? visitor.visit( ctx.expr( 1 ) )
+            : visitor.visit( ctx.expr( 2 ) );
     }
 
     @Override
@@ -90,7 +93,7 @@ public class FunctionIf
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return " case when " + visitor.castStringVisit( ctx.expr( 0 ) ) +
+        return " case when " + visitor.sqlBooleanVisit( ctx.expr( 0 ) ) +
             " then " + visitor.castStringVisit( ctx.expr( 1 ) ) +
             " else " + visitor.castStringVisit( ctx.expr( 2 ) ) + " end";
     }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareEqual.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareEqual.java
@@ -45,6 +45,6 @@ public class OperatorCompareEqual
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.castStringVisit( ctx.expr( 0 ) ) + " = " + visitor.castStringVisit( ctx.expr( 1 ) );
+        return visitor.sqlNumericVisit( ctx.expr( 0 ) ) + " = " + visitor.sqlNumericVisit( ctx.expr( 1 ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareGreaterThan.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareGreaterThan.java
@@ -46,7 +46,7 @@ public class OperatorCompareGreaterThan
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.castStringVisit( ctx.expr( 0 ) )
-            + " > " + visitor.castStringVisit( ctx.expr( 1 ) );
+        return visitor.sqlNumericVisit( ctx.expr( 0 ) )
+            + " > " + visitor.sqlNumericVisit( ctx.expr( 1 ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareGreaterThanOrEqual.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareGreaterThanOrEqual.java
@@ -45,7 +45,7 @@ public class OperatorCompareGreaterThanOrEqual
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.castStringVisit( ctx.expr( 0 ) )
-            + " >= " + visitor.castStringVisit( ctx.expr( 1 ) );
+        return visitor.sqlNumericVisit( ctx.expr( 0 ) )
+            + " >= " + visitor.sqlNumericVisit( ctx.expr( 1 ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareLessThan.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareLessThan.java
@@ -45,7 +45,7 @@ public class OperatorCompareLessThan
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.castStringVisit( ctx.expr( 0 ) )
-            + " < " + visitor.castStringVisit( ctx.expr( 1 ) );
+        return visitor.sqlNumericVisit( ctx.expr( 0 ) )
+            + " < " + visitor.sqlNumericVisit( ctx.expr( 1 ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareLessThanOrEqual.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareLessThanOrEqual.java
@@ -45,7 +45,7 @@ public class OperatorCompareLessThanOrEqual
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.castStringVisit( ctx.expr( 0 ) )
-            + " <= " + visitor.castStringVisit( ctx.expr( 1 ) );
+        return visitor.sqlNumericVisit( ctx.expr( 0 ) )
+            + " <= " + visitor.sqlNumericVisit( ctx.expr( 1 ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareNotEqual.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/operator/OperatorCompareNotEqual.java
@@ -45,7 +45,7 @@ public class OperatorCompareNotEqual
     @Override
     public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        return visitor.castStringVisit( ctx.expr( 0 ) )
-            + " != " + visitor.castStringVisit( ctx.expr( 1 ) );
+        return visitor.sqlNumericVisit( ctx.expr( 0 ) )
+            + " != " + visitor.sqlNumericVisit( ctx.expr( 1 ) );
     }
 }


### PR DESCRIPTION
See [DHIS2-12657](https://jira.dhis2.org/browse/DHIS2-12657). Analytics boolean values are stored as numbers (1 = true, 0 = false). This is done for both aggregate data which can be queried by indicators and event data which can be queried by program indicators.

In the case of aggregate data, ticket [DHIS2-13227](https://jira.dhis2.org/browse/DHIS2-13227) allows boolean data to be used in indicator expressions as either numeric or boolean. It does so by considering the datatype of boolean data to be numeric. When a boolean values is used, such as in the first argument to an if() statement inside an expression, the integer value is automatically converted to boolean (zero = false, nonzero = true). This was implemented because existing indicators had relied on the fact that boolean data elements are represented as numbers, and their values can be summed within an indicator for uses such as "count all the organisation units where the value is true".

Likewise, this PR allows boolean event data to be used in program indicators as either numeric or boolean. This is because some existing program indicators had relied on the fact that boolean data elements are represented as numbers. In the example in ticket [DHIS2-12657](https://jira.dhis2.org/browse/DHIS2-12657), a boolean data element is multiplied by a numeric data element to return the numeric value if true (1 * value), or zero if false (0 * value). This change also makes sense because it allows for consistent evaluation of boolean values between indicators and program indicators.

The implementation of this PR is different from the implementation of [DHIS2-13227](https://jira.dhis2.org/browse/DHIS2-13227) because of the differences in the way indicators and program indicators are processed. With indicators, data is first fetched from the database while being aggregated, and then the indicator expression is evaluated in Java using the fetched, aggregated values. As the expression is evaluated in Java, boolean values (stored as numeric) can easily be converted to boolean on the fly if a boolean value is expected.

By contrast, program indicator expressions (as well as the new indicator subexpressions in 2.38.1) are translated into SQL and evaluated in the database engine against individual analytics values before they are aggregated. Unlike indicator values which can be converted from numeric to boolean on the fly depending on the value type, program indicator values must know ahead of time whether a boolean or numeric value is expected at a given point in the expression, so the SQL can be generated with the correct type. Fortunately this is knowable. Here are notes on how it is done:

- `ExpressionParams.dataType` is initially set to the dataType expected of the expression as a whole. `DefaultProgramIndicatorService` now specifies that the main expression of a program indicator should return `DataType.NUMERIC`, and the filter expression of a PI should return `DataType.BOOLEAN`.

- `FunctionIf` always expects its first argument to return a BOOLEAN value. So the `getSql` method calls `visitor.sqlBooleanVisit()` to force the expected datatype for that argument to boolean. The second and third arguments are expected to return the same dataType that is expected of the if() function as a whole, therefore when evaluating these arguments the dataType is not changed. Likewise, `D2Condition` sets the type to BOOLEAN when evaluating the conditional expression.

- Comparison operators `OperatorCompareEqual, ...GreaterThan, ...GreaterThanOrEqual, ...LessThan,  ...LessThanOrEqual`, and `...NotEqual` always return a boolean value, but the items they compare may be integer, boolean, or string. (string includes dates in string format 'yyyy-mm-dd'). When walking the parse tree for a comparison operator, it is not knowable ahead of time what data type the values will have to the left and right of the operator. But this is not necessary. The comparison operators request that the left and right sides be generated in SQL as NUMERIC if they are numeric or boolean. This allows two numeric values to be compared, two booleans to be compared (as numeric 1 and 0), or even a numeric value to be compared with a boolean (as 1 or 0). (String and date values will still be generated as SQL text and compared as such.)

- `CommonExpressionVisitor` adds two public methods for the convenience of the above conditional and comparison classes: sqlBooleanVisit, to generate SQL for a subtree returning BOOLEAN, and sqlNumericVisit, to generate SQL for a subtree returning NUMERIC. They both use the private method visitWithDataType which regenerates the visitor object with the specified type and uses it to visit the subtree.

- `ProgramExpressionItem` generates the correct SQL according to datatype: If the valueType of a Program DataElement or Attribute is boolean or numeric, then SQL is generated for either dataType BOOLEAN or NUMERIC depending on what is desired at this point in the expression, with a default value of 0 or false, respectively. SQL for other datatypes (including text and date) are processed as text (the SQL column is text already), with a default value of the empty string ''.

Unit tests have been modified and added as appropriate. Manual testing was also done.