### PR TITLE
fix: User defined names for time attributes in headers [DHIS2-13136]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -738,11 +738,11 @@ public class DefaultEventAnalyticsService
             grid
                 .addHeader( new GridHeader(
                     ITEM_ENROLLMENT_DATE,
-                    LabelMapper.getEnrollmentDateLabel( params.getProgramStage(), NAME_ENROLLMENT_DATE ), DATE, false,
+                    LabelMapper.getEnrollmentDateLabel( params.getProgram(), NAME_ENROLLMENT_DATE ), DATE, false,
                     true ) )
                 .addHeader( new GridHeader(
                     ITEM_INCIDENT_DATE,
-                    LabelMapper.getIncidentDateLabel( params.getProgramStage(), NAME_INCIDENT_DATE ), DATE, false,
+                    LabelMapper.getIncidentDateLabel( params.getProgram(), NAME_INCIDENT_DATE ), DATE, false,
                     true ) )
                 .addHeader( new GridHeader(
                     ITEM_TRACKED_ENTITY_INSTANCE, NAME_TRACKED_ENTITY_INSTANCE, TEXT, false, true ) )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/LabelMapper.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.program.ProgramStage;
  */
 public class LabelMapper
 {
+
     private LabelMapper()
     {
     }
@@ -55,40 +56,6 @@ public class LabelMapper
         if ( programStage != null && isNotBlank( programStage.getDisplayExecutionDateLabel() ) )
         {
             return programStage.getDisplayExecutionDateLabel();
-        }
-
-        return defaultLabel;
-    }
-
-    /**
-     * Finds for a custom label for enrollment date if one exists.
-     *
-     * @param programStage
-     * @return the custom label, otherwise the default one
-     */
-    static String getEnrollmentDateLabel( final ProgramStage programStage, final String defaultLabel )
-    {
-        if ( programStage != null && programStage.getProgram() != null
-            && isNotBlank( programStage.getProgram().getDisplayEnrollmentDateLabel() ) )
-        {
-            return programStage.getProgram().getDisplayEnrollmentDateLabel();
-        }
-
-        return defaultLabel;
-    }
-
-    /**
-     * Finds for a custom label for incident date if one exists.
-     *
-     * @param programStage
-     * @return the custom label, otherwise the default one
-     */
-    static String getIncidentDateLabel( final ProgramStage programStage, final String defaultLabel )
-    {
-        if ( programStage != null && programStage.getProgram() != null
-            && isNotBlank( programStage.getProgram().getDisplayIncidentDateLabel() ) )
-        {
-            return programStage.getProgram().getDisplayIncidentDateLabel();
         }
 
         return defaultLabel;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
  */
 class LabelMapperTest
 {
+
     public static final String EVENT_DATE = "Event date";
 
     public static final String INCIDENT_DATE = "Incident date";
@@ -52,8 +53,10 @@ class LabelMapperTest
     {
         // Given
         final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+
         // When
         final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithLabels, EVENT_DATE );
+
         // Then
         assertThat( actualName, is( aMockedProgramStageWithLabels.getDisplayExecutionDateLabel() ) );
     }
@@ -62,22 +65,26 @@ class LabelMapperTest
     void testGetHeaderNameFor_NAME_ENROLLMENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithLabels();
+
         // When
-        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithLabels, ENROLLMENT_DATE );
+        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramWithLabels, ENROLLMENT_DATE );
+
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getDisplayEnrollmentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramWithLabels.getDisplayEnrollmentDateLabel() ) );
     }
 
     @Test
     void testGetHeaderNameFor_NAME_INCIDENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithLabels();
+
         // When
-        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithLabels, INCIDENT_DATE );
+        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramWithLabels, INCIDENT_DATE );
+
         // Then
-        assertThat( actualName, is( aMockedProgramStageWithLabels.getProgram().getDisplayIncidentDateLabel() ) );
+        assertThat( actualName, is( aMockedProgramWithLabels.getDisplayIncidentDateLabel() ) );
     }
 
     @Test
