### PR TITLE
feat: Add implement.io pre and post steps to dev pipeline [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -25,6 +25,7 @@ pipeline {
     stages {
         stage ('Build') {
             steps {
+                implementIoBuildStarted(buildJob: true, buildName: "${STAGE_NAME}")
                 echo 'Building DHIS2 ...'
                 script {
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
@@ -32,24 +33,44 @@ pipeline {
                     }
                 }
             }
+
+            post {
+                always {
+                    implementIoBuildEnded(buildName: "${STAGE_NAME}")
+                }
+            }
         }
 
         stage ('Sync WAR') {
             steps {
+                implementIoBuildStarted(buildName: "${STAGE_NAME}")
                 echo 'Syncing WAR ...'
                 sh 'curl "https://raw.githubusercontent.com/dhis2/dhis2-server-setup/master/ci/scripts/copy-war-s3.sh" -O'
                 sh 'chmod +x copy-war-s3.sh'
                 sh './copy-war-s3.sh dev ${GIT_BRANCH}'
             }
+
+            post {
+                always {
+                    implementIoBuildEnded(buildName: "${STAGE_NAME}")
+                }
+            }
         }
 
         stage ('Update Play Instance') {
             steps {
+                implementIoBuildStarted(buildEnvironment: "TEST", buildName: "${STAGE_NAME}")
                 echo 'Updating Play Instance ...'
                 script {
                     withCredentials([usernameColonPassword(credentialsId: 'awx-bot-user-credentials', variable: 'AWX_CREDENTIALS')]) {
                         awx.resetWarIfInstanceExists("$AWX_CREDENTIALS", "$HOST", "$INSTANCE_NAME", "$AWX_TEMPLATE")
                     }
+                }
+            }
+
+            post {
+                always {
+                    implementIoBuildEnded(buildName: "${STAGE_NAME}")
                 }
             }
         }


### PR DESCRIPTION
Adding implement.io pre and post steps for each stage of the Jenkins `dev` pipeline, so we can start getting metrics for our builds.

[Reference for integrating Jenkins with implement.io](https://implement.helpdocs.io/article/20ku2jchd5-jenkins-integration-with-implement)