### PR TITLE
fix: update validation rules via super.update

### DIFF
--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationRuleStore.java
@@ -92,7 +92,7 @@ public class HibernateValidationRuleStore
 
         validationRule.setPeriodType( periodType );
 
-        super.save( validationRule );
+        super.update( validationRule );
     }
 
     @Override


### PR DESCRIPTION
Was testing out some IDE features and noticed by chance that `save` and `update` were implemented identical. I assume the `update` method should call `super.update` not `super.save` unless we had a special reason to use `super.save` in both cases.