### PR TITLE
fix: Support i18n name in /dataStatistics/favorites [DHIS2-13370]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
@@ -106,6 +106,7 @@ public class HibernateDbmsManager
         emptyTable( "interpretation" );
 
         emptyTable( "report" );
+        emptyTable( "datastatisticsevent" );
 
         emptyTable( "visualization_yearlyseries" );
         emptyTable( "visualization_rows" );


### PR DESCRIPTION
Currently, the `name` DB column is always returned in the default version.
This fix will change that, so the `name` will be returned respecting the current user's locale.

So, if there is a translation for the `name` column, in the respective table, it will take priority and will be returned. Otherwise, the default value will take place.

[Backport] from master/2.39