### PR TITLE
test: use assertNoImportErrors for better context

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -31,7 +31,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
@@ -47,8 +46,16 @@ public class Assertions
 
     private static Supplier<String> errorMessage( TrackerImportReport report )
     {
-        return () -> report.getValidationReport().getErrors().stream()
-            .map( e -> e.getErrorCode() + ": " + e.getMessage() )
-            .collect( Collectors.joining( "\n" ) );
+        return () -> {
+            StringBuilder msg = new StringBuilder( "Expected import with status OK, instead got:\n" );
+            report.getValidationReport().getErrors()
+                .forEach( e -> {
+                    msg.append( e.getErrorCode() );
+                    msg.append( ": " );
+                    msg.append( e.getMessage() );
+                    msg.append( '\n' );
+                } );
+            return msg.toString();
+        };
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.tracker.report.TrackerImportReport;
+import org.hisp.dhis.tracker.report.TrackerStatus;
+
+public class Assertions
+{
+
+    public static void assertNoImportErrors( TrackerImportReport report )
+    {
+        assertNotNull( report );
+        assertEquals( TrackerStatus.OK, report.getStatus(), errorMessage( report ) );
+    }
+
+    private static Supplier<String> errorMessage( TrackerImportReport report )
+    {
+        return () -> report.getValidationReport().getErrors().stream()
+            .map( e -> e.getErrorCode() + ": " + e.getMessage() )
+            .collect( Collectors.joining( "\n" ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -69,8 +69,8 @@ class EventExporterTest extends TrackerTest
     {
         setUpMetadata( "tracker/simple_metadata.json" );
         userA = userService.getUser( "M5zQapPyTZI" );
-        TrackerImportParams enrollmentParams = fromJson( "tracker/event_and_enrollment.json", userA.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/event_and_enrollment.json", userA.getUid() ) ) );
         orgUnit = manager.get( OrganisationUnit.class, "h4w96yEMlzO" );
         manager.flush();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerTest.java
@@ -27,14 +27,11 @@
  */
 package org.hisp.dhis.tracker;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -50,8 +47,6 @@ import org.hisp.dhis.dxf2.metadata.objectbundle.feedback.ObjectBundleValidationR
 import org.hisp.dhis.importexport.ImportStrategy;
 import org.hisp.dhis.render.RenderFormat;
 import org.hisp.dhis.render.RenderService;
-import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -168,17 +163,5 @@ public abstract class TrackerTest extends SingleSetupIntegrationTestBase
     {
         return renderService.fromJson( new ClassPathResource( path ).getInputStream(),
             TrackerImportParams.class );
-    }
-
-    protected void assertNoImportErrors( TrackerImportReport report )
-    {
-        assertEquals( TrackerStatus.OK, report.getStatus(), logTrackerErrors( report ) );
-    }
-
-    private Supplier<String> logTrackerErrors( TrackerImportReport trackerImportReport )
-    {
-        return () -> trackerImportReport.getValidationReport().getErrors().stream()
-            .map( e -> e.getErrorCode() + ": " + e.getMessage() )
-            .collect( Collectors.joining( "\n" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.bundle;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
-import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -44,6 +43,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.user.User;
@@ -84,8 +84,9 @@ class EventDataValueTest extends TrackerTest
     void successWhenEventHasNoProgramAndHasProgramStage()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/validations/events-with_no_program.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/validations/events-with_no_program.json" ) );
+
         assertNoImportErrors( trackerImportReport );
     }
 
@@ -93,8 +94,9 @@ class EventDataValueTest extends TrackerTest
     void testEventDataValue()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/event_with_data_values.json" ) );
+
         assertNoImportErrors( trackerImportReport );
         List<ProgramStageInstance> events = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, events.size() );
@@ -107,8 +109,9 @@ class EventDataValueTest extends TrackerTest
     void testTrackedEntityProgramAttributeValueUpdate()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/event_with_data_values.json" ) );
+
         assertNoImportErrors( trackerImportReport );
         List<ProgramStageInstance> events = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, events.size() );
@@ -116,12 +119,12 @@ class EventDataValueTest extends TrackerTest
         Set<EventDataValue> eventDataValues = psi.getEventDataValues();
         assertEquals( 4, eventDataValues.size() );
         // update
-        trackerImportParams = fromJson( "tracker/event_with_updated_data_values.json" );
+        TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_updated_data_values.json" );
         // make sure that the uid property is populated as well - otherwise
         // update will
         // not work
         trackerImportParams.getEvents().get( 0 ).setEvent( trackerImportParams.getEvents().get( 0 ).getEvent() );
-        trackerImportParams.setImportStrategy( CREATE_AND_UPDATE );
+        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
         assertNoImportErrors( trackerImportReport );
         List<ProgramStageInstance> updatedEvents = manager.getAll( ProgramStageInstance.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.tracker.bundle;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -42,10 +44,8 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
-import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,7 +86,7 @@ class EventDataValueTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/events-with_no_program.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -95,7 +95,7 @@ class EventDataValueTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         List<ProgramStageInstance> events = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, events.size() );
         ProgramStageInstance psi = events.get( 0 );
@@ -109,7 +109,7 @@ class EventDataValueTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         List<ProgramStageInstance> events = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, events.size() );
         ProgramStageInstance psi = events.get( 0 );
@@ -121,9 +121,9 @@ class EventDataValueTest extends TrackerTest
         // update will
         // not work
         trackerImportParams.getEvents().get( 0 ).setEvent( trackerImportParams.getEvents().get( 0 ).getEvent() );
-        trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
+        trackerImportParams.setImportStrategy( CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         List<ProgramStageInstance> updatedEvents = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, updatedEvents.size() );
         ProgramStageInstance updatedPsi = programStageInstanceService

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
@@ -72,8 +72,7 @@ class LastUpdateImportTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/single_tei.json" );
         assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
         trackedEntity = trackerImportParams.getTrackedEntities().get( 0 );
-        TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json" );
-        assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
+        assertNoImportErrors( trackerImportService.importTracker( fromJson( "tracker/single_enrollment.json" ) ) );
         manager.flush();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -47,7 +47,6 @@ import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -124,7 +123,7 @@ class LastUpdateImportTest extends TrackerTest
         enrollment.setStatus( EnrollmentStatus.COMPLETED );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.UPDATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         manager.clear();
         assertTrue( manager.get( TrackedEntityInstance.class, trackedEntity.getTrackedEntity() ).getLastUpdated()
             .getTime() > lastUpdateBefore.getTime() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
@@ -88,10 +88,10 @@ class OwnershipTest extends TrackerTest
         injectSecurityContext( superUser );
 
         nonSuperUser = userService.getUser( "Tu9fv8ezgHl" );
-        TrackerImportParams teiParams = fromJson( "tracker/ownership_tei.json", superUser.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( teiParams ) );
-        TrackerImportParams enrollmentParams = fromJson( "tracker/ownership_enrollment.json", superUser.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/ownership_tei.json", superUser.getUid() ) ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/ownership_enrollment.json", superUser.getUid() ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/RelationshipImportTest.java
@@ -64,12 +64,12 @@ class RelationshipImportTest extends TrackerTest
     {
         setUpMetadata( "tracker/simple_metadata.json" );
         userA = userService.getUser( "M5zQapPyTZI" );
-        TrackerImportParams teiParams = fromJson( "tracker/single_tei.json", userA.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( teiParams ) );
-        TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json", userA.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
-        TrackerImportParams eventParams = fromJson( "tracker/single_event.json", userA.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( eventParams ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/single_tei.json", userA.getUid() ) ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/single_enrollment.json", userA.getUid() ) ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/single_event.json", userA.getUid() ) ) );
         manager.flush();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/RelationshipImportTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.bundle;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 
 import java.io.IOException;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -89,7 +90,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         assertEquals( 9, params.getTrackedEntities().size() );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         assertDeletedObjects( 9, trackerImportReport.getBundleReport(), TrackerType.TRACKED_ENTITY );
         // remaining
         assertEquals( 4, manager.getAll( TrackedEntityInstance.class ).size() );
@@ -106,7 +107,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         params.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.ENROLLMENT );
         // remaining
@@ -124,7 +125,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.EVENT );
         // remaining
         assertEquals( 1, manager.getAll( ProgramStageInstance.class ).size() );
@@ -154,7 +155,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.ENROLLMENT );
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.TRACKED_ENTITY );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -72,9 +72,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportTeiReport );
-        assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
-        assertTrue( trackerImportTeiReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportTeiReport );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getIgnored() );
@@ -96,9 +94,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportTeiReport );
-        assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
-        assertTrue( trackerImportTeiReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportTeiReport );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 1, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getIgnored() );
@@ -145,9 +141,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportEnrollmentReport );
-        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -169,20 +163,19 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportEnrollmentReport );
-        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getDeleted() );
+
         params = fromJson( "tracker/single_enrollment.json" );
         params.setUserId( userA.getUid() );
         params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
