### PR TITLE
fix: metadata with dependencies export mapView as embeddedObject

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -74,7 +74,6 @@ import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.interpretation.Interpretation;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.legend.LegendSet;
-import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.program.Program;
@@ -937,17 +936,6 @@ public class DefaultMetadataExportService implements MetadataExportService
         return metadata;
     }
 
-    private SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> handleMapView(
-        SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata, MapView mapView )
-    {
-        if ( mapView == null )
-            return metadata;
-        metadata.putValue( MapView.class, mapView );
-        handleAttributes( metadata, mapView );
-
-        return metadata;
-    }
-
     private SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> handleMap(
         SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata, org.hisp.dhis.mapping.Map map )
     {
@@ -955,8 +943,6 @@ public class DefaultMetadataExportService implements MetadataExportService
             return metadata;
         metadata.putValue( org.hisp.dhis.mapping.Map.class, map );
         handleAttributes( metadata, map );
-
-        map.getMapViews().forEach( mapView -> handleMapView( metadata, mapView ) );
 
         return metadata;
     }
@@ -1006,15 +992,15 @@ public class DefaultMetadataExportService implements MetadataExportService
         return metadata;
     }
 
-    private SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> handleEmbbedItem(
-        SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata, InterpretableObject embbededItem )
+    private SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> handleEmbeddedItem(
+        SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> metadata, InterpretableObject embeddedItem )
     {
-        if ( embbededItem == null )
+        if ( embeddedItem == null )
             return metadata;
 
-        if ( embbededItem.getInterpretations() != null )
+        if ( embeddedItem.getInterpretations() != null )
         {
-            embbededItem.getInterpretations()
+            embeddedItem.getInterpretations()
                 .forEach( interpretation -> handleInterpretation( metadata, interpretation ) );
         }
 
@@ -1044,7 +1030,7 @@ public class DefaultMetadataExportService implements MetadataExportService
         handleEventChart( metadata, dashboardItem.getEventChart() );
         handleEventReport( metadata, dashboardItem.getEventReport() );
         handleMap( metadata, dashboardItem.getMap() );
-        handleEmbbedItem( metadata, dashboardItem.getEmbeddedItem() );
+        handleEmbeddedItem( metadata, dashboardItem.getEmbeddedItem() );
 
         dashboardItem.getReports().forEach( report -> handleReport( metadata, report ) );
         dashboardItem.getResources().forEach( document -> handleDocument( metadata, document ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportServiceTest.java
@@ -27,12 +27,20 @@
  */
 package org.hisp.dhis.dxf2.metadata;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.SetMap;
+import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.dashboard.DashboardItem;
+import org.hisp.dhis.mapping.MapView;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.schema.Schema;
@@ -105,5 +113,35 @@ class DefaultMetadataExportServiceTest
         MetadataExportParams exportParams = service.getParamsFromMap( params );
         Assertions.assertFalse( exportParams.getClasses().contains( JobConfiguration.class ) );
         Assertions.assertTrue( exportParams.getClasses().contains( Option.class ) );
+    }
+
+    @Test
+    void testGetMetadataWithDependenciesForDashboardWithMapView()
+    {
+        MapView mapView = new MapView();
+        mapView.setName( "mapViewA" );
+
+        org.hisp.dhis.mapping.Map map = new org.hisp.dhis.mapping.Map();
+        map.setName( "mapA" );
+        map.getMapViews().add( mapView );
+
+        DashboardItem item = new DashboardItem();
+        item.setName( "itemA" );
+        item.setMap( map );
+
+        Dashboard dashboard = new Dashboard( "dashboardA" );
+        dashboard.getItems().add( item );
+
+        SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> result = service
+            .getMetadataWithDependencies( dashboard );
+        // MapView is embedded object, it must not be included at top level
+        assertNull( result.get( MapView.class ) );
+        assertNotNull( result.get( Dashboard.class ) );
+        assertNotNull( result.get( org.hisp.dhis.mapping.Map.class ) );
+        Set<IdentifiableObject> setMap = result.get( org.hisp.dhis.mapping.Map.class );
+        assertEquals( 1, setMap.size() );
+        org.hisp.dhis.mapping.Map mapResult = (org.hisp.dhis.mapping.Map) setMap.iterator().next();
+        assertEquals( 1, mapResult.getMapViews().size() );
+        assertEquals( mapView.getName(), mapResult.getMapViews().get( 0 ).getName() );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7586

- `MapView` has been changed to be `EmbeddedObject` but `MetadataExportService.getMetadataWithDependencies()` hasn't been updated to reflect that.
- I have removed the code for generating `MapView` at the top level of the metadata export file. So it will only be included in the `Map` object as embedded objects.
- Added unit test.