### PR TITLE
feat: Add filters to TEDV audit endpoint [DHIS2-13421] [2.38]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -69,6 +69,19 @@ public interface IdentifiableObjectManager
 
     <T extends IdentifiableObject> T get( Class<T> type, String uid );
 
+    /**
+     * Retrieves the object of the given type and UID, throws exception if no
+     * object exists.
+     *
+     * @param <T>
+     * @param type the object class type.
+     * @param uid the UID.
+     * @return the object with the given UID.
+     * @throws IllegalQueryException if no object exists.
+     */
+    <T extends IdentifiableObject> T load( Class<T> type, String uid )
+        throws IllegalQueryException;
+
     <T extends IdentifiableObject> boolean exists( Class<T> type, String uid );
 
     <T extends IdentifiableObject> T get( Collection<Class<? extends IdentifiableObject>> types, String uid );
@@ -108,7 +121,17 @@ public interface IdentifiableObjectManager
 
     <T extends IdentifiableObject> List<T> getByUid( Class<T> type, Collection<String> uids );
 
-    <T extends IdentifiableObject> List<T> getAndValidateByUid( Class<T> type, Collection<String> uids )
+    /**
+     * Retrieves the objects of the given type and collection of UIDs, throws
+     * exception is any object does not exist.
+     *
+     * @param <T>
+     * @param type the object class type.
+     * @param uids the collection of UIDs.
+     * @return a list of objects.
+     * @throws IllegalQueryException if any object does not exist.
+     */
+    <T extends IdentifiableObject> List<T> loadByUid( Class<T> type, Collection<String> uids )
         throws IllegalQueryException;
 
     <T extends IdentifiableObject> List<T> getByUid( Collection<Class<? extends IdentifiableObject>> types,

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
@@ -90,6 +90,16 @@ public interface IdentifiableObjectStore<T>
     T getByUid( String uid );
 
     /**
+     * Retrieves the object with the given UID, throws exception if no object
+     * exists.
+     *
+     * @param uid the UID.
+     * @return the object with the given UID.
+     * @throws IllegalQueryException if no object exists.
+     */
+    T loadByUid( String uid );
+
+    /**
      * Retrieves the object with the given uid. Bypasses the ACL system.
      *
      * @param uid the uid.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalAuditQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalAuditQueryParams.java
@@ -31,6 +31,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import lombok.Data;
+import lombok.experimental.Accessors;
+
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 
@@ -39,6 +42,8 @@ import com.google.common.base.MoreObjects;
 /**
  * @author Jim Grace
  */
+@Data
+@Accessors( chain = true )
 public class DataApprovalAuditQueryParams
 {
     /**
@@ -70,14 +75,6 @@ public class DataApprovalAuditQueryParams
      * Ending date.
      */
     private Date endDate = null;
-
-    // -------------------------------------------------------------------------
-    // Constructor
-    // -------------------------------------------------------------------------
-
-    public DataApprovalAuditQueryParams()
-    {
-    }
 
     // -------------------------------------------------------------------------
     // Logic
@@ -119,69 +116,5 @@ public class DataApprovalAuditQueryParams
         return MoreObjects.toStringHelper( this ).add( "levels", levels ).add( "workflows", workflows )
             .add( "organisationUnits", organisationUnits ).add( "attributeOptionCombos", attributeOptionCombos )
             .add( "startDate", startDate ).add( "endDate", endDate ).toString();
-    }
-
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    public Set<DataApprovalLevel> getLevels()
-    {
-        return levels;
-    }
-
-    public void setLevels( Set<DataApprovalLevel> levels )
-    {
-        this.levels = levels;
-    }
-
-    public Set<DataApprovalWorkflow> getWorkflows()
-    {
-        return workflows;
-    }
-
-    public void setWorkflows( Set<DataApprovalWorkflow> workflows )
-    {
-        this.workflows = workflows;
-    }
-
-    public Set<OrganisationUnit> getOrganisationUnits()
-    {
-        return organisationUnits;
-    }
-
-    public void setOrganisationUnits( Set<OrganisationUnit> organisationUnits )
-    {
-        this.organisationUnits = organisationUnits;
-    }
-
-    public Set<CategoryOptionCombo> getAttributeOptionCombos()
-    {
-        return attributeOptionCombos;
-    }
-
-    public void setAttributeOptionCombos( Set<CategoryOptionCombo> attributeOptionCombos )
-    {
-        this.attributeOptionCombos = attributeOptionCombos;
-    }
-
-    public Date getStartDate()
-    {
-        return startDate;
-    }
-
-    public void setStartDate( Date startDate )
-    {
-        this.startDate = startDate;
-    }
-
-    public Date getEndDate()
-    {
-        return endDate;
-    }
-
-    public void setEndDate( Date endDate )
-    {
-        this.endDate = endDate;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode
     E1108( "Could not add item to collection: {0}" ),
     E1109( "Could not remove item from collection: {0}" ),
     E1112( "Object(s) of type `{0}` not found or not accessible: `{1}`" ),
+    E1113( "Object of type `{0}` not found or not accessible: `{1}`" ),
 
     /* Org unit merge */
     E1500( "At least two source orgs unit must be specified" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditQueryParams.java
@@ -35,80 +35,40 @@ import lombok.Data;
 import lombok.experimental.Accessors;
 
 import org.hisp.dhis.common.AuditType;
+import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
 
 /**
- * @author Abyot Asalefew Gizaw abyota@gmail.com
+ * Encapsulation of a web API request for tracked entity data value audit
+ * records.
+ *
+ * @author Lars Helge Overland
  */
 @Data
 @Accessors( chain = true )
-public class TrackedEntityInstanceAuditQueryParams
+public class TrackedEntityDataValueAuditQueryParams
 {
-    /**
-     * Tracked entity instances.
-     */
-    private List<String> trackedEntityInstances = new ArrayList<>();
+    private List<DataElement> dataElements = new ArrayList<>();
 
-    /**
-     * Users.
-     */
-    private List<String> users = new ArrayList<>();
+    private List<OrganisationUnit> orgUnits = new ArrayList<>();
 
-    /**
-     * AuditType to fetch for
-     */
+    private List<ProgramStageInstance> programStageInstances = new ArrayList<>();
+
+    private List<ProgramStage> programStages = new ArrayList<>();
+
+    private Date startDate;
+
+    private Date endDate;
+
     private AuditType auditType;
 
-    /**
-     * Starting date.
-     */
-    private Date startDate = null;
+    private Pager pager;
 
-    /**
-     * Ending date.
-     */
-    private Date endDate = null;
-
-    /**
-     * Tracked entity instance audit count start
-     */
-    private int first;
-
-    /**
-     * Tracked entity instance audit count end
-     */
-    private int max;
-
-    /**
-     * Traked entity instance audit skip paging or not
-     */
-    private boolean skipPaging;
-
-    // -------------------------------------------------------------------------
-    // Logic
-    // -------------------------------------------------------------------------
-
-    public boolean hasTrackedEntityInstances()
+    public boolean hasPaging()
     {
-        return trackedEntityInstances != null && !trackedEntityInstances.isEmpty();
-    }
-
-    public boolean hasUsers()
-    {
-        return users != null && !users.isEmpty();
-    }
-
-    public boolean hasAuditType()
-    {
-        return auditType != null;
-    }
-
-    public boolean hasStartDate()
-    {
-        return startDate != null;
-    }
-
-    public boolean hasEndDate()
-    {
-        return endDate != null;
+        return pager != null;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueAudit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueAudit.java
@@ -77,7 +77,6 @@ public class TrackedEntityDataValueAudit
         this.dataElement = dataElement;
         this.programStageInstance = programStageInstance;
         this.providedElsewhere = providedElsewhere;
-
         this.created = new Date();
         this.value = value;
         this.modifiedBy = modifiedBy;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueAuditService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueAuditService.java
@@ -29,9 +29,9 @@ package org.hisp.dhis.trackedentitydatavalue;
 
 import java.util.List;
 
-import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -40,16 +40,9 @@ public interface TrackedEntityDataValueAuditService
 {
     void addTrackedEntityDataValueAudit( TrackedEntityDataValueAudit trackedEntityDataValueAudit );
 
-    List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances,
-        AuditType auditType );
+    List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( TrackedEntityDataValueAuditQueryParams params );
 
-    List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances,
-        AuditType auditType, int first, int max );
-
-    int countTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType );
+    int countTrackedEntityDataValueAudits( TrackedEntityDataValueAuditQueryParams params );
 
     void deleteTrackedEntityDataValueAudit( DataElement dataElement );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueAuditStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentitydatavalue/TrackedEntityDataValueAuditStore.java
@@ -29,9 +29,9 @@ package org.hisp.dhis.trackedentitydatavalue;
 
 import java.util.List;
 
-import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -40,14 +40,9 @@ public interface TrackedEntityDataValueAuditStore
 {
     void addTrackedEntityDataValueAudit( TrackedEntityDataValueAudit trackedEntityDataValueAudit );
 
-    List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType );
+    List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( TrackedEntityDataValueAuditQueryParams params );
 
-    List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType, int first, int max );
-
-    int countTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType );
+    int countTrackedEntityDataValueAudits( TrackedEntityDataValueAuditQueryParams params );
 
     void deleteTrackedEntityDataValueAudit( DataElement dataElement );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -625,18 +625,16 @@ public class DateUtils
     }
 
     /**
-     * This method adds days to a date
+     * Adds days to the given date.
      *
      * @param date the date.
      * @param days the number of days to add.
      */
-    public static Date getDateAfterAddition( Date date, int days )
+    public static Date addDays( Date date, int days )
     {
         Calendar cal = Calendar.getInstance();
-
         cal.setTime( date );
         cal.add( Calendar.DATE, days );
-
         return cal.getTime();
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -292,6 +292,20 @@ public class DefaultIdentifiableObjectManager
     }
 
     @Override
