### PR TITLE
fix: update audit cron pattern to be correct format

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/log/Log4JLogConfigInitializer.java
@@ -161,7 +161,7 @@ public class Log4JLogConfigInitializer
             .setName( "appender_" + file )
             .withFilePattern( file + ".%i" )
             .setLayout( PATTERN_LAYOUT )
-            .withPolicy( CronTriggeringPolicy.createPolicy( getLogConfiguration(), "true", "0 0 * * *" ) )
+            .withPolicy( CronTriggeringPolicy.createPolicy( getLogConfiguration(), "true", "0 0 * * * ?" ) )
             .withStrategy( DefaultRolloverStrategy.newBuilder()
                 .withCompressionLevelStr( String.valueOf( Deflater.BEST_COMPRESSION ) )
                 .withFileIndex( "nomax" )


### PR DESCRIPTION
## Summary

* Updates audit cron pattern to be in correct format (adds `?` to align it with master) 

[DHIS2-13250](https://jira.dhis2.org/browse/DHIS2-13250)

(integration tests failing because of mock current user, as we have seen in other PRs)