### PR TITLE
fix: fix test-api issue

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
@@ -80,7 +80,7 @@ public class ProgramStageInstanceDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        return vetoIfExists( VETO, "select count(*) from programstageinstance where eventdatavalues ? :uid",
+        return vetoIfExists( VETO, "select count(*) from programstageinstance where eventdatavalues ?? :uid",
             Map.of( "uid", dataElement.getUid() ) );
     }
 }


### PR DESCRIPTION
```sql
select count(*) from programstageinstance where eventdatavalues ? :uid
```

is causing

```
org.springframework.dao.InvalidDataAccessApiUsageException: Not allowed to mix named and traditional ? placeholders. You have 1 named parameter(s) and 1 traditional placeholder(s) in statement: select count(*) from programstageinstance where eventdatavalues ? :uid
```

This error was not allowing the e2e-tests to do proper cleanup and `MetadataImportTest.shouldUpdateExistingMetadata` was failing because `TrackedEntityInstanceAclReadTests` was creating data elements that were not deleted