### PR TITLE
chore: Handle H2 test for schema and setting modules [TECH-1208]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-schema/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-schema/pom.xml
@@ -105,12 +105,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-test</artifactId>
-      <scope>test</scope>
-
-    </dependency>
 
   </dependencies>
   <properties>

--- a/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/test/java/org/hisp/dhis/schema/TranslatablePropertyIntrospectorTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.predictor.Predictor;
@@ -42,7 +41,7 @@ import org.hisp.dhis.program.ProgramStageSection;
 import org.hisp.dhis.schema.introspection.TranslatablePropertyIntrospector;
 import org.junit.jupiter.api.Test;
 
-class TranslatablePropertyIntrospectorTest extends DhisSpringTest
+class TranslatablePropertyIntrospectorTest
 {
 
     private final TranslatablePropertyIntrospector introspector = new TranslatablePropertyIntrospector();

--- a/dhis-2/dhis-services/dhis-service-setting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-setting/pom.xml
@@ -99,11 +99,6 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-test</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -322,6 +322,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <scope>test</scope>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/RelativePropertyContextTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/RelativePropertyContextTest.java
@@ -37,8 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.junit.jupiter.api.Test;
@@ -50,7 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  *
  * @author Jan Bernitt
  */
-class RelativePropertyContextTest extends DhisSpringTest
+class RelativePropertyContextTest extends SingleSetupIntegrationTestBase
 {
 
     @Autowired

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaFieldIntrospectorTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaFieldIntrospectorTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import lombok.Data;
 
-import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -42,7 +42,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 /**
  * @author Morten Olav Hansen
  */
-class SchemaFieldIntrospectorTest extends DhisSpringTest
+class SchemaFieldIntrospectorTest extends SingleSetupIntegrationTestBase
 {
 
     @Autowired

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaServiceTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashSet;
 
-import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
@@ -43,13 +42,14 @@ import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.sqlview.SqlView;
 import org.hisp.dhis.system.util.ReflectionUtils;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-class SchemaServiceTest extends DhisSpringTest
+class SchemaServiceTest extends SingleSetupIntegrationTestBase
 {
     @Autowired
     private SchemaService schemaService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaValidatorTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/schema/SchemaValidatorTest.java
@@ -33,11 +33,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hisp.dhis.DhisSpringTest;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.schema.validation.SchemaValidator;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -46,7 +46,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-class SchemaValidatorTest extends DhisSpringTest
+class SchemaValidatorTest extends SingleSetupIntegrationTestBase
 {
 
     @Autowired

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingManagerTest.java
@@ -45,7 +45,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -55,7 +55,7 @@ import com.google.common.collect.ImmutableSet;
  * @author Stian Strandli
  * @author Lars Helge Overland
  */
-class SystemSettingManagerTest extends DhisSpringTest
+class SystemSettingManagerTest extends SingleSetupIntegrationTestBase
 {
 
     @Autowired

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingStoreTest.java
@@ -31,14 +31,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
-import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Stian Strandli
  */
-class SystemSettingStoreTest extends DhisSpringTest
+class SystemSettingStoreTest extends TransactionalIntegrationTest
 {
 
     @Autowired


### PR DESCRIPTION
After some discussion with the backend team we agreed that tests that need to access the DB should use postgres if there is no strong reason to use H2. (This doesn't apply to `dhis-web-api-test` module as H2 is used to prevent mocking the whole persistence layer).

In this PR the tests that access the DB are transformed to integration tests and moved to `dhis-test-integration`.
The ones that are not accessing the DB are transformed into unit tests