### PR TITLE
test: mistakenly did not use now var

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/MessageFormatterTest.java
@@ -140,7 +140,7 @@ class MessageFormatterTest
     {
         final Instant now = Instant.now();
 
-        List<String> args = MessageFormatter.formatArguments( idSchemes, Instant.now() );
+        List<String> args = MessageFormatter.formatArguments( idSchemes, now );
 
         assertThat( args.size(), is( 1 ) );
         assertThat( args.get( 0 ), is( DateUtils.getIso8601NoTz( DateUtils.fromInstant( now ) ) ) );


### PR DESCRIPTION
which can lead to a failing test if time passed between calls to now