### PR TITLE
Configure JitPack to build dhis2-core on Java 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Configure JitPack to build dhis2-core on Java 11