### PR TITLE
fix: error loading authorities in Users app (2.37)

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/security/config/AuthoritiesProviderConfig.java
@@ -55,7 +55,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.access.AccessDecisionManager;
 
@@ -71,6 +71,9 @@ public class AuthoritiesProviderConfig
 {
     @Autowired
     private SecurityService securityService;
+
+    @Autowired
+    private ModuleManager moduleManager;
 
     @Autowired
     private SchemaService schemaService;
@@ -93,8 +96,9 @@ public class AuthoritiesProviderConfig
     @Qualifier( "org.hisp.dhis.organisationunit.OrganisationUnitService" )
     public OrganisationUnitService organisationUnitService;
 
-    @Bean( "org.hisp.dhis.security.authority.SystemAuthoritiesProvider" )
-    public SystemAuthoritiesProvider systemAuthoritiesProvider( @Lazy ModuleManager moduleManager )
+    @Primary
+    @Bean( "org.hisp.dhis.security.SystemAuthoritiesProvider" )
+    public SystemAuthoritiesProvider systemAuthoritiesProvider()
     {
         SchemaAuthoritiesProvider schemaAuthoritiesProvider = new SchemaAuthoritiesProvider( schemaService );
         AppsSystemAuthoritiesProvider appsSystemAuthoritiesProvider = new AppsSystemAuthoritiesProvider( appManager );
@@ -105,7 +109,7 @@ public class AuthoritiesProviderConfig
         CompositeSystemAuthoritiesProvider provider = new CompositeSystemAuthoritiesProvider();
         provider.setSources( ImmutableSet.of(
             new CachingSystemAuthoritiesProvider( detectingSystemAuthoritiesProvider ),
-            new CachingSystemAuthoritiesProvider( moduleSystemAuthoritiesProvider( moduleManager ) ),
+            new CachingSystemAuthoritiesProvider( moduleSystemAuthoritiesProvider() ),
             new CachingSystemAuthoritiesProvider( simpleSystemAuthoritiesProvider() ),
             schemaAuthoritiesProvider,
             appsSystemAuthoritiesProvider ) );
@@ -129,7 +133,7 @@ public class AuthoritiesProviderConfig
         return provider;
     }
 
-    private ModuleSystemAuthoritiesProvider moduleSystemAuthoritiesProvider( ModuleManager moduleManager )
+    private ModuleSystemAuthoritiesProvider moduleSystemAuthoritiesProvider()
     {
         ModuleSystemAuthoritiesProvider provider = new ModuleSystemAuthoritiesProvider();
         provider.setAuthorityPrefix( "M_" );


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-13415

Got below server error when open a UserRole in Users app.

```
* ERROR 2022-07-01T15:17:18,720 Exception occurred during processing request: Unable to instantiate Action, org.hisp.dhis.commons.action.GetSystemAuthoritiesAction,  defined for 'getSystemAuthorities' in namespace '/dhis-web-commons/security'Error creating bean with name 'org.hisp.dhis.commons.action.GetSystemAuthoritiesAction' defined in URL [jar:file:/Users/viet/code/dhis2-core/dhis-2/dhis-web/dhis-web-portal/target/dhis/WEB-INF/lib/dhis-web-commons-2.37.8-SNAPSHOT.jar!/META-INF/dhis/beans.xml]: Cannot resolve reference to bean 'org.hisp.dhis.security.SystemAuthoritiesProvider' while setting bean property 'authoritiesProvider'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'org.hisp.dhis.security.SystemAuthoritiesProvider' available (DefaultDispatcherErrorHandler.java [qtp360898540-131])
com.opensymphony.xwork2.XWorkException: Unable to instantiate Action, org.hisp.dhis.commons.action.GetSystemAuthoritiesAction,  defined for 'getSystemAuthorities' in namespace '/dhis-web-commons/security'Error creating bean with name 'org.hisp.dhis.commons.action.GetSystemAuthoritiesAction' defined in URL [jar:file:/Users/viet/code/dhis2-core/dhis-2/dhis-web/dhis-web-portal/target/dhis/WEB-INF/lib/dhis-web-commons-2.37.8-SNAPSHOT.jar!/META-INF/dhis/beans.xml]: Cannot resolve reference to bean 'org.hisp.dhis.security.SystemAuthoritiesProvider' while setting bean property 'authoritiesProvider'; nested exception is org.springframework.beans.factory.NoSuchBeanDefinitionException: No bean named 'org.hisp.dhis.security.SystemAuthoritiesProvider' available
	at com.opensymphony.xwork2.DefaultActionInvocation.createAction(DefaultActionInvocation.java:320) ~[struts2-core-2.5.30.jar:2.5.30]
```