+
         trackerImportEnrollmentReport = trackerImportService.importTracker( params );
-        assertNotNull( trackerImportEnrollmentReport );
-        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
+
+        assertNoImportErrors( trackerImportEnrollmentReport );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -209,9 +202,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportEnrollmentReport );
-        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
-        assertTrue( trackerImportEnrollmentReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -268,9 +259,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportEventReport );
-        assertEquals( TrackerStatus.OK, trackerImportEventReport.getStatus() );
-        assertTrue( trackerImportEventReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportEventReport );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEventReport.getStats().getIgnored() );
@@ -303,9 +292,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportEventReport );
-        assertEquals( TrackerStatus.OK, trackerImportEventReport.getStatus() );
-        assertTrue( trackerImportEventReport.getValidationReport().getErrors().isEmpty() );
+        assertNoImportErrors( trackerImportEventReport );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEventReport.getStats().getIgnored() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
@@ -93,8 +93,8 @@ class TrackedEntityAttributeTest extends TrackerTest
     void testTrackedAttributeValueBundleImporter()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/te_with_tea_data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/te_with_tea_data.json" ) );
         assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -46,7 +47,6 @@ import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -95,7 +95,7 @@ class TrackedEntityAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -46,7 +47,6 @@ import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -103,7 +103,7 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         List<TrackedEntityAttributeValue> attributeValues1 = trackedEntityAttributeValueService
             .getTrackedEntityAttributeValues( manager.getAll( TrackedEntityInstance.class ).get( 0 ) );
         List<TrackedEntityAttribute> attributes1 = attributeValues1.stream()
