### PR TITLE
fix: User defined names for time attributes in headers [DHIS2-13136]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -721,7 +721,7 @@ public class DefaultEventAnalyticsService
             .addHeader( new GridHeader( ITEM_EVENT, NAME_EVENT, TEXT, false, true ) )
             .addHeader( new GridHeader( ITEM_PROGRAM_STAGE, NAME_PROGRAM_STAGE, TEXT, false, true ) )
             .addHeader( new GridHeader( ITEM_EVENT_DATE,
-                LabelMapper.getEventDateLabel( params.getProgramStage(), NAME_EVENT_DATE ), DATE, false, true ) )
+                LabelMapper.getEventDateLabel( params.getProgram(), NAME_EVENT_DATE ), DATE, false, true ) )
             .addHeader( new GridHeader( ITEM_STORED_BY, NAME_STORED_BY, TEXT, false, true ) )
             .addHeader( new GridHeader(
                 ITEM_CREATED_BY_DISPLAY_NAME, NAME_CREATED_BY_DISPLAY_NAME, TEXT, false, true ) )
@@ -740,11 +740,11 @@ public class DefaultEventAnalyticsService
             grid
                 .addHeader( new GridHeader(
                     ITEM_ENROLLMENT_DATE,
-                    LabelMapper.getEnrollmentDateLabel( params.getProgramStage(), NAME_ENROLLMENT_DATE ), DATE, false,
+                    LabelMapper.getEnrollmentDateLabel( params.getProgram(), NAME_ENROLLMENT_DATE ), DATE, false,
                     true ) )
                 .addHeader( new GridHeader(
                     ITEM_INCIDENT_DATE,
-                    LabelMapper.getIncidentDateLabel( params.getProgramStage(), NAME_INCIDENT_DATE ), DATE, false,
+                    LabelMapper.getIncidentDateLabel( params.getProgram(), NAME_INCIDENT_DATE ), DATE, false,
                     true ) )
                 .addHeader( new GridHeader(
                     ITEM_TRACKED_ENTITY_INSTANCE, NAME_TRACKED_ENTITY_INSTANCE, TEXT, false, true ) )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -721,7 +721,7 @@ public class DefaultEventAnalyticsService
             .addHeader( new GridHeader( ITEM_EVENT, NAME_EVENT, TEXT, false, true ) )
             .addHeader( new GridHeader( ITEM_PROGRAM_STAGE, NAME_PROGRAM_STAGE, TEXT, false, true ) )
             .addHeader( new GridHeader( ITEM_EVENT_DATE,
-                LabelMapper.getEventDateLabel( params.getProgram(), NAME_EVENT_DATE ), DATE, false, true ) )
+                LabelMapper.getEventDateLabel( params.getProgramStage(), NAME_EVENT_DATE ), DATE, false, true ) )
             .addHeader( new GridHeader( ITEM_STORED_BY, NAME_STORED_BY, TEXT, false, true ) )
             .addHeader( new GridHeader(
                 ITEM_CREATED_BY_DISPLAY_NAME, NAME_CREATED_BY_DISPLAY_NAME, TEXT, false, true ) )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/linelisting/CommonRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/linelisting/CommonRequestMapper.java
@@ -50,11 +50,11 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 import com.google.common.collect.ImmutableMap;
 
