### PR TITLE
fix: Broken ApiToken internal authority list (#11072)

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/apikey/ApiTokenAuthenticationToken.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/apikey/ApiTokenAuthenticationToken.java
@@ -53,7 +53,7 @@ public class ApiTokenAuthenticationToken extends AbstractAuthenticationToken
 
     public ApiTokenAuthenticationToken( ApiToken token, User user )
     {
-        super( Collections.emptyList() );
+        super( user.getAuthorities() );
         this.tokenRef = token;
         this.user = user;
     }


### PR DESCRIPTION
(cherry picked from commit 5febdef74c8986c15129c38b20eaf73ff12818dc)