@@ -111,7 +111,7 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_null_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         List<TrackedEntityAttributeValueAudit> attributeValueAudits = attributeValueAuditService
             .getTrackedEntityAttributeValueAudits( attributes1, trackedEntityInstances, AuditType.DELETE );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
@@ -80,8 +80,8 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
     void testTrackedEntityAttributeValueAuditCreate()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/te_program_with_tea_data.json" ) ) );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -41,7 +41,6 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
-import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.junit.jupiter.api.Test;
@@ -79,17 +78,12 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
     void testTrackedEntityDataValueAuditCreate()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/event_and_enrollment_with_data_values.json" );
-
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
-
-        trackerImportParams = fromJson( "tracker/event_with_data_values_for_update_audit.json" );
-
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
-
-        trackerImportParams = fromJson( "tracker/event_with_data_values_for_delete_audit.json" );
-
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/event_and_enrollment_with_data_values.json" ) ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/event_with_data_values_for_update_audit.json" ) ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/event_with_data_values_for_delete_audit.json" ) ) );
 
         DataElement dataElement = manager.search( DataElement.class, DE );
         ProgramStageInstance psi = manager.search( ProgramStageInstance.class, PSI );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeEncryptionTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeEncryptionTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeEncryptionTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeEncryptionTest.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
@@ -77,8 +76,8 @@ class TrackedEntityProgramAttributeEncryptionTest extends TrackerTest
     void testTrackedEntityProgramAttributeEncryptedValue()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_encryption_data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/te_program_with_tea_encryption_data.json" ) );
         assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -46,7 +47,6 @@ import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -88,7 +88,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends TrackerTest
         assertFalse( fileResource.isAssigned() );
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_fileresource_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -43,7 +43,6 @@ import org.hisp.dhis.fileresource.FileResourceService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
@@ -86,8 +85,8 @@ class TrackedEntityProgramAttributeFileResourceTest extends TrackerTest
         File file = File.createTempFile( "file-resource", "test" );
         fileResourceService.saveFileResource( fileResource, file );
         assertFalse( fileResource.isAssigned() );
