### PR TITLE
fix: Validate enrollment attributes values based on valueType in NTI [DHIS2-12669] (2.39)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -28,13 +28,20 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsValid;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1077;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1085;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1112;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.ATTRIBUTE_CANT_BE_NULL;
 import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_CANT_BE_NULL;
+import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors.TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL;
 
 import java.util.List;
 import java.util.Objects;
 
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.encryption.EncryptionStatus;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -44,6 +51,7 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
+import org.hisp.dhis.tracker.util.Constant;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 
 /**
@@ -54,9 +62,13 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
 
     private final TrackedAttributeValidationService teAttrService;
 
-    protected AttributeValidationHook( TrackedAttributeValidationService teAttrService )
+    private final DhisConfigurationProvider dhisConfigurationProvider;
+
+    protected AttributeValidationHook( TrackedAttributeValidationService teAttrService,
+        DhisConfigurationProvider dhisConfigurationProvider )
     {
         this.teAttrService = teAttrService;
+        this.dhisConfigurationProvider = dhisConfigurationProvider;
     }
 
     protected void validateAttrValueType( ValidationErrorReporter reporter, TrackerPreheat preheat, TrackerDto dto,
@@ -101,6 +113,31 @@ public abstract class AttributeValidationHook extends AbstractTrackerDtoValidati
         {
             reporter.addError( dto, TrackerErrorCode.E1007, valueType, error );
         }
+    }
+
+    protected void validateAttributeValue( ValidationErrorReporter reporter, TrackerDto trackerDto,
+        TrackedEntityAttribute tea,
+        String value )
+    {
+        checkNotNull( tea, TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL );
+        checkNotNull( value, TRACKED_ENTITY_ATTRIBUTE_VALUE_CANT_BE_NULL );
+
+        // Validate value (string) don't exceed the max length
+        reporter.addErrorIf( () -> value.length() > Constant.MAX_ATTR_VALUE_LENGTH, trackerDto,
+            E1077, value,
+            Constant.MAX_ATTR_VALUE_LENGTH );
+
+        // Validate if that encryption is configured properly if someone sets
+        // value to (confidential)
+        boolean isConfidential = tea.isConfidentialBool();
+        EncryptionStatus encryptionStatus = dhisConfigurationProvider.getEncryptionStatus();
+        reporter.addErrorIf( () -> isConfidential && !encryptionStatus.isOk(), trackerDto, E1112,
+            value, encryptionStatus.getKey() );
+
+        // Uses ValidationUtils to check that the data value corresponds to the
+        // data value type set on the attribute
+        final String result = dataValueIsValid( value, tea.getValueType() );
+        reporter.addErrorIf( () -> result != null, trackerDto, E1085, tea, result );
     }
 
     protected void validateAttributeUniqueness( ValidationErrorReporter reporter,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
@@ -68,9 +69,10 @@ import com.google.common.collect.Streams;
 public class EnrollmentAttributeValidationHook extends AttributeValidationHook
 {
 
-    public EnrollmentAttributeValidationHook( TrackedAttributeValidationService teAttrService )
+    public EnrollmentAttributeValidationHook( TrackedAttributeValidationService teAttrService,
+        DhisConfigurationProvider dhisConfigurationProvider )
     {
-        super( teAttrService );
+        super( teAttrService, dhisConfigurationProvider );
     }
 
     @Override
@@ -98,7 +100,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
             {
 
                 attributeValueMap.put( attribute.getAttribute(), attribute.getValue() );
-
+                validateAttributeValue( reporter, enrollment, teAttribute, attribute.getValue() );
                 validateAttrValueType( reporter, bundle.getPreheat(), enrollment, attribute, teAttribute );
                 validateOptionSet( reporter, enrollment, teAttribute,
                     attribute.getValue() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
@@ -88,12 +88,12 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
         List<TrackedEntityAttributeValue> attributeValues = trackedEntityAttributeValueService
             .getTrackedEntityAttributeValues( trackedEntityInstance );
-        assertEquals( 4, attributeValues.size() );
+        assertEquals( 5, attributeValues.size() );
         List<TrackedEntityAttribute> attributes = attributeValues.stream()
             .map( TrackedEntityAttributeValue::getAttribute ).collect( Collectors.toList() );
         List<TrackedEntityAttributeValueAudit> attributeValueAudits = attributeValueAuditService
             .getTrackedEntityAttributeValueAudits( attributes, trackedEntityInstances, AuditType.CREATE );
-        assertEquals( 4, attributeValueAudits.size() );
+        assertEquals( 5, attributeValueAudits.size() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeTest.java
@@ -81,7 +81,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
         List<TrackedEntityAttributeValue> attributeValues = trackedEntityAttributeValueService
             .getTrackedEntityAttributeValues( trackedEntityInstance );
-        assertEquals( 4, attributeValues.size() );
+        assertEquals( 5, attributeValues.size() );
     }
 
     @Test
@@ -97,7 +97,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
         List<TrackedEntityAttributeValue> attributeValues = trackedEntityAttributeValueService
             .getTrackedEntityAttributeValues( trackedEntityInstance );
-        assertEquals( 4, attributeValues.size() );
+        assertEquals( 5, attributeValues.size() );
         manager.clear();
         // update
         trackerImportParams = fromJson( "tracker/te_program_with_tea_update_data.json" );
@@ -109,7 +109,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         assertEquals( 1, trackedEntityInstances.size() );
         trackedEntityInstance = trackedEntityInstances.get( 0 );
         attributeValues = trackedEntityAttributeValueService.getTrackedEntityAttributeValues( trackedEntityInstance );
-        assertEquals( 4, attributeValues.size() );
+        assertEquals( 5, attributeValues.size() );
     }
 
     @Test
@@ -125,7 +125,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstances.get( 0 );
         List<TrackedEntityAttributeValue> attributeValues = trackedEntityAttributeValueService
             .getTrackedEntityAttributeValues( trackedEntityInstance );
-        assertEquals( 4, attributeValues.size() );
+        assertEquals( 5, attributeValues.size() );
         manager.clear();
         // update
         trackerImportParams = fromJson( "tracker/te_program_with_tea_update_data.json" );
@@ -137,7 +137,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         assertEquals( 1, trackedEntityInstances.size() );
         trackedEntityInstance = trackedEntityInstances.get( 0 );
         attributeValues = trackedEntityAttributeValueService.getTrackedEntityAttributeValues( trackedEntityInstance );
-        assertEquals( 4, attributeValues.size() );
+        assertEquals( 5, attributeValues.size() );
         manager.clear();
         // delete
         trackerImportParams = fromJson( "tracker/te_program_with_tea_delete_data.json" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -39,6 +39,8 @@ import java.util.HashSet;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.ValueType;
+import org.hisp.dhis.encryption.EncryptionStatus;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -82,6 +84,9 @@ class EnrollmentAttributeValidationHookTest
     @Mock
     private TrackerPreheat preheat;
 
+    @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
     private TrackerBundle bundle;
 
     @Mock
@@ -93,9 +98,13 @@ class EnrollmentAttributeValidationHookTest
 
     private final static String trackedAttribute1 = "attribute1";
 
+    private final static String trackedAttributeP = "attributeP";
+
     private TrackedEntityAttribute trackedEntityAttribute;
 
     private TrackedEntityAttribute trackedEntityAttribute1;
+
+    private TrackedEntityAttribute trackedEntityAttributeP;
 
     private ValidationErrorReporter reporter;
 
@@ -111,6 +120,10 @@ class EnrollmentAttributeValidationHookTest
             false );
         trackedEntityAttribute1.setUid( trackedAttribute1 );
 
+        trackedEntityAttributeP = new TrackedEntityAttribute( "percentage", "percent", ValueType.PERCENTAGE, false,
+            false );
+        trackedEntityAttributeP.setUid( trackedAttributeP );
+
         when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getProgram( (MetadataIdentifier) any() ) ).thenReturn( program );
         when( enrollment.getProgram() ).thenReturn( MetadataIdentifier.ofUid( "program" ) );
@@ -118,6 +131,11 @@ class EnrollmentAttributeValidationHookTest
             .thenReturn( trackedEntityAttribute );
         when( preheat.getTrackedEntityAttribute( MetadataIdentifier.ofUid( trackedAttribute1 ) ) )
             .thenReturn( trackedEntityAttribute1 );
+        when( preheat.getTrackedEntityAttribute( MetadataIdentifier.ofUid( trackedAttributeP ) ) )
+            .thenReturn( trackedEntityAttributeP );
+
+        when( dhisConfigurationProvider.getEncryptionStatus() )
+            .thenReturn( EncryptionStatus.MISSING_ENCRYPTION_PASSWORD );
 
         String uid = CodeGenerator.generateUid();
         when( enrollment.getUid() ).thenReturn( uid );
@@ -188,6 +206,35 @@ class EnrollmentAttributeValidationHookTest
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertThat( reporter.getReportList(), hasSize( 0 ) );
+    }
+
+    @Test
+    void shouldFailValidationWhenValueIsInvalidPercentage()
+    {
+        // given 1 percentage attribute has invalid value
+        Attribute attribute = Attribute.builder().attribute( MetadataIdentifier.ofUid( trackedAttribute ) )
+            .valueType( ValueType.TEXT )
+            .value( "value" ).build();
+        Attribute attribute1 = Attribute.builder().attribute( MetadataIdentifier.ofUid( trackedAttributeP ) )
+            .valueType( ValueType.PERCENTAGE )
+            .value( "1000" ).build();
+
+        when( program.getProgramAttributes() ).thenReturn( Arrays.asList(
+            new ProgramTrackedEntityAttribute( program, trackedEntityAttribute, false, true ),
+            new ProgramTrackedEntityAttribute( program, trackedEntityAttributeP, false, false ) ) );
+
+        when( enrollment.getAttributes() ).thenReturn( Arrays.asList( attribute, attribute1 ) );
+        when( trackedEntityInstance.getTrackedEntityAttributeValues() )
+            .thenReturn( new HashSet<>(
+                Arrays.asList( new TrackedEntityAttributeValue( trackedEntityAttribute, trackedEntityInstance ),
+                    new TrackedEntityAttributeValue( trackedEntityAttributeP, trackedEntityInstance ) ) ) );
+        when( preheat.getTrackedEntity( enrollment.getTrackedEntity() ) )
+            .thenReturn( trackedEntityInstance );
+
+        hookToTest.validateEnrollment( reporter, bundle, enrollment );
+
+        assertThat( reporter.getReportList(), hasSize( 1 ) );
+        hasTrackerError( reporter, TrackerErrorCode.E1085, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_allow_audit_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_allow_audit_metadata.json
@@ -419,6 +419,42 @@
           "userAccesses": []
         },
         {
+          "lastUpdated": "2020-02-20T12:08:40.006",
+          "id": "OQeqChgVcM0",
+          "created": "2020-02-12T15:07:06.260",
+          "name": "Program Attribute_Percentage",
+          "displayName": "Program Attribute_Percentage",
+          "mandatory": false,
+          "displayShortName": "Program Attribute_Percentage",
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "valueType": "PERCENTAGE",
+          "searchable": false,
+          "displayInList": true,
+          "sortOrder": 4,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "program": {
+            "id": "hJUBNVQWl4e"
+          },
+          "trackedEntityAttribute": {
+            "id": "TsfP85GKsUZ"
+          },
+          "favorites": [],
+          "programTrackedEntityAttributeGroups": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
           "lastUpdated": "2020-02-20T12:08:40.008",
           "id": "UOCaOMetAO5",
           "created": "2020-02-20T12:08:39.841",
@@ -431,7 +467,7 @@
           "valueType": "TEXT",
           "searchable": false,
           "displayInList": false,
-          "sortOrder": 4,
+          "sortOrder": 5,
           "favorite": false,
           "access": {
             "read": true,
@@ -646,6 +682,36 @@
       "generated": false,
       "displayOnVisitSchedule": false,
       "valueType": "TEXT",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    },
+    {
+      "lastUpdated": "2020-02-10T10:55:46.706",
+      "id": "TsfP85GKsUZ",
+      "created": "2020-02-10T09:10:00.847",
+      "name": "Attribute_Percentage",
+      "shortName": "Attribute_Percentage",
+      "aggregationType": "NONE",
+      "displayInListNoProgram": true,
+      "publicAccess": "rw------",
+      "pattern": "",
+      "skipSynchronization": false,
+      "generated": false,
+      "displayOnVisitSchedule": false,
+      "valueType": "PERCENTAGE",
       "orgunitScope": false,
       "confidential": false,
       "unique": false,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_data.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_data.json
@@ -113,6 +113,16 @@
           "storedBy": "admin",
           "valueType": "INTEGER_POSITIVE",
           "value": "321"
+        },
+        {
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "TsfP85GKsUZ"
+          },
+          "displayName": "Attribute_Percentage",
+          "storedBy": "admin",
+          "valueType": "PERCENTAGE",
+          "value": "80"
         }
       ],
       "notes": []

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_metadata.json
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/resources/tracker/te_program_with_tea_metadata.json
@@ -419,6 +419,42 @@
           "userAccesses": []
         },
         {
+          "lastUpdated": "2020-02-20T12:08:40.006",
+          "id": "OQeqChgVcM0",
+          "created": "2020-02-12T15:07:06.260",
+          "name": "Program Attribute_Percentage",
+          "displayName": "Program Attribute_Percentage",
+          "mandatory": false,
+          "displayShortName": "Program Attribute_Percentage",
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "valueType": "PERCENTAGE",
+          "searchable": false,
+          "displayInList": true,
+          "sortOrder": 4,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "program": {
+            "id": "hJUBNVQWl4e"
+          },
+          "trackedEntityAttribute": {
+            "id": "TsfP85GKsUZ"
+          },
+          "favorites": [],
+          "programTrackedEntityAttributeGroups": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
           "lastUpdated": "2020-02-20T12:08:40.008",
           "id": "UOCaOMetAO5",
           "created": "2020-02-20T12:08:39.841",
@@ -431,7 +467,7 @@
           "valueType": "TEXT",
           "searchable": false,
           "displayInList": false,
-          "sortOrder": 4,
+          "sortOrder": 5,
           "favorite": false,
           "access": {
             "read": true,
@@ -646,6 +682,36 @@
       "generated": false,
       "displayOnVisitSchedule": false,
       "valueType": "TEXT",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    },
+    {
+      "lastUpdated": "2020-02-10T10:55:46.706",
+      "id": "TsfP85GKsUZ",
+      "created": "2020-02-10T09:10:00.847",
+      "name": "Attribute_Percentage",
+      "shortName": "Attribute_Percentage",
+      "aggregationType": "NONE",
+      "displayInListNoProgram": true,
+      "publicAccess": "rw------",
+      "pattern": "",
+      "skipSynchronization": false,
+      "generated": false,
+      "displayOnVisitSchedule": false,
+      "valueType": "PERCENTAGE",
       "orgunitScope": false,
       "confidential": false,
       "unique": false,


### PR DESCRIPTION
In NTI, program attributes can be specified as part of the Enrollment tracker Dto. Validation based on valueType for enrollment attributes was missing in the NTI. This PR fixes it by moving the `validateAttributeValue` method from `TrackedEntityAttributeValidationHook` class into its base abstract class `AttributeValidationHook`, so that the second subclass `EnrollmentAttributeValidationHook` can reuse the same method.