### PR TITLE
fix: reattach user of GeoJson async import [DHIS2-7171]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/GeoJsonImportParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/GeoJsonImportParams.java
@@ -35,7 +35,7 @@ import lombok.Getter;
 import org.hisp.dhis.common.IdentifiableProperty;
 import org.hisp.dhis.user.User;
 
-@Builder
+@Builder( toBuilder = true )
 @Getter
 @AllArgsConstructor( access = AccessLevel.PRIVATE )
 public class GeoJsonImportParams


### PR DESCRIPTION
Issue is the `User` in the `GeoJsonImportParams` is from the thread that the async `POST` was made. When it runs asynchronously that user instance is no longer attached to a valid database session. Therefore the user is reloaded by UID.

As the comment says the better fix would be to use `CurrentUserDetails` instead. That is a bigger change that requires updates on many central internal APIs so this is left for another explicit task.