-        TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_fileresource_data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/te_program_with_tea_fileresource_data.json" ) );
         assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -41,7 +42,6 @@ import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -74,7 +74,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -90,7 +90,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -103,7 +103,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_update_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -118,7 +118,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -131,7 +131,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_update_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -143,7 +143,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_delete_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.DELETE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 0, trackedEntityInstances.size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerEventBundleServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -39,7 +40,6 @@ import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -69,7 +69,7 @@ class TrackerEventBundleServiceTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_events_and_enrollment.json" );
         assertEquals( 8, trackerImportParams.getEvents().size() );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<ProgramStageInstance> programStageInstances = programStageInstanceStore.getAll();
         assertEquals( 8, programStageInstances.size() );
@@ -82,11 +82,11 @@ class TrackerEventBundleServiceTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_events_and_enrollment.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         assertEquals( 8, programStageInstanceStore.getAll().size() );
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         assertEquals( 8, programStageInstanceStore.getAll().size() );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationTemplateStore;
-import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
@@ -72,10 +71,8 @@ class TrackerSideEffectHandlerServiceTest extends TrackerTest
     void testRuleEngineSideEffectHandlerService()
         throws IOException
     {
-        TrackerImportParams trackerImportParams = fromJson(
-            "tracker/enrollment_data_with_program_rule_side_effects.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/enrollment_data_with_program_rule_side_effects.json" ) );
         assertNoImportErrors( trackerImportReport );
 
         List<ProgramNotificationInstance> instances = manager.getAll( ProgramNotificationInstance.class );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -40,7 +41,6 @@ import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,7 +76,7 @@ class TrackerSideEffectHandlerServiceTest extends TrackerTest
             "tracker/enrollment_data_with_program_rule_side_effects.json" );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         List<ProgramNotificationInstance> instances = manager.getAll( ProgramNotificationInstance.class );
         assertFalse( instances.isEmpty() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/params/AtomicModeIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/params/AtomicModeIntegrationTest.java
@@ -67,6 +67,7 @@ class AtomicModeIntegrationTest extends TrackerTest
         params.setAtomicMode( AtomicMode.OBJECT );
 
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
+
         assertNotNull( trackerImportTeiReport );
         assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
         assertEquals( 1, trackerImportTeiReport.getValidationReport().getErrors().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.tracker.programrule;
 
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.List;
@@ -52,7 +52,6 @@ import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerWarningReport;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -135,8 +134,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportReport );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         assertEquals( 1, trackerImportReport.getValidationReport().getWarnings().size() );
     }
 
@@ -148,15 +146,13 @@ class ProgramRuleIntegrationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/single_tei.json" );
 
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
-        assertNotNull( trackerImportTeiReport );
-        assertEquals( TrackerStatus.OK, trackerImportTeiReport.getStatus() );
+        assertNoImportErrors( trackerImportTeiReport );
 
         TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json" );
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( enrollmentParams );
 
-        assertNotNull( trackerImportEnrollmentReport );
-        assertEquals( TrackerStatus.OK, trackerImportEnrollmentReport.getStatus() );
+        assertNoImportErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getWarnings().size() );
     }
 
@@ -168,8 +164,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportReport );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         List<TrackerWarningReport> warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 4, warningReports.size() );
         assertEquals( 3,
@@ -182,8 +177,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportReport );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 3, warningReports.size() );
         assertEquals( TrackerErrorCode.E1308, warningReports.get( 0 ).getWarningCode() );
