### PR TITLE
fix: revert response type for collections api (2.37)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -692,25 +692,25 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
 
     @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public WebMessage addCollectionItemsJson(
+    public void addCollectionItemsJson(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
         HttpServletRequest request )
         throws Exception
     {
-        return addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
             renderService.fromJson( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
     @PostMapping( value = "/{uid}/{property}", consumes = APPLICATION_XML_VALUE )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public WebMessage addCollectionItemsXml(
+    public void addCollectionItemsXml(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
         HttpServletRequest request )
         throws Exception
     {
-        return addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
+        addCollectionItems( pvProperty, getEntity( pvUid ).get( 0 ),
             renderService.fromXml( request.getInputStream(), IdentifiableObjects.class ) );
     }
 
@@ -761,7 +761,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
 
     @PostMapping( value = "/{uid}/{property}/{itemId}" )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public WebMessage addCollectionItem(
+    public void addCollectionItem(
         @PathVariable( "uid" ) String pvUid,
         @PathVariable( "property" ) String pvProperty,
         @PathVariable( "itemId" ) String pvItemId,
@@ -779,10 +779,9 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
         items.setAdditions( singletonList( new BaseIdentifiableObject( pvItemId, "", "" ) ) );
 
         preUpdateItems( object, items );
-        TypeReport report = collectionService.addCollectionItems( object, pvProperty, items.getIdentifiableObjects() );
+        collectionService.addCollectionItems( object, pvProperty, items.getIdentifiableObjects() );
         postUpdateItems( object, items );
         hibernateCacheManager.clearCache();
-        return typeReport( report );
     }
 
     @DeleteMapping( value = "/{uid}/{property}", consumes = APPLICATION_JSON_VALUE )


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12958
This PR revert a part of the PR https://github.com/dhis2/dhis2-core/pull/10531

In details, PR#10531 uses response type `HttpStatus.OK` and return `WebMessage` while in 2.37 the endpoint return `HttpStatus.NO_CONTENT`. This is an api change introduced in 2.38 so it shouldn't be changed in a 2.37 patch.
