### PR TITLE
feat: i18n for disable inactive users email texts [DHIS2-13307]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -355,7 +355,7 @@ public interface JobProgress
                 }
             }
         }
-        completedStage( summary.apply( i - failed, failed ) );
+        completedStage( summary == null ? null : summary.apply( i - failed, failed ) );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -416,7 +416,8 @@ public interface UserService
      *
      * @param from start of the selected time-frame (inclusive)
      * @param to end of the selected time-frame (exclusive)
-     * @return user emails having a last login within the given time-frame.
+     * @return user emails having a last login within the given time-frame as
+     *         keys and if available their preferred locale as value
      */
     Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -30,7 +30,9 @@ package org.hisp.dhis.user;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -416,7 +418,7 @@ public interface UserService
      * @param to end of the selected time-frame (exclusive)
      * @return user emails having a last login within the given time-frame.
      */
-    Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
+    Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 
     /**
      * Get user display name by concat( firstname,' ', surname ) Return null if

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -133,7 +133,8 @@ public interface UserStore
      *
      * @param from start of the selected time-frame (inclusive)
      * @param to end of the selected time-frame (exclusive)
-     * @return user emails having a last login within the given time-frame.
+     * @return user emails having a last login within the given time-frame as
+     *         keys and if available their preferred locale as value
      */
     Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -30,7 +30,9 @@ package org.hisp.dhis.user;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.Set;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -133,7 +135,7 @@ public interface UserStore
      * @param to end of the selected time-frame (exclusive)
      * @return user emails having a last login within the given time-frame.
      */
-    Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
+    Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 
     String getDisplayName( String userUid );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -41,7 +41,10 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
@@ -782,7 +785,7 @@ public class DefaultUserService
 
     @Override
     @Transactional( readOnly = true )
