### PR TITLE
fix: postgres integration tests has its own config provider

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/DefaultDhisConfigurationProvider.java
@@ -66,7 +66,10 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 /**
  * @author Lars Helge Overland
  */
-@Profile( "!test-h2" )
+@Profile( {
+    "!test-h2",
+    "!test-postgres",
+} )
 @Component( "dhisConfigurationProvider" )
 @Slf4j
 public class DefaultDhisConfigurationProvider extends LogOnceLogger


### PR DESCRIPTION
so DefaultDhisConfigurationProvider should be excluded. Only PostgresDhisConfigurationProvider
should be used with profile test-postgres