+    public <T extends IdentifiableObject> T load( Class<T> type, String uid )
+        throws IllegalQueryException
+    {
+        IdentifiableObjectStore<IdentifiableObject> store = getIdentifiableObjectStore( type );
+
+        if ( store == null )
+        {
+            return null;
+        }
+
+        return (T) store.loadByUid( uid );
+    }
+
+    @Override
     @Transactional( readOnly = true )
     public <T extends IdentifiableObject> boolean exists( Class<T> type, String uid )
     {
@@ -608,9 +622,14 @@ public class DefaultIdentifiableObjectManager
 
     @Override
     @Transactional( readOnly = true )
-    public <T extends IdentifiableObject> List<T> getAndValidateByUid( Class<T> type, Collection<String> uids )
+    public <T extends IdentifiableObject> List<T> loadByUid( Class<T> type, Collection<String> uids )
         throws IllegalQueryException
     {
+        if ( uids == null )
+        {
+            return new ArrayList<>();
+        }
+
         List<T> objects = getByUid( type, uids );
 
         List<String> identifiers = IdentifiableObjectUtils.getUids( objects );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -53,7 +53,10 @@ import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.GenericDimensionalObjectStore;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.hibernate.InternalHibernateGenericStore;
@@ -334,6 +337,19 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
             .addPredicate( root -> builder.equal( root.get( "uid" ), uid ) );
 
         return getSingleResult( builder, param );
+    }
+
+    @Override
+    public final T loadByUid( String uid )
+    {
+        T object = getByUid( uid );
+
+        if ( object == null )
+        {
+            throw new IllegalQueryException( new ErrorMessage( ErrorCode.E1113, getClazz().getSimpleName(), uid ) );
+        }
+
+        return object;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
@@ -200,7 +200,7 @@ public class DefaultProgramService
     @Override
     public SetValuedMap<String, String> getProgramOrganisationUnitsAssociationsForCurrentUser( Set<String> programUids )
     {
-        idObjectManager.getAndValidateByUid( Program.class, programUids );
+        idObjectManager.loadByUid( Program.class, programUids );
 
         return jdbcOrgUnitAssociationsStore.getOrganisationUnitsAssociationsForCurrentUser( programUids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramStageInstanceService.java
@@ -286,7 +286,7 @@ public class DefaultProgramStageInstanceService
             dateCreatedEvent = incidentDate;
         }
 
-        Date dueDate = DateUtils.getDateAfterAddition( dateCreatedEvent, programStage.getMinDaysFromStart() );
+        Date dueDate = DateUtils.addDays( dateCreatedEvent, programStage.getMinDaysFromStart() );
 
         if ( !programInstance.getProgram().getIgnoreOverdueEvents() || dueDate.before( currentDate ) )
         {
@@ -320,9 +320,7 @@ public class DefaultProgramStageInstanceService
 
         if ( singleValue )
         {
-            // If it is only a single value update, I don't won't to miss the
-            // values that
-            // are missing in the payload but already present in the DB
+            // If only a single value update, merge with existing data
             Set<EventDataValue> changedDataValues = Sets.union( updatedOrNewDataValues, removedDataValues );
             Set<EventDataValue> unchangedDataValues = Sets.difference( programStageInstance.getEventDataValues(),
                 changedDataValues );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -43,7 +43,7 @@ import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.Order
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.POTENTIAL_DUPLICATE;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.TRACKED_ENTITY_ID;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.TRACKED_ENTITY_INSTANCE_ID;
-import static org.hisp.dhis.util.DateUtils.getDateAfterAddition;
+import static org.hisp.dhis.util.DateUtils.addDays;
 import static org.hisp.dhis.util.DateUtils.getLongGmtDateString;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
@@ -610,7 +610,7 @@ public class HibernateTrackedEntityInstanceStore
             if ( params.hasLastUpdatedEndDate() )
             {
                 trackedEntity.append( whereAnd.whereAnd() ).append( " TEI.lastupdated < '" )
-                    .append( getMediumDateString( getDateAfterAddition( params.getLastUpdatedEndDate(), 1 ) ) )
+                    .append( getMediumDateString( addDays( params.getLastUpdatedEndDate(), 1 ) ) )
                     .append( SINGLE_QUOTE );
             }
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/DefaultTrackedEntityDataValueAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/DefaultTrackedEntityDataValueAuditService.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 import org.hisp.dhis.trackedentity.TrackerAccessManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.springframework.stereotype.Service;
@@ -82,31 +82,18 @@ public class DefaultTrackedEntityDataValueAuditService
 
     @Override
     @Transactional( readOnly = true )
-    public List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType )
+    public List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits(
+        TrackedEntityDataValueAuditQueryParams params )
     {
-        return trackedEntityDataValueAuditStore
-            .getTrackedEntityDataValueAudits( dataElements, programStageInstances, auditType ).stream()
+        return trackedEntityDataValueAuditStore.getTrackedEntityDataValueAudits( params ).stream()
             .filter( aclFilter ).collect( Collectors.toList() );
     }
 
     @Override
     @Transactional( readOnly = true )
-    public List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType, int first, int max )
+    public int countTrackedEntityDataValueAudits( TrackedEntityDataValueAuditQueryParams params )
     {
-        return trackedEntityDataValueAuditStore
-            .getTrackedEntityDataValueAudits( dataElements, programStageInstances, auditType, first, max ).stream()
-            .filter( aclFilter ).collect( Collectors.toList() );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public int countTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType )
-    {
-        return trackedEntityDataValueAuditStore.countTrackedEntityDataValueAudits( dataElements, programStageInstances,
-            auditType );
+        return trackedEntityDataValueAuditStore.countTrackedEntityDataValueAudits( params );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueAuditStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitydatavalue/hibernate/HibernateTrackedEntityDataValueAuditStore.java
@@ -30,17 +30,18 @@ package org.hisp.dhis.trackedentitydatavalue.hibernate;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.Query;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Join;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditStore;
 import org.springframework.stereotype.Repository;
@@ -52,6 +53,10 @@ import org.springframework.stereotype.Repository;
 public class HibernateTrackedEntityDataValueAuditStore
     implements TrackedEntityDataValueAuditStore
 {
+    private static final String PROP_PSI = "programStageInstance";
+
+    private static final String PROP_CREATED = "created";
+
     // -------------------------------------------------------------------------
     // Dependencies
     // -------------------------------------------------------------------------
@@ -75,56 +80,45 @@ public class HibernateTrackedEntityDataValueAuditStore
     }
 
     @Override
-    public List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType )
+    @SuppressWarnings( "unchecked" )
+    public List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits(
+        TrackedEntityDataValueAuditQueryParams params )
     {
         CriteriaBuilder builder = sessionFactory.getCurrentSession().getCriteriaBuilder();
-        CriteriaQuery<TrackedEntityDataValueAudit> query = builder.createQuery( TrackedEntityDataValueAudit.class );
-        Root<TrackedEntityDataValueAudit> root = query.from( TrackedEntityDataValueAudit.class );
-        query.select( root );
+        CriteriaQuery<TrackedEntityDataValueAudit> criteria = builder.createQuery( TrackedEntityDataValueAudit.class );
+        Root<TrackedEntityDataValueAudit> tedva = criteria.from( TrackedEntityDataValueAudit.class );
+        Join<TrackedEntityDataValueAudit, ProgramStageInstance> psi = tedva.join( PROP_PSI );
+        criteria.select( tedva );
 
-        List<Predicate> predicates = getTrackedEntityDataValueAuditCriteria( dataElements, programStageInstances,
-            auditType, builder, root );
-        query.where( predicates.toArray( new Predicate[predicates.size()] ) );
-        query.orderBy( builder.desc( root.get( "created" ) ) );
+        List<Predicate> predicates = getTrackedEntityDataValueAuditCriteria( params, builder, tedva, psi );
+        criteria.where( predicates.toArray( new Predicate[0] ) );
+        criteria.orderBy( builder.desc( tedva.get( PROP_CREATED ) ) );
 
-        return sessionFactory.getCurrentSession().createQuery( query ).getResultList();
+        Query query = sessionFactory.getCurrentSession().createQuery( criteria );
+
+        if ( params.hasPaging() )
+        {
+            query
+                .setFirstResult( params.getPager().getOffset() )
+                .setMaxResults( params.getPager().getPageSize() );
+        }
+
+        return query.getResultList();
     }
 
     @Override
-    public List<TrackedEntityDataValueAudit> getTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType, int first, int max )
+    public int countTrackedEntityDataValueAudits( TrackedEntityDataValueAuditQueryParams params )
     {
         CriteriaBuilder builder = sessionFactory.getCurrentSession().getCriteriaBuilder();
-        CriteriaQuery<TrackedEntityDataValueAudit> query = builder.createQuery( TrackedEntityDataValueAudit.class );
-        Root<TrackedEntityDataValueAudit> root = query.from( TrackedEntityDataValueAudit.class );
-        query.select( root );
+        CriteriaQuery<Long> criteria = builder.createQuery( Long.class );
+        Root<TrackedEntityDataValueAudit> tedva = criteria.from( TrackedEntityDataValueAudit.class );
+        Join<TrackedEntityDataValueAudit, ProgramStageInstance> psi = tedva.join( PROP_PSI );
+        criteria.select( builder.countDistinct( tedva.get( "id" ) ) );
 
-        List<Predicate> predicates = getTrackedEntityDataValueAuditCriteria( dataElements, programStageInstances,
-            auditType, builder, root );
-        query.where( predicates.toArray( new Predicate[predicates.size()] ) );
-        query.orderBy( builder.desc( root.get( "created" ) ) );
+        List<Predicate> predicates = getTrackedEntityDataValueAuditCriteria( params, builder, tedva, psi );
+        criteria.where( predicates.toArray( new Predicate[predicates.size()] ) );
 
-        return sessionFactory.getCurrentSession().createQuery( query )
-            .setFirstResult( first )
-            .setMaxResults( max )
-            .getResultList();
-    }
-
-    @Override
-    public int countTrackedEntityDataValueAudits( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances, AuditType auditType )
-    {
-        CriteriaBuilder builder = sessionFactory.getCurrentSession().getCriteriaBuilder();
-        CriteriaQuery<Long> query = builder.createQuery( Long.class );
-        Root<TrackedEntityDataValueAudit> root = query.from( TrackedEntityDataValueAudit.class );
-        query.select( builder.countDistinct( root.get( "id" ) ) );
-
-        List<Predicate> predicates = getTrackedEntityDataValueAuditCriteria( dataElements, programStageInstances,
-            auditType, builder, root );
-        query.where( predicates.toArray( new Predicate[predicates.size()] ) );
-
-        return sessionFactory.getCurrentSession().createQuery( query ).getSingleResult().intValue();
+        return sessionFactory.getCurrentSession().createQuery( criteria ).getSingleResult().intValue();
     }
 
     @Override
@@ -143,29 +137,46 @@ public class HibernateTrackedEntityDataValueAuditStore
         sessionFactory.getCurrentSession().createQuery( hql ).setParameter( "psi", psi ).executeUpdate();
     }
 
-    private List<Predicate> getTrackedEntityDataValueAuditCriteria( List<DataElement> dataElements,
-        List<ProgramStageInstance> programStageInstances,
-        AuditType auditType, CriteriaBuilder builder, Root<TrackedEntityDataValueAudit> root )
+    private List<Predicate> getTrackedEntityDataValueAuditCriteria( TrackedEntityDataValueAuditQueryParams params,
+        CriteriaBuilder builder,
+        Root<TrackedEntityDataValueAudit> tedva,
+        Join<TrackedEntityDataValueAudit, ProgramStageInstance> psi )
     {
         List<Predicate> predicates = new ArrayList<>();
 
-        if ( dataElements != null && !dataElements.isEmpty() )
+        if ( !params.getDataElements().isEmpty() )
         {
-            Expression<DataElement> dataElementExpression = root.get( "dataElement" );
-            Predicate dataElementPredicate = dataElementExpression.in( dataElements );
-            predicates.add( dataElementPredicate );
+            predicates.add( tedva.get( "dataElement" ).in( params.getDataElements() ) );
         }
 
-        if ( programStageInstances != null && !programStageInstances.isEmpty() )
+        if ( !params.getOrgUnits().isEmpty() )
         {
-            Expression<DataElement> psiExpression = root.get( "programStageInstance" );
-            Predicate psiPredicate = psiExpression.in( programStageInstances );
-            predicates.add( psiPredicate );
+            predicates.add( psi.get( "organisationUnit" ).in( params.getOrgUnits() ) );
         }
 
-        if ( auditType != null )
+        if ( !params.getProgramStageInstances().isEmpty() )
         {
-            predicates.add( builder.equal( root.get( "auditType" ), auditType ) );
+            predicates.add( tedva.get( PROP_PSI ).in( params.getProgramStageInstances() ) );
+        }
+
+        if ( !params.getProgramStages().isEmpty() )
+        {
+            predicates.add( psi.get( "programStage" ).in( params.getProgramStages() ) );
+        }
+
+        if ( params.getStartDate() != null )
+        {
+            predicates.add( builder.greaterThanOrEqualTo( tedva.get( PROP_CREATED ), params.getStartDate() ) );
+        }
+
+        if ( params.getEndDate() != null )
+        {
+            predicates.add( builder.lessThanOrEqualTo( tedva.get( PROP_CREATED ), params.getEndDate() ) );
+        }
+
+        if ( params.getAuditType() != null )
+        {
+            predicates.add( builder.equal( tedva.get( "auditType" ), params.getAuditType() ) );
         }
 
         return predicates;

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.common;
 
-import static java.util.Collections.singleton;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,7 +82,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     private DataElementService dataElementService;
 
     @Autowired
-    private IdentifiableObjectManager identifiableObjectManager;
+    private IdentifiableObjectManager idObjectManager;
 
     @Autowired
     private UserService _userService;
@@ -100,9 +99,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         DataElement dataElementA = createDataElement( 'A' );
         dataElementService.addDataElement( dataElementA );
-        assertEquals( dataElementA, identifiableObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
+        assertEquals( dataElementA, idObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
             IdScheme.CODE, dataElementA.getCode() ) );
-        assertEquals( dataElementA, identifiableObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
+        assertEquals( dataElementA, idObjectManager.get( DataDimensionItem.DATA_DIMENSION_CLASSES,
             IdScheme.UID, dataElementA.getUid() ) );
     }
 
@@ -122,13 +121,13 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementService.addDataElementGroup( dataElementGroupB );
         long dataElementGroupIdB = dataElementGroupB.getId();
         assertEquals( dataElementA,
-            identifiableObjectManager.getObject( dataElementIdA, DataElement.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementIdA, DataElement.class.getSimpleName() ) );
         assertEquals( dataElementB,
-            identifiableObjectManager.getObject( dataElementIdB, DataElement.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementIdB, DataElement.class.getSimpleName() ) );
         assertEquals( dataElementGroupA,
-            identifiableObjectManager.getObject( dataElementGroupIdA, DataElementGroup.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementGroupIdA, DataElementGroup.class.getSimpleName() ) );
         assertEquals( dataElementGroupB,
-            identifiableObjectManager.getObject( dataElementGroupIdB, DataElementGroup.class.getSimpleName() ) );
+            idObjectManager.getObject( dataElementGroupIdB, DataElementGroup.class.getSimpleName() ) );
     }
 
     @Test
