### PR TITLE
fix: Improve data element deletion performance - sections [DHIS2-5761]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/SectionStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/SectionStore.java
@@ -27,10 +27,11 @@
  */
 package org.hisp.dhis.dataset;
 
+import java.util.List;
+
 import org.hisp.dhis.common.IdentifiableObjectStore;
 
-public interface SectionStore
-    extends IdentifiableObjectStore<Section>
+public interface SectionStore extends IdentifiableObjectStore<Section>
 {
     String ID = SectionStore.class.getName();
 
@@ -41,4 +42,6 @@ public interface SectionStore
      * @return the Section.
      */
     Section getSectionByName( String name, DataSet dataSet );
+
+    List<Section> getSectionsByDataElement( String dataElementUid );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultSectionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DefaultSectionService.java
@@ -27,42 +27,23 @@
  */
 package org.hisp.dhis.dataset;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.List;
+
+import lombok.AllArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Tri
- * @version $Id$
  */
-@Service( "org.hisp.dhis.dataset.SectionService" )
-public class DefaultSectionService
-    implements SectionService
+@Service
+@AllArgsConstructor
+public class DefaultSectionService implements SectionService
 {
-    // -------------------------------------------------------------------------
-    // Dependencies
-    // -------------------------------------------------------------------------
+    private final SectionStore sectionStore;
 
-    private SectionStore sectionStore;
-
-    private DataSetService dataSetService;
-
-    public DefaultSectionService( SectionStore sectionStore, DataSetService dataSetService )
-    {
-
-        checkNotNull( sectionStore );
-        checkNotNull( dataSetService );
-
-        this.sectionStore = sectionStore;
-        this.dataSetService = dataSetService;
-    }
-
-    // -------------------------------------------------------------------------
-    // SectionService implementation
-    // -------------------------------------------------------------------------
+    private final DataSetService dataSetService;
 
     @Override
     @Transactional

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
@@ -73,7 +73,8 @@ public class HibernateSectionStore
             + " left join sectiongreyedfields sgf on s.sectionid = sgf.sectionid"
             + " left join dataelementoperand deo on sgf.dataelementoperandid = deo.dataelementoperandid"
             + ", dataelement de"
-            + " where de.uid = :Id and (sde.dataelementid = de.dataelementid or deo.dataelementid = de.dataelementid);";
-        return getSession().createNativeQuery( hql, Section.class ).setParameter( "Id", dataElementUid ).list();
+            + " where de.uid = :dataElementId and (sde.dataelementid = de.dataelementid or deo.dataelementid = de.dataelementid);";
+        return getSession().createNativeQuery( hql, Section.class ).setParameter( "dataElementId", dataElementUid )
+            .list();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateSectionStore.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.dataset.hibernate;
 
+import java.util.List;
+
 import javax.persistence.criteria.CriteriaBuilder;
 
 import org.hibernate.SessionFactory;
@@ -42,9 +44,8 @@ import org.springframework.stereotype.Repository;
 
 /**
  * @author Tri
- * @version $Id$
  */
-@Repository( "org.hisp.dhis.dataset.hibernate.HibernateSectionStore" )
+@Repository
 public class HibernateSectionStore
     extends HibernateIdentifiableObjectStore<Section> implements SectionStore
 {
@@ -62,5 +63,17 @@ public class HibernateSectionStore
         return getSingleResult( builder, newJpaParameters()
             .addPredicate( root -> builder.equal( root.get( "name" ), name ) )
             .addPredicate( root -> builder.equal( root.get( "dataSet" ), dataSet ) ) );
+    }
+
+    @Override
+    public List<Section> getSectionsByDataElement( String dataElementUid )
+    {
+        String hql = "select * from section s"
+            + " left join sectiondataelements sde on s.sectionid = sde.sectionid"
+            + " left join sectiongreyedfields sgf on s.sectionid = sgf.sectionid"
+            + " left join dataelementoperand deo on sgf.dataelementoperandid = deo.dataelementoperandid"
+            + ", dataelement de"
+            + " where de.uid = :Id and (sde.dataelementid = de.dataelementid or deo.dataelementid = de.dataelementid);";
+        return getSession().createNativeQuery( hql, Section.class ).setParameter( "Id", dataElementUid ).list();
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/SectionStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/SectionStoreTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataset;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests the {@link SectionStore} additional methods.
+ *
+ * @author Jan Bernitt
+ */
+class SectionStoreTest extends SingleSetupIntegrationTestBase
+{
+    @Autowired
+    private SectionStore sectionStore;
+
+    @Autowired
+    private DataElementService dataElementService;
+
+    @Autowired
+    private DataSetService dataSetService;
+
+    private DataElement de;
+
+    private DataSet ds;
+
+    @BeforeEach
+    void setUp()
+    {
+        de = createDataElement( 'A' );
+        dataElementService.addDataElement( de );
+
+        ds = createDataSet( 'A' );
+        dataSetService.addDataSet( ds );
+    }
+
+    @Test
+    void testGetSectionsByDataElement_SectionOfDataElement()
+    {
+        Section s = new Section( "test", ds, List.of( de ), Set.of() );
+        assertDoesNotThrow( () -> sectionStore.save( s ) );
+
+        assertEquals( 1, sectionStore.getSectionsByDataElement( de.getUid() ).size() );
+    }
+
+    @Test
+    void testGetSectionsByDataElement_SectionOfDataElementOperand()
+    {
+        DataElementOperand deo = new DataElementOperand( de );
+        Section s = new Section( "test", ds, List.of(), Set.of( deo ) );
+        assertDoesNotThrow( () -> sectionStore.save( s ) );
+
+        assertEquals( 1, sectionStore.getSectionsByDataElement( de.getUid() ).size() );
+    }
+}


### PR DESCRIPTION
### Summary
This PR improves the deletion of data elements, specifically the "unlinking" for `Section`s.
Instead of iterating all sections, only those affected by the deletion are loaded and updated.

This is one of multiple improvments to reduce time it takes to delete data elements.

### Automatic Tests
Added new test to make sure the SQL for the new method selection the affected methods works as intended.