### PR TITLE
ci: run tests on master as well as PRs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,8 +2,11 @@ name: Test
 env:
   # This is to make sure Maven don't timeout fetching dependencies. See: https://github.com/actions/virtual-environments/issues/1499
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
-
-on: [ pull_request ]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
     cancel-in-progress: true


### PR DESCRIPTION
To get accurate coverage results for master and PRs.
To identify compilation/test errors early. master was
broken multiple times. Its not clear if that was always due to
failed checks being overridden on a PR. PRs might not always
run against latest master which could cause such issues.