### PR TITLE
ci: disable codecov annotations and report when done

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,10 @@
+github_checks:
+    annotations: false
+
+codecov:
+  notify:
+      after_n_builds: 4 # 4 since we upload in 4 separate test jobs (unit, integration, integration-analytics, integrationH2)
+
 coverage:
   status:
     project:


### PR DESCRIPTION
https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds
as comments being posted after each upload was done is confusing devs. This showed coverage as
decreasing at first.

Annotations on GitHub are to chatty. If devs want to see the coverage diff, they actively click
on the file in the file summary on the codecov PR comment