### PR TITLE
ci: remove e2e containers and volumes

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Run tests
         run: |
           cd dhis-2/dhis-e2e-test
+          IMAGE_NAME=$CORE_IMAGE_NAME docker-compose rm --force -v
           IMAGE_NAME=$CORE_IMAGE_NAME docker-compose up --remove-orphans -d
           IMAGE_NAME=$TEST_IMAGE_NAME docker-compose -f docker-compose.e2e.yml up --exit-code-from e2e-test
 


### PR DESCRIPTION
just in case. They might be causing these unexcepted errors we see in e2e tests. Not sure what cleanup runners perform on docker. So maybe a DB volume of an older test is still lying around. TrackedEntityInstanceAclReadTests seems to make changes that are affecting the MetadataImportTest we currently see failing
