### PR TITLE
ci: keep surefire reports for 5 days

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           name: surefire-reports
           path: "**/target/surefire-reports/TEST-*.xml"
-          retention-days: 10
+          retention-days: 5
 
   integration-h2-test:
     runs-on: ubuntu-latest
@@ -131,7 +131,7 @@ jobs:
         with:
           name: surefire-reports
           path: "**/target/surefire-reports/TEST-*.xml"
-          retention-days: 10
+          retention-days: 5
 
   integration-test-analytics:
     runs-on: ubuntu-latest
@@ -180,7 +180,7 @@ jobs:
         with:
           name: surefire-reports-analytics
           path: "**/target/surefire-reports/TEST-*.xml"
-          retention-days: 10
+          retention-days: 5
 
   send-slack-message:
     runs-on: ubuntu-latest


### PR DESCRIPTION
we used them a while back for analyzing test duration. We are not
actively doing so right now, so 10 days is not needed. We might
use them again soon, but 5 days should be enough