### PR TITLE
fix: UserRoleDeletionHandler DHIS2-13336

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.user;
 
+import java.util.HashSet;
+
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
@@ -49,10 +51,12 @@ public class UserRoleDeletionHandler extends DeletionHandler
 
     private void deleteUser( User user )
     {
-        for ( UserRole group : user.getUserRoles() )
+        for ( UserRole role : user.getUserRoles() )
         {
-            group.getMembers().remove( user );
-            userService.updateUserRole( group );
+            role.getMembers().remove( user );
+            userService.updateUserRole( role );
         }
+
+        user.setUserRoles( new HashSet<>() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
-import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
-
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -54,7 +51,6 @@ import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.system.util.ValidationUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupService;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
@@ -255,20 +251,6 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
             handleNoAccessRoles( user, bundle, userRoles );
 
             sessionFactory.getCurrentSession().update( user );
-        }
-    }
-
-    @Override
-    public void preDelete( User user, ObjectBundle bundle )
-    {
-        Set<UserGroup> groups = user.getGroups();
-        userGroupService.removeUserFromGroups( user, getUids( groups ) );
-
-        Set<UserRole> userRoles = user.getUserRoles();
-        for ( UserRole userRole : new ArrayList<>( userRoles ) )
-        {
-            userRole.removeUser( user );
-            sessionFactory.getCurrentSession().update( userRole );
         }
     }
 


### PR DESCRIPTION
@larshelge I quite agree with [your comment](https://github.com/dhis2/dhis2-core/pull/10900#issuecomment-1141995568) on the first PR for [DHIS2-13336](https://jira.dhis2.org/browse/DHIS2-13336). For consistency with the rest of the code base this is better done in the deletion handler. In fact the logic is already there in `UserRoleDeletionHandler`.

What apparently happened is that the `UserRoleDeletionHandler` logic was broken by another code refactor. Instead of fixing it, `UserObjectBundleHook#preDelete` was added to remove the user roles before deletion. However this logic was flawed because it tried to remove a Set member while iterating through the Set. My [first PR for the ticket](https://github.com/dhis2/dhis2-core/pull/10900) fixed this flaw.

But the original cause of the problem seems to be that `UserRoleDeletionHandler` had removed the user from the roles, but had not removed the roles from the user. Presumably because of the user refactor, this logic no longer worked and the attempt at deleting the user resulted in a foreign key violation between the user and the user role. (Did Hibernate re-persist the connections to roles that were still attached in Java to the User object???)

In this PR, I have cleared the user roles from the user (after removing the user from the roles). When deleting a user with one or more roles, `UserRoleDeletionHandler` now works again, as I have tested. I have also deleted the unneeded `UserObjectBundleHook#preDelete`.