### PR TITLE
fix: jclouds connection to aws-s3

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -219,7 +219,7 @@
       <artifactId>gson</artifactId>
     </dependency>
 
-    <!-- JClouds -->
+    <!-- Apache jclouds -->
 
     <dependency>
       <groupId>org.apache.jclouds</groupId>
@@ -236,6 +236,10 @@
     <dependency>
       <groupId>org.apache.jclouds.api</groupId>
       <artifactId>s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>aws-s3</artifactId>
     </dependency>
 
     <!-- Image Processing -->

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/JCloudsProviderTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/fileresource/JCloudsProviderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.fileresource;
+
+import static org.jclouds.ContextBuilder.newBuilder;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify that the supported jclouds providers can be selected.
+ *
+ * @author Jim Grace
+ */
+class JCloudsProviderTest
+{
+    @Test
+    void verifyFilesystem()
+    {
+        assertDoesNotThrow( () -> newBuilder( "filesystem" ) );
+    }
+
+    @Test
+    void verifyAwsS3()
+    {
+        assertDoesNotThrow( () -> newBuilder( "aws-s3" ) );
+    }
+
+    @Test
+    void verifyTransient()
+    {
+        assertDoesNotThrow( () -> newBuilder( "transient" ) );
+    }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -14,7 +14,7 @@
         aggregating and reporting statistical health data. The goal is to allow users to analyze
         and use this data to guide local action. The system is based around an goals of empowering
         users, by allowing them to decide what to register and report data for.
-    </description>
+  </description>
 
   <organization>
     <name>UiO</name>
@@ -119,14 +119,16 @@
     <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
     <xercesImpl.version>2.12.2</xercesImpl.version>
 
-    <!--Reporting -->
+    <!--- Apache jclouds -->
+    <jclouds.version>2.5.0</jclouds.version>
+
+    <!-- Reporting -->
     <jasperreports.version>6.19.1</jasperreports.version>
     <jfreechart.version>1.5.3</jfreechart.version>
     <htmlparser.version>2.1</htmlparser.version>
     <htmllexer.version>2.1</htmllexer.version>
     <poi.version>5.2.2</poi.version>
     <itext.version>2.1.7</itext.version>
-    <jclouds.version>2.5.0</jclouds.version>
     <antlr.version>4.9.3</antlr.version>
 
     <!-- GIS -->
@@ -738,6 +740,7 @@
               <ignoredUnusedDeclaredDependency>org.springframework:spring-context-support</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>javax.servlet:javax.servlet-api</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.xmlgraphics:batik-codec</ignoredUnusedDeclaredDependency>
+              <ignoredUnusedDeclaredDependency>org.apache.jclouds.provider:aws-s3</ignoredUnusedDeclaredDependency>
 
               <!-- Removing these dependencies from the pom makes some tests 
                 fail -->
@@ -1166,7 +1169,7 @@
         <version>${spring-ldap.version}</version>
       </dependency>
 
-      <!--Spring Security -->
+      <!-- Spring Security -->
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
@@ -1721,12 +1724,14 @@
         <version>${flyway-core.version}</version>
       </dependency>
 
-      <!-- Apache jClouds -->
+      <!-- Google gson -->
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>
       </dependency>
+
+      <!--- Apache jclouds -->
       <dependency>
         <groupId>org.apache.jclouds</groupId>
         <artifactId>jclouds-core</artifactId>
@@ -1747,15 +1752,20 @@
         <artifactId>s3</artifactId>
         <version>${jclouds.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.jclouds.provider</groupId>
+        <artifactId>aws-s3</artifactId>
+        <version>${jclouds.version}</version>
+      </dependency>
 
-      <!--ExpressionParser -->
+      <!-- ExpressionParser -->
       <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${antlr.version}</version>
       </dependency>
 
-      <!--Reporting -->
+      <!-- Reporting -->
       <dependency>
         <groupId>net.sf.jasperreports</groupId>
         <artifactId>jasperreports</artifactId>


### PR DESCRIPTION
Fix pom.xml so that it works again for aws-s3 file storage with Apache jclouds, as used by PEPFAR. It was broken in 2.38. This fix has been tested by PEPFAR and it works for them.

I also added the unit test `JCloudsProviderTest` that makes sure each of the three jclouds providers we use can be configured. This test fails with the unfixed 2.38 pom.xml and succeeds with the fix.