### PR TITLE
fix: initialize ExpressionParams.SAMPLE_PERIODS differently

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -29,6 +29,11 @@ package org.hisp.dhis.expression;
 
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,8 +50,8 @@ import org.hisp.dhis.common.MapMap;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
+import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
 
 /**
@@ -67,7 +72,18 @@ public class ExpressionParams
      * description. The actual date doesn't matter; a date was chosen that is
      * likely to not be confused with real data.
      */
-    private static final List<Period> SAMPLE_PERIODS = List.of( PeriodType.getPeriodFromIsoString( "19990101" ) );
+    private static final List<Period> SAMPLE_PERIODS;
+
+    static
+    {
+        Date genTheFirst99 = Date
+            .from( LocalDate.of( 1999, Month.JANUARY, 1 ).atStartOfDay( ZoneId.systemDefault() ).toInstant() );
+        Period period = new Period();
+        period.setPeriodType( new DailyPeriodType() );
+        period.setStartDate( genTheFirst99 );
+        period.setEndDate( genTheFirst99 );
+        SAMPLE_PERIODS = Collections.singletonList( period );
+    }
 
     /**
      * The expression to parse


### PR DESCRIPTION
forward-port of https://github.com/dhis2/dhis2-core/pull/10672 fix added to unblock the release of 2.38

currently blocked by TrackedEntityProgramAttributeEncryptionTest.testTrackedEntityProgramAttributeEncryptedValue

```
TrackedEntityProgramAttributeEncryptionTest.testTrackedEntityProgramAttributeEncryptedValue:81->TrackerTest.assertNoImportErrors:175 E1112: Attribute value: `Value To Encrypt`, is set to confidential but system is not properly configured to encrypt data. ==> expected: <OK> but was: <ERROR>
```