@@ -196,8 +190,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNotNull( trackerImportReport );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 3, warningReports.size() );
         assertEquals( TrackerErrorCode.E1308, warningReports.get( 0 ).getWarningCode() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -129,10 +129,8 @@ class ProgramRuleIntegrationTest extends TrackerTest
     void testImportProgramEventSuccessWithWarningRaised()
         throws IOException
     {
-
-        TrackerImportParams params = fromJson( "tracker/program_event.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/program_event.json" ) );
 
         assertNoImportErrors( trackerImportReport );
         assertEquals( 1, trackerImportReport.getValidationReport().getWarnings().size() );
@@ -142,15 +140,12 @@ class ProgramRuleIntegrationTest extends TrackerTest
     void testImportEnrollmentSuccessWithWarningRaised()
         throws IOException
     {
-
-        TrackerImportParams params = fromJson( "tracker/single_tei.json" );
-
-        TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
+        TrackerImportReport trackerImportTeiReport = trackerImportService
+            .importTracker( fromJson( "tracker/single_tei.json" ) );
         assertNoImportErrors( trackerImportTeiReport );
 
-        TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json" );
-
-        TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( enrollmentParams );
+        TrackerImportReport trackerImportEnrollmentReport = trackerImportService
+            .importTracker( fromJson( "tracker/single_enrollment.json" ) );
 
         assertNoImportErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getWarnings().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
@@ -62,9 +62,8 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata_mandatory_attr.json" );
         injectAdminUser();
-        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data_2.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/validations/enrollments_te_te-data_2.json" ) ) );
         manager.flush();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
@@ -31,19 +31,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.tracker.TrackerImportParams;
 import org.hisp.dhis.tracker.TrackerImportService;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -66,13 +64,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
         injectAdminUser();
         TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data_2.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        List<TrackerErrorReport> errors = trackerImportReport.getValidationReport().getErrors();
-        errors.forEach( error -> {
-            System.out.println( error.getErrorCode() + ": " + error.getMessage() );
-        } );
-
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         manager.flush();
     }
 
@@ -163,8 +155,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         manager.flush();
         manager.clear();
         params = fromJson( "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
@@ -185,8 +176,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         manager.flush();
         manager.clear();
         params = fromJson( "tracker/validations/enrollments_te_unique_attr.json" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -77,8 +77,8 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data.json" );
-        assertNoImportErrors( trackerImportService.importTracker( trackerBundleParams ) );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/validations/enrollments_te_te-data.json" ) ) );
         manager.flush();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,7 +51,6 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.TrackerPreheatService;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
@@ -88,8 +88,7 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -98,8 +97,7 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         TrackerImportParams secondParams = fromJson(
             "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerPreheat preheat = trackerPreheatService.preheat( secondParams );
@@ -163,8 +161,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_attr-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         manager.flush();
         importProgramStageInstances();
         manager.flush();
@@ -186,8 +183,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/events-with-registration.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -215,8 +211,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams paramsCreate = fromJson(
             "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( paramsCreate );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         manager.flush();
         manager.clear();
@@ -226,8 +221,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
-        assertEquals( 0, trackerImportReportDelete.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReportDelete.getStatus() );
+        assertNoImportErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -170,9 +170,8 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoImportErrors(
+            trackerImportService.importTracker( fromJson( "tracker/validations/enrollments_te_te-data.json" ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -56,7 +57,6 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -172,8 +172,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         injectAdminUser();
         TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/enrollments_te_te-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -91,24 +91,20 @@ class EventImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        TrackerImportParams trackerImportParams = fromJson(
-            "tracker/validations/enrollments_te_te-data.json" );
 
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
-        trackerImportParams = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
-
-        trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoImportErrors( trackerImportService.importTracker( fromJson(
+            "tracker/validations/enrollments_te_te-data.json" ) ) );
+        assertNoImportErrors( trackerImportService
+            .importTracker( fromJson( "tracker/validations/enrollments_te_enrollments-data.json" ) ) );
     }
 
     @Test
     void failValidationWhenTrackedEntityAttributeHasWrongOptionValue()
         throws IOException
     {
-        TrackerImportParams params = fromJson(
-            "tracker/validations/events-with_invalid_option_value.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events-with_invalid_option_value.json" ) );
+
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
@@ -118,17 +114,18 @@ class EventImportValidationTest extends TrackerTest
     void successWhenTrackedEntityAttributeHasValidOptionValue()
         throws IOException
     {
-        TrackerImportParams params = fromJson( "tracker/validations/events-with_valid_option_value.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/validations/events-with_valid_option_value.json" ) );
+
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
     void testEventValidationOkAll()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/events-with-registration.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService
+            .importTracker( fromJson( "tracker/validations/events-with-registration.json" ) );
 
         assertNoImportErrors( trackerImportReport );
     }
@@ -137,10 +134,8 @@ class EventImportValidationTest extends TrackerTest
     void testEventValidationOkWithoutAttributeOptionCombo()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events-without-attribute-option-combo.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events-without-attribute-option-combo.json" ) );
 
         assertNoImportErrors( trackerImportReport );
     }
@@ -222,10 +217,8 @@ class EventImportValidationTest extends TrackerTest
     void testEventProgramHasNonDefaultCategoryCombo()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_non-default-combo.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_non-default-combo.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -236,10 +229,8 @@ class EventImportValidationTest extends TrackerTest
     void testCategoryOptionComboNotFound()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_cant-find-cat-opt-combo.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_cant-find-cat-opt-combo.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -250,10 +241,8 @@ class EventImportValidationTest extends TrackerTest
     void testCategoryOptionComboNotFoundGivenSubsetOfCategoryOptions()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_cant-find-aoc-with-subset-of-cos.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_cant-find-aoc-with-subset-of-cos.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -264,10 +253,8 @@ class EventImportValidationTest extends TrackerTest
     void testCOFoundButAOCNotFound()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_cant-find-aoc-but-co-exists.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_cant-find-aoc-but-co-exists.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -278,10 +265,8 @@ class EventImportValidationTest extends TrackerTest
     void testCategoryOptionsNotFound()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_cant-find-cat-option.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_cant-find-cat-option.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -292,10 +277,8 @@ class EventImportValidationTest extends TrackerTest
     void testAttributeCategoryOptionNotInProgramCC()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events-aoc-not-in-program-cc.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events-aoc-not-in-program-cc.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -306,10 +289,8 @@ class EventImportValidationTest extends TrackerTest
     void testAttributeCategoryOptionAndCODoNotMatch()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events-aoc-and-co-dont-match.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events-aoc-and-co-dont-match.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -320,10 +301,8 @@ class EventImportValidationTest extends TrackerTest
     void testAttributeCategoryOptionCannotBeFoundForEventProgramCCAndGivenCategoryOption()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json" ) );
 
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
@@ -334,10 +313,8 @@ class EventImportValidationTest extends TrackerTest
     void testWrongDatesInCatCombo()
         throws IOException
     {
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/events_combo-date-wrong.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
+            "tracker/validations/events_combo-date-wrong.json" ) );
 
         assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -33,7 +33,9 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
+import static org.hisp.dhis.tracker.TrackerImportStrategy.DELETE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.UPDATE;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.validation.Users.USER_6;
@@ -64,7 +66,6 @@ import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
@@ -94,13 +95,11 @@ class EventImportValidationTest extends TrackerTest
             "tracker/validations/enrollments_te_te-data.json" );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         trackerImportParams = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -131,8 +130,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportParams trackerBundleParams = fromJson( "tracker/validations/events-with-registration.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -144,8 +142,7 @@ class EventImportValidationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -157,14 +154,12 @@ class EventImportValidationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
 
         trackerBundleParams.setImportStrategy( UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -437,19 +432,17 @@ class EventImportValidationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
 
         manager.flush();
         manager.clear();
 
         TrackerImportParams paramsDelete = fromJson(
             "tracker/validations/event-data-delete.json" );
-        paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
+        paramsDelete.setImportStrategy( DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
-        assertEquals( 0, trackerImportReportDelete.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReportDelete.getStatus() );
+        assertNoImportErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }
 
@@ -462,8 +455,7 @@ class EventImportValidationTest extends TrackerTest
         // When
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         // Then
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
         return trackerImportReport;
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.validation.Users.USER_5;
@@ -68,7 +69,6 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,12 +142,10 @@ class EventSecurityImportValidationTest extends TrackerTest
         TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/enrollments_te_te-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         trackerBundleParams = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         manager.flush();
     }
 
@@ -258,8 +256,7 @@ class EventSecurityImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/events_error-no-uncomplete.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         // Change just inserted Event to status COMPLETED...
         ProgramStageInstance zwwuwNp6gVd = programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" );
         zwwuwNp6gVd.setStatus( EventStatus.COMPLETED );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -139,13 +139,10 @@ class EventSecurityImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        TrackerImportParams trackerBundleParams = fromJson(
-            "tracker/validations/enrollments_te_te-data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertNoImportErrors( trackerImportReport );
-        trackerBundleParams = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
-        trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoImportErrors( trackerImportService.importTracker( fromJson(
+            "tracker/validations/enrollments_te_te-data.json" ) ) );
+        assertNoImportErrors( trackerImportService
+            .importTracker( fromJson( "tracker/validations/enrollments_te_enrollments-data.json" ) ) );
         manager.flush();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
@@ -31,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -42,7 +43,6 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -70,17 +70,17 @@ class TeTaEncryptionValidationTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_region.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -90,7 +90,7 @@ class TeTaEncryptionValidationTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         trackerImportParams = fromJson( "tracker/validations/te-program_with_tea_unique_data2.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
@@ -32,6 +32,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_1;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
@@ -42,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.IOException;
 import java.util.HashSet;
 
-import org.hamcrest.core.IsCollectionContaining;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.TrackerImportParams;
@@ -51,7 +52,6 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -112,8 +112,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -138,8 +137,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
         assertEquals( 3, trackerImportReport.getStats().getCreated() );
         // For some reason teiSearchOrgunits is not created properly from
         // metadata
@@ -154,8 +152,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         params.setAtomicMode( AtomicMode.OBJECT );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
         assertEquals( 3, trackerImportReport.getStats().getUpdated() );
     }
 
@@ -165,8 +162,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
         assertEquals( 3, trackerImportReport.getStats().getCreated() );
         dbmsManager.clearSession();
         params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
@@ -179,7 +175,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         assertEquals( 2, trackerImportReport.getStats().getUpdated() );
         assertEquals( 1, trackerImportReport.getStats().getIgnored() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
-            IsCollectionContaining.hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1003 ) ) ) );
+            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1003 ) ) ) );
     }
 
     @Test
