### PR TITLE
ci: fix sonarqube maven plugin warning

### DIFF
--- a/.github/workflows/analyse-pr.yml
+++ b/.github/workflows/analyse-pr.yml
@@ -38,11 +38,11 @@ jobs:
           PR: ${{ github.event.number }}
         if: github.event_name == 'pull_request'
         run: |
-          mvn -f dhis-2/pom.xml clean install --batch-mode --no-transfer-progress -Psonarqube
+          mvn -f dhis-2/pom.xml clean install --threads 2C --batch-mode --no-transfer-progress -Psonarqube
           mvn -f dhis-2/pom.xml sonar:sonar -Dsonar.internal.analysis.dbd=false --batch-mode --no-transfer-progress -Dsonar.scm.revision=${{ github.event.pull_request.head.sha }} -Dsonar.projectKey=dhis2_dhis2-core -Dsonar.coverage.jacoco.xmlReportPaths=$(find "$(pwd)" -path '*jacoco.xml' | sed 's/.*/&/' | tr '\n' ',')
 
       - name: Analyse long-living branch
         if: github.event_name != 'pull_request'
         run: |
-          mvn -f dhis-2/pom.xml clean install --batch-mode --no-transfer-progress -Psonarqube
+          mvn -f dhis-2/pom.xml clean install --threads 2C --batch-mode --no-transfer-progress -Psonarqube
           mvn -f dhis-2/pom.xml sonar:sonar -Dsonar.internal.analysis.dbd=false --batch-mode --no-transfer-progress -Dsonar.branch.name=${GITHUB_REF#refs/heads/} -Dsonar.projectKey=dhis2_dhis2-core -Dsonar.coverage.jacoco.xmlReportPaths=$(find "$(pwd)" -path '*jacoco.xml' | sed 's/.*/&/' | tr '\n' ',')

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -546,6 +546,11 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>3.9.1.2184</version>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
           <version>${versions-maven-plugin.version}</version>


### PR DESCRIPTION
The artifact org.codehaus.mojo:sonar-maven-plugin:jar:3.9.1.2184 has been relocated to org.sonarsource.scanner.maven:sonar-maven-plugin:jar:3.9.1.2184: SonarQube plugin was moved to SonarSource organisation


Analysis was sent https://github.com/dhis2/dhis2-core/pull/10966/checks?check_run_id=6703670802 successfully

and warning is gone https://github.com/dhis2/dhis2-core/runs/6703593044?check_suite_focus=true#step:4:2367