### PR TITLE
test: run api tests on master

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -4,7 +4,10 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125
 
 on:
-  pull_request: 
+  push:
+    branches:
+      - master
+  pull_request:
     types: [ opened, labeled, synchronize ]
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
like we do with other tests. This way we can quickly identify to a
commit that broke e2e tests. Not sure what the root cause of it is when
it happens. Some PRs suddenly have failing e2e tests in a consistent
way, even though they did only move some non-e2e test files around.