-    public Set<String> findNotifiableUsersWithLastLoginBetween( Date from, Date to )
+    public Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to )
     {
         return userStore.findNotifiableUsersWithLastLoginBetween( from, to );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -589,7 +589,7 @@ public class HibernateUserStore
     {
         String hql = "select u.email, s.value " +
             "from User u " +
-            "left outer join UserSetting s on u.id = s.user " +
+            "left outer join UserSetting s on u.id = s.user and s.name = 'keyUiLocale' " +
             "where u.email is not null and u.disabled = false and u.lastLogin >= :from and u.lastLogin < :to";
         return getSession().createQuery( hql, Object[].class )
             .setParameter( "from", from )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -117,7 +117,8 @@ public class DisableInactiveUsersJob implements Job
         LocalDate reference = since.plusDays( daysUntilDisable );
         ZonedDateTime nDaysPriorToDisabling = reference.atStartOfDay( systemDefault() );
         ZonedDateTime nDaysPriorToDisablingEod = reference.plusDays( 1 ).atStartOfDay( systemDefault() );
-        progress.startingStage( format( "Fetching users for reminder, %d days until disable", daysUntilDisable ) );
+        progress.startingStage( format( "Fetching users for reminder, %d days until disable", daysUntilDisable ),
+            SKIP_STAGE );
         Map<String, Optional<Locale>> receivers = progress.runStage( Map.of(),
             map -> format( "Found %d receivers", map.size() ),
             () -> userService.findNotifiableUsersWithLastLoginBetween(

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -34,11 +34,19 @@ import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.email.EmailService;
+import org.hisp.dhis.i18n.I18n;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.i18n.locale.LocaleManager;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
@@ -61,6 +69,10 @@ public class DisableInactiveUsersJob implements Job
     private final UserService userService;
 
     private final EmailService emailService;
+
+    private final LocaleManager localeManager;
+
+    private final I18nManager i18nManager;
 
     @Override
     public JobType getJobType()
@@ -106,18 +118,29 @@ public class DisableInactiveUsersJob implements Job
         LocalDate reference = since.plusDays( daysUntilDisable );
         ZonedDateTime nDaysPriorToDisabling = reference.atStartOfDay( systemDefault() );
         ZonedDateTime nDaysPriorToDisablingEod = reference.plusDays( 1 ).atStartOfDay( systemDefault() );
-        Set<String> receivers = userService.findNotifiableUsersWithLastLoginBetween(
+        Map<String, Optional<Locale>> receivers = userService.findNotifiableUsersWithLastLoginBetween(
             Date.from( nDaysPriorToDisabling.toInstant() ),
             Date.from( nDaysPriorToDisablingEod.toInstant() ) );
-        if ( !receivers.isEmpty() )
+        if ( receivers.isEmpty() )
         {
-            emailService.sendEmail(
-                "Your DHIS2 account gets disabled soon",
-                format(
-                    "Your DHIS2 user account was inactive for a while. " +
-                        "Login during the next %d days to prevent your account from being disabled.",
-                    daysUntilDisable ),
-                receivers );
+            return;
+        }
+        Locale fallback = localeManager.getFallbackLocale();
+        Map<Locale, Set<String>> receiversByLocale = new HashMap<>();
+        for ( Map.Entry<String, Optional<Locale>> e : receivers.entrySet() )
+        {
+            receiversByLocale.computeIfAbsent( e.getValue().orElse( fallback ), key -> new HashSet<>() )
+                .add( e.getKey() );
+        }
+        for ( Map.Entry<Locale, Set<String>> e : receiversByLocale.entrySet() )
+        {
+            I18n i18n = i18nManager.getI18n( e.getKey() );
+            String subject = i18n.getString( "notification.user_inactive.subject",
+                "Your DHIS2 account gets disabled soon" );
+            String body = i18n.getString( "notification.user_inactive.body",
+                "Your DHIS2 user account was inactive for a while. Login during the next {0} days to prevent your account from being disabled." );
+            emailService.sendEmail( subject, format( body.replace( "{0}", "%d" ), daysUntilDisable ),
+                receivers.keySet() );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/job/DisableInactiveUsersJob.java
@@ -138,7 +138,7 @@ public class DisableInactiveUsersJob implements Job
         progress.startingStage( format( "Sending reminder for %d days until disable", daysUntilDisable ),
             receiversByLocale.size(), JobProgress.FailurePolicy.SKIP_ITEM );
         progress.runStage( receiversByLocale.entrySet().stream(),
-            e -> format( "Sending %s email to %d users", e.getKey(), e.getValue().size() ),
+            e -> format( "Sending email to %d user(s) in %s", e.getValue().size(), e.getKey().getDisplayLanguage() ),
             OutboundMessageResponse::getDescription,
             e -> {
                 I18n i18n = i18nManager.getI18n( e.getKey() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -1960,3 +1960,7 @@ data_integrity.program_rule_actions_without_section.description=Lists program ru
 data_integrity.program_rule_actions_without_stage.section=Program Rules
 data_integrity.program_rule_actions_without_stage.name=Program rules with actions lacking a program stage
 data_integrity.program_rule_actions_without_stage.description=Lists program rules connected to an action of a type that requires a program stage but is not yet connected to one
+
+# disable inactive users job notification texts
+notification.user_inactive.subject=Your DHIS2 account gets disabled soon
+notification.user_inactive.body=Your DHIS2 user account was inactive for a while. Login during the next {0} days to prevent your account from being disabled.

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -559,6 +559,9 @@ class UserServiceTest extends DhisSpringTest
         addUser( "C", User::setLastLogin, twentyTwoDaysAgo );
         addUser( "D" );
         userSettingService.saveUserSetting( UserSettingKey.UI_LOCALE, Locale.CANADA, userA );
+        // the point of setting this setting is to see that the query does not
+        // get confused by other setting existing for the same user
+        userSettingService.saveUserSetting( UserSettingKey.DB_LOCALE, Locale.FRANCE, userA );
 
         Map<String, Optional<Locale>> users = userService.findNotifiableUsersWithLastLoginBetween(
             threeMonthAgo, twoMonthsAgo );


### PR DESCRIPTION
### Summary
Allows i18n for texts used in emails send to users whose account is soon to be disabled.
The local is joined in the database query using `UserSetting` with name `keyUiLocale`.

As a consequence the emails send have to be grouped by the language they used so that all users of a language can be send in one operations.

This slightly more complicated processing is also tracked in more detail by the job progress tracking to provide more insight into what happens in the job. The failure policy also got fine tuned so that the job effectively does a "best effort" approach skipping those attempts that fail. 

### Automatic Testing
Existing test scenario for the service finding the users to notify got updated so this also tests that the local for the user is fetched from the database.

### Manual Testing
See testing instructions in #7307 and possibly #10179 

The easiest way to create a user that matches the criteria for receiving a reminder email is to use 1 month inactivity in the job settings and maybe 14 days reminder setting.
Then update the users `lastlogin` in the database to be todays date day of the month one month back and move one day forward. For example if today is 30th of May set the last login to 1st of May since one month back is 30th April and adding one day to that is 1st of May.

### Example Output
From job tracking as provided by `/api/scheduling/completed/DISABLE_INACTIVE_USERS`:

```json
[
  {
    "status":"SUCCESS",
    "completedTime":"2022-05-30T13:54:18.230",
    "startedTime":"2022-05-30T13:54:18.143",
    "description":"Disable inactive users",
    "stages":[
      {
        "summary":"Disabled 0 users with 1 months of inactivity",
        "status":"SUCCESS",
        "completedTime":"2022-05-30T13:54:18.148",
        "startedTime":"2022-05-30T13:54:18.143",
        "description":"Disabling inactive users",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":5,
        "complete":true
      },
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-05-30T13:54:18.156",
        "startedTime":"2022-05-30T13:54:18.148",
        "description":"Fetching users for reminder, 14 days until disable",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":8,
        "complete":true
      },
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-05-30T13:54:18.159",
        "startedTime":"2022-05-30T13:54:18.157",
        "description":"Fetching users for reminder, 7 days until disable",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":2,
        "complete":true
      },
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-05-30T13:54:18.162",
        "startedTime":"2022-05-30T13:54:18.160",
        "description":"Fetching users for reminder, 3 days until disable",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":2,
        "complete":true
      },
      {
        "summary":"Found 1 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-05-30T13:54:18.227",
        "startedTime":"2022-05-30T13:54:18.162",
        "description":"Fetching users for reminder, 1 days until disable",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":65,
        "complete":true
      },
      {
        "status":"SUCCESS",
        "completedTime":"2022-05-30T13:54:18.229",
        "startedTime":"2022-05-30T13:54:18.228",
        "description":"Sending reminder for 1 days until disable",
        "totalItems":1,
        "onFailure":"SKIP_ITEM",
        "items":[
          {
            "summary":"Host configuration not found",
            "status":"SUCCESS",
            "completedTime":"2022-05-30T13:54:18.229",
            "startedTime":"2022-05-30T13:54:18.229",
            "description":"Sending email to 1 user(s) in English",
            "onFailure":"SKIP_ITEM",
            "duration":0,
            "complete":true
          }
        ],
        "duration":1,
        "complete":true
      }
    ],
    "jobId":"y6EtNtnVWrQ",
    "duration":87,
    "complete":true
  }
]
```
Note the `description`: _"Sending email to 1 user(s) in English"_.
Also note that the item is considered a `SUCCESS` even if the response state of sending is not OK and has a message like _Host configuration not found_. So far this is intentional. We could fail the item by throwing an exception but the additional value here is minimal.