### PR TITLE
ci: show coverage in codecov TECH-1188

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 comment:
   layout: "diff, flags, files, footer"
   behavior: default

--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,4 @@
+comment:
+  layout: "diff, flags, files, footer"
+  behavior: default
+  require_changes: true

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,10 +18,17 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: maven
-      - name: Test core
+      - name: Test core # NOTE: dhis-2/pom.xml needs to be installed as built artifacts are needed by dhis-web
         run: mvn clean install --threads 2C --batch-mode --no-transfer-progress --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
       - name: Test dhis-web
         run: mvn verify --threads 2C --batch-mode --no-transfer-progress --update-snapshots -f ./dhis-2/dhis-web/pom.xml
+      - name: Report coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./dhis-2
+          flags: unit
+          fail_ci_if_error: true
+          verbose: true
 
   integration-test:
     runs-on: ubuntu-latest
@@ -34,7 +41,14 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress -Pintegration -DexcludeAnalyticsTests=true -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress -Pintegration -DexcludeAnalyticsTests=true -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+      - name: Report coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./dhis-2
+          flags: integration
+          fail_ci_if_error: true
+          verbose: true
       - name: Archive surefire reports
         uses: actions/upload-artifact@v3
         with:
@@ -53,7 +67,14 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Run integration h2 tests
-        run: mvn clean test --threads 2C --batch-mode --no-transfer-progress -PintegrationH2 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+        run: mvn clean verify --threads 2C --batch-mode --no-transfer-progress -PintegrationH2 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+      - name: Report coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./dhis-2
+          flags: integration-h2
+          fail_ci_if_error: true
+          verbose: true
       - name: Archive surefire reports
         uses: actions/upload-artifact@v3
         with:
@@ -78,7 +99,14 @@ jobs:
       - name: Run analytics integration tests
         env:
           MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-        run: mvn test -Pintegration --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml
+        run: mvn verify -Pintegration --batch-mode --no-transfer-progress -f ./dhis-2/dhis-services/dhis-service-analytics/pom.xml
+      - name: Report coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./dhis-2
+          flags: integration
+          fail_ci_if_error: true
+          verbose: true
       - name: Archive surefire reports
         uses: actions/upload-artifact@v3
         with:

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -350,7 +350,7 @@
               <threadCount>10</threadCount>
               <skipTests>${skipTests}</skipTests>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>${surefireArgLine}</argLine>
+              <argLine>@{argLine} ${surefireArgLine}</argLine>
               <excludedGroups>integration,integrationH2</excludedGroups>
             </configuration>
             <dependencies>
@@ -376,7 +376,7 @@
             <configuration>
               <skipTests>false</skipTests>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>${surefireArgLine}</argLine>
+              <argLine>@{argLine} ${surefireArgLine}</argLine>
               <groups>integration</groups>
             </configuration>
             <dependencies>
@@ -403,7 +403,7 @@
             <configuration>
               <skipTests>false</skipTests>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>${surefireArgLine}</argLine>
+              <argLine>@{argLine} ${surefireArgLine}</argLine>
               <groups>integrationH2</groups>
             </configuration>
             <dependencies>
@@ -431,7 +431,7 @@
             <configuration>
               <skipTests>true</skipTests>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>${argLine} ${surefireArgLine}</argLine>
+              <argLine>@{argLine} ${surefireArgLine}</argLine>
               <excludedGroups>org.hisp.dhis.IntegrationTest</excludedGroups>
             </configuration>
             <dependencies>
@@ -441,26 +441,6 @@
                 <version>${ow2.asm.version}</version>
               </dependency>
             </dependencies>
-          </plugin>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>prepare-agent</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>report</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>
@@ -479,7 +459,7 @@
             <configuration>
               <skipTests>true</skipTests>
               <trimStackTrace>false</trimStackTrace>
-              <argLine>${surefireArgLine}</argLine>
+              <argLine>@{argLine} ${surefireArgLine}</argLine>
               <excludedGroups>integration,integrationH2</excludedGroups>
             </configuration>
             <dependencies>
@@ -804,6 +784,26 @@
             </ignoredNonTestScopedDependencies>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>prepare-agent</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>report</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -916,6 +916,10 @@
             <phase>process-test-classes</phase>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
 


### PR DESCRIPTION
* adds step `Report coverage to codecov` after all types of tests we run (unit, integration, integrationH2)
* each type of test gets a flag attached https://docs.codecov.com/docs/flags so we can track coverage by type and set different targets and thresholds

If coverage has been reported you will see
`[2022-06-03T06:24:02.569Z] ['info'] {"status":"success","resultURL":"https://codecov.io/github/dhis2/dhis2-core/commit/f73c8f8a2bd5a920b81076c4e9d44b5a0ee28a45"}`
https://github.com/dhis2/dhis2-core/runs/6721138233?check_suite_focus=true#step:6:126

which takes you to the report. You can see the uploads by type (using the different flags) https://codecov.io/gh/dhis2/dhis2-core/commit/f73c8f8a2bd5a920b81076c4e9d44b5a0ee28a45/build

Right now coverage is only reported as informational and will not fail a PR if coverage is decreased.

Lets get it configured correctly and talk about targets and failing PRs later on.

We might need to enable the integration so that it can comment with a report on a PR directly.