-@Service
+@Component
 public class CommonRequestMapper
 {
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/LabelMapper.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.analytics.shared;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 
 /**
  * Specific component responsible mapping custom labels for specific cases where
@@ -64,48 +63,14 @@ public class LabelMapper
     /**
      * Finds for a custom label for event date if one exists.
      *
-     * @param programStage
+     * @param program
      * @return the custom label, otherwise the default one
      */
-    public static String getEventDateLabel( final ProgramStage programStage, final String defaultLabel )
+    public static String getEventDateLabel( final Program program, final String defaultLabel )
     {
-        if ( programStage != null && isNotBlank( programStage.getDisplayExecutionDateLabel() ) )
+        if ( program != null && isNotBlank( program.getDisplayIncidentDateLabel() ) )
         {
-            return programStage.getDisplayExecutionDateLabel();
-        }
-
-        return defaultLabel;
-    }
-
-    /**
-     * Finds for a custom label for enrollment date if one exists.
-     *
-     * @param programStage
-     * @return the custom label, otherwise the default one
-     */
-    public static String getEnrollmentDateLabel( final ProgramStage programStage, final String defaultLabel )
-    {
-        if ( programStage != null && programStage.getProgram() != null
-            && isNotBlank( programStage.getProgram().getDisplayEnrollmentDateLabel() ) )
-        {
-            return programStage.getProgram().getDisplayEnrollmentDateLabel();
-        }
-
-        return defaultLabel;
-    }
-
-    /**
-     * Finds for a custom label for incident date if one exists.
-     *
-     * @param programStage
-     * @return the custom label, otherwise the default one
-     */
-    public static String getIncidentDateLabel( final ProgramStage programStage, final String defaultLabel )
-    {
-        if ( programStage != null && programStage.getProgram() != null
-            && isNotBlank( programStage.getProgram().getDisplayIncidentDateLabel() ) )
-        {
-            return programStage.getProgram().getDisplayIncidentDateLabel();
+            return program.getDisplayIncidentDateLabel();
         }
 
         return defaultLabel;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/LabelMapper.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.shared;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 
 /**
  * Specific component responsible mapping custom labels for specific cases where
@@ -63,14 +64,14 @@ public class LabelMapper
     /**
      * Finds for a custom label for event date if one exists.
      *
-     * @param program
+     * @param programStage
      * @return the custom label, otherwise the default one
      */
-    public static String getEventDateLabel( final Program program, final String defaultLabel )
+    public static String getEventDateLabel( final ProgramStage programStage, final String defaultLabel )
     {
-        if ( program != null && isNotBlank( program.getDisplayIncidentDateLabel() ) )
+        if ( programStage != null && isNotBlank( programStage.getDisplayExecutionDateLabel() ) )
         {
-            return program.getDisplayIncidentDateLabel();
+            return programStage.getDisplayExecutionDateLabel();
         }
 
         return defaultLabel;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
@@ -32,7 +32,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hisp.dhis.analytics.shared.LabelMapper;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.program.ProgramStage;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -52,42 +51,50 @@ class LabelMapperTest
     void testGetHeaderNameFor_NAME_EVENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithLabels();
+
         // When
-        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithLabels, EVENT_DATE );
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramWithLabels, EVENT_DATE );
+
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getDisplayExecutionDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramWithLabels.getIncidentDateLabel() ) );
     }
 
     @Test
     void testGetHeaderNameFor_NAME_ENROLLMENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithLabels();
+
         // When
-        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithLabels, ENROLLMENT_DATE );
+        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramWithLabels, ENROLLMENT_DATE );
+
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getDisplayEnrollmentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramWithLabels.getDisplayEnrollmentDateLabel() ) );
     }
 
     @Test
     void testGetHeaderNameFor_NAME_INCIDENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithLabels();
+
         // When
-        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithLabels, INCIDENT_DATE );
+        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramWithLabels, INCIDENT_DATE );
+
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getDisplayIncidentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramWithLabels.getDisplayIncidentDateLabel() ) );
     }
 
     @Test
     void testGetHeaderNameWhenNoLabelIsSetFor_NAME_EVENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithoutLabels();
+
         // When
-        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithNoLabels, EVENT_DATE );
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramWithLabels, EVENT_DATE );
+
         // Then
         assertThat( actualName, is( EVENT_DATE ) );
     }
@@ -96,10 +103,11 @@ class LabelMapperTest
     void testGetHeaderNameWhenNoLabelIsSetFor_NAME_ENROLLMENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithoutLabels();
+
         // When
-        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithNoLabels,
-            ENROLLMENT_DATE );
+        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramWithLabels, ENROLLMENT_DATE );
+
         // Then
         assertThat( actualName, is( ENROLLMENT_DATE ) );
     }
@@ -108,20 +116,11 @@ class LabelMapperTest
     void testGetHeaderNameWhenNoLabelIsSetFor_NAME_INCIDENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
-        // When
-        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithNoLabels, INCIDENT_DATE );
-        // Then
-        assertThat( actualName, is( INCIDENT_DATE ) );
-    }
+        final Program aMockedProgramWithLabels = mockProgramWithoutLabels();
 
