### PR TITLE
test: improve assertions of flaky DefaultMetadataVersionServiceTest

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -48,14 +48,11 @@ import org.hisp.dhis.metadata.version.MetadataVersion;
 import org.hisp.dhis.metadata.version.MetadataVersionService;
 import org.hisp.dhis.metadata.version.VersionType;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author sultanm
  */
-@ExtendWith( MockitoExtension.class )
 class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
 {
     @Autowired

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -27,11 +27,14 @@
  */
 package org.hisp.dhis.dxf2.metadata.version;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Date;
 import java.util.List;
@@ -71,21 +74,6 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
 
     private MetadataVersion versionB;
 
-    public static boolean compareVersionsUtil( MetadataVersion v1, MetadataVersion v2 )
-    {
-        if ( v1 == null && v2 == null )
-        {
-            return true;
-        }
-        else if ( v1 == null || v2 == null )
-        {
-            return false;
-        }
-
-        return (v1.getCreated() == v2.getCreated()) && (v1.getName().equals( v2.getName() ))
-            && (v1.getType() == v2.getType());
-    }
-
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -109,13 +97,14 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     void testShouldAddVersions()
     {
         long idA = versionService.addVersion( versionA );
-        long idB = versionService.addVersion( versionB );
 
         assertTrue( idA >= 0 );
-        assertTrue( idB >= 0 );
+        assertEqualMetadataVersions( versionA, versionService.getVersionById( idA ) );
 
-        assertTrue( compareVersionsUtil( versionA, versionService.getVersionById( idA ) ) );
-        assertTrue( compareVersionsUtil( versionB, versionService.getVersionById( idB ) ) );
+        long idB = versionService.addVersion( versionB );
+
+        assertTrue( idB >= 0 );
+        assertEqualMetadataVersions( versionB, versionService.getVersionById( idB ) );
     }
 
     @Test
@@ -133,11 +122,11 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     {
         long idA = versionService.addVersion( versionA );
 
-        assertTrue( compareVersionsUtil( versionA, versionService.getVersionById( idA ) ) );
+        assertEqualMetadataVersions( versionA, versionService.getVersionById( idA ) );
 
         versionService.addVersion( versionB );
 
-        assertTrue( compareVersionsUtil( versionB, versionService.getVersionByName( "Version_2" ) ) );
+        assertEqualMetadataVersions( versionB, versionService.getVersionByName( "Version_2" ) );
     }
 
     @Test
@@ -147,7 +136,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
         dbmsManager.clearSession();
         versionService.addVersion( versionB );
 
-        assertTrue( compareVersionsUtil( versionB, versionService.getCurrentVersion() ) );
+        assertEqualMetadataVersions( versionB, versionService.getCurrentVersion() );
     }
 
     @Test
@@ -163,25 +152,25 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     @Test
     void testShouldReturnVersionsBetweenGivenTimeStamps()
     {
-        List<MetadataVersion> versions = null;
+        List<MetadataVersion> versions;
         Date startDate = new Date();
         versionService.addVersion( versionA );
         versions = versionService.getAllVersionsInBetween( startDate, new Date() );
 
         assertEquals( 1, versions.size() );
-        assertTrue( compareVersionsUtil( versionA, versions.get( 0 ) ) );
+        assertEqualMetadataVersions( versionA, versions.get( 0 ) );
 
         versionService.addVersion( versionB );
         versions = versionService.getAllVersionsInBetween( startDate, new Date() );
 
         assertEquals( 2, versions.size() );
-        assertTrue( compareVersionsUtil( versionB, versions.get( 1 ) ) );
+        assertEqualMetadataVersions( versionB, versions.get( 1 ) );
 
         Date dateBetweenAandB = DateUtils.addMilliseconds( versions.get( 0 ).getCreated(), 1 );
         versions = versionService.getAllVersionsInBetween( dateBetweenAandB, new Date() );
 
         assertEquals( 1, versions.size() );
-        assertTrue( compareVersionsUtil( versionB, versions.get( 0 ) ) );
+        assertEqualMetadataVersions( versionB, versions.get( 0 ) );
     }
 
     @Test
