### PR TITLE
ci: jacoco does not report cross module coverage by default

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -794,7 +794,7 @@
               <id>report</id>
               <phase>verify</phase>
               <goals>
-                <goal>report</goal>
+                <goal>report-aggregate</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
it assumes tests within a module only test the module itself. This is why
some changes of lets say code in dhis-api, which is tested in dhis-service-core or so
did not show up as covered

see
* https://www.eclemma.org/jacoco/trunk/doc/report-aggregate-mojo.html
* https://blog.jcore.com/2020/04/how-to-fix-a-drop-of-code-coverage-with-a-multi-module-maven-project/
