### PR TITLE
fix: update Option.sortOrder resulted with null sortOrders (2.36)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -94,6 +94,59 @@ public class OptionObjectBundleHook
         }
     }
 
+    @Override
+    public <T extends IdentifiableObject> void preUpdate( T object, T persistedObject, ObjectBundle bundle )
+    {
+        if ( !(object instanceof Option) )
+        {
+            return;
+        }
+
+        Option option = (Option) object;
+
+        if ( option.getOptionSet() == null )
+        {
+            return;
+        }
+
+        OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
+            option.getOptionSet().getUid() );
+
+        if ( optionSet != null )
+        {
+            // Remove the existed option from OptionSet, will add the updating
+            // one
+            // in postUpdate()
+            optionSet.getOptions().remove( persistedObject );
+        }
+    }
+
+    @Override
+    public <T extends IdentifiableObject> void postUpdate( T object, ObjectBundle bundle )
+    {
+        if ( !(object instanceof Option) )
+        {
+            return;
+        }
+
+        Option option = (Option) object;
+
+        if ( option.getOptionSet() == null )
+        {
+            return;
+        }
+
+        OptionSet optionSet = bundle.getPreheat().get( bundle.getPreheatIdentifier(), OptionSet.class,
+            option.getOptionSet().getUid() );
+
+        if ( optionSet != null )
+        {
+            // Add the updated Option to OptionSet, this will allow Hibernate to
+            // re-organize sortOrder gaps if any.
+            optionSet.addOption( option );
+        }
+    }
+
     /**
      * Check for duplication of Option's name OR code within given OptionSet
      *


### PR DESCRIPTION
backport https://github.com/dhis2/dhis2-core/pull/10842
The controller test from the original PR has been removed as it's not applicable for 2.36 