### PR TITLE
chore: Handle H2 test for support system module [TECH-1208]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/SystemTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/SystemTest.java
@@ -25,32 +25,20 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.system.leader;
+package org.hisp.dhis.system;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.hisp.dhis.IntegrationH2Test;
+import org.hisp.dhis.config.ConfigProviderConfiguration;
+import org.hisp.dhis.leader.election.LeaderElectionConfiguration;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import org.hisp.dhis.leader.election.LeaderManager;
-import org.hisp.dhis.system.SystemTest;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
-/**
- * @author Ameen Mohamed
- */
-class LeaderManagerTest extends SystemTest
+@ExtendWith( SpringExtension.class )
+@ContextConfiguration( classes = { ConfigProviderConfiguration.class, LeaderElectionConfiguration.class } )
+@ActiveProfiles( profiles = { "test-h2" } )
+@IntegrationH2Test
+public abstract class SystemTest
 {
-
-    @Autowired
-    private LeaderManager leaderManager;
-
-    @Test
-    void testNodeInfo()
-    {
-        assertNotNull( leaderManager.getCurrentNodeUuid() );
-        assertNotNull( leaderManager.getLeaderNodeUuid() );
-        assertEquals( leaderManager.getCurrentNodeUuid(), leaderManager.getLeaderNodeUuid() );
-        assertTrue( leaderManager.isLeader() );
-    }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/filter/AggregatableDataElementFilterTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/filter/AggregatableDataElementFilterTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 
-import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.commons.filter.FilterUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -42,7 +42,7 @@ import com.google.common.collect.Sets;
 /**
  * @author Lars Helge Overland
  */
-class AggregatableDataElementFilterTest extends DhisSpringTest
+class AggregatableDataElementFilterTest extends DhisConvenienceTest
 {
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotifierTest.java
@@ -41,21 +41,18 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-import org.hisp.dhis.DhisSpringTest;
+import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Lars Helge Overland
  */
-class NotifierTest extends DhisSpringTest
+class NotifierTest extends DhisConvenienceTest
 {
-
-    @Autowired
-    private Notifier notifier;
+    private Notifier notifier = new InMemoryNotifier();
 
     private final User user = makeUser( "A" );
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/ConfigProviderConfiguration.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/ConfigProviderConfiguration.java
@@ -25,32 +25,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.system.leader;
+package org.hisp.dhis.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-import org.hisp.dhis.leader.election.LeaderManager;
-import org.hisp.dhis.system.SystemTest;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-
-/**
- * @author Ameen Mohamed
- */
-class LeaderManagerTest extends SystemTest
+@Configuration
+public class ConfigProviderConfiguration
 {
-
-    @Autowired
-    private LeaderManager leaderManager;
-
-    @Test
-    void testNodeInfo()
+    @Bean( name = "dhisConfigurationProvider" )
+    public DhisConfigurationProvider dhisConfigurationProvider()
     {
-        assertNotNull( leaderManager.getCurrentNodeUuid() );
-        assertNotNull( leaderManager.getLeaderNodeUuid() );
-        assertEquals( leaderManager.getCurrentNodeUuid(), leaderManager.getLeaderNodeUuid() );
-        assertTrue( leaderManager.isLeader() );
+        return new H2DhisConfigurationProvider();
     }
 }


### PR DESCRIPTION
Cleaning up H2 tests in `dhis-support-system` module.
To notice that `LeaderManagerTest` is now classified as an H2 test even though it is not really accessing the DB.
At some point we will need to discuss where is the best way to run tests like this one that has the following properties:

- It needs a Spring Context to be run
- It does not access the DB
- It does not use mocks