### PR TITLE
fix: UserGroupDeletionHandler drop groups from user

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserGroupDeletionHandler.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.user;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import lombok.AllArgsConstructor;
@@ -62,6 +63,8 @@ public class UserGroupDeletionHandler extends DeletionHandler
             group.getMembers().remove( user );
             idObjectManager.updateNoAcl( group );
         }
+
+        user.setGroups( new HashSet<>() );
     }
 
     private void deleteUserGroup( UserGroup userGroup )


### PR DESCRIPTION
In `UserGroupDeletionHandler#deleteUser`, after removing user from groups, also remove groups from user.

This follows the (new) pattern in `UserRoleDeletionHandler#deleteUser`.