@@ -85,8 +92,10 @@ class LabelMapperTest
     {
         // Given
         final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+
         // When
         final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithNoLabels, EVENT_DATE );
+
         // Then
         assertThat( actualName, is( EVENT_DATE ) );
     }
@@ -95,10 +104,11 @@ class LabelMapperTest
     void testGetHeaderNameWhenNoLabelIsSetFor_NAME_ENROLLMENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+        final Program aMockedProgramWithLabels = mockProgramWithoutLabels();
+
         // When
-        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramStageWithNoLabels,
-            ENROLLMENT_DATE );
+        final String actualName = LabelMapper.getEnrollmentDateLabel( aMockedProgramWithLabels, ENROLLMENT_DATE );
+
         // Then
         assertThat( actualName, is( ENROLLMENT_DATE ) );
     }
@@ -107,20 +117,11 @@ class LabelMapperTest
     void testGetHeaderNameWhenNoLabelIsSetFor_NAME_INCIDENT_DATE()
     {
         // Given
-        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
-        // When
-        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramStageWithNoLabels, INCIDENT_DATE );
-        // Then
-        assertThat( actualName, is( INCIDENT_DATE ) );
-    }
+        final Program aMockedProgramWithLabels = mockProgramWithoutLabels();
 
-    @Test
-    void testGetHeaderNameWhenProgramStageIsNull()
-    {
-        // Given
-        final ProgramStage nullProgramStage = null;
         // When
-        final String actualName = LabelMapper.getIncidentDateLabel( nullProgramStage, INCIDENT_DATE );
+        final String actualName = LabelMapper.getIncidentDateLabel( aMockedProgramWithLabels, INCIDENT_DATE );
+
         // Then
         assertThat( actualName, is( INCIDENT_DATE ) );
     }
@@ -129,11 +130,28 @@ class LabelMapperTest
     void testGetHeaderNameWhenProgramIsNull()
     {
         // Given
-        final ProgramStage programStageWithNullProgram = mockProgramStageWithNullProgram();
+        final Program nullProgram = null;
+
         // When
-        final String actualName = LabelMapper.getEnrollmentDateLabel( programStageWithNullProgram, ENROLLMENT_DATE );
+        final String actualName = LabelMapper.getEnrollmentDateLabel( nullProgram, ENROLLMENT_DATE );
+
         // Then
         assertThat( actualName, is( ENROLLMENT_DATE ) );
+    }
+
+    private Program mockProgramWithLabels()
+    {
+        final Program program = new Program();
+        program.setEnrollmentDateLabel( "enrollment date label" );
+        program.setIncidentDateLabel( "incident date label" );
+
+        return program;
+    }
+
+    private Program mockProgramWithoutLabels()
+    {
+        final Program program = new Program();
+        return program;
     }
 
     private ProgramStage mockProgramStageWithLabels()
@@ -152,13 +170,6 @@ class LabelMapperTest
         final ProgramStage programStage = new ProgramStage();
         final Program program = new Program();
         programStage.setProgram( program );
-        return programStage;
-    }
-
-    private ProgramStage mockProgramStageWithNullProgram()
-    {
-        final ProgramStage programStage = new ProgramStage();
-        programStage.setProgram( null );
         return programStage;
     }
 }


### PR DESCRIPTION
**_[Backport from 2.39/master]_**

This fix aims to apply the correct usage of the labels for each time attribute that has a custom name defined in enrollments or events.

The GET request below, for example, should not bring "Enrollment date" in the response header. It should be the user-defined value "Start of treatment date".

```
https://play.dhis2.org/dev/api/analytics/events/query/ur1Edk5Oe2n.html+css?dimension=ou:USER_ORGUNIT&outputType=EVENT&tableLayout=true&columns=ou;enrollmentDate&enrollmentDate=LAST_12_MONTHS&headers=ouname,enrollmentdate&dataIdScheme=NAME&paging=false&asc=ouname
```

For more details about the mapping rule, see DHIS2-13136.