@@ -140,8 +139,8 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementService.addDataElement( dataElementB );
         Set<Class<? extends IdentifiableObject>> classes = ImmutableSet.<Class<? extends IdentifiableObject>> builder()
             .add( Indicator.class ).add( DataElement.class ).add( DataElementOperand.class ).build();
-        assertEquals( dataElementA, identifiableObjectManager.get( classes, dataElementA.getUid() ) );
-        assertEquals( dataElementB, identifiableObjectManager.get( classes, dataElementB.getUid() ) );
+        assertEquals( dataElementA, idObjectManager.get( classes, dataElementA.getUid() ) );
+        assertEquals( dataElementB, idObjectManager.get( classes, dataElementB.getUid() ) );
     }
 
     @Test
@@ -153,23 +152,23 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementService.addDataElement( dataElementB );
         OrganisationUnit unitA = createOrganisationUnit( 'A' );
         OrganisationUnit unitB = createOrganisationUnit( 'B' );
-        identifiableObjectManager.save( unitA );
-        identifiableObjectManager.save( unitB );
+        idObjectManager.save( unitA );
+        idObjectManager.save( unitB );
         Set<Class<? extends IdentifiableObject>> classes = ImmutableSet.<Class<? extends IdentifiableObject>> builder()
             .add( DataElement.class ).add( OrganisationUnit.class ).build();
         Set<String> uids = ImmutableSet.of( dataElementA.getUid(), unitB.getUid() );
-        assertEquals( 2, identifiableObjectManager.getByUid( classes, uids ).size() );
-        assertTrue( identifiableObjectManager.getByUid( classes, uids ).contains( dataElementA ) );
-        assertTrue( identifiableObjectManager.getByUid( classes, uids ).contains( unitB ) );
-        assertFalse( identifiableObjectManager.getByUid( classes, uids ).contains( dataElementB ) );
-        assertFalse( identifiableObjectManager.getByUid( classes, uids ).contains( unitA ) );
+        assertEquals( 2, idObjectManager.getByUid( classes, uids ).size() );
+        assertTrue( idObjectManager.getByUid( classes, uids ).contains( dataElementA ) );
+        assertTrue( idObjectManager.getByUid( classes, uids ).contains( unitB ) );
+        assertFalse( idObjectManager.getByUid( classes, uids ).contains( dataElementB ) );
+        assertFalse( idObjectManager.getByUid( classes, uids ).contains( unitA ) );
     }
 
     @Test
     void publicAccessSetIfNoUser()
     {
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getPublicAccess() );
         assertFalse( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertFalse( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
@@ -178,31 +177,31 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     @Test
     void getCount()
     {
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
     }
 
     @Test
     void getEqualToName()
     {
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
-        assertNotNull( identifiableObjectManager.getByName( DataElement.class, "DataElementA" ) );
-        assertNull( identifiableObjectManager.getByName( DataElement.class, "DataElementB" ) );
-        assertEquals( dataElement, identifiableObjectManager.getByName( DataElement.class, "DataElementA" ) );
+        idObjectManager.save( dataElement );
+        assertNotNull( idObjectManager.getByName( DataElement.class, "DataElementA" ) );
+        assertNull( idObjectManager.getByName( DataElement.class, "DataElementB" ) );
+        assertEquals( dataElement, idObjectManager.getByName( DataElement.class, "DataElementA" ) );
     }
 
     @Test
     void getAllOrderedName()
     {
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        List<DataElement> dataElements = new ArrayList<>( identifiableObjectManager.getAllSorted( DataElement.class ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'A' ) );
+        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAllSorted( DataElement.class ) );
         assertEquals( 4, dataElements.size() );
         assertEquals( "DataElementA", dataElements.get( 0 ).getName() );
         assertEquals( "DataElementB", dataElements.get( 1 ).getName() );
@@ -215,7 +214,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         User user = createUserAndInjectSecurityContext( true );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getCreatedBy() );
         assertEquals( user, dataElement.getCreatedBy() );
     }
@@ -225,7 +224,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD" );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getPublicAccess() );
         assertTrue( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertTrue( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
@@ -236,7 +235,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         assertNotNull( dataElement.getPublicAccess() );
         assertFalse( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertFalse( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
@@ -247,7 +246,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false );
         assertThrows( CreateAccessDeniedException.class,
-            () -> identifiableObjectManager.save( createDataElement( 'A' ) ) );
+            () -> idObjectManager.save( createDataElement( 'A' ) ) );
     }
 
     @Test
@@ -256,7 +255,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
         assertFalse( AccessStringHelper.canRead( dataElement.getPublicAccess() ) );
         assertFalse( AccessStringHelper.canWrite( dataElement.getPublicAccess() ) );
     }
@@ -267,7 +266,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
     }
 
     @Test
@@ -276,7 +275,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        assertThrows( CreateAccessDeniedException.class, () -> identifiableObjectManager.save( dataElement, false ) );
+        assertThrows( CreateAccessDeniedException.class, () -> idObjectManager.save( dataElement, false ) );
     }
 
     @Test
@@ -285,7 +284,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
     }
 
     @Test
@@ -294,9 +293,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PRIVATE_ADD" );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
-        identifiableObjectManager.save( dataElement, false );
+        idObjectManager.save( dataElement, false );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        assertThrows( UpdateAccessDeniedException.class, () -> identifiableObjectManager.update( dataElement ) );
+        assertThrows( UpdateAccessDeniedException.class, () -> idObjectManager.update( dataElement ) );
     }
 
     @Test
@@ -305,7 +304,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         createUserAndInjectSecurityContext( false );
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setPublicAccess( AccessStringHelper.READ_WRITE );
-        assertThrows( CreateAccessDeniedException.class, () -> identifiableObjectManager.save( dataElement, false ) );
+        assertThrows( CreateAccessDeniedException.class, () -> idObjectManager.save( dataElement, false ) );
     }
 
     @Test
@@ -313,24 +312,24 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD", "F_USER_ADD" );
         User user = createUser( 'B' );
-        identifiableObjectManager.save( user );
+        idObjectManager.save( user );
         DataElement dataElement = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElement );
+        idObjectManager.save( dataElement );
         dataElement.setOwner( user.getUid() );
         dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
         sessionFactory.getCurrentSession().update( dataElement );
-        assertThrows( DeleteAccessDeniedException.class, () -> identifiableObjectManager.delete( dataElement ) );
+        assertThrows( DeleteAccessDeniedException.class, () -> idObjectManager.delete( dataElement ) );
     }
 
     @Test
     void objectsWithNoUser()
     {
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
     }
 
     @Test
@@ -338,21 +337,21 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     {
         createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD", "F_USER_ADD" );
         User user = createUser( 'B' );
-        identifiableObjectManager.save( user );
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
-        List<DataElement> dataElements = new ArrayList<>( identifiableObjectManager.getAll( DataElement.class ) );
+        idObjectManager.save( user );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
+        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAll( DataElement.class ) );
         for ( DataElement dataElement : dataElements )
         {
             dataElement.setOwner( user.getUid() );
             dataElement.setPublicAccess( AccessStringHelper.DEFAULT );
             sessionFactory.getCurrentSession().update( dataElement );
         }
-        assertEquals( 0, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 0, identifiableObjectManager.getAll( DataElement.class ).size() );
+        assertEquals( 0, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 0, idObjectManager.getAll( DataElement.class ).size() );
     }
 
     @Test
@@ -361,20 +360,20 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         User loginUser = createUserAndInjectSecurityContext( false, "F_DATAELEMENT_PUBLIC_ADD", "F_USER_ADD",
             "F_USERGROUP_PUBLIC_ADD" );
         User user = createUser( 'B' );
-        identifiableObjectManager.save( user );
+        idObjectManager.save( user );
         UserGroup userGroup = createUserGroup( 'A', Sets.newHashSet( loginUser ) );
-        identifiableObjectManager.save( userGroup );
+        idObjectManager.save( userGroup );
         user.getGroups().add( userGroup );
         loginUser.getGroups().add( userGroup );
-        identifiableObjectManager.save( loginUser );
-        identifiableObjectManager.save( user );
-        identifiableObjectManager.save( createDataElement( 'A' ) );
-        identifiableObjectManager.save( createDataElement( 'B' ) );
-        identifiableObjectManager.save( createDataElement( 'C' ) );
-        identifiableObjectManager.save( createDataElement( 'D' ) );
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
-        List<DataElement> dataElements = new ArrayList<>( identifiableObjectManager.getAll( DataElement.class ) );
+        idObjectManager.save( loginUser );
+        idObjectManager.save( user );
+        idObjectManager.save( createDataElement( 'A' ) );
+        idObjectManager.save( createDataElement( 'B' ) );
+        idObjectManager.save( createDataElement( 'C' ) );
+        idObjectManager.save( createDataElement( 'D' ) );
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
+        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAll( DataElement.class ) );
         for ( DataElement dataElement : dataElements )
         {
             dataElement.getSharing().setOwner( user );
@@ -382,9 +381,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
             dataElement.getSharing().addUserGroupAccess( new UserGroupAccess( userGroup, AccessStringHelper.READ ) );
             sessionFactory.getCurrentSession().update( dataElement );
         }
-        identifiableObjectManager.flush();
-        assertEquals( 4, identifiableObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, identifiableObjectManager.getAll( DataElement.class ).size() );
+        idObjectManager.flush();
+        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
+        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
     }
 
     @Test
