### PR TITLE
chore: avoid id parameter concat in deletion handlers [DHIS2-13359]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/AttributeValueDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/AttributeValueDeletionHandler.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.attribute;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.singletonList;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -36,18 +37,11 @@ import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
 import org.springframework.stereotype.Component;
 
-@Component( "org.hisp.dhis.attribute.AttributeValueDeletionHandler" )
-public class AttributeValueDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class AttributeValueDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager identifiableObjectManager;
-
-    public AttributeValueDeletionHandler( IdentifiableObjectManager identifiableObjectManager )
-    {
-        checkNotNull( identifiableObjectManager );
-
-        this.identifiableObjectManager = identifiableObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryComboDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryComboDeletionHandler.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.category;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -39,25 +40,13 @@ import org.springframework.stereotype.Component;
  * @author Lars Helge Overland
  * @version $Id$
  */
-@Component( "org.hisp.dhis.category.CategoryComboDeletionHandler" )
-public class CategoryComboDeletionHandler
-    extends
-    DeletionHandler
+@Component
+@AllArgsConstructor
+public class CategoryComboDeletionHandler extends DeletionHandler
 {
-    // -------------------------------------------------------------------------
-    // Dependencies
-    // -------------------------------------------------------------------------
     private final IdentifiableObjectManager idObjectManager;
 
     private final CategoryService categoryService;
-
-    public CategoryComboDeletionHandler( CategoryService categoryService, IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( categoryService );
-        checkNotNull( idObjectManager );
-        this.categoryService = categoryService;
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.category;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,17 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Dang Duy Hieu
  */
-@Component( "org.hisp.dhis.category.CategoryDeletionHandler" )
-public class CategoryDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class CategoryDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public CategoryDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDimensionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDimensionDeletionHandler.java
@@ -27,31 +27,19 @@
  */
 package org.hisp.dhis.category;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.category.CategoryDimensionDeletionHandler" )
-public class CategoryDimensionDeletionHandler
-    extends DeletionHandler
+@Component
+public class CategoryDimensionDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( CategoryDimension.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public CategoryDimensionDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -62,15 +50,13 @@ public class CategoryDimensionDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOption( CategoryOption categoryOption )
     {
-        String sql = "select count(*) from categorydimension_items where categoryoptionid = " + categoryOption.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from categorydimension_items where categoryoptionid = :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", categoryOption.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategory( Category category )
     {
-        String sql = "select count(*) from categorydimension where categoryid = " + category.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from categorydimension where categoryid = :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", category.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionComboDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionComboDeletionHandler.java
@@ -27,37 +27,27 @@
  */
 package org.hisp.dhis.category;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Iterator;
+import java.util.Map;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.category.CategoryOptionComboDeletionHandler" )
-public class CategoryOptionComboDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class CategoryOptionComboDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( CategoryOptionCombo.class );
 
     private final CategoryService categoryService;
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public CategoryOptionComboDeletionHandler( CategoryService categoryService, JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( categoryService );
-        checkNotNull( jdbcTemplate );
-
-        this.categoryService = categoryService;
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     // TODO expressionoptioncombo
 
@@ -75,12 +65,12 @@ public class CategoryOptionComboDeletionHandler
         final String dvSql = "select count(*) from datavalue dv " +
             "where dv.categoryoptioncomboid in ( " +
             "select cc.categoryoptioncomboid from categoryoptioncombos_categoryoptions cc " +
-            "where cc.categoryoptionid = " + categoryOption.getId() + " ) " +
+            "where cc.categoryoptionid = :coId ) " +
             "or dv.attributeoptioncomboid in ( " +
             "select cc.categoryoptioncomboid from categoryoptioncombos_categoryoptions cc " +
-            "where cc.categoryoptionid = " + categoryOption.getId() + " );";
+            "where cc.categoryoptionid = :coId );";
 
-        if ( jdbcTemplate.queryForObject( dvSql, Integer.class ) > 0 )
+        if ( exists( dvSql, Map.of( "coId", categoryOption.getId() ) ) )
         {
             return VETO;
         }
@@ -88,9 +78,9 @@ public class CategoryOptionComboDeletionHandler
         final String crSql = "select count(*) from completedatasetregistration cdr " +
             "where cdr.attributeoptioncomboid in ( " +
             "select cc.categoryoptioncomboid from categoryoptioncombos_categoryoptions cc " +
-            "where cc.categoryoptionid = " + categoryOption.getId() + " );";
+            "where cc.categoryoptionid = :coId );";
 
-        if ( jdbcTemplate.queryForObject( crSql, Integer.class ) > 0 )
+        if ( exists( crSql, Map.of( "coId", categoryOption.getId() ) ) )
         {
             return VETO;
         }
@@ -103,12 +93,12 @@ public class CategoryOptionComboDeletionHandler
         final String dvSql = "select count(*) from datavalue dv " +
             "where dv.categoryoptioncomboid in ( " +
             "select co.categoryoptioncomboid from categorycombos_optioncombos co " +
-            "where co.categorycomboid=" + categoryCombo.getId() + " ) " +
+            "where co.categorycomboid= :coId ) " +
             "or dv.attributeoptioncomboid in ( " +
             "select co.categoryoptioncomboid from categorycombos_optioncombos co " +
-            "where co.categorycomboid=" + categoryCombo.getId() + " );";
+            "where co.categorycomboid= :coId );";
 
-        if ( jdbcTemplate.queryForObject( dvSql, Integer.class ) > 0 )
+        if ( exists( dvSql, Map.of( "coId", categoryCombo.getId() ) ) )
         {
             return VETO;
         }
@@ -116,9 +106,9 @@ public class CategoryOptionComboDeletionHandler
         final String crSql = "select count(*) from completedatasetregistration cdr " +
             "where cdr.attributeoptioncomboid in ( " +
             "select co.categoryoptioncomboid from categorycombos_optioncombos co " +
-            "where co.categorycomboid=" + categoryCombo.getId() + " );";
+            "where co.categorycomboid= :coId );";
 
-        if ( jdbcTemplate.queryForObject( crSql, Integer.class ) > 0 )
+        if ( exists( crSql, Map.of( "coId", categoryCombo.getId() ) ) )
         {
             return VETO;
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.category;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -35,18 +35,12 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.category.CategoryOptionGroupDeletionHandler" )
+@Component
+@AllArgsConstructor
 public class CategoryOptionGroupDeletionHandler
     extends DeletionHandler
 {
     private final CategoryService categoryService;
-
-    public CategoryOptionGroupDeletionHandler( CategoryService categoryService )
-    {
-        checkNotNull( categoryService );
-
-        this.categoryService = categoryService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSetDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.category;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,17 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.category.CategoryOptionGroupSetDeletionHandler" )
-public class CategoryOptionGroupSetDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class CategoryOptionGroupSetDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public CategoryOptionGroupSetDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/configuration/ConfigurationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/configuration/ConfigurationDeletionHandler.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.configuration;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElementGroup;
 import org.hisp.dhis.indicator.IndicatorGroup;
@@ -44,20 +45,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.configuration.ConfigurationDeletionHandler" )
-public class ConfigurationDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ConfigurationDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( Configuration.class );
 
     private final ConfigurationService configService;
-
-    public ConfigurationDeletionHandler( ConfigurationService configService )
-    {
-        checkNotNull( configService );
-
-        this.configService = configService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevelDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevelDeletionHandler.java
@@ -27,27 +27,20 @@
  */
 package org.hisp.dhis.dataapproval;
 
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
-
-import lombok.AllArgsConstructor;
+import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionGroupSet;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Jim Grace
  */
 @Component
-@AllArgsConstructor
-public class DataApprovalLevelDeletionHandler
-    extends DeletionHandler
+public class DataApprovalLevelDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( DataApproval.class );
-
-    private final JdbcTemplate jdbcTemplate;
 
     @Override
     protected void register()
@@ -58,16 +51,13 @@ public class DataApprovalLevelDeletionHandler
 
     public DeletionVeto allowDeleteCategoryOptionGroupSet( CategoryOptionGroupSet categoryOptionGroupSet )
     {
-        String sql = "select count(*) from dataapprovallevel where categoryoptiongroupsetid="
-            + categoryOptionGroupSet.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from dataapprovallevel where categoryoptiongroupsetid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", categoryOptionGroupSet.getId() ) );
     }
 
     public DeletionVeto allowDeleteDataApprovalWorkflow( DataApprovalWorkflow workflow )
     {
-        String sql = "select count(*) from dataapprovalworkflowlevels where workflowid=" + workflow.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from dataapprovalworkflowlevels where workflowid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", workflow.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalWorkflowDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalWorkflowDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.dataapproval;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.dataapproval.DataApprovalWorkflowDeletionHandler" )
-public class DataApprovalWorkflowDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class DataApprovalWorkflowDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public DataApprovalWorkflowDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementDeletionHandler.java
@@ -27,11 +27,12 @@
  */
 package org.hisp.dhis.dataelement;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Iterator;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
@@ -40,37 +41,22 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.OptionSet;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.dataelement.DataElementDeletionHandler" )
-public class DataElementDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class DataElementDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( DataElement.class );
 
     private final IdentifiableObjectManager idObjectManager;
 
     private final CategoryService categoryService;
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public DataElementDeletionHandler( IdentifiableObjectManager idObjectManager, CategoryService categoryService,
-        JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( idObjectManager );
-        checkNotNull( categoryService );
-        checkNotNull( jdbcTemplate );
-
-        this.idObjectManager = idObjectManager;
-        this.categoryService = categoryService;
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -138,8 +124,7 @@ public class DataElementDeletionHandler
 
     private DeletionVeto allowDeleteOptionSet( OptionSet optionSet )
     {
-        String sql = "SELECT COUNT(*) FROM dataelement WHERE optionsetid = " + optionSet.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM dataelement WHERE optionsetid = :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", optionSet.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.dataelement;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.dataelement.DataElementGroupDeletionHandler" )
-public class DataElementGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class DataElementGroupDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public DataElementGroupDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupSetDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.dataelement;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Dang Duy Hieu
  */
-@Component( "org.hisp.dhis.dataelement.DataElementGroupSetDeletionHandler" )
-public class DataElementGroupSetDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class DataElementGroupSetDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public DataElementGroupSetDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementOperandDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementOperandDeletionHandler.java
@@ -27,32 +27,20 @@
  */
 package org.hisp.dhis.dataelement;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Jim Grace
  */
-@Component( "org.hisp.dhis.dataelement.DataElementOperandDeletionHandler" )
-public class DataElementOperandDeletionHandler
-    extends DeletionHandler
+@Component
+public class DataElementOperandDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( DataElementOperand.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public DataElementOperandDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -65,8 +53,7 @@ public class DataElementOperandDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "select count(*) from dataelementoperand where categoryoptioncomboid=" + optionCombo.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from dataelementoperand where categoryoptioncomboid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataInputPeriodDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataInputPeriodDeletionHandler.java
@@ -27,32 +27,20 @@
  */
 package org.hisp.dhis.dataset;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Stian Sandvold
  */
-@Component( "org.hisp.dhis.dataset.DataInputPeriodDeletionHandler" )
-public class DataInputPeriodDeletionHandler
-    extends DeletionHandler
+@Component
+public class DataInputPeriodDeletionHandler extends JdbcDeletionHandler
 {
-
     private static final DeletionVeto VETO = new DeletionVeto( DataInputPeriod.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public DataInputPeriodDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -62,9 +50,7 @@ public class DataInputPeriodDeletionHandler
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        String sql = "SELECT COUNT(*) FROM datainputperiod where periodid=" + period.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM datainputperiod where periodid= :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", period.getId() ) );
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataSetDeletionHandler.java
@@ -27,12 +27,13 @@
  */
 package org.hisp.dhis.dataset;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
@@ -50,27 +51,15 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.dataset.DataSetDeletionHandler" )
-public class DataSetDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class DataSetDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
 
     private final DataSetService dataSetService;
 
     private final CategoryService categoryService;
-
-    public DataSetDeletionHandler( IdentifiableObjectManager idObjectManager, DataSetService dataSetService,
-        CategoryService categoryService )
-    {
-        checkNotNull( idObjectManager );
-        checkNotNull( dataSetService );
-        checkNotNull( categoryService );
-
-        this.idObjectManager = idObjectManager;
-        this.dataSetService = dataSetService;
-        this.categoryService = categoryService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/SectionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/SectionDeletionHandler.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.dataset;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -42,17 +42,11 @@ import org.springframework.stereotype.Component;
  * @author Lars Helge Overland
  * @version $Id$
  */
-@Component( "org.hisp.dhis.dataset.SectionDeletionHandler" )
-public class SectionDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class SectionDeletionHandler extends DeletionHandler
 {
     private final SectionService sectionService;
-
-    public SectionDeletionHandler( SectionService sectionService )
-    {
-        checkNotNull( sectionService );
-        this.sectionService = sectionService;
-    }
 
     @Override
     protected void register()
@@ -72,7 +66,6 @@ public class SectionDeletionHandler
                 .collect( Collectors.toList() );
 
             operandsToRemove
-                .stream()
                 .forEach( operand -> section.getGreyedFields().remove( operand ) );
 
             if ( section.getDataElements().remove( dataElement ) || !operandsToRemove.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueAuditDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueAuditDeletionHandler.java
@@ -27,31 +27,20 @@
  */
 package org.hisp.dhis.datavalue;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
-@Component( "org.hisp.dhis.datavalue.DataValueAuditDeletionHandler" )
-public class DataValueAuditDeletionHandler
-    extends DeletionHandler
+@Component
+public class DataValueAuditDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( DataValueAudit.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public DataValueAuditDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -64,30 +53,25 @@ public class DataValueAuditDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        String sql = "SELECT COUNT(*) FROM datavalueaudit where dataelementid=" + dataElement.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM datavalueaudit where dataelementid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", dataElement.getId() ) );
     }
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        String sql = "SELECT COUNT(*) FROM datavalueaudit where periodid=" + period.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM datavalueaudit where periodid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", period.getId() ) );
     }
 
     private DeletionVeto allowDeleteOrganisationUnit( OrganisationUnit unit )
     {
-        String sql = "SELECT COUNT(*) FROM datavalueaudit where organisationunitid=" + unit.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM datavalueaudit where organisationunitid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", unit.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "SELECT COUNT(*) FROM datavalueaudit where categoryoptioncomboid=" + optionCombo.getId()
-            + " or attributeoptioncomboid=" + optionCombo.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM datavalueaudit where categoryoptioncomboid=:id or attributeoptioncomboid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueDeletionHandler.java
@@ -27,29 +27,23 @@
  */
 package org.hisp.dhis.datavalue;
 
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
-
-import lombok.AllArgsConstructor;
+import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class DataValueDeletionHandler extends DeletionHandler
+public class DataValueDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( DataValue.class );
-
-    private final JdbcTemplate jdbcTemplate;
 
     @Override
     protected void register()
@@ -62,28 +56,25 @@ public class DataValueDeletionHandler extends DeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        return vetoIfExists( "SELECT COUNT(*) FROM datavalue where dataelementid=" + dataElement.getId() );
+        return vetoIfExists( VETO, "SELECT COUNT(*) FROM datavalue where dataelementid=:id",
+            Map.of( "id", dataElement.getId() ) );
     }
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        return vetoIfExists( "SELECT COUNT(*) FROM datavalue where periodid=" + period.getId() );
+        return vetoIfExists( VETO, "SELECT COUNT(*) FROM datavalue where periodid=:id",
+            Map.of( "id", period.getId() ) );
     }
 
     private DeletionVeto allowDeleteOrganisationUnit( OrganisationUnit unit )
     {
-        return vetoIfExists( "SELECT COUNT(*) FROM datavalue where sourceid=" + unit.getId() );
+        return vetoIfExists( VETO, "SELECT COUNT(*) FROM datavalue where sourceid=:id", Map.of( "id", unit.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        return vetoIfExists( "SELECT COUNT(*) FROM datavalue where categoryoptioncomboid=" + optionCombo.getId()
-            + " or attributeoptioncomboid=" + optionCombo.getId() );
-    }
-
-    private DeletionVeto vetoIfExists( String sql )
-    {
-        Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
-        return count == null || count == 0 ? ACCEPT : VETO;
+        return vetoIfExists( VETO,
+            "SELECT COUNT(*) FROM datavalue where categoryoptioncomboid=:id or attributeoptioncomboid=:id",
+            Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionItemDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionItemDeletionHandler.java
@@ -27,33 +27,21 @@
  */
 package org.hisp.dhis.dimension;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.DataDimensionItem;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@Component( "org.hisp.dhis.dimension.DataDimensionItemDeletionHandler" )
-public class DataDimensionItemDeletionHandler
-    extends DeletionHandler
+@Component
+public class DataDimensionItemDeletionHandler extends JdbcDeletionHandler
 {
-
     private static final DeletionVeto VETO = new DeletionVeto( DataDimensionItem.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public DataDimensionItemDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -63,9 +51,7 @@ public class DataDimensionItemDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "SELECT COUNT(*) FROM datadimensionitem where dataelementoperand_categoryoptioncomboid="
-            + optionCombo.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM datadimensionitem where dataelementoperand_categoryoptioncomboid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventchart/EventChartDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventchart/EventChartDeletionHandler.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.eventchart.EventChartDeletionHandler" )
+@Component
 public class EventChartDeletionHandler
     extends GenericAnalyticalObjectDeletionHandler<EventChart, EventChartService>
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventreport/EventReportDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventreport/EventReportDeletionHandler.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.eventreport.EventReportDeletionHandler" )
+@Component
 public class EventReportDeletionHandler
     extends GenericAnalyticalObjectDeletionHandler<EventReport, EventReportService>
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ExternalFileResourceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ExternalFileResourceDeletionHandler.java
@@ -27,52 +27,41 @@
  */
 package org.hisp.dhis.fileresource;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import java.util.Map;
+
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Kristian Wærstad <kristian@dhis2.org>
  */
-@Component( "org.hisp.dhis.fileresource.ExternalFileResourceDeletionHandler" )
-public class ExternalFileResourceDeletionHandler
-    extends DeletionHandler
+@Component
+public class ExternalFileResourceDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( ExternalFileResource.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public ExternalFileResourceDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
     {
-
         whenVetoing( FileResource.class, this::allowDeleteFileResource );
         whenDeleting( FileResource.class, this::deleteFileResource );
     }
 
     private DeletionVeto allowDeleteFileResource( FileResource fileResource )
     {
-        String sql = "SELECT COUNT(*) FROM externalfileresource WHERE fileresourceid=" + fileResource.getId();
-
-        int result = jdbcTemplate.queryForObject( sql, Integer.class );
-
-        return result == 0 || fileResource.getStorageStatus() != FileResourceStorageStatus.STORED ? ACCEPT : VETO;
+        if ( fileResource.getStorageStatus() != FileResourceStorageStatus.STORED )
+        {
+            return ACCEPT;
+        }
+        String sql = "SELECT COUNT(*) FROM externalfileresource WHERE fileresourceid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 
     private void deleteFileResource( FileResource fileResource )
     {
-        String sql = "DELETE FROM externalfileresource WHERE fileresourceid=" + fileResource.getId();
-
-        jdbcTemplate.execute( sql );
+        delete( "DELETE FROM externalfileresource WHERE fileresourceid=:id", Map.of( "id", fileResource.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/MessageAttachmentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/MessageAttachmentDeletionHandler.java
@@ -27,26 +27,18 @@
  */
 package org.hisp.dhis.fileresource;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import java.util.Map;
+
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
-@Component( "org.hisp.dhis.fileresource.MessageAttachmentDeletionHandler" )
-public class MessageAttachmentDeletionHandler extends DeletionHandler
+@Component
+public class MessageAttachmentDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( FileResource.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public MessageAttachmentDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -57,17 +49,16 @@ public class MessageAttachmentDeletionHandler extends DeletionHandler
 
     private DeletionVeto allowDeleteFileResource( FileResource fileResource )
     {
-        String sql = "SELECT COUNT(*) FROM messageattachments WHERE fileresourceid=" + fileResource.getId();
-
-        int result = jdbcTemplate.queryForObject( sql, Integer.class );
-
-        return result == 0 || fileResource.getStorageStatus() != FileResourceStorageStatus.STORED ? ACCEPT : VETO;
+        if ( fileResource.getStorageStatus() != FileResourceStorageStatus.STORED )
+        {
+            return ACCEPT;
+        }
+        String sql = "SELECT COUNT(*) FROM messageattachments WHERE fileresourceid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 
     private void deleteFileResource( FileResource fileResource )
     {
-        String sql = "DELETE FROM messageattachments WHERE fileresourceid=" + fileResource.getId();
-
-        jdbcTemplate.execute( sql );
+        delete( "DELETE FROM messageattachments WHERE fileresourceid=:id", Map.of( "id", fileResource.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.indicator;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.collections4.CollectionUtils.containsAny;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
@@ -35,6 +34,8 @@ import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -49,22 +50,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.indicator.IndicatorDeletionHandler" )
-public class IndicatorDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class IndicatorDeletionHandler extends DeletionHandler
 {
     private final IndicatorService indicatorService;
 
     private final ExpressionService expressionService;
-
-    public IndicatorDeletionHandler( IndicatorService indicatorService, ExpressionService expressionService )
-    {
-        checkNotNull( indicatorService );
-        checkNotNull( expressionService );
-
-        this.indicatorService = indicatorService;
-        this.expressionService = expressionService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.indicator;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.indicator.IndicatorGroupDeletionHandler" )
-public class IndicatorGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class IndicatorGroupDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public IndicatorGroupDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSetDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.indicator;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.indicator.IndicatorGroupSetDeletionHandler" )
-public class IndicatorGroupSetDeletionHandler
-    extends
-    DeletionHandler
+@Component
+@AllArgsConstructor
+public class IndicatorGroupSetDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public IndicatorGroupSetDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/InterpretationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/InterpretationDeletionHandler.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.interpretation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.mapping.Map;
@@ -41,18 +41,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.interpretation.InterpretationDeletionHandler" )
-public class InterpretationDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class InterpretationDeletionHandler extends DeletionHandler
 {
     private final InterpretationService interpretationService;
-
-    public InterpretationDeletionHandler( InterpretationService interpretationService )
-    {
-        checkNotNull( interpretationService );
-
-        this.interpretationService = interpretationService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/legend/LegendSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/legend/LegendSetDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.legend;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -35,17 +35,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.legend.LegendSetDeletionHandler" )
-public class LegendSetDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class LegendSetDeletionHandler extends DeletionHandler
 {
     private final LegendSetService legendSetService;
-
-    public LegendSetDeletionHandler( LegendSetService legendSetService )
-    {
-        checkNotNull( legendSetService );
-        this.legendSetService = legendSetService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/MapViewDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/MapViewDeletionHandler.java
@@ -48,7 +48,7 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.mapping.MapViewDeletionHandler" )
+@Component
 public class MapViewDeletionHandler
     extends GenericAnalyticalObjectDeletionHandler<MapView, MappingService>
 {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/MessageConversationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/MessageConversationDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.message;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.user.User;
@@ -36,17 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.message.MessageConversationDeletionHandler" )
-public class MessageConversationDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class MessageConversationDeletionHandler extends DeletionHandler
 {
     private final MessageService messageService;
-
-    public MessageConversationDeletionHandler( MessageService messageService )
-    {
-        checkNotNull( messageService );
-        this.messageService = messageService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitDeletionHandler.java
@@ -27,9 +27,10 @@
  */
 package org.hisp.dhis.organisationunit;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -43,18 +44,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.organisationunit.OrganisationUnitDeletionHandler" )
-public class OrganisationUnitDeletionHandler
-    extends
-    DeletionHandler
+@Component
+@AllArgsConstructor
+public class OrganisationUnitDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public OrganisationUnitDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.organisationunit;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,17 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.organisationunit.OrganisationUnitGroupDeletionHandler" )
-public class OrganisationUnitGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class OrganisationUnitGroupDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public OrganisationUnitGroupDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupSetDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.organisationunit;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDeletionHandler" )
-public class OrganisationUnitGroupSetDeletionHandler
-    extends
-    DeletionHandler
+@Component
+@AllArgsConstructor
+public class OrganisationUnitGroupSetDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public OrganisationUnitGroupSetDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 
@@ -38,9 +39,8 @@ import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.expression.Expression;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -48,11 +48,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @AllArgsConstructor
-public class PredictorDeletionHandler extends DeletionHandler
+public class PredictorDeletionHandler extends JdbcDeletionHandler
 {
-    private final PredictorService predictorService;
+    private static final DeletionVeto VETO = new DeletionVeto( Predictor.class );
 
-    private final JdbcTemplate jdbcTemplate;
+    private final PredictorService predictorService;
 
     @Override
     protected void register()
@@ -110,21 +110,15 @@ public class PredictorDeletionHandler extends DeletionHandler
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        return vetoIfExists( "SELECT COUNT(*) FROM predictor where generatoroutputcombo=" + optionCombo.getId() );
+        return vetoIfExists( VETO, "SELECT COUNT(*) FROM predictor where generatoroutputcombo=:id",
+            Map.of( "id", optionCombo.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryCombo( CategoryCombo categoryCombo )
     {
-        return vetoIfExists( "SELECT COUNT(*) FROM predictor p where exists ("
+        return vetoIfExists( VETO, "SELECT COUNT(*) FROM predictor p where exists ("
             + "select 1 from categorycombos_optioncombos co"
-            + " where co.categorycomboid=" + categoryCombo.getId()
-            + " and co.categoryoptioncomboid=p.generatoroutputcombo"
-            + ")" );
-    }
-
-    private DeletionVeto vetoIfExists( String sql )
-    {
-        Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
-        return count == null || count == 0 ? ACCEPT : new DeletionVeto( Predictor.class );
+            + " where co.categorycomboid=:id and co.categoryoptioncomboid=p.generatoroutputcombo"
+            + ")", Map.of( "id", categoryCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.predictor;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Jim Grace
  */
-@Component( "org.hisp.dhis.predictor.PredictorGroupDeletionHandler" )
-public class PredictorGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class PredictorGroupDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public PredictorGroupDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramDataEntryFormDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramDataEntryFormDeletionHandler.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Set;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.dataentryform.DataEntryFormService;
@@ -39,22 +39,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.program.ProgramDataEntryFormDeletionHandler" )
-public class ProgramDataEntryFormDeletionHandler
-    extends DeletionHandler
+@AllArgsConstructor
+@Component
+public class ProgramDataEntryFormDeletionHandler extends DeletionHandler
 {
     private final DataEntryFormService dataEntryFormService;
 
     private final ProgramStageService programStageService;
-
-    public ProgramDataEntryFormDeletionHandler( DataEntryFormService dataEntryFormService,
-        ProgramStageService programStageService )
-    {
-        checkNotNull( dataEntryFormService );
-        checkNotNull( programStageService );
-        this.dataEntryFormService = dataEntryFormService;
-        this.programStageService = programStageService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramDeletionHandler.java
@@ -27,13 +27,14 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
@@ -50,9 +51,9 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.program.ProgramDeletionHandler" )
-public class ProgramDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( Program.class );
 
@@ -61,18 +62,6 @@ public class ProgramDeletionHandler
     private final IdentifiableObjectManager idObjectManager;
 
     private final CategoryService categoryService;
-
-    public ProgramDeletionHandler( ProgramService programService, IdentifiableObjectManager idObjectManager,
-        CategoryService categoryService )
-    {
-        checkNotNull( programService );
-        checkNotNull( idObjectManager );
-        checkNotNull( categoryService );
-
-        this.programService = programService;
-        this.idObjectManager = idObjectManager;
-        this.categoryService = categoryService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorDeletionHandler.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Collection;
 import java.util.HashSet;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -38,16 +38,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.program.ProgramIndicatorDeletionHandler" )
+@Component
+@AllArgsConstructor
 public class ProgramIndicatorDeletionHandler extends DeletionHandler
 {
     private final ProgramIndicatorService programIndicatorService;
-
-    public ProgramIndicatorDeletionHandler( ProgramIndicatorService programIndicatorService )
-    {
-        checkNotNull( programIndicatorService );
-        this.programIndicatorService = programIndicatorService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -35,18 +35,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Viet Nguyen
  */
-@Component( "org.hisp.dhis.program.ProgramIndicatorGroupDeletionHandler" )
-public class ProgramIndicatorGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramIndicatorGroupDeletionHandler extends DeletionHandler
 {
-
     private final ProgramIndicatorService programIndicatorService;
-
-    public ProgramIndicatorGroupDeletionHandler( ProgramIndicatorService programIndicatorService )
-    {
-        checkNotNull( programIndicatorService );
-        this.programIndicatorService = programIndicatorService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
@@ -27,39 +27,29 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Quang Nguyen
  */
-@Component( "org.hisp.dhis.program.ProgramInstanceDeletionHandler" )
-public class ProgramInstanceDeletionHandler
-    extends
-    DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramInstanceDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( ProgramInstance.class );
 
-    private final JdbcTemplate jdbcTemplate;
-
     private final ProgramInstanceService programInstanceService;
-
-    public ProgramInstanceDeletionHandler( JdbcTemplate jdbcTemplate, ProgramInstanceService programInstanceService )
-    {
-        checkNotNull( programInstanceService );
-        checkNotNull( jdbcTemplate );
-        this.programInstanceService = programInstanceService;
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -83,10 +73,8 @@ public class ProgramInstanceDeletionHandler
         {
             return ACCEPT;
         }
-
-        String sql = "SELECT COUNT(*) FROM programinstance where programid = " + program.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM programinstance where programid = :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", program.getId() ) );
     }
 
     private void deleteProgram( Program program )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramNotificationInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramNotificationInstanceDeletionHandler.java
@@ -27,10 +27,11 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
@@ -43,21 +44,13 @@ import org.springframework.stereotype.Component;
  * @author Zubair Asghar
  */
 
-@Component( "org.hisp.dhis.program.ProgramNotificationInstanceDeletionHandler" )
-public class ProgramNotificationInstanceDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramNotificationInstanceDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( ProgramNotificationInstance.class );
 
     private final ProgramNotificationInstanceService programNotificationInstanceService;
-
-    public ProgramNotificationInstanceDeletionHandler(
-        ProgramNotificationInstanceService programNotificationInstanceService )
-    {
-        checkNotNull( programNotificationInstanceService );
-
-        this.programNotificationInstanceService = programNotificationInstanceService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDataElementDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDataElementDeletionHandler.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
@@ -40,18 +40,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.program.ProgramStageDataElementDeletionHandler" )
-public class ProgramStageDataElementDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramStageDataElementDeletionHandler extends DeletionHandler
 {
     private final ProgramStageDataElementService programStageDataElementService;
-
-    public ProgramStageDataElementDeletionHandler( ProgramStageDataElementService programStageDataElementService )
-    {
-        checkNotNull( programStageDataElementService );
-
-        this.programStageDataElementService = programStageDataElementService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDeletionHandler.java
@@ -27,39 +27,28 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
-
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.program.ProgramStageDeletionHandler" )
-public class ProgramStageDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramStageDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( ProgramStage.class );
 
     private final ProgramStageService programStageService;
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public ProgramStageDeletionHandler( ProgramStageService programStageService, JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( programStageService );
-        checkNotNull( jdbcTemplate );
-        this.programStageService = programStageService;
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -95,8 +84,7 @@ public class ProgramStageDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        String sql = "SELECT COUNT(*) FROM programstagedataelement WHERE dataelementid=" + dataElement.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM programstagedataelement WHERE dataelementid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", dataElement.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
@@ -27,14 +27,13 @@
  */
 package org.hisp.dhis.program;
 
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,11 +41,9 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @AllArgsConstructor
-public class ProgramStageInstanceDeletionHandler extends DeletionHandler
+public class ProgramStageInstanceDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( ProgramStageInstance.class );
-
-    private final JdbcTemplate jdbcTemplate;
 
     private final ProgramStageInstanceService programStageInstanceService;
 
@@ -61,8 +58,9 @@ public class ProgramStageInstanceDeletionHandler extends DeletionHandler
 
     private DeletionVeto allowDeleteProgramStage( ProgramStage programStage )
     {
-        return vetoIfExists(
-            "SELECT COUNT(*) FROM programstageinstance WHERE programstageid = " + programStage.getId() );
+        return vetoIfExists( VETO,
+            "SELECT COUNT(*) FROM programstageinstance WHERE programstageid = :id",
+            Map.of( "id", programStage.getId() ) );
     }
 
     private void deleteProgramInstance( ProgramInstance programInstance )
@@ -75,20 +73,14 @@ public class ProgramStageInstanceDeletionHandler extends DeletionHandler
 
     private DeletionVeto allowDeleteProgram( Program program )
     {
-        return vetoIfExists(
-            "SELECT COUNT(*) FROM programstageinstance psi join programinstance pi on pi.programinstanceid=psi.programinstanceid where pi.programid = "
-                + program.getId() );
+        return vetoIfExists( VETO,
+            "SELECT COUNT(*) FROM programstageinstance psi join programinstance pi on pi.programinstanceid=psi.programinstanceid where pi.programid = :id",
+            Map.of( "id", program.getId() ) );
     }
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        return vetoIfExists(
-            "select count(*) from programstageinstance where eventdatavalues ? '" + dataElement.getUid() + "'" );
-    }
-
-    private DeletionVeto vetoIfExists( String sql )
-    {
-        Integer count = jdbcTemplate.queryForObject( sql, Integer.class );
-        return count == null || count == 0 ? ACCEPT : VETO;
+        return vetoIfExists( VETO, "select count(*) from programstageinstance where eventdatavalues ? :uid",
+            Map.of( "uid", dataElement.getUid() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageSectionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageSectionDeletionHandler.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -40,23 +40,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.program.ProgramStageSectionDeletionHandler" )
-public class ProgramStageSectionDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramStageSectionDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
 
     private final ProgramStageSectionService programStageSectionService;
-
-    public ProgramStageSectionDeletionHandler( IdentifiableObjectManager idObjectManager,
-        ProgramStageSectionService programStageSectionService )
-    {
-        checkNotNull( idObjectManager );
-        checkNotNull( programStageSectionService );
-
-        this.idObjectManager = idObjectManager;
-        this.programStageSectionService = programStageSectionService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/TrackedEntityDataValueAuditDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/TrackedEntityDataValueAuditDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.program;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -37,18 +37,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Zubair Asghar
  */
-@Component( "org.hisp.dhis.program.TrackedEntityDataValueAuditDeletionHandler" )
-public class TrackedEntityDataValueAuditDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class TrackedEntityDataValueAuditDeletionHandler extends DeletionHandler
 {
     private final TrackedEntityDataValueAuditService trackedEntityDataValueAuditService;
-
-    public TrackedEntityDataValueAuditDeletionHandler(
-        TrackedEntityDataValueAuditService trackedEntityDataValueAuditService )
-    {
-        checkNotNull( trackedEntityDataValueAuditService );
-        this.trackedEntityDataValueAuditService = trackedEntityDataValueAuditService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipDeletionHandler.java
@@ -31,6 +31,8 @@ import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Collection;
 
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -41,18 +43,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.relationship.RelationshipDeletionHandler" )
-public class RelationshipDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class RelationshipDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( Relationship.class );
 
     private final RelationshipService relationshipService;
-
-    public RelationshipDeletionHandler( RelationshipService relationshipService )
-    {
-        this.relationshipService = relationshipService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipTypeDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipTypeDeletionHandler.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.relationship;
 
 import java.util.Objects;
 
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -36,17 +38,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Enrico Colasante
  */
-@Component( "org.hisp.dhis.relationship.RelationshipTypeDeletionHandler" )
-public class RelationshipTypeDeletionHandler
-    extends
-    DeletionHandler
+@Component
+@AllArgsConstructor
+public class RelationshipTypeDeletionHandler extends DeletionHandler
 {
     private final RelationshipTypeService relationshipTypeService;
-
-    public RelationshipTypeDeletionHandler( RelationshipTypeService relationshipTypeService )
-    {
-        this.relationshipTypeService = relationshipTypeService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/ReservedValueDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/ReservedValueDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.reservedvalue;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.springframework.stereotype.Component;
 
-@Component( "org.hisp.dhis.reservedvalue.ReservedValueDeletionHandler" )
+@Component
+@AllArgsConstructor
 public class ReservedValueDeletionHandler extends DeletionHandler
 {
-
     private final ReservedValueService reservedValueService;
-
-    public ReservedValueDeletionHandler( ReservedValueService reservedValueService )
-    {
-        checkNotNull( reservedValueService );
-        this.reservedValueService = reservedValueService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/SequentialNumberCounterDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/reservedvalue/SequentialNumberCounterDeletionHandler.java
@@ -27,22 +27,17 @@
  */
 package org.hisp.dhis.reservedvalue;
 
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.springframework.stereotype.Component;
 
-@Component( "org.hisp.dhis.reservedvalue.SequentialNumberCounterDeletionHandler" )
-public class SequentialNumberCounterDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class SequentialNumberCounterDeletionHandler extends DeletionHandler
 {
-
     private final SequentialNumberCounterStore sequentialNumberCounterStore;
-
-    public SequentialNumberCounterDeletionHandler(
-        SequentialNumberCounterStore sequentialNumberCounterStore )
-    {
-        this.sequentialNumberCounterStore = sequentialNumberCounterStore;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/SMSCommandDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/SMSCommandDeletionHandler.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.sms.command;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -38,19 +39,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Component( "org.hisp.dhis.sms.command.SMSCommandDeletionHandler" )
-public class SMSCommandDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class SMSCommandDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( SMSCommand.class );
 
     private final SMSCommandService smsCommandService;
-
-    public SMSCommandDeletionHandler( SMSCommandService smsCommandService )
-    {
-        checkNotNull( smsCommandService );
-        this.smsCommandService = smsCommandService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/code/SMSCodesDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/code/SMSCodesDeletionHandler.java
@@ -27,29 +27,18 @@
  */
 package org.hisp.dhis.sms.command.code;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public class SMSCodesDeletionHandler
-    extends DeletionHandler
+public class SMSCodesDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( SMSCode.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public SMSCodesDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -59,8 +48,7 @@ public class SMSCodesDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        String sql = "SELECT COUNT(*) FROM smscodes where dataelementid=" + dataElement.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM smscodes where dataelementid=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", dataElement.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataElementDimensionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataElementDimensionDeletionHandler.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.trackedentity;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.query.Query;
@@ -41,16 +41,10 @@ import org.springframework.stereotype.Component;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Component
-public class TrackedEntityDataElementDimensionDeletionHandler
-    extends DeletionHandler
+@AllArgsConstructor
+public class TrackedEntityDataElementDimensionDeletionHandler extends DeletionHandler
 {
     private final SessionFactory sessionFactory;
-
-    public TrackedEntityDataElementDimensionDeletionHandler( SessionFactory sessionFactory )
-    {
-        checkNotNull( sessionFactory );
-        this.sessionFactory = sessionFactory;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceDeletionHandler.java
@@ -27,31 +27,20 @@
  */
 package org.hisp.dhis.trackedentity;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+import java.util.Map;
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.trackedentity.TrackedEntityInstanceDeletionHandler" )
-public class TrackedEntityInstanceDeletionHandler
-    extends DeletionHandler
+@Component
+public class TrackedEntityInstanceDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( TrackedEntityInstance.class );
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public TrackedEntityInstanceDeletionHandler( JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( jdbcTemplate );
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -62,16 +51,13 @@ public class TrackedEntityInstanceDeletionHandler
 
     private DeletionVeto allowDeleteOrganisationUnit( OrganisationUnit unit )
     {
-        String sql = "select count(*) from trackedentityinstance where organisationunitid = " + unit.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from trackedentityinstance where organisationunitid = :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", unit.getId() ) );
     }
 
     private DeletionVeto allowDeleteTrackedEntityType( TrackedEntityType trackedEntityType )
     {
-        String sql = "select count(*) from trackedentityinstance where trackedentitytypeid = "
-            + trackedEntityType.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "select count(*) from trackedentityinstance where trackedentitytypeid = :id";
+        return vetoIfExists( VETO, sql, Map.of( "id", trackedEntityType.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueDeletionHandler.java
@@ -27,10 +27,11 @@
  */
 package org.hisp.dhis.trackedentityattributevalue;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Collection;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
@@ -41,20 +42,14 @@ import org.springframework.stereotype.Component;
 /**
  * @author Chau Thu Tran
  */
-@Component( "org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueDeletionHandler" )
-public class TrackedEntityAttributeValueDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class TrackedEntityAttributeValueDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( TrackedEntityAttributeValue.class,
         "Some values are still assigned to this attribute" );
 
     private final TrackedEntityAttributeValueService attributeValueService;
-
-    public TrackedEntityAttributeValueDeletionHandler( TrackedEntityAttributeValueService attributeValueService )
-    {
-        checkNotNull( attributeValueService );
-        this.attributeValueService = attributeValueService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentDeletionHandler.java
@@ -38,8 +38,7 @@ import org.hisp.dhis.system.deletion.DeletionHandler;
  *
  */
 @AllArgsConstructor
-public class TrackedEntityCommentDeletionHandler
-    extends DeletionHandler
+public class TrackedEntityCommentDeletionHandler extends DeletionHandler
 {
     private final TrackedEntityCommentService commentService;
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
@@ -29,27 +29,25 @@ package org.hisp.dhis.user;
 
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.springframework.jdbc.core.JdbcTemplate;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @AllArgsConstructor
-@Component( "org.hisp.dhis.user.UserDeletionHandler" )
-public class UserDeletionHandler
-    extends DeletionHandler
+@Component
+public class UserDeletionHandler extends JdbcDeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    private final JdbcTemplate jdbcTemplate;
 
     private static final DeletionVeto VETO = new DeletionVeto( User.class );
 
@@ -107,8 +105,7 @@ public class UserDeletionHandler
 
     private DeletionVeto allowDeleteFileResource( FileResource fileResource )
     {
-        String sql = "SELECT COUNT(*) FROM userinfo where avatar=" + fileResource.getId();
-
-        return jdbcTemplate.queryForObject( sql, Integer.class ) == 0 ? ACCEPT : VETO;
+        String sql = "SELECT COUNT(*) FROM userinfo where avatar=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserGroupDeletionHandler.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.user;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Set;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -38,22 +38,13 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.user.UserGroupDeletionHandler" )
-public class UserGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class UserGroupDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
 
     private final CurrentUserService currentUserService;
-
-    public UserGroupDeletionHandler( IdentifiableObjectManager idObjectManager, CurrentUserService currentUserService )
-    {
-        checkNotNull( idObjectManager );
-        checkNotNull( currentUserService );
-
-        this.idObjectManager = idObjectManager;
-        this.currentUserService = currentUserService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.user;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -35,18 +35,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.user.UserRoleDeletionHandler" )
-public class UserRoleDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class UserRoleDeletionHandler extends DeletionHandler
 {
     private final UserService userService;
-
-    public UserRoleDeletionHandler( UserService userService )
-    {
-        checkNotNull( userService );
-
-        this.userService = userService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserSettingDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserSettingDeletionHandler.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.user;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Iterator;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -37,18 +37,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.user.UserSettingDeletionHandler" )
-public class UserSettingDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class UserSettingDeletionHandler extends DeletionHandler
 {
     private final UserSettingService userSettingService;
-
-    public UserSettingDeletionHandler( UserSettingService userSettingService )
-    {
-        checkNotNull( userSettingService );
-
-        this.userSettingService = userSettingService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/userdatastore/UserDatastoreDeletionHandler.java
@@ -27,19 +27,15 @@
  */
 package org.hisp.dhis.userdatastore;
 
-import lombok.AllArgsConstructor;
+import java.util.Map;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.hisp.dhis.user.User;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-public class UserDatastoreDeletionHandler extends DeletionHandler
+public class UserDatastoreDeletionHandler extends JdbcDeletionHandler
 {
-    private final JdbcTemplate jdbcTemplate;
-
     @Override
     protected void register()
     {
@@ -48,6 +44,6 @@ public class UserDatastoreDeletionHandler extends DeletionHandler
 
     private void deleteUser( User user )
     {
-        jdbcTemplate.execute( "DELETE FROM userkeyjsonvalue WHERE userid = " + user.getId() );
+        delete( "DELETE FROM userkeyjsonvalue WHERE userid = :id", Map.of( "id", user.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleDeletionHandler.java
@@ -27,10 +27,10 @@
  */
 package org.hisp.dhis.programrule;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -44,22 +44,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author markusbekken
  */
-@Component( "org.hisp.dhis.programrule.ProgramRuleDeletionHandler" )
-public class ProgramRuleDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramRuleDeletionHandler extends DeletionHandler
 {
-    // -------------------------------------------------------------------------
-    // Dependencies
-    // -------------------------------------------------------------------------
-
     private final ProgramRuleService programRuleService;
-
-    public ProgramRuleDeletionHandler( ProgramRuleService programRuleService )
-    {
-        checkNotNull( programRuleService );
-
-        this.programRuleService = programRuleService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariableDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/ProgramRuleVariableDeletionHandler.java
@@ -27,11 +27,12 @@
  */
 package org.hisp.dhis.programrule;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -44,17 +45,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author markusbekken
  */
-@Component( "org.hisp.dhis.programrule.ProgramRuleVariableDeletionHandler" )
-public class ProgramRuleVariableDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ProgramRuleVariableDeletionHandler extends DeletionHandler
 {
     private final ProgramRuleVariableService programRuleVariableService;
-
-    public ProgramRuleVariableDeletionHandler( ProgramRuleVariableService programRuleVariableService )
-    {
-        checkNotNull( programRuleVariableService );
-        this.programRuleVariableService = programRuleVariableService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/DashboardDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/DashboardDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.dashboard;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
@@ -35,16 +35,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Component( "org.hisp.dhis.dashboard.DashboardDeletionHandler" )
+@Component
+@AllArgsConstructor
 public class DashboardDeletionHandler extends DeletionHandler
 {
     private final DashboardService dashboardService;
-
-    public DashboardDeletionHandler( DashboardService dashboardService )
-    {
-        checkNotNull( dashboardService );
-        this.dashboardService = dashboardService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/DashboardItemDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/dashboard/DashboardItemDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.dashboard;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.document.Document;
 import org.hisp.dhis.eventchart.EventChart;
@@ -43,16 +43,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Component( "org.hisp.dhis.dashboard.DashboardItemDeletionHandler" )
+@Component
+@AllArgsConstructor
 public class DashboardItemDeletionHandler extends DeletionHandler
 {
     private final DashboardService dashboardService;
-
-    public DashboardItemDeletionHandler( DashboardService dashboardService )
-    {
-        checkNotNull( dashboardService );
-        this.dashboardService = dashboardService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/document/DocumentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/document/DocumentDeletionHandler.java
@@ -27,37 +27,29 @@
  */
 package org.hisp.dhis.document;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceStorageStatus;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
 import org.hisp.dhis.user.User;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
  */
-@Component( "org.hisp.dhis.document.DocumentDeletionHandler" )
-public class DocumentDeletionHandler extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class DocumentDeletionHandler extends JdbcDeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( Document.class );
 
     private final DocumentService documentService;
-
-    private final JdbcTemplate jdbcTemplate;
-
-    public DocumentDeletionHandler( DocumentService documentService, JdbcTemplate jdbcTemplate )
-    {
-        checkNotNull( documentService );
-        checkNotNull( jdbcTemplate );
-
-        this.documentService = documentService;
-        this.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     protected void register()
@@ -74,17 +66,16 @@ public class DocumentDeletionHandler extends DeletionHandler
 
     private DeletionVeto allowDeleteFileResource( FileResource fileResource )
     {
-        String sql = "SELECT COUNT(*) FROM document WHERE fileresource=" + fileResource.getId();
-
-        int result = jdbcTemplate.queryForObject( sql, Integer.class );
-
-        return result == 0 || fileResource.getStorageStatus() != FileResourceStorageStatus.STORED ? ACCEPT : VETO;
+        if ( fileResource.getStorageStatus() != FileResourceStorageStatus.STORED )
+        {
+            return ACCEPT;
+        }
+        String sql = "SELECT COUNT(*) FROM document WHERE fileresource=:id";
+        return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 
     private void deleteFileResource( FileResource fileResource )
     {
-        String sql = "DELETE FROM document WHERE fileresource=" + fileResource.getId();
-
-        jdbcTemplate.execute( sql );
+        delete( "DELETE FROM document WHERE fileresource=:id", Map.of( "id", fileResource.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/orgunitprofile/impl/OrgUnitProfileDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/orgunitprofile/impl/OrgUnitProfileDeletionHandler.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.orgunitprofile.impl;
 
+import lombok.AllArgsConstructor;
+
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.dataelement.DataElement;
@@ -39,16 +41,11 @@ import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.springframework.stereotype.Component;
 
-@Component( "org.hisp.dhis.orgunitprofile.impl.OrgUnitProfileDeletionHandler" )
-public class OrgUnitProfileDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class OrgUnitProfileDeletionHandler extends DeletionHandler
 {
     private OrgUnitProfileService orgUnitProfileService;
-
-    public OrgUnitProfileDeletionHandler( OrgUnitProfileService orgUnitProfileService )
-    {
-        this.orgUnitProfileService = orgUnitProfileService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/report/ReportDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/report/ReportDeletionHandler.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.report;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
@@ -38,17 +39,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.report.ReportDeletionHandler" )
-public class ReportDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ReportDeletionHandler extends DeletionHandler
 {
     private final ReportService reportService;
-
-    public ReportDeletionHandler( ReportService reportService )
-    {
-        checkNotNull( reportService );
-        this.reportService = reportService;
-    }
 
     @Override
     protected void register()
@@ -65,7 +60,6 @@ public class ReportDeletionHandler
                 return new DeletionVeto( Visualization.class, report.getName() );
             }
         }
-
         return ACCEPT;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/MinMaxDataElementDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/minmax/MinMaxDataElementDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.minmax;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
@@ -38,18 +38,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.minmax.MinMaxDataElementDeletionHandler" )
-public class MinMaxDataElementDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class MinMaxDataElementDeletionHandler extends DeletionHandler
 {
     private final MinMaxDataElementService minMaxDataElementService;
-
-    public MinMaxDataElementDeletionHandler( MinMaxDataElementService minMaxDataElementService )
-    {
-        checkNotNull( minMaxDataElementService );
-
-        this.minMaxDataElementService = minMaxDataElementService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/ValidationResultDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/ValidationResultDeletionHandler.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.validation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -41,19 +42,13 @@ import org.springframework.stereotype.Component;
  *
  * @author Stian Sandvold
  */
-@Component( "org.hisp.dhis.validation.ValidationResultDeletionHandler" )
-public class ValidationResultDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ValidationResultDeletionHandler extends DeletionHandler
 {
     private static final DeletionVeto VETO = new DeletionVeto( ValidationResult.class );
 
     private final ValidationResultService validationResultService;
-
-    public ValidationResultDeletionHandler( ValidationResultService validationResultService )
-    {
-        checkNotNull( validationResultService );
-        this.validationResultService = validationResultService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/ValidationRuleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/ValidationRuleDeletionHandler.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.validation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Iterator;
+
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.expression.Expression;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -38,17 +38,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.validation.ValidationRuleDeletionHandler" )
-public class ValidationRuleDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ValidationRuleDeletionHandler extends DeletionHandler
 {
     private final ValidationRuleService validationRuleService;
-
-    public ValidationRuleDeletionHandler( ValidationRuleService validationRuleService )
-    {
-        checkNotNull( validationRuleService );
-        this.validationRuleService = validationRuleService;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/ValidationRuleGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/ValidationRuleGroupDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.validation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -36,18 +36,11 @@ import org.springframework.stereotype.Component;
 /**
  * @author Lars Helge Overland
  */
-@Component( "org.hisp.dhis.validation.ValidationRuleGroupDeletionHandler" )
-public class ValidationRuleGroupDeletionHandler
-    extends DeletionHandler
+@Component
+@AllArgsConstructor
+public class ValidationRuleGroupDeletionHandler extends DeletionHandler
 {
     private final IdentifiableObjectManager idObjectManager;
-
-    public ValidationRuleGroupDeletionHandler( IdentifiableObjectManager idObjectManager )
-    {
-        checkNotNull( idObjectManager );
-
-        this.idObjectManager = idObjectManager;
-    }
 
     @Override
     protected void register()

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionHandler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DeletionHandler.java
@@ -44,7 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * override the allowDeleteDataElement() method and return a non-null String
  * value if there exists objects that are dependent on the DataElement and are
  * considered not be deleted. The return value could be a hint for which object
- * is denying the delete, like the name.
+ * is denying the deletion, like the name.
  *
  * @author Lars Helge Overland
  */
@@ -81,4 +81,5 @@ public abstract class DeletionHandler
     }
 
     protected abstract void register();
+
 }


### PR DESCRIPTION
Goal is to not use string concatenation to insert IDs into the SQL used by the deletion handlers.
While these are not user input and also numeric they cannot be exploited for an SQL attack but they still get flagged by static analysis tools.