### PR TITLE
fix: flaky test because of created date

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -74,6 +74,10 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
 
     private MetadataVersion versionB;
 
+    private Date startDate;
+
+    private Date endDate;
+
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
@@ -87,10 +91,14 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     @Override
     protected void setUpTest()
     {
+        startDate = new Date();
         versionA = new MetadataVersion( "Version_1", VersionType.ATOMIC );
         versionA.setHashCode( "12345" );
+        versionA.setCreated( startDate );
         versionB = new MetadataVersion( "Version_2", VersionType.BEST_EFFORT );
+        versionB.setCreated( DateUtils.addHours( startDate, 1 ) );
         versionB.setHashCode( "abcdef" );
+        endDate = DateUtils.addDays( startDate, 1 );
     }
 
     @Test
@@ -153,21 +161,20 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     void testShouldReturnVersionsBetweenGivenTimeStamps()
     {
         List<MetadataVersion> versions;
-        Date startDate = new Date();
         versionService.addVersion( versionA );
-        versions = versionService.getAllVersionsInBetween( startDate, new Date() );
+        versions = versionService.getAllVersionsInBetween( startDate, endDate );
 
         assertEquals( 1, versions.size() );
         assertEqualMetadataVersions( versionA, versions.get( 0 ) );
 
         versionService.addVersion( versionB );
-        versions = versionService.getAllVersionsInBetween( startDate, new Date() );
+        versions = versionService.getAllVersionsInBetween( startDate, endDate );
 
         assertEquals( 2, versions.size() );
         assertEqualMetadataVersions( versionB, versions.get( 1 ) );
 
-        Date dateBetweenAandB = DateUtils.addMilliseconds( versions.get( 0 ).getCreated(), 1 );
-        versions = versionService.getAllVersionsInBetween( dateBetweenAandB, new Date() );
+        Date dateBetweenAandB = DateUtils.addMinutes( versionA.getCreated(), 1 );
+        versions = versionService.getAllVersionsInBetween( dateBetweenAandB, endDate );
 
         assertEquals( 1, versions.size() );
         assertEqualMetadataVersions( versionB, versions.get( 0 ) );


### PR DESCRIPTION
### Issue
 - This `testShouldReturnTheLatestVersion` fails occasionally  with below error 
 - I couldn't reproduce it, but i guess the reason is because the query from `versionService.getCurrentVersion()` try to get the latest version by `created` date. But from the `assertEqualMetadataVersions`, we can see that both version 1 & 2 have same `created` date. 

```
[ERROR] Failures:
[ERROR]   DefaultMetadataVersionServiceTest.testShouldReturnTheLatestVersion:139->assertEqualMetadataVersions:301 Mult
res (2 failures)
        org.opentest4j.AssertionFailedError: name must match ==> expected: <Version_2> but was: <Version_1>
        org.opentest4j.AssertionFailedError: type must match ==> expected: <BEST_EFFORT> but was: <ATOMIC>
```

### Fix
- I set `created` date explicitly when create new `Version` objects in order to avoid `new Date()` return same value when code are run parallel.

### Test
- Need to observer for a few days to check if the error occur again on master before create backports for the fix.