@@ -394,14 +393,15 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<DataElement> ab = identifiableObjectManager.getByUid( DataElement.class,
-            Arrays.asList( dataElementA.getUid(), dataElementB.getUid() ) );
-        List<DataElement> cd = identifiableObjectManager.getByUid( DataElement.class,
-            Arrays.asList( dataElementC.getUid(), dataElementD.getUid() ) );
+
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<DataElement> ab = idObjectManager.getByUid( DataElement.class,
+            List.of( dataElementA.getUid(), dataElementB.getUid() ) );
+        List<DataElement> cd = idObjectManager.getByUid( DataElement.class,
+            List.of( dataElementC.getUid(), dataElementD.getUid() ) );
         assertTrue( ab.contains( dataElementA ) );
         assertTrue( ab.contains( dataElementB ) );
         assertFalse( ab.contains( dataElementC ) );
@@ -413,28 +413,54 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void getAndValidateByUidTest()
+    void getByUidWithNull()
+    {
+        assertIsEmpty( idObjectManager.getByUid( DataElement.class, null ) );
+    }
+
+    @Test
+    void loadByUidTest()
     {
         DataElement dataElementA = createDataElement( 'A' );
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        List<DataElement> ab = identifiableObjectManager.getAndValidateByUid( DataElement.class,
-            Arrays.asList( dataElementA.getUid(), dataElementB.getUid() ) );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        List<DataElement> ab = idObjectManager.loadByUid( DataElement.class,
+            List.of( dataElementA.getUid(), dataElementB.getUid() ) );
         assertTrue( ab.contains( dataElementA ) );
         assertTrue( ab.contains( dataElementB ) );
         assertFalse( ab.contains( dataElementC ) );
     }
 
     @Test
-    void getAndValidateByUidExceptionTest()
+    void loadByUidNullTest()
+    {
+        assertIsEmpty( idObjectManager.loadByUid( DataElement.class, null ) );
+    }
+
+    @Test
+    void loadByUidExceptionTestA()
     {
         DataElement dataElementA = createDataElement( 'A' );
-        identifiableObjectManager.save( dataElementA );
-        IllegalQueryException ex = assertThrows( IllegalQueryException.class, () -> identifiableObjectManager
-            .getAndValidateByUid( DataElement.class, Arrays.asList( dataElementA.getUid(), "xhjG82jHaky" ) ) );
+        idObjectManager.save( dataElementA );
+        List<String> ids = List.of( dataElementA.getUid(), "xhjG82jHaky" );
+        IllegalQueryException ex = assertThrows( IllegalQueryException.class, () -> idObjectManager
+            .loadByUid( DataElement.class, ids ) );
+        assertEquals( ErrorCode.E1112, ex.getErrorCode() );
+    }
+
+    @Test
+    void loadByUidExceptionTestB()
+    {
+        OrganisationUnit ouA = createOrganisationUnit( 'A' );
+        OrganisationUnit ouB = createOrganisationUnit( 'B' );
+        idObjectManager.save( ouA );
+        idObjectManager.save( ouB );
+        List<String> ids = List.of( ouA.getUid(), "hy67TrE2nhK", ouB.getUid() );
+        IllegalQueryException ex = assertThrows( IllegalQueryException.class, () -> idObjectManager
+            .loadByUid( DataElement.class, ids ) );
         assertEquals( ErrorCode.E1112, ex.getErrorCode() );
     }
 
@@ -445,16 +471,16 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<String> uids = Arrays.asList( dataElementA.getUid(), dataElementC.getUid(), dataElementB.getUid(),
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<String> uids = List.of( dataElementA.getUid(), dataElementC.getUid(), dataElementB.getUid(),
             dataElementD.getUid() );
         List<DataElement> expected = new ArrayList<>(
-            Arrays.asList( dataElementA, dataElementC, dataElementB, dataElementD ) );
+            List.of( dataElementA, dataElementC, dataElementB, dataElementD ) );
         List<DataElement> actual = new ArrayList<>(
-            identifiableObjectManager.getOrdered( DataElement.class, IdScheme.UID, uids ) );
+            idObjectManager.getOrdered( DataElement.class, IdScheme.UID, uids ) );
         assertEquals( expected, actual );
     }
 
@@ -465,16 +491,16 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<String> codes = Arrays.asList( dataElementA.getCode(), dataElementC.getCode(), dataElementB.getCode(),
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<String> codes = List.of( dataElementA.getCode(), dataElementC.getCode(), dataElementB.getCode(),
             dataElementD.getCode() );
         List<DataElement> expected = new ArrayList<>(
-            Arrays.asList( dataElementA, dataElementC, dataElementB, dataElementD ) );
+            List.of( dataElementA, dataElementC, dataElementB, dataElementD ) );
         List<DataElement> actual = new ArrayList<>(
-            identifiableObjectManager.getOrdered( DataElement.class, IdScheme.CODE, codes ) );
+            idObjectManager.getOrdered( DataElement.class, IdScheme.CODE, codes ) );
         assertEquals( expected, actual );
     }
 
@@ -485,16 +511,16 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         DataElement dataElementC = createDataElement( 'C' );
         DataElement dataElementD = createDataElement( 'D' );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<String> uids = Arrays.asList( dataElementA.getUid(), dataElementC.getUid(), dataElementB.getUid(),
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<String> uids = List.of( dataElementA.getUid(), dataElementC.getUid(), dataElementB.getUid(),
             dataElementD.getUid() );
         List<DataElement> expected = new ArrayList<>(
-            Arrays.asList( dataElementA, dataElementC, dataElementB, dataElementD ) );
+            List.of( dataElementA, dataElementC, dataElementB, dataElementD ) );
         List<DataElement> actual = new ArrayList<>(
-            identifiableObjectManager.getByUidOrdered( DataElement.class, uids ) );
+            idObjectManager.getByUidOrdered( DataElement.class, uids ) );
         assertEquals( expected, actual );
     }
 
@@ -509,14 +535,14 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementB.setCode( "DE_B" );
         dataElementC.setCode( "DE_C" );
         dataElementD.setCode( "DE_D" );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
-        identifiableObjectManager.save( dataElementD );
-        List<DataElement> ab = identifiableObjectManager.getByCode( DataElement.class,
-            Arrays.asList( dataElementA.getCode(), dataElementB.getCode() ) );
-        List<DataElement> cd = identifiableObjectManager.getByCode( DataElement.class,
-            Arrays.asList( dataElementC.getCode(), dataElementD.getCode() ) );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+        List<DataElement> ab = idObjectManager.getByCode( DataElement.class,
+            List.of( dataElementA.getCode(), dataElementB.getCode() ) );
+        List<DataElement> cd = idObjectManager.getByCode( DataElement.class,
+            List.of( dataElementC.getCode(), dataElementD.getCode() ) );
         assertTrue( ab.contains( dataElementA ) );
         assertTrue( ab.contains( dataElementB ) );
         assertFalse( ab.contains( dataElementC ) );
@@ -537,12 +563,12 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         dataElementB.setCode( "DE_B" );
         dataElementC.setCode( "DE_C" );
         OrganisationUnit unit1 = createOrganisationUnit( 'A' );
-        identifiableObjectManager.save( unit1 );
-        identifiableObjectManager.save( dataElementA );
-        identifiableObjectManager.save( dataElementB );
-        identifiableObjectManager.save( dataElementC );
+        idObjectManager.save( unit1 );
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
         List<String> uids = Lists.newArrayList( dataElementA.getUid(), dataElementB.getUid(), dataElementC.getUid() );
-        List<DataElement> dataElements = identifiableObjectManager.getNoAcl( DataElement.class, uids );
+        List<DataElement> dataElements = idObjectManager.getNoAcl( DataElement.class, uids );
         assertEquals( 3, dataElements.size() );
         assertTrue( dataElements.contains( dataElementA ) );
         assertTrue( dataElements.contains( dataElementB ) );
@@ -555,11 +581,11 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         OrganisationUnit unit1 = createOrganisationUnit( 'A' );
         OrganisationUnit unit2 = createOrganisationUnit( 'B' );
         OrganisationUnit unit3 = createOrganisationUnit( 'C' );
-        identifiableObjectManager.save( unit1 );
-        identifiableObjectManager.save( unit2 );
-        identifiableObjectManager.save( unit3 );
+        idObjectManager.save( unit1 );
+        idObjectManager.save( unit2 );
+        idObjectManager.save( unit3 );
         Set<String> codes = Sets.newHashSet( unit2.getCode(), unit3.getCode() );
-        List<OrganisationUnit> units = identifiableObjectManager.getObjects( OrganisationUnit.class,
+        List<OrganisationUnit> units = idObjectManager.getObjects( OrganisationUnit.class,
             IdentifiableProperty.CODE, codes );
         assertEquals( 2, units.size() );
         assertTrue( units.contains( unit2 ) );
@@ -573,7 +599,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         DataElement dataElementB = createDataElement( 'B' );
         dataElementService.addDataElement( dataElementA );
         dataElementService.addDataElement( dataElementB );
-        Map<String, DataElement> map = identifiableObjectManager.getIdMap( DataElement.class, IdScheme.CODE );
+        Map<String, DataElement> map = idObjectManager.getIdMap( DataElement.class, IdScheme.CODE );
         assertEquals( dataElementA, map.get( "DataElementCodeA" ) );
         assertEquals( dataElementB, map.get( "DataElementCodeB" ) );
         assertNull( map.get( "DataElementCodeX" ) );
@@ -585,26 +611,26 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         User userA = createUser( 'A' );
         userService.addUser( userA );
         UserGroup userGroupA = createUserGroup( 'A', Sets.newHashSet( userA ) );
-        identifiableObjectManager.save( userGroupA );
+        idObjectManager.save( userGroupA );
         String userGroupUid = userGroupA.getUid();
         DataElement de = createDataElement( 'A' );
         Sharing sharing = new Sharing();
-        sharing.setUserGroupAccess( singleton( new UserGroupAccess( "rw------", userGroupA.getUid() ) ) );
+        sharing.setUserGroupAccess( Set.of( new UserGroupAccess( "rw------", userGroupA.getUid() ) ) );
         de.setSharing( sharing );
-        identifiableObjectManager.save( de, false );
-        de = identifiableObjectManager.get( de.getUid() );
+        idObjectManager.save( de, false );
+        de = idObjectManager.get( de.getUid() );
         assertEquals( 1, de.getSharing().getUserGroups().size() );
-        identifiableObjectManager.delete( userGroupA );
-        identifiableObjectManager.removeUserGroupFromSharing( userGroupUid );
+        idObjectManager.delete( userGroupA );
+        idObjectManager.removeUserGroupFromSharing( userGroupUid );
         dbmsManager.clearSession();
-        de = identifiableObjectManager.get( de.getUid() );
+        de = idObjectManager.get( de.getUid() );
         assertEquals( 0, de.getSharing().getUserGroups().size() );
     }
 
     @Test
     void testGetDefaults()
     {
-        Map<Class<? extends IdentifiableObject>, IdentifiableObject> objects = identifiableObjectManager.getDefaults();
+        Map<Class<? extends IdentifiableObject>, IdentifiableObject> objects = idObjectManager.getDefaults();
         assertEquals( 4, objects.size() );
         assertNotNull( objects.get( Category.class ) );
         assertNotNull( objects.get( CategoryCombo.class ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramStageInstanceServiceTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
@@ -374,8 +375,11 @@ class ProgramStageInstanceServiceTest extends DhisSpringTest
             .getProgramStageInstance( programStageInstanceA.getUid() );
         assertEquals( 4, tempPsiA.getEventDataValues().size() );
         // Check that there are 4 audits of CREATE type
-        long auditCreateCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.CREATE );
+        long auditCreateCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.CREATE ) );
         assertEquals( 4, auditCreateCount );
         // Fetch value of the EventDataValueB and compare that it is correct
         String eventDataValueBValue = tempPsiA.getEventDataValues().stream()