@@ -215,7 +204,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
         assertEquals( metadataVersionSnap.getHashCode(), versionService.getCurrentVersion().getHashCode() );
 
         // testing if correct version is saved in keyjsonvalue table
-        List<String> versions = null;
+        List<String> versions;
         versions = metaDataDatastoreService.getAllVersions();
 
         assertEquals( 1, versions.size() );
@@ -231,7 +220,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
 
         assertEquals( 2, allVersions.size() );
         assertEquals( "Version_3", allVersions.get( 1 ) );
-        assertEquals( true, expectedJson.getJbPlainValue().contains( "DataElementA" ) );
+        assertTrue( expectedJson.getJbPlainValue().contains( "DataElementA" ) );
     }
 
     @Test
@@ -249,8 +238,8 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
 
         DatastoreEntry expectedJson = metaDataDatastoreService.getMetaDataVersion( "Version_3" );
 
-        assertEquals( false, expectedJson.getJbPlainValue().contains( "DataElementA" ) );
-        assertEquals( true, expectedJson.getJbPlainValue().contains( "DataElementB" ) );
+        assertFalse( expectedJson.getJbPlainValue().contains( "DataElementA" ) );
+        assertTrue( expectedJson.getJbPlainValue().contains( "DataElementB" ) );
     }
 
     @Test
@@ -264,7 +253,7 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     @Test
     void testShouldReturnNullWhenAVersionDoesNotExist()
     {
-        assertEquals( null, versionService.getVersionData( "myNonExistingVersion" ) );
+        assertNull( versionService.getVersionData( "myNonExistingVersion" ) );
     }
 
     @Test
@@ -296,5 +285,22 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     {
         assertThrows( MetadataVersionServiceException.class,
             () -> versionService.isMetadataPassingIntegrity( null, null ) );
+    }
+
+    public static void assertEqualMetadataVersions( MetadataVersion v1, MetadataVersion v2 )
+    {
+        if ( v1 == null && v2 == null )
+        {
+            return;
+        }
+        else if ( v1 == null || v2 == null )
+        {
+            fail( String.format( "Either both versions or none must be null. v1: %s, v2: %s", v1, v2 ) );
+        }
+
+        assertAll(
+            () -> assertEquals( v1.getCreated(), v2.getCreated(), "date must match" ),
+            () -> assertEquals( v1.getName(), v2.getName(), "name must match" ),
+            () -> assertEquals( v1.getType(), v2.getType(), "type must match" ) );
     }
 }


### PR DESCRIPTION
DefaultMetadataVersionServiceTest.testShouldReturnTheLatestVersion has been flaky on GitHub. 

Improve assertions we can figure out why. Also remove unused mockito annotation its a pure integration test that is not using any mocks.

Instead of assertion errors like `expected true got false` we now get

in case of one of the versions being null

```
org.opentest4j.AssertionFailedError: Either both versions or none must be null. v1: null, v2: MetadataVersion{importDate=null, type=BEST_EFFORT, name='Version_2', hashCode='abcdef'}
```

in case the versions do not match

```
name must match ==> expected: <Version_1> but was: <Version_2>
Comparison Failure: 
Expected :Version_1
Actual   :Version_2
<Click to see difference>



type must match ==> expected: <ATOMIC> but was: <BEST_EFFORT>
Comparison Failure: 
Expected :ATOMIC
Actual   :BEST_EFFORT
<Click to see difference>



org.opentest4j.MultipleFailuresError: Multiple Failures (2 failures)
	org.opentest4j.AssertionFailedError: names must match ==> expected: <Version_1> but was: <Version_2>
	org.opentest4j.AssertionFailedError: types must match ==> expected: <ATOMIC> but was: <BEST_EFFORT>
```