### PR TITLE
fix: GeoJson import - always return status OK [DHIS2-7171]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GeoJsonImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GeoJsonImportControllerTest.java
@@ -72,7 +72,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         Map<Integer, String> ouIds = postNewOrganisationUnits( IntStream.range( 0, 7 ) );
 
-        JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import partially successful.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "WARNING", "Import partially successful.",
             POST( "/organisationUnits/geometry?geoJsonId=false&geoJsonProperty=name&orgUnitProperty=name",
                 "geo-json/sierra-leone-districts.geojson" ).content() );
 
@@ -87,7 +87,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         String attrId = postNewGeoJsonAttribute();
         Map<Integer, String> ouIds = postNewOrganisationUnits( IntStream.range( 0, 7 ) );
 
-        JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import partially successful.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "WARNING", "Import partially successful.",
             POST(
                 "/organisationUnits/geometry?geoJsonId=false&geoJsonProperty=name&orgUnitProperty=name&attributeId="
                     + attrId,
@@ -103,7 +103,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         Map<Integer, String> ouIds = postNewOrganisationUnits( IntStream.of( 1, 3, 5, 7, 9, 11, 13 ) );
 
-        JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import partially successful.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "WARNING", "Import partially successful.",
             POST( "/organisationUnits/geometry", "geo-json/sierra-leone-districts.geojson" ).content() );
 
         assertImportedAndIgnored( msg, 4, 11 );
@@ -118,7 +118,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         String attrId = postNewGeoJsonAttribute();
         Map<Integer, String> ouIds = postNewOrganisationUnits( IntStream.of( 1, 3, 5, 7, 9, 11, 13 ) );
 
-        JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import partially successful.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "WARNING", "Import partially successful.",
             POST( "/organisationUnits/geometry?attributeId=" + attrId, "geo-json/sierra-leone-districts.geojson" )
                 .content() );
 
@@ -133,7 +133,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         Map<Integer, String> ouIds = postNewOrganisationUnits( IntStream.range( 3, 14 ) );
 
-        JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import partially successful.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "WARNING", "Import partially successful.",
             POST( "/organisationUnits/geometry?geoJsonId=false&geoJsonProperty=code&orgUnitProperty=code",
                 "geo-json/sierra-leone-districts.geojson" ).content() );
 
@@ -149,7 +149,7 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         String attrId = postNewGeoJsonAttribute();
         Map<Integer, String> ouIds = postNewOrganisationUnits( IntStream.range( 3, 14 ) );
 
-        JsonWebMessage msg = assertWebMessage( "OK", 200, "OK", "Import partially successful.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "WARNING", "Import partially successful.",
             POST(
                 "/organisationUnits/geometry?geoJsonId=false&geoJsonProperty=code&orgUnitProperty=code&attributeId="
                     + attrId,
@@ -164,16 +164,16 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     @Test
     void testPostImport_ErrorInputNotGeoJson()
     {
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
-            POST( "/organisationUnits/geometry", "not-valid-geojson" ).content( HttpStatus.CONFLICT ) );
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
+            POST( "/organisationUnits/geometry", "not-valid-geojson" ).content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7701, List.of() );
     }
 
     @Test
     void testPostImport_ErrorAttributeDoesNotExist()
     {
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
-            POST( "/organisationUnits/geometry?attributeId=fake", "does not matter" ).content( HttpStatus.CONFLICT ) );
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
+            POST( "/organisationUnits/geometry?attributeId=fake", "does not matter" ).content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7702, List.of() );
     }
 
@@ -182,9 +182,9 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         String attrId = postNewAttribute( "TEXT", Attribute.ObjectType.ORGANISATION_UNIT );
 
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry?attributeId=" + attrId, "does not matter" )
-                .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7703, List.of() );
     }
 
@@ -193,19 +193,19 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         String attrId = postNewAttribute( "GEOJSON", Attribute.ObjectType.CATEGORY );
 
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry?attributeId=" + attrId, "does not matter" )
-                .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7704, List.of() );
     }
 
     @Test
     void testPostImport_ErrorFeatureHasNoIdentifier()
     {
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'geometry': {'type':'MultiPolygon', 'coordinates': [ [ [ [ -12, 9 ], [ -13, 10 ], [ -11, 8 ] ] ] ] }}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                    .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7705, List.of( 0 ) );
     }
 
@@ -214,9 +214,9 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         postNewOrganisationUnits( IntStream.of( 0 ) );
 
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry", "{'features':[{'id':'Kare5678901'}]}" )
-                .content( HttpStatus.CONFLICT ) );
+                .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7706, List.of( 0 ) );
     }
 
@@ -225,20 +225,20 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
     {
         postNewOrganisationUnits( IntStream.of( 0 ) );
 
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'id':'Kare5678901', 'geometry': {'type':'Invalid'} }]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                    .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7707, List.of( 0 ) );
     }
 
     @Test
     void testPostImport_ErrorOrgUnitDoesNotExist()
     {
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry",
                 "{'features':[{'id':'foo', 'geometry': {'type':'MultiPolygon', 'coordinates': [ [ [ [ -12, 9 ], [ -13, 10 ], [ -11, 8 ] ] ] ]}}]}" )
-                    .content( HttpStatus.CONFLICT ) );
+                    .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7708, List.of( 0 ) );
     }
 
@@ -248,13 +248,13 @@ class GeoJsonImportControllerTest extends DhisControllerConvenienceTest
         postNewOrganisationUnit( "Alpha", "Alpha", "ALP" );
         postNewOrganisationUnit( "Alpha", "Beta", "BET" );
 
-        JsonWebMessage msg = assertWebMessage( "Conflict", 409, "ERROR", "Import failed.",
+        JsonWebMessage msg = assertWebMessage( "OK", 200, "ERROR", "Import failed.",
             POST( "/organisationUnits/geometry?geoJsonId=false&geoJsonProperty=name&orgUnitProperty=name",
                 "{'features':[{"
                     + "'properties': { 'name': 'Alpha'}, "
                     + "'geometry': {'type':'MultiPolygon', 'coordinates': [ [ [ [ 1,1 ], [ 2,2 ], [ 1,3 ], [1,1] ] ] ] }"
                     + "}]}" )
-                        .content( HttpStatus.CONFLICT ) );
+                        .content( HttpStatus.OK ) );
         assertReportError( msg, ErrorCode.E7711, List.of( 0 ) );
     }
 


### PR DESCRIPTION
### Summary
GeoJSON import API now always returns HTTP status code 200 OK. 
This is to be consistent with other imports in DHIS2.

However, the import status is reflected in the `status` property of the response object.

### Automatic Testing
Existing tests were adjusted to the change of behaviour.