@@ -400,7 +404,7 @@ class ProgramStageInstanceServiceTest extends DhisSpringTest
         Set<EventDataValue> updatedEventDataValues = new HashSet<>(
             Arrays.asList( eventDataValueA, eventDataValueB, eventDataValueC ) );
         // Update PSI: create 0, update 3, delete 1
-        programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( Collections.emptySet(),
+        programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( Set.of(),
             updatedEventDataValues, Collections.singleton( eventDataValueD ), convertToMap( dataElementMap ),
             programStageInstanceA, false );
         programStageInstanceService.updateProgramStageInstance( programStageInstanceA );
@@ -410,14 +414,23 @@ class ProgramStageInstanceServiceTest extends DhisSpringTest
         assertEquals( 3, tempPsiA.getEventDataValues().size() );
         // Check that there are 4 audits of CREATE type, 3 of UPDATE type and 1
         // of DELETE type
-        long auditCreateCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.CREATE );
+        long auditCreateCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.CREATE ) );
         assertEquals( 4, auditCreateCount );
-        long auditUpdateCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.UPDATE );
+        long auditUpdateCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.UPDATE ) );
         assertEquals( 3, auditUpdateCount );
-        long auditDeleteCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.DELETE );
+        long auditDeleteCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.DELETE ) );
         assertEquals( 1, auditDeleteCount );
         // Fetch value of the EventDataValueB and compare that it is correct
         String eventDataValueBValue = tempPsiA.getEventDataValues().stream()
@@ -436,8 +449,8 @@ class ProgramStageInstanceServiceTest extends DhisSpringTest
         // Update 1 EventDataVaue and run a "SingleValue" update and check that
         // others, not mentioned, EventDataValues are not touched
         eventDataValueB.setValue( "22" );
-        programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( Collections.emptySet(),
-            Collections.singleton( eventDataValueB ), Collections.emptySet(), convertToMap( dataElementMap ),
+        programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( Set.of(),
+            Collections.singleton( eventDataValueB ), Set.of(), convertToMap( dataElementMap ),
             programStageInstanceA, true );
         programStageInstanceService.updateProgramStageInstance( programStageInstanceA );
         // Check that there are 4 EventDataValues
@@ -446,14 +459,23 @@ class ProgramStageInstanceServiceTest extends DhisSpringTest
         assertEquals( 4, tempPsiA.getEventDataValues().size() );
         // Check that there are 4 audits of CREATE type, 3 of UPDATE type and 1
         // of DELETE type
-        long auditCreateCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.CREATE );
+        long auditCreateCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.CREATE ) );
         assertEquals( 4, auditCreateCount );
-        long auditUpdateCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.UPDATE );
+        long auditUpdateCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.UPDATE ) );
         assertEquals( 1, auditUpdateCount );
-        long auditDeleteCount = dataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-            Collections.singletonList( programStageInstanceA ), AuditType.DELETE );
+        long auditDeleteCount = dataValueAuditService.countTrackedEntityDataValueAudits(
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( dataElements )
+                .setProgramStageInstances( List.of( programStageInstanceA ) )
+                .setAuditType( AuditType.DELETE ) );
         assertEquals( 0, auditDeleteCount );
         // Fetch value of the EventDataValueB and compare that it is correct
         String eventDataValueBValue = tempPsiA.getEventDataValues().stream()
@@ -480,7 +502,7 @@ class ProgramStageInstanceServiceTest extends DhisSpringTest
         Set<EventDataValue> newEventDataValues = new HashSet<>(
             Arrays.asList( eventDataValueA, eventDataValueB, eventDataValueC, eventDataValueD ) );
         programStageInstanceService.auditDataValuesChangesAndHandleFileDataValues( newEventDataValues,
-            Collections.emptySet(), Collections.emptySet(), convertToMap( dataElementMap ), programStageInstanceA,
+            Set.of(), Set.of(), convertToMap( dataElementMap ), programStageInstanceA,
             false );
         programStageInstanceService.updateProgramStageInstance( programStageInstanceA );
     }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -72,7 +72,7 @@ import static org.hisp.dhis.dxf2.events.trackedentity.store.query.EventQuery.COL
 import static org.hisp.dhis.system.util.SqlUtils.castToNumber;
 import static org.hisp.dhis.system.util.SqlUtils.escapeSql;
 import static org.hisp.dhis.system.util.SqlUtils.lower;
-import static org.hisp.dhis.util.DateUtils.getDateAfterAddition;
+import static org.hisp.dhis.util.DateUtils.addDays;
 import static org.hisp.dhis.util.DateUtils.getLongGmtDateString;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
@@ -1180,7 +1180,7 @@ public class JdbcEventStore implements EventStore
 
         if ( params.getEndDate() != null )
         {
-            Date dateAfterEndDate = getDateAfterAddition( params.getEndDate(), 1 );
+            Date dateAfterEndDate = addDays( params.getEndDate(), 1 );
             sqlBuilder.append( hlp.whereAnd() ).append( " (psi.executiondate < '" )
                 .append( getMediumDateString( dateAfterEndDate ) ).append( "' " )
                 .append( "or (psi.executiondate is null and psi.duedate < '" )
@@ -1470,7 +1470,7 @@ public class JdbcEventStore implements EventStore
             {
                 if ( useDateAfterEndDate )
                 {
-                    Date dateAfterEndDate = getDateAfterAddition( params.getLastUpdatedEndDate(), 1 );
+                    Date dateAfterEndDate = addDays( params.getLastUpdatedEndDate(), 1 );
                     sqlBuilder.append( hlp.whereAnd() ).append( " psi.lastupdated < '" )
                         .append( DateUtils.getLongDateString( dateAfterEndDate ) ).append( "' " );
                 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/update/validation/ExpirationDaysCheck.java
@@ -110,7 +110,7 @@ public class ExpirationDaysCheck implements Checker
                 }
 
                 if ( (new Date()).after(
-                    DateUtils.getDateAfterAddition( referenceDate, program.getCompleteEventsExpiryDays() ) ) )
+                    DateUtils.addDays( referenceDate, program.getCompleteEventsExpiryDays() ) ) )
                 {
                     return error(
                         "The event's completeness date has expired. Not possible to make changes to this event",
@@ -139,7 +139,7 @@ public class ExpirationDaysCheck implements Checker
                 }
 
                 Period period = periodType.createPeriod( programStageInstance.getExecutionDate() );
-                if ( today.after( DateUtils.getDateAfterAddition( period.getEndDate(), program.getExpiryDays() ) ) )
+                if ( today.after( DateUtils.addDays( period.getEndDate(), program.getExpiryDays() ) ) )
                 {
                     return error(
                         "The program's expiry date has passed. It is not possible to make changes to this event",

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -138,8 +138,8 @@ public class DefaultPredictionService
     @Override
     public PredictionSummary predictJob( PredictorJobParameters params, JobConfiguration jobId )
     {
-        Date startDate = DateUtils.getDateAfterAddition( new Date(), params.getRelativeStart() );
-        Date endDate = DateUtils.getDateAfterAddition( new Date(), params.getRelativeEnd() );
+        Date startDate = DateUtils.addDays( new Date(), params.getRelativeStart() );
+        Date endDate = DateUtils.addDays( new Date(), params.getRelativeEnd() );
 
         return predictTask( startDate, endDate, params.getPredictors(), params.getPredictorGroups(), jobId );
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/validation/scheduling/MonitoringJob.java
@@ -136,9 +136,9 @@ public class MonitoringJob implements Job
 
             if ( monitoringJobParameters.getRelativeStart() != 0 && monitoringJobParameters.getRelativeEnd() != 0 )
             {
-                Date startDate = DateUtils.getDateAfterAddition( new Date(),
+                Date startDate = DateUtils.addDays( new Date(),
                     monitoringJobParameters.getRelativeStart() );
-                Date endDate = DateUtils.getDateAfterAddition( new Date(), monitoringJobParameters.getRelativeEnd() );
+                Date endDate = DateUtils.addDays( new Date(), monitoringJobParameters.getRelativeEnd() );
 
                 periods = periodService.getPeriodsBetweenDates( startDate, endDate );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java~DHIS2-13421
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java~DHIS2-13421
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * @author Stian Sandvold
+ */
+@Value
+@Builder
+@JsonDeserialize( builder = TrackerIdSchemeParam.TrackerIdSchemeParamBuilder.class )
+@AllArgsConstructor( staticName = "of" )
+public class TrackerIdSchemeParam
+{
+    public static final TrackerIdSchemeParam UID = builder().idScheme( TrackerIdScheme.UID ).build();
+
+    public static final TrackerIdSchemeParam CODE = builder().idScheme( TrackerIdScheme.CODE ).build();
+
+    public static final TrackerIdSchemeParam NAME = builder().idScheme( TrackerIdScheme.NAME ).build();
+
+    @JsonProperty
+    @Builder.Default
+    private final TrackerIdScheme idScheme = TrackerIdScheme.UID;
+
+    @JsonProperty
+    @Builder.Default
+    private final String attributeUid = null;
+
+    /**
+     * Creates a TrackerIdSchemeParam of idScheme ATTRIBUTE.
+     *
+     * @param uid attribute uid
+     * @return tracker idscheme parameter representing an attribute
+     */
+    public static TrackerIdSchemeParam ofAttribute( String uid )
+    {
+        return new TrackerIdSchemeParam( TrackerIdScheme.ATTRIBUTE, uid );
+    }
+
+    public <T extends IdentifiableObject> String getIdentifier( T object )
+    {
+        switch ( idScheme )
+        {
+        case UID:
+            return object.getUid();
+        case CODE:
+            return object.getCode();
+        case NAME:
+            return object.getName();
+        case ATTRIBUTE:
+            return object.getAttributeValues()
+                .stream()
+                .filter( av -> av.getAttribute().getUid().equals( attributeUid ) )
+                .map( AttributeValue::getValue )
+                .findFirst()
+                .orElse( null );
+        }
+
+        throw new RuntimeException( "Unhandled identifier type." );
+    }
+
+    /**
+     * Creates an identifier for given {@code metadata} using this idScheme
+     * parameter. This means the metadata identifier will have the this
+     * {@link #idScheme} and {@link #attributeUid} for idScheme ATTRIBUTE. The
+     * {@link MetadataIdentifier#getIdentifier()} will be the appropriate one
+     * for this idScheme.
+     *
+     * @param metadata to create metadata identifier for
+     * @return metadata identifier representing metadata using this idScheme
+     *         parameter
+     */
+    public MetadataIdentifier toMetadataIdentifier( IdentifiableObject metadata )
+    {
+        if ( metadata == null )
+        {
+            return toMetadataIdentifier( (String) null );
+        }
+        return toMetadataIdentifier( getIdentifier( metadata ) );
+    }
+
+    /**
+     * Creates an identifier for given {@code identifier} using this idScheme
+     * parameter. This means the metadata identifier will have the this
+     * {@link #idScheme} and {@link #attributeUid} for idScheme ATTRIBUTE. The
+     * {@link MetadataIdentifier#getIdentifier()} will be the appropriate one
+     * for this idScheme.
+     *
+     * @param identifier to create metadata identifier for
+     * @return metadata identifier representing metadata using this idScheme
+     *         parameter
+     */
+    public MetadataIdentifier toMetadataIdentifier( String identifier )
+    {
+        if ( this.idScheme == TrackerIdScheme.ATTRIBUTE )
+        {
+            return MetadataIdentifier.ofAttribute( this.attributeUid, identifier );
+        }
+        return MetadataIdentifier.of( this.idScheme, identifier, null );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java~HEAD
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParam.java~HEAD
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import org.hisp.dhis.attribute.AttributeValue;
+import org.hisp.dhis.common.IdentifiableObject;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * @author Stian Sandvold
+ */
+@Value
+@Builder
+@JsonDeserialize( builder = TrackerIdSchemeParam.TrackerIdSchemeParamBuilder.class )
+@AllArgsConstructor( staticName = "of" )
+public class TrackerIdSchemeParam
+{
+    public static final TrackerIdSchemeParam UID = builder().idScheme( TrackerIdScheme.UID ).build();
+
+    public static final TrackerIdSchemeParam CODE = builder().idScheme( TrackerIdScheme.CODE ).build();
+
+    public static final TrackerIdSchemeParam NAME = builder().idScheme( TrackerIdScheme.NAME ).build();
+
+    @JsonProperty
+    @Builder.Default
+    private final TrackerIdScheme idScheme = TrackerIdScheme.UID;
+
+    @JsonProperty
+    @Builder.Default
+    private final String value = null;
+
+    /**
+     * Creates a TrackerIdentifier of idScheme ATTRIBUTE.
+     *
+     * @param value the attribute value
+     * @return tracker identifier representing an attribute
+     */
+    public static TrackerIdSchemeParam ofAttribute( String value )
+    {
+        return new TrackerIdSchemeParam( TrackerIdScheme.ATTRIBUTE, value );
+    }
+
+    public <T extends IdentifiableObject> String getIdentifier( T object )
+    {
+        switch ( idScheme )
+        {
+        case UID:
+            return object.getUid();
+        case CODE:
+            return object.getCode();
+        case NAME:
+            return object.getName();
+        case ATTRIBUTE:
+            return object.getAttributeValues()
+                .stream()
+                .filter( av -> av.getAttribute().getUid().equals( value ) )
+                .map( AttributeValue::getValue )
+                .findFirst()
+                .orElse( null );
+        }
+
+        throw new RuntimeException( "Unhandled identifier type." );
+    }
+
+    public <T extends IdentifiableObject> String getIdAndName( T object )
+    {
+        String identifier = getIdentifier( object );
+        return object.getClass().getSimpleName() + " (" + identifier + ")";
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java~DHIS2-13421
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java~DHIS2-13421
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.tracker.domain.MetadataIdentifier;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wrapper object to handle identifier-related parameters for tracker
+ * import/export
+ *
+ * @author Stian Sandvold
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrackerIdSchemeParams
+{
+    /**
+     * Specific identifier to match data elements on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam dataElementIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match organisation units on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam orgUnitIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match program on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam programIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match program stage on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam programStageIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match all metadata on. Will be overridden by
+     * metadata-specific idSchemes.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam idScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match category option combo on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam categoryOptionComboIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match category option on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam categoryOptionIdScheme = TrackerIdSchemeParam.UID;
+
+    public TrackerIdSchemeParam getByClass( Class<?> klazz )
+    {
+        switch ( klazz.getSimpleName() )
+        {
+        case "CategoryOptionCombo":
+            return categoryOptionComboIdScheme;
+        case "OrganisationUnit":
+            return orgUnitIdScheme;
+        case "CategoryOption":
+            return categoryOptionIdScheme;
+        case "DataElement":
+            return dataElementIdScheme;
+        case "Program":
+            return programIdScheme;
+        case "ProgramStage":
+            return programStageIdScheme;
+        default:
+            return idScheme;
+        }
+
+    }
+
+    /**
+     * Creates metadata identifier for given {@code metadata} using
+     * {@link #idScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param metadata to create metadata identifier for
+     * @return metadata identifier representing metadata using the idScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( IdentifiableObject metadata )
+    {
+        return idScheme.toMetadataIdentifier( metadata );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code categoryOptionCombo} using
+     * {@link #categoryOptionComboIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param categoryOptionCombo to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         categoryOptionComboIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( CategoryOptionCombo categoryOptionCombo )
+    {
+        return categoryOptionComboIdScheme.toMetadataIdentifier( categoryOptionCombo );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code categoryOption} using
+     * {@link #categoryOptionIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param categoryOption to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         categoryOptionIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( CategoryOption categoryOption )
+    {
+        return categoryOptionIdScheme.toMetadataIdentifier( categoryOption );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code dataElement} using
+     * {@link #dataElementIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param dataElement to create metadata identifier for
+     * @return metadata identifier representing dataElement using the idScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( DataElement dataElement )
+    {
+        return dataElementIdScheme.toMetadataIdentifier( dataElement );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code orgUnit} using
+     * {@link #orgUnitIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param orgUnit to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         orgUnitIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( OrganisationUnit orgUnit )
+    {
+        return orgUnitIdScheme.toMetadataIdentifier( orgUnit );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code program} using
+     * {@link #programIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param program to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         programIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( Program program )
+    {
+        return programIdScheme.toMetadataIdentifier( program );
+    }
+
+    /**
+     * Creates metadata identifier for given {@code programStage} using
+     * {@link #programStageIdScheme}. For more details refer to
+     * {@link TrackerIdSchemeParam#toMetadataIdentifier(IdentifiableObject)}
+     *
+     * @param programStage to create metadata identifier for
+     * @return metadata identifier representing metadata using the
+     *         programIdScheme
+     */
+    public MetadataIdentifier toMetadataIdentifier( ProgramStage programStage )
+    {
+        return programStageIdScheme.toMetadataIdentifier( programStage );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java~HEAD
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerIdSchemeParams.java~HEAD
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Wrapper object to handle identifier-related parameters for tracker
+ * import/export
+ *
+ * @author Stian Sandvold
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrackerIdSchemeParams
+{
+    /**
+     * Specific identifier to match data elements on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam dataElementIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match organisation units on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam orgUnitIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match program on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam programIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match program stage on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam programStageIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match all metadata on. Will be overridden by
+     * metadata-specific idSchemes.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam idScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match category option combo on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam categoryOptionComboIdScheme = TrackerIdSchemeParam.UID;
+
+    /**
+     * Specific identifier to match category option on.
+     */
+    @JsonProperty
+    @Builder.Default
+    private TrackerIdSchemeParam categoryOptionIdScheme = TrackerIdSchemeParam.UID;
+
+    public TrackerIdSchemeParam getByClass( Class<?> klazz )
+    {
+        switch ( klazz.getSimpleName() )
+        {
+        case "CategoryOptionCombo":
+            return categoryOptionComboIdScheme;
+        case "OrganisationUnit":
+            return orgUnitIdScheme;
+        case "CategoryOption":
+            return categoryOptionIdScheme;
+        case "DataElement":
+            return dataElementIdScheme;
+        case "Program":
+            return programIdScheme;
+        case "ProgramStage":
+            return programStageIdScheme;
+        default:
+            return idScheme;
+        }
+
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.program.ProgramStageInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAudit;
 import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
 import org.hisp.dhis.tracker.TrackerImportParams;
@@ -48,8 +49,6 @@ import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import com.google.common.collect.Lists;
 
 /**
  * @author Zubair Asghar
@@ -106,11 +105,20 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
         assertEquals( psi.getUid(), PSI );
 
         List<TrackedEntityDataValueAudit> createdAudit = dataValueAuditService.getTrackedEntityDataValueAudits(
-            Lists.newArrayList( dataElement ), Lists.newArrayList( psi ), AuditType.CREATE );
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( List.of( dataElement ) )
+                .setProgramStageInstances( List.of( psi ) )
+                .setAuditType( AuditType.CREATE ) );
         List<TrackedEntityDataValueAudit> updatedAudit = dataValueAuditService.getTrackedEntityDataValueAudits(
-            Lists.newArrayList( dataElement ), Lists.newArrayList( psi ), AuditType.UPDATE );
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( List.of( dataElement ) )
+                .setProgramStageInstances( List.of( psi ) )
+                .setAuditType( AuditType.UPDATE ) );
         List<TrackedEntityDataValueAudit> deletedAudit = dataValueAuditService.getTrackedEntityDataValueAudits(
-            Lists.newArrayList( dataElement ), Lists.newArrayList( psi ), AuditType.DELETE );
+            new TrackedEntityDataValueAuditQueryParams()
+                .setDataElements( List.of( dataElement ) )
+                .setProgramStageInstances( List.of( psi ) )
+                .setAuditType( AuditType.DELETE ) );
 
         assertNotNull( createdAudit );
         assertNotNull( updatedAudit );

--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -40,6 +40,18 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -89,6 +89,8 @@ import org.hisp.dhis.dataset.notifications.DataSetNotificationRecipient;
 import org.hisp.dhis.dataset.notifications.DataSetNotificationTemplate;
 import org.hisp.dhis.dataset.notifications.DataSetNotificationTrigger;
 import org.hisp.dhis.datavalue.DataValue;
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationType;
 import org.hisp.dhis.expression.Expression;
@@ -176,8 +178,6 @@ import org.hisp.dhis.visualization.Visualization;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDateTime;
 import org.locationtech.jts.geom.Geometry;
-import org.springframework.aop.framework.Advised;
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -428,25 +428,6 @@ public abstract class DhisConvenienceTest
             throw new IllegalArgumentException( "Failed to set dependency " + role + " on service "
                 + targetService.getClass().getSimpleName() );
         }
-    }
-
-    /**
-     * If the given class is advised by Spring AOP it will return the target
-     * class, i.e. the advised class. If not the given class is returned
-     * unchanged.
-     *
-     * @param object the object.
-     */
-    @SuppressWarnings( "unchecked" )
-    private <T> T getRealObject( T object )
-        throws Exception
-    {
-        if ( AopUtils.isAopProxy( object ) )
-        {
-            return (T) ((Advised) object).getTargetSource().getTarget();
-        }
-
-        return object;
     }
 
     // -------------------------------------------------------------------------
@@ -1535,6 +1516,16 @@ public abstract class DhisConvenienceTest
         psi.setProgramInstance( pi );
         psi.setOrganisationUnit( organisationUnit );
 
+        return psi;
+    }
+
+    public static ProgramStageInstance createProgramStageInstance( ProgramInstance programInstance,
+        ProgramStage programStage, OrganisationUnit organisationUnit, Set<EventDataValue> dataValues )
+    {
+        ProgramStageInstance psi = createProgramStageInstance( programStage, programInstance, organisationUnit );
+        psi.setExecutionDate( new Date() );
+        psi.setStatus( EventStatus.ACTIVE );
+        psi.setEventDataValues( dataValues );
         return psi;
     }
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
@@ -38,7 +39,6 @@ import java.util.Map;
  */
 public final class Assertions
 {
-
     private Assertions()
     {
         throw new UnsupportedOperationException( "util" );
@@ -64,5 +64,17 @@ public final class Assertions
         {
             assertEquals( e.getValue(), expected.get( e.getKey() ), "Did not expect value in " + actual.toString() );
         }
+    }
+
+    /**
+     * Asserts that the given collection is not null and empty.
+     *
+     * @param <E>
+     * @param actual the collection.
+     */
+    public static <E> void assertIsEmpty( Collection<E> actual )
+    {
+        assertNotNull( actual );
+        assertTrue( actual.isEmpty() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AuditController.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.controller;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
@@ -37,8 +36,12 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletResponse;
+
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.audit.payloads.TrackedEntityInstanceAudit;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -71,9 +74,10 @@ import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityDataValueAuditQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceAuditQueryParams;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceAuditService;
@@ -84,26 +88,24 @@ import org.hisp.dhis.trackedentitydatavalue.TrackedEntityDataValueAuditService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.springframework.http.HttpHeaders;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.google.common.collect.Lists;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Controller
+@RestController
+@RequiredArgsConstructor
 @RequestMapping( "/audits" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class AuditController
 {
     private final IdentifiableObjectManager manager;
-
-    private final ProgramStageInstanceService programStageInstanceService;
 
     private final DataValueAuditService dataValueAuditService;
 
@@ -121,42 +123,6 @@ public class AuditController
 
     private final FileResourceService fileResourceService;
 
-    public AuditController( IdentifiableObjectManager manager, ProgramStageInstanceService programStageInstanceService,
-        DataValueAuditService dataValueAuditService,
-        TrackedEntityDataValueAuditService trackedEntityDataValueAuditService,
-        TrackedEntityAttributeValueAuditService trackedEntityAttributeValueAuditService,
-        DataApprovalAuditService dataApprovalAuditService,
-        TrackedEntityInstanceAuditService trackedEntityInstanceAuditService,
-        FieldFilterService fieldFilterService,
-        ContextService contextService, FileResourceService fileResourceService )
-    {
-        checkNotNull( manager );
-        checkNotNull( programStageInstanceService );
-        checkNotNull( dataValueAuditService );
-        checkNotNull( trackedEntityDataValueAuditService );
-        checkNotNull( trackedEntityAttributeValueAuditService );
-        checkNotNull( dataApprovalAuditService );
-        checkNotNull( fieldFilterService );
-        checkNotNull( contextService );
-        checkNotNull( fileResourceService );
-
-        this.manager = manager;
-        this.programStageInstanceService = programStageInstanceService;
-        this.dataValueAuditService = dataValueAuditService;
-        this.trackedEntityDataValueAuditService = trackedEntityDataValueAuditService;
-        this.trackedEntityAttributeValueAuditService = trackedEntityAttributeValueAuditService;
-        this.dataApprovalAuditService = dataApprovalAuditService;
-        this.trackedEntityInstanceAuditService = trackedEntityInstanceAuditService;
-        this.fieldFilterService = fieldFilterService;
-        this.contextService = contextService;
-        this.fileResourceService = fileResourceService;
-    }
-
-    /**
-     * Returns the file with the given uid
-     *
-     * @param uid the unique id of the file resource
-     */
     @GetMapping( "/files/{uid}" )
     public void getFileAudit( @PathVariable String uid, HttpServletResponse response )
         throws WebMessageException
@@ -195,11 +161,11 @@ public class AuditController
     }
 
     @GetMapping( "dataValue" )
-    public @ResponseBody RootNode getAggregateDataValueAudit(
-        @RequestParam( required = false, defaultValue = "" ) List<String> ds,
-        @RequestParam( required = false, defaultValue = "" ) List<String> de,
-        @RequestParam( required = false, defaultValue = "" ) List<String> pe,
-        @RequestParam( required = false, defaultValue = "" ) List<String> ou,
+    public RootNode getAggregateDataValueAudit(
+        @RequestParam( required = false ) List<String> ds,
+        @RequestParam( required = false ) List<String> de,
+        @RequestParam( required = false ) List<String> pe,
+        @RequestParam( required = false ) List<String> ou,
         @RequestParam( required = false ) String co,
         @RequestParam( required = false ) String cc,
         @RequestParam( required = false ) AuditType auditType,
@@ -217,13 +183,13 @@ public class AuditController
         }
 
         List<DataElement> dataElements = new ArrayList<>();
-        dataElements.addAll( getDataElements( de ) );
+        dataElements.addAll( manager.loadByUid( DataElement.class, de ) );
         dataElements.addAll( getDataElementsByDataSet( ds ) );
 
         List<Period> periods = getPeriods( pe );
-        List<OrganisationUnit> organisationUnits = getOrganisationUnit( ou );
-        CategoryOptionCombo categoryOptionCombo = getCategoryOptionCombo( co );
-        CategoryOptionCombo attributeOptionCombo = getAttributeOptionCombo( cc );
+        List<OrganisationUnit> organisationUnits = manager.loadByUid( OrganisationUnit.class, ou );
+        CategoryOptionCombo categoryOptionCombo = manager.load( CategoryOptionCombo.class, co );
+        CategoryOptionCombo attributeOptionCombo = manager.load( CategoryOptionCombo.class, cc );
 
         List<DataValueAudit> dataValueAudits;
         Pager pager = null;
@@ -262,9 +228,13 @@ public class AuditController
     }
 
     @GetMapping( "trackedEntityDataValue" )
-    public @ResponseBody RootNode getTrackedEntityDataValueAudit(
-        @RequestParam( required = false, defaultValue = "" ) List<String> de,
-        @RequestParam( required = false, defaultValue = "" ) List<String> psi,
+    public RootNode getTrackedEntityDataValueAudit(
+        @RequestParam( required = false ) List<String> de,
+        @RequestParam( required = false ) List<String> ou,
+        @RequestParam( required = false ) List<String> psi,
+        @RequestParam( required = false ) List<String> ps,
+        @RequestParam( required = false ) Date startDate,
+        @RequestParam( required = false ) Date endDate,
         @RequestParam( required = false ) AuditType auditType,
         @RequestParam( required = false ) Boolean skipPaging,
         @RequestParam( required = false ) Boolean paging,
@@ -279,26 +249,43 @@ public class AuditController
             fields.addAll( Preset.ALL.getFields() );
         }
 
-        List<DataElement> dataElements = getDataElements( de );
-        List<ProgramStageInstance> programStageInstances = getProgramStageInstances( psi );
+        List<DataElement> dataElements = manager.loadByUid( DataElement.class, de );
+        List<OrganisationUnit> orgUnits = manager.loadByUid( OrganisationUnit.class, ou );
+        List<ProgramStage> programStages = manager.loadByUid( ProgramStage.class, ps );
+        List<ProgramStageInstance> programStageInstances = manager.loadByUid( ProgramStageInstance.class, psi );
 
         List<TrackedEntityDataValueAudit> dataValueAudits;
         Pager pager = null;
 
+        TrackedEntityDataValueAuditQueryParams params = new TrackedEntityDataValueAuditQueryParams()
+            .setDataElements( dataElements )
+            .setOrgUnits( orgUnits )
+            .setProgramStageInstances( programStageInstances )
+            .setProgramStages( programStages )
+            .setStartDate( startDate )
+            .setEndDate( endDate )
+            .setAuditType( auditType );
+
         if ( PagerUtils.isSkipPaging( skipPaging, paging ) )
         {
-            dataValueAudits = trackedEntityDataValueAuditService.getTrackedEntityDataValueAudits(
-                dataElements, programStageInstances, auditType );
+            dataValueAudits = trackedEntityDataValueAuditService.getTrackedEntityDataValueAudits( params );
         }
         else
         {
-            int total = trackedEntityDataValueAuditService.countTrackedEntityDataValueAudits( dataElements,
-                programStageInstances, auditType );
+            int total = trackedEntityDataValueAuditService.countTrackedEntityDataValueAudits( params );
 
             pager = new Pager( page, total, pageSize );
 
             dataValueAudits = trackedEntityDataValueAuditService.getTrackedEntityDataValueAudits(
-                dataElements, programStageInstances, auditType, pager.getOffset(), pager.getPageSize() );
+                new TrackedEntityDataValueAuditQueryParams()
+                    .setDataElements( dataElements )
+                    .setOrgUnits( orgUnits )
+                    .setProgramStageInstances( programStageInstances )
+                    .setProgramStages( programStages )
+                    .setStartDate( startDate )
+                    .setEndDate( endDate )
+                    .setAuditType( auditType )
+                    .setPager( pager ) );
         }
 
         RootNode rootNode = NodeUtils.createMetadata();
@@ -318,9 +305,9 @@ public class AuditController
     }
 
     @GetMapping( "trackedEntityAttributeValue" )
-    public @ResponseBody RootNode getTrackedEntityAttributeValueAudit(
-        @RequestParam( required = false, defaultValue = "" ) List<String> tea,
-        @RequestParam( required = false, defaultValue = "" ) List<String> tei,
+    public RootNode getTrackedEntityAttributeValueAudit(
+        @RequestParam( required = false ) List<String> tea,
+        @RequestParam( required = false ) List<String> tei,
         @RequestParam( required = false ) AuditType auditType,
         @RequestParam( required = false ) Boolean skipPaging,
         @RequestParam( required = false ) Boolean paging,
@@ -330,8 +317,8 @@ public class AuditController
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
 
-        List<TrackedEntityAttribute> trackedEntityAttributes = getTrackedEntityAttributes( tea );
-        List<TrackedEntityInstance> trackedEntityInstances = getTrackedEntityInstances( tei );
+        List<TrackedEntityAttribute> trackedEntityAttributes = manager.loadByUid( TrackedEntityAttribute.class, tea );
+        List<TrackedEntityInstance> trackedEntityInstances = manager.loadByUid( TrackedEntityInstance.class, tei );
 
         List<TrackedEntityAttributeValueAudit> attributeValueAudits;
         Pager pager = null;
@@ -344,8 +331,7 @@ public class AuditController
         else
         {
             int total = trackedEntityAttributeValueAuditService.countTrackedEntityAttributeValueAudits(
-                trackedEntityAttributes,
-                trackedEntityInstances, auditType );
+                trackedEntityAttributes, trackedEntityInstances, auditType );
 
             pager = new Pager( page, total, pageSize );
 
@@ -370,11 +356,11 @@ public class AuditController
     }
 
     @GetMapping( "dataApproval" )
-    public @ResponseBody RootNode getDataApprovalAudit(
-        @RequestParam( required = false, defaultValue = "" ) List<String> dal,
-        @RequestParam( required = false, defaultValue = "" ) List<String> wf,
-        @RequestParam( required = false, defaultValue = "" ) List<String> ou,
-        @RequestParam( required = false, defaultValue = "" ) List<String> aoc,
+    public RootNode getDataApprovalAudit(
+        @RequestParam( required = false ) List<String> dal,
+        @RequestParam( required = false ) List<String> wf,
+        @RequestParam( required = false ) List<String> ou,
+        @RequestParam( required = false ) List<String> aoc,
         @RequestParam( required = false ) Date startDate,
         @RequestParam( required = false ) Date endDate,
         @RequestParam( required = false ) Boolean skipPaging,
@@ -389,14 +375,13 @@ public class AuditController
             fields.addAll( Preset.ALL.getFields() );
         }
 
-        DataApprovalAuditQueryParams params = new DataApprovalAuditQueryParams();
-
-        params.setLevels( new HashSet<>( getDataApprovalLevel( dal ) ) );
-        params.setWorkflows( new HashSet<>( getDataApprovalWorkflow( wf ) ) );
-        params.setOrganisationUnits( new HashSet<>( getOrganisationUnit( ou ) ) );
-        params.setAttributeOptionCombos( new HashSet<>( getCategoryOptionCombo( aoc ) ) );
-        params.setStartDate( startDate );
-        params.setEndDate( endDate );
+        DataApprovalAuditQueryParams params = new DataApprovalAuditQueryParams()
+            .setLevels( new HashSet<>( manager.loadByUid( DataApprovalLevel.class, dal ) ) )
+            .setWorkflows( new HashSet<>( manager.loadByUid( DataApprovalWorkflow.class, wf ) ) )
+            .setOrganisationUnits( new HashSet<>( manager.loadByUid( OrganisationUnit.class, ou ) ) )
+            .setAttributeOptionCombos( new HashSet<>( manager.loadByUid( CategoryOptionCombo.class, aoc ) ) )
+            .setStartDate( startDate )
+            .setEndDate( endDate );
 
         List<DataApprovalAudit> audits = dataApprovalAuditService.getDataApprovalAudits( params );
 
@@ -421,9 +406,9 @@ public class AuditController
     }
 
     @GetMapping( "trackedEntityInstance" )
-    public @ResponseBody RootNode getTrackedEnityInstanceAudit(
-        @RequestParam( required = false, defaultValue = "" ) List<String> tei,
-        @RequestParam( required = false, defaultValue = "" ) List<String> user,
+    public RootNode getTrackedEnityInstanceAudit(
+        @RequestParam( required = false ) List<String> tei,
+        @RequestParam( required = false ) List<String> user,
         @RequestParam( required = false ) AuditType auditType,
         @RequestParam( required = false ) Date startDate,
         @RequestParam( required = false ) Date endDate,
@@ -439,14 +424,13 @@ public class AuditController
             fields.addAll( Preset.ALL.getFields() );
         }
 
-        TrackedEntityInstanceAuditQueryParams params = new TrackedEntityInstanceAuditQueryParams();
-
-        params.setTrackedEntityInstances( new HashSet<>( tei ) );
-        params.setUsers( new HashSet<>( user ) );
-        params.setAuditType( auditType );
-        params.setStartDate( startDate );
-        params.setEndDate( endDate );
-        params.setSkipPaging( PagerUtils.isSkipPaging( skipPaging, paging ) );
+        TrackedEntityInstanceAuditQueryParams params = new TrackedEntityInstanceAuditQueryParams()
+            .setTrackedEntityInstances( tei )
+            .setUsers( user )
+            .setAuditType( auditType )
+            .setStartDate( startDate )
+            .setEndDate( endDate )
+            .setSkipPaging( PagerUtils.isSkipPaging( skipPaging, paging ) );
 
         List<TrackedEntityInstanceAudit> teiAudits;
         Pager pager = null;
@@ -483,179 +467,28 @@ public class AuditController
     // Helpers
     // -----------------------------------------------------------------------------------------------------------------
 
-    private List<TrackedEntityInstance> getTrackedEntityInstances( List<String> teiIdentifiers )
+    private List<DataElement> getDataElementsByDataSet( List<String> uids )
         throws WebMessageException
     {
-        List<TrackedEntityInstance> trackedEntityInstances = new ArrayList<>();
+        List<DataSet> dataSets = manager.loadByUid( DataSet.class, uids );
 
-        for ( String tei : teiIdentifiers )
-        {
-            TrackedEntityInstance trackedEntityInstance = getTrackedEntityInstance( tei );
-
-            if ( trackedEntityInstance != null )
-            {
-                trackedEntityInstances.add( trackedEntityInstance );
-            }
-        }
-
-        return trackedEntityInstances;
+        return dataSets.stream()
+            .map( ds -> ds.getDataElements() )
+            .flatMap( Set::stream )
+            .collect( Collectors.toList() );
     }
 
-    private TrackedEntityInstance getTrackedEntityInstance( String tei )
+    private List<Period> getPeriods( List<String> isoPeriods )
         throws WebMessageException
     {
-        if ( tei == null )
+        if ( isoPeriods == null )
         {
-            return null;
+            return new ArrayList<>();
         }
 
-        TrackedEntityInstance trackedEntityInstance = manager.get( TrackedEntityInstance.class, tei );
-
-        if ( trackedEntityInstance == null )
-        {
-            throw new WebMessageException(
-                conflict( "Illegal trackedEntityInstance identifier: " + tei ) );
-        }
-
-        return trackedEntityInstance;
-    }
-
-    private List<TrackedEntityAttribute> getTrackedEntityAttributes( List<String> teaIdentifiers )
-        throws WebMessageException
-    {
-        List<TrackedEntityAttribute> trackedEntityAttributes = new ArrayList<>();
-
-        for ( String tea : teaIdentifiers )
-        {
-            TrackedEntityAttribute trackedEntityAttribute = getTrackedEntityAttribute( tea );
-
-            if ( trackedEntityAttribute != null )
-            {
-                trackedEntityAttributes.add( trackedEntityAttribute );
-            }
-        }
-
-        return trackedEntityAttributes;
-    }
-
-    private TrackedEntityAttribute getTrackedEntityAttribute( String tea )
-        throws WebMessageException
-    {
-        if ( tea == null )
-        {
-            return null;
-        }
-
-        TrackedEntityAttribute trackedEntityAttribute = manager.get( TrackedEntityAttribute.class, tea );
-
-        if ( trackedEntityAttribute == null )
-        {
-            throw new WebMessageException(
-                conflict( "Illegal trackedEntityAttribute identifier: " + tea ) );
-        }
-
-        return trackedEntityAttribute;
-    }
-
-    private List<ProgramStageInstance> getProgramStageInstances( List<String> psIdentifiers )
-        throws WebMessageException
-    {
-        List<ProgramStageInstance> programStageInstances = new ArrayList<>();
-
-        for ( String ps : psIdentifiers )
-        {
-            ProgramStageInstance programStageInstance = getProgramStageInstance( ps );
-
-            if ( programStageInstance != null )
-            {
-                programStageInstances.add( programStageInstance );
-            }
-        }
-
-        return programStageInstances;
-    }
-
-    private ProgramStageInstance getProgramStageInstance( String ps )
-        throws WebMessageException
-    {
-        if ( ps == null )
-        {
-            return null;
-        }
-
-        ProgramStageInstance programStageInstance = programStageInstanceService.getProgramStageInstance( ps );
-
-        if ( programStageInstance == null )
-        {
-            throw new WebMessageException(
-                conflict( "Illegal programStageInstance identifier: " + ps ) );
-        }
-
-        return programStageInstance;
-    }
-
-    private List<DataElement> getDataElementsByDataSet( List<String> dsIdentifiers )
-        throws WebMessageException
-    {
-        List<DataElement> dataElements = new ArrayList<>();
-
-        for ( String ds : dsIdentifiers )
-        {
-            DataSet dataSet = manager.get( DataSet.class, ds );
-
-            if ( dataSet == null )
-            {
-                throw new WebMessageException( conflict( "Illegal dataSet identifier: " + ds ) );
-            }
-
-            dataElements.addAll( dataSet.getDataElements() );
-        }
-
-        return dataElements;
-    }
-
-    private List<DataElement> getDataElements( List<String> deIdentifier )
-        throws WebMessageException
-    {
-        List<DataElement> dataElements = new ArrayList<>();
-
-        for ( String de : deIdentifier )
-        {
-            DataElement dataElement = getDataElement( de );
-
-            if ( dataElement != null )
-            {
-                dataElements.add( dataElement );
-            }
-        }
-
-        return dataElements;
-    }
-
-    private DataElement getDataElement( String de )
-        throws WebMessageException
-    {
-        if ( de == null )
-        {
-            return null;
-        }
-
-        DataElement dataElement = manager.search( DataElement.class, de );
-
-        if ( dataElement == null )
-        {
-            throw new WebMessageException( conflict( "Illegal dataElement identifier: " + de ) );
-        }
-
-        return dataElement;
-    }
-
-    private List<Period> getPeriods( List<String> peIdentifiers )
-        throws WebMessageException
-    {
         List<Period> periods = new ArrayList<>();
 
-        for ( String pe : peIdentifiers )
+        for ( String pe : isoPeriods )
         {
             Period period = PeriodType.getPeriodFromIsoString( pe );
 
@@ -670,83 +503,5 @@ public class AuditController
         }
 
         return periods;
-    }
-
-    private List<OrganisationUnit> getOrganisationUnit( List<String> ou )
-    {
-        if ( ou == null )
-        {
-            return new ArrayList<>();
-        }
-
-        return manager.getByUid( OrganisationUnit.class, ou );
-    }
-
-    private List<CategoryOptionCombo> getCategoryOptionCombo( List<String> coc )
-    {
-        if ( coc == null )
-        {
-            return new ArrayList<>();
-        }
-
-        return manager.getByUid( CategoryOptionCombo.class, coc );
-    }
-
-    private CategoryOptionCombo getCategoryOptionCombo( @RequestParam String co )
-        throws WebMessageException
-    {
-        if ( co == null )
-        {
-            return null;
-        }
-
-        CategoryOptionCombo categoryOptionCombo = manager.search( CategoryOptionCombo.class, co );
-
-        if ( categoryOptionCombo == null )
-        {
-            throw new WebMessageException(
-                conflict( "Illegal categoryOptionCombo identifier: " + co ) );
-        }
-
-        return categoryOptionCombo;
-    }
-
-    private CategoryOptionCombo getAttributeOptionCombo( @RequestParam String cc )
-        throws WebMessageException
-    {
-        if ( cc == null )
-        {
-            return null;
-        }
-
-        CategoryOptionCombo attributeOptionCombo = manager.search( CategoryOptionCombo.class, cc );
-
-        if ( attributeOptionCombo == null )
-        {
-            throw new WebMessageException(
-                conflict( "Illegal attributeOptionCombo identifier: " + cc ) );
-        }
-
-        return attributeOptionCombo;
-    }
-
-    private List<DataApprovalLevel> getDataApprovalLevel( @RequestParam List<String> dal )
-    {
-        if ( dal == null )
-        {
-            return new ArrayList<>();
-        }
-
-        return manager.getByUid( DataApprovalLevel.class, dal );
-    }
-
-    private List<DataApprovalWorkflow> getDataApprovalWorkflow( @RequestParam List<String> wf )
-    {
-        if ( wf == null )
-        {
-            return new ArrayList<>();
-        }
-
-        return manager.getByUid( DataApprovalWorkflow.class, wf );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/MinMaxValueController.java
@@ -101,7 +101,7 @@ public class MinMaxValueController
         }
 
         OrganisationUnit organisationUnit = this.organisationUnitService.getOrganisationUnit( organisationUnitId );
-        if ( organisationUnitId == null )
+        if ( organisationUnit == null )
         {
             throw new WebMessageException( conflict( " No valid organisation unit" ) );
         }
@@ -117,7 +117,6 @@ public class MinMaxValueController
         Double factor = this.systemSettingManager.getSystemSetting( SettingKey.FACTOR_OF_DEVIATION, Double.class );
 
         this.minMaxDataAnalysisService.generateMinMaxValues( organisationUnit, dataElements, factor );
-
     }
 
     @DeleteMapping( "/{ou}" )
@@ -127,14 +126,13 @@ public class MinMaxValueController
         @RequestParam( "ds" ) List<String> dataSetIds )
         throws WebMessageException
     {
-
         if ( dataSetIds == null || dataSetIds.isEmpty() )
         {
             throw new WebMessageException( conflict( " No datasets defined" ) );
         }
 
         OrganisationUnit organisationUnit = this.organisationUnitService.getOrganisationUnit( organisationUnitId );
-        if ( organisationUnitId == null )
+        if ( organisationUnit == null )
         {
             throw new WebMessageException( conflict( " No valid organisation unit" ) );
         }
@@ -148,6 +146,5 @@ public class MinMaxValueController
         }
 
         minMaxDataElementService.removeMinMaxDataElements( dataElements, organisationUnit );
-
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityAttributeController.java
@@ -146,7 +146,7 @@ public class TrackedEntityAttributeController
 
         Map<String, String> values = getRequiredValues( attribute, params );
 
-        Date expiration = DateUtils.getDateAfterAddition( new Date(), daysToLive );
+        Date expiration = DateUtils.addDays( new Date(), daysToLive );
 
         try
         {


### PR DESCRIPTION
Backport from master.

Adds new query parameters for organisation unit, program stage, start date and end date to the tracked entity data value audit API endpoint.

```
/api/audits/trackedEntityDataValue?ou={id}&ps={id}&startDate={date}&endDate={date}
```

Refactors the current code to use a query parameter object and avoid having a large number of filter arguments in method signatures.

Refactors boilerplate code for retrieving and checking objects based on user input to use ID object manager in `AuditController`. More refactoring could be done but want to avoid a growing task.

Added unit tests.

Sample URL for manual testing:

```
/api/audits/trackedEntityDataValue.json?ou=DiszpKrYNg8&startDate=2015-05-01&endDate=2018-01-01
```
```
/api/audits/trackedEntityDataValue.json?ou=DiszpKrYNg8&ps=A03MvHHogjR
```