@@ -206,8 +202,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         user.setPassword( "user4password" );
         injectSecurityContext( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -216,8 +211,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_error_geo-ok.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+        assertNoImportErrors( trackerImportReport );
     }
 
     @Test
@@ -237,8 +231,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
         importProgramInstances();
         manager.flush();
         manager.clear();
@@ -258,8 +251,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
 
         manager.flush();
         manager.clear();
@@ -269,8 +261,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
-        assertEquals( 0, trackerImportReportDelete.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReportDelete.getStatus() );
+        assertNoImportErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }
 
@@ -279,7 +270,6 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
-        assertEquals( TrackerStatus.OK, trackerImportReport.getStatus() );
+        assertNoImportErrors( trackerImportReport );
     }
 }


### PR DESCRIPTION
in case an import fails we shouldn't be left wondering why and re-run CI over and over again.
Re-use our own `assertNoImportErrors`. Adjust `assertNoImportErrors` so its message more readable.

so a test like

```java
        TrackerImportReport trackerImportReport = trackerImportService.importTracker(fromJson( "tracker/validations/events-with-registration.json" ));

        assertNoImportErrors( trackerImportReport );
```

not expecting any import errors would fail with for example

```
org.opentest4j.AssertionFailedError: Expected import with status OK, instead got:
E1123: Missing required event property: `orgUnit`.
E1123: Missing required event property: `programStage`.
E1123: Missing required event property: `program`.
 ==> 
Expected :OK
Actual   :ERROR
```

instead of just

```
Expected :OK
Actual   :ERROR
```