-    @Test
-    void testGetHeaderNameWhenProgramStageIsNull()
-    {
-        // Given
-        final ProgramStage nullProgramStage = null;
         // When
-        final String actualName = LabelMapper.getIncidentDateLabel( nullProgramStage, INCIDENT_DATE );
+        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramWithLabels, INCIDENT_DATE );
+
         // Then
         assertThat( actualName, is( INCIDENT_DATE ) );
     }
@@ -130,36 +129,27 @@ class LabelMapperTest
     void testGetHeaderNameWhenProgramIsNull()
     {
         // Given
-        final ProgramStage programStageWithNullProgram = mockProgramStageWithNullProgram();
+        final Program nullProgram = null;
+
         // When
-        final String actualName = LabelMapper.getEnrollmentDateLabel( programStageWithNullProgram, ENROLLMENT_DATE );
+        final String actualName = LabelMapper.getEnrollmentDateLabel( nullProgram, ENROLLMENT_DATE );
+
         // Then
         assertThat( actualName, is( ENROLLMENT_DATE ) );
     }
 
-    private ProgramStage mockProgramStageWithLabels()
+    private Program mockProgramWithLabels()
     {
-        final ProgramStage programStage = new ProgramStage();
-        programStage.setExecutionDateLabel( "execution date label" );
         final Program program = new Program();
         program.setEnrollmentDateLabel( "enrollment date label" );
         program.setIncidentDateLabel( "incident date label" );
-        programStage.setProgram( program );
-        return programStage;
+
+        return program;
     }
 
-    private ProgramStage mockProgramStageWithoutLabels()
+    private Program mockProgramWithoutLabels()
     {
-        final ProgramStage programStage = new ProgramStage();
         final Program program = new Program();
-        programStage.setProgram( program );
-        return programStage;
-    }
-
-    private ProgramStage mockProgramStageWithNullProgram()
-    {
-        final ProgramStage programStage = new ProgramStage();
-        programStage.setProgram( null );
-        return programStage;
+        return program;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.hisp.dhis.analytics.shared.LabelMapper;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -51,13 +52,13 @@ class LabelMapperTest
     void testGetHeaderNameFor_NAME_EVENT_DATE()
     {
         // Given
-        final Program aMockedProgramWithLabels = mockProgramWithLabels();
+        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
 
         // When
-        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramWithLabels, EVENT_DATE );
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithLabels, EVENT_DATE );
 
         // Then
-        assertThat( actualName, is( aMockedProgramWithLabels.getIncidentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getDisplayExecutionDateLabel() ) );
     }
 
     @Test
@@ -90,10 +91,10 @@ class LabelMapperTest
     void testGetHeaderNameWhenNoLabelIsSetFor_NAME_EVENT_DATE()
     {
         // Given
-        final Program aMockedProgramWithLabels = mockProgramWithoutLabels();
+        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
 
         // When
-        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramWithLabels, EVENT_DATE );
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithNoLabels, EVENT_DATE );
 
         // Then
         assertThat( actualName, is( EVENT_DATE ) );
@@ -151,5 +152,24 @@ class LabelMapperTest
     {
         final Program program = new Program();
         return program;
+    }
+
+    private ProgramStage mockProgramStageWithLabels()
+    {
+        final ProgramStage programStage = new ProgramStage();
+        programStage.setExecutionDateLabel( "execution date label" );
+        final Program program = new Program();
+        program.setEnrollmentDateLabel( "enrollment date label" );
+        program.setIncidentDateLabel( "incident date label" );
+        programStage.setProgram( program );
+        return programStage;
+    }
+
+    private ProgramStage mockProgramStageWithoutLabels()
+    {
+        final ProgramStage programStage = new ProgramStage();
+        final Program program = new Program();
+        programStage.setProgram( program );
+        return programStage;
     }
 }


### PR DESCRIPTION
This fix aims to apply the correct usage of the labels for each time attribute that has a custom name defined in enrollments or events.

The GET request below, for example, should not bring "Enrollment date" in the response header. It should be the user-defined value "Start of treatment date".

```
https://play.dhis2.org/dev/api/analytics/events/query/ur1Edk5Oe2n.html+css?dimension=ou:USER_ORGUNIT&outputType=EVENT&tableLayout=true&columns=ou;enrollmentDate&enrollmentDate=LAST_12_MONTHS&headers=ouname,enrollmentdate&dataIdScheme=NAME&paging=false&asc=ouname
```

For more details about the mapping rule, see DHIS2-13136.