### PR TITLE
fix: Remove sensitive properties from system info [DHIS2-8677]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -130,10 +130,6 @@
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-xml</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemInfo.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemInfo.java
@@ -36,7 +36,6 @@ import lombok.Setter;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.springframework.beans.BeanUtils;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -159,13 +158,13 @@ public class SystemInfo
     private Integer cpuCores;
 
     @JsonProperty
-    private Boolean encryption;
+    private boolean encryption;
 
     @JsonProperty
-    private Boolean emailConfigured;
+    private boolean emailConfigured;
 
     @JsonProperty
-    private Boolean redisEnabled;
+    private boolean redisEnabled;
 
     @JsonProperty
     private String redisHostname;
@@ -238,17 +237,5 @@ public class SystemInfo
         {
             this.databaseInfo.clearSensitiveInfo();
         }
-    }
-
-    @JsonIgnore
-    public boolean isEmailConfigured()
-    {
-        return emailConfigured != null && emailConfigured;
-    }
-
-    @JsonIgnore
-    public boolean isRedisEnabled()
-    {
-        return redisEnabled != null && redisEnabled;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemInfo.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemInfo.java
@@ -121,11 +121,11 @@ public class SystemInfo
 
     private Integer cpuCores;
 
-    private boolean encryption;
+    private Boolean encryption;
 
-    private boolean emailConfigured;
+    private Boolean emailConfigured;
 
-    private boolean redisEnabled;
+    private Boolean redisEnabled;
 
     private String redisHostname;
 
@@ -145,7 +145,7 @@ public class SystemInfo
 
     private Date lastMetadataVersionSyncAttempt;
 
-    private boolean isMetadataSyncEnabled;
+    private Boolean isMetadataSyncEnabled;
 
     public SystemInfo instance()
     {
@@ -162,6 +162,8 @@ public class SystemInfo
 
     public void clearSensitiveInfo()
     {
+        this.jasperReportsVersion = null;
+        this.environmentVariable = null;
         this.fileStoreProvider = null;
         this.readOnlyMode = null;
         this.nodeId = null;
@@ -176,6 +178,11 @@ public class SystemInfo
         this.memoryInfo = null;
         this.cpuCores = null;
         this.systemMonitoringUrl = null;
+        this.encryption = false;
+        this.redisEnabled = false;
+        this.redisHostname = null;
+        this.systemId = null;
+        this.clusterHostname = null;
 
         if ( this.databaseInfo != null )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemInfo.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/system/SystemInfo.java
@@ -29,122 +29,172 @@ package org.hisp.dhis.system;
 
 import java.util.Date;
 
-import org.hisp.dhis.common.DxfNamespaces;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.springframework.beans.BeanUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
  * @author Lars Helge Overland
  */
-@JacksonXmlRootElement( localName = "systemInfo", namespace = DxfNamespaces.DXF_2_0 )
+@Getter
+@Setter
+@NoArgsConstructor
 public class SystemInfo
 {
     // -------------------------------------------------------------------------
     // Transient properties
     // -------------------------------------------------------------------------
 
+    @JsonProperty
     private String contextPath;
 
+    @JsonProperty
     private String userAgent;
 
     // -------------------------------------------------------------------------
     // Volatile properties
     // -------------------------------------------------------------------------
 
+    @JsonProperty
     private String calendar;
 
+    @JsonProperty
     private String dateFormat;
 
+    @JsonProperty
     private Date serverDate;
 
+    @JsonProperty
     private String serverTimeZoneId;
 
+    @JsonProperty
     private String serverTimeZoneDisplayName;
 
+    @JsonProperty
     private Date lastAnalyticsTableSuccess;
 
+    @JsonProperty
     private String intervalSinceLastAnalyticsTableSuccess;
 
+    @JsonProperty
     private String lastAnalyticsTableRuntime;
 
+    @JsonProperty
     private Date lastSystemMonitoringSuccess;
 
+    @JsonProperty
     private Date lastAnalyticsTablePartitionSuccess;
 
+    @JsonProperty
     private String intervalSinceLastAnalyticsTablePartitionSuccess;
 
+    @JsonProperty
     private String lastAnalyticsTablePartitionRuntime;
 
     // -------------------------------------------------------------------------
     // Stable properties
     // -------------------------------------------------------------------------
 
+    @JsonProperty
     private String version;
 
+    @JsonProperty
     private String revision;
 
+    @JsonProperty
     private Date buildTime;
 
+    @JsonProperty
     private String jasperReportsVersion;
 
+    @JsonProperty
     private String environmentVariable;
 
+    @JsonProperty
     private String fileStoreProvider;
 
+    @JsonProperty
     private String readOnlyMode;
 
+    @JsonProperty
     private String nodeId;
 
+    @JsonProperty
     private String javaVersion;
 
+    @JsonProperty
     private String javaVendor;
 
+    @JsonProperty
     private String javaOpts;
 
+    @JsonProperty
     private String osName;
 
+    @JsonProperty
     private String osArchitecture;
 
+    @JsonProperty
     private String osVersion;
 
+    @JsonProperty
     private String externalDirectory;
 
+    @JsonProperty
     private DatabaseInfo databaseInfo;
 
+    @JsonProperty
     private Integer readReplicaCount;
 
+    @JsonProperty
     private String memoryInfo;
 
+    @JsonProperty
     private Integer cpuCores;
 
+    @JsonProperty
     private Boolean encryption;
 
+    @JsonProperty
     private Boolean emailConfigured;
 
+    @JsonProperty
     private Boolean redisEnabled;
 
+    @JsonProperty
     private String redisHostname;
 
+    @JsonProperty
     private String systemId;
 
+    @JsonProperty
     private String systemName;
 
+    @JsonProperty
     private String systemMetadataVersion;
 
+    @JsonProperty
     private String instanceBaseUrl;
 
+    @JsonProperty
     private String systemMonitoringUrl;
 
+    @JsonProperty
     private String clusterHostname;
 
+    @JsonProperty
     private Boolean isMetadataVersionEnabled;
 
+    @JsonProperty
     private Date lastMetadataVersionSyncAttempt;
 
+    @JsonProperty
     private Boolean isMetadataSyncEnabled;
 
     public SystemInfo instance()
@@ -190,560 +240,15 @@ public class SystemInfo
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getContextPath()
-    {
-        return contextPath;
-    }
-
-    public void setContextPath( String contextPath )
-    {
-        this.contextPath = contextPath;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getUserAgent()
-    {
-        return userAgent;
-    }
-
-    public void setUserAgent( String userAgent )
-    {
-        this.userAgent = userAgent;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getCalendar()
-    {
-        return calendar;
-    }
-
-    public void setCalendar( String calendar )
-    {
-        this.calendar = calendar;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getDateFormat()
-    {
-        return dateFormat;
-    }
-
-    public void setDateFormat( String dateFormat )
-    {
-        this.dateFormat = dateFormat;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Date getServerDate()
-    {
-        return serverDate;
-    }
-
-    public void setServerDate( Date serverDate )
-    {
-        this.serverDate = serverDate;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getServerTimeZoneId()
-    {
-        return serverTimeZoneId;
-    }
-
-    public void setServerTimeZoneId( String serverTimeZoneId )
-    {
-        this.serverTimeZoneId = serverTimeZoneId;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getServerTimeZoneDisplayName()
-    {
-        return serverTimeZoneDisplayName;
-    }
-
-    public void setServerTimeZoneDisplayName( String serverTimeZoneDisplayName )
-    {
-        this.serverTimeZoneDisplayName = serverTimeZoneDisplayName;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Date getLastAnalyticsTableSuccess()
-    {
-        return lastAnalyticsTableSuccess;
-    }
-
-    public void setLastAnalyticsTableSuccess( Date lastAnalyticsTableSuccess )
-    {
-        this.lastAnalyticsTableSuccess = lastAnalyticsTableSuccess;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getIntervalSinceLastAnalyticsTableSuccess()
-    {
-        return intervalSinceLastAnalyticsTableSuccess;
-    }
-
-    public void setIntervalSinceLastAnalyticsTableSuccess( String intervalSinceLastAnalyticsTableSuccess )
-    {
-        this.intervalSinceLastAnalyticsTableSuccess = intervalSinceLastAnalyticsTableSuccess;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getLastAnalyticsTableRuntime()
-    {
-        return lastAnalyticsTableRuntime;
-    }
-
-    public void setLastAnalyticsTableRuntime( String lastAnalyticsTableRuntime )
-    {
-        this.lastAnalyticsTableRuntime = lastAnalyticsTableRuntime;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Date getLastAnalyticsTablePartitionSuccess()
-    {
-        return lastAnalyticsTablePartitionSuccess;
-    }
-
-    public void setLastAnalyticsTablePartitionSuccess( Date lastAnalyticsTablePartitionSuccess )
-    {
-        this.lastAnalyticsTablePartitionSuccess = lastAnalyticsTablePartitionSuccess;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getIntervalSinceLastAnalyticsTablePartitionSuccess()
-    {
-        return intervalSinceLastAnalyticsTablePartitionSuccess;
-    }
-
-    public void setIntervalSinceLastAnalyticsTablePartitionSuccess(
-        String intervalSinceLastAnalyticsTablePartitionSuccess )
-    {
-        this.intervalSinceLastAnalyticsTablePartitionSuccess = intervalSinceLastAnalyticsTablePartitionSuccess;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getLastAnalyticsTablePartitionRuntime()
-    {
-        return lastAnalyticsTablePartitionRuntime;
-    }
-
-    public void setLastAnalyticsTablePartitionRuntime( String lastAnalyticsTablePartitionRuntime )
-    {
-        this.lastAnalyticsTablePartitionRuntime = lastAnalyticsTablePartitionRuntime;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Date getLastSystemMonitoringSuccess()
-    {
-        return lastSystemMonitoringSuccess;
-    }
-
-    public void setLastSystemMonitoringSuccess( Date lastSystemMonitoringSuccess )
-    {
-        this.lastSystemMonitoringSuccess = lastSystemMonitoringSuccess;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getVersion()
-    {
-        return version;
-    }
-
-    public void setVersion( String version )
-    {
-        this.version = version;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getRevision()
-    {
-        return revision;
-    }
-
-    public void setRevision( String revision )
-    {
-        this.revision = revision;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Date getBuildTime()
-    {
-        return buildTime;
-    }
-
-    public void setBuildTime( Date buildTime )
-    {
-        this.buildTime = buildTime;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getJasperReportsVersion()
-    {
-        return jasperReportsVersion;
-    }
-
-    public void setJasperReportsVersion( String jasperReportsVersion )
-    {
-        this.jasperReportsVersion = jasperReportsVersion;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getEnvironmentVariable()
-    {
-        return environmentVariable;
-    }
-
-    public void setEnvironmentVariable( String environmentVariable )
-    {
-        this.environmentVariable = environmentVariable;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getFileStoreProvider()
-    {
-        return fileStoreProvider;
-    }
-
-    public void setFileStoreProvider( String fileStoreProvider )
-    {
-        this.fileStoreProvider = fileStoreProvider;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getReadOnlyMode()
-    {
-        return readOnlyMode;
-    }
-
-    public void setReadOnlyMode( String readOnlyMode )
-    {
-        this.readOnlyMode = readOnlyMode;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getNodeId()
-    {
-        return nodeId;
-    }
-
-    public void setNodeId( String nodeId )
-    {
-        this.nodeId = nodeId;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getJavaVersion()
-    {
-        return javaVersion;
-    }
-
-    public void setJavaVersion( String javaVersion )
-    {
-        this.javaVersion = javaVersion;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getJavaVendor()
-    {
-        return javaVendor;
-    }
-
-    public void setJavaVendor( String javaVendor )
-    {
-        this.javaVendor = javaVendor;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getJavaOpts()
-    {
-        return javaOpts;
-    }
-
-    public void setJavaOpts( String javaOpts )
-    {
-        this.javaOpts = javaOpts;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getOsName()
-    {
-        return osName;
-    }
-
-    public void setOsName( String osName )
-    {
-        this.osName = osName;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getOsArchitecture()
-    {
-        return osArchitecture;
-    }
-
-    public void setOsArchitecture( String osArchitecture )
-    {
-        this.osArchitecture = osArchitecture;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getOsVersion()
-    {
-        return osVersion;
-    }
-
-    public void setOsVersion( String osVersion )
-    {
-        this.osVersion = osVersion;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getExternalDirectory()
-    {
-        return externalDirectory;
-    }
-
-    public void setExternalDirectory( String externalDirectory )
-    {
-        this.externalDirectory = externalDirectory;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public DatabaseInfo getDatabaseInfo()
-    {
-        return databaseInfo;
-    }
-
-    public void setDatabaseInfo( DatabaseInfo databaseInfo )
-    {
-        this.databaseInfo = databaseInfo;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Integer getReadReplicaCount()
-    {
-        return readReplicaCount;
-    }
-
-    public void setReadReplicaCount( Integer readReplicaCount )
-    {
-        this.readReplicaCount = readReplicaCount;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getMemoryInfo()
-    {
-        return memoryInfo;
-    }
-
-    public void setMemoryInfo( String memoryInfo )
-    {
-        this.memoryInfo = memoryInfo;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Integer getCpuCores()
-    {
-        return cpuCores;
-    }
-
-    public void setCpuCores( Integer cpuCores )
-    {
-        this.cpuCores = cpuCores;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isEncryption()
-    {
-        return encryption;
-    }
-
-    public void setEncryption( boolean encryption )
-    {
-        this.encryption = encryption;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonIgnore
     public boolean isEmailConfigured()
     {
-        return emailConfigured;
+        return emailConfigured != null && emailConfigured;
     }
 
-    public void setEmailConfigured( boolean emailConfigured )
-    {
-        this.emailConfigured = emailConfigured;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonIgnore
     public boolean isRedisEnabled()
     {
-        return redisEnabled;
-    }
-
-    public void setRedisEnabled( boolean redisEnabled )
-    {
-        this.redisEnabled = redisEnabled;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getRedisHostname()
-    {
-        return redisHostname;
-    }
-
-    public void setRedisHostname( String redisHostname )
-    {
-        this.redisHostname = redisHostname;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getSystemId()
-    {
-        return systemId;
-    }
-
-    public void setSystemId( String systemId )
-    {
-        this.systemId = systemId;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getSystemName()
-    {
-        return systemName;
-    }
-
-    public void setSystemName( String systemName )
-    {
-        this.systemName = systemName;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getSystemMetadataVersion()
-    {
-        return systemMetadataVersion;
-    }
-
-    public void setSystemMetadataVersion( String systemMetadataVersion )
-    {
-        this.systemMetadataVersion = systemMetadataVersion;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getInstanceBaseUrl()
-    {
-        return instanceBaseUrl;
-    }
-
-    public void setInstanceBaseUrl( String instanceBaseUrl )
-    {
-        this.instanceBaseUrl = instanceBaseUrl;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getSystemMonitoringUrl()
-    {
-        return systemMonitoringUrl;
-    }
-
-    public void setSystemMonitoringUrl( String systemMonitoringUrl )
-    {
-        this.systemMonitoringUrl = systemMonitoringUrl;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getClusterHostname()
-    {
-        return clusterHostname;
-    }
-
-    public void setClusterHostname( String clusterHostname )
-    {
-        this.clusterHostname = clusterHostname;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Boolean getIsMetadataVersionEnabled()
-    {
-        return isMetadataVersionEnabled;
-    }
-
-    public void setIsMetadataVersionEnabled( Boolean isMetadataVersionEnabled )
-    {
-        this.isMetadataVersionEnabled = isMetadataVersionEnabled;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public Date getLastMetadataVersionSyncAttempt()
-    {
-        return lastMetadataVersionSyncAttempt;
-    }
-
-    public void setLastMetadataVersionSyncAttempt( Date lastMetadataVersionSyncAttempt )
-    {
-        this.lastMetadataVersionSyncAttempt = lastMetadataVersionSyncAttempt;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isMetadataSyncEnabled()
-    {
-        return isMetadataSyncEnabled;
-    }
-
-    public void setMetadataSyncEnabled( boolean isMetadataSyncEnabled )
-    {
-        this.isMetadataSyncEnabled = isMetadataSyncEnabled;
+        return redisEnabled != null && redisEnabled;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/database/DatabaseInfo.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/database/DatabaseInfo.java
@@ -52,7 +52,7 @@ public class DatabaseInfo
 
     private String databaseVersion;
 
-    private boolean spatialSupport;
+    private Boolean spatialSupport;
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -73,6 +73,7 @@ public class DatabaseInfo
         this.password = null;
         this.url = null;
         this.databaseVersion = null;
+        this.spatialSupport = null;
     }
 
     // -------------------------------------------------------------------------
@@ -175,7 +176,9 @@ public class DatabaseInfo
     @Override
     public String toString()
     {
-        return "[Name: " + name + ", User: " + user + ", Password: " + password +
+        return "[Name: " + name +
+            ", User: " + user +
+            ", Password: " + password +
             ", URL: " + url + "]";
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/database/DatabaseInfo.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/database/DatabaseInfo.java
@@ -37,7 +37,6 @@ import lombok.Setter;
 
 import org.apache.commons.beanutils.BeanUtils;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -64,7 +63,7 @@ public class DatabaseInfo
     private String databaseVersion;
 
     @JsonProperty
-    private Boolean spatialSupport;
+    private boolean spatialSupport;
 
     // -------------------------------------------------------------------------
     // Logic
@@ -77,7 +76,7 @@ public class DatabaseInfo
         this.password = null;
         this.url = null;
         this.databaseVersion = null;
-        this.spatialSupport = null;
+        this.spatialSupport = false;
     }
 
     /**
@@ -97,12 +96,6 @@ public class DatabaseInfo
         }
 
         return cloned;
-    }
-
-    @JsonIgnore
-    public boolean isSpatialSupport()
-    {
-        return spatialSupport != null && spatialSupport;
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/database/DatabaseInfo.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/database/DatabaseInfo.java
@@ -31,36 +31,40 @@ import java.lang.reflect.InvocationTargetException;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.beanutils.BeanUtils;
-import org.hisp.dhis.common.DxfNamespaces;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import org.apache.commons.beanutils.BeanUtils;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * @author Lars Helge Overland
  */
+@Getter
+@Setter
+@NoArgsConstructor
 public class DatabaseInfo
 {
+    @JsonProperty
     private String name;
 
+    @JsonProperty
     private String user;
 
+    @JsonProperty
     private String password;
 
+    @JsonProperty
     private String url;
 
+    @JsonProperty
     private String databaseVersion;
 
+    @JsonProperty
     private Boolean spatialSupport;
-
-    // -------------------------------------------------------------------------
-    // Constructor
-    // -------------------------------------------------------------------------
-
-    public DatabaseInfo()
-    {
-    }
 
     // -------------------------------------------------------------------------
     // Logic
@@ -76,80 +80,6 @@ public class DatabaseInfo
         this.spatialSupport = null;
     }
 
-    // -------------------------------------------------------------------------
-    // Getters and setters
-    // -------------------------------------------------------------------------
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getName()
-    {
-        return name;
-    }
-
-    public void setName( String name )
-    {
-        this.name = name;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getUser()
-    {
-        return user;
-    }
-
-    public void setUser( String user )
-    {
-        this.user = user;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getDatabaseVersion()
-    {
-        return databaseVersion;
-    }
-
-    public void setDatabaseVersion( String databaseVersion )
-    {
-        this.databaseVersion = databaseVersion;
-    }
-
-    public String getPassword()
-    {
-        return password;
-    }
-
-    public void setPassword( String password )
-    {
-        this.password = password;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public String getUrl()
-    {
-        return url;
-    }
-
-    public void setUrl( String url )
-    {
-        this.url = url;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public boolean isSpatialSupport()
-    {
-        return spatialSupport;
-    }
-
-    public void setSpatialSupport( boolean spatialSupport )
-    {
-        this.spatialSupport = spatialSupport;
-    }
-
     /**
      * @return a cloned instance of this object.
      */
@@ -161,12 +91,18 @@ public class DatabaseInfo
         {
             BeanUtils.copyProperties( cloned, this );
         }
-        catch ( IllegalAccessException | InvocationTargetException e )
+        catch ( IllegalAccessException | InvocationTargetException ex )
         {
-            throw new IllegalStateException( e );
+            throw new IllegalStateException( ex );
         }
 
         return cloned;
+    }
+
+    @JsonIgnore
+    public boolean isSpatialSupport()
+    {
+        return spatialSupport != null && spatialSupport;
     }
 
     // -------------------------------------------------------------------------
@@ -178,7 +114,6 @@ public class DatabaseInfo
     {
         return "[Name: " + name +
             ", User: " + user +
-            ", Password: " + password +
             ", URL: " + url + "]";
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/DatabaseInfoTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/DatabaseInfoTest.java
@@ -50,7 +50,7 @@ class DatabaseInfoTest
         databaseInfo.setUrl( "theUrl" );
         databaseInfo.setPassword( "myPassword" );
         databaseInfo.setDatabaseVersion( "xzy 10.7" );
-        databaseInfo.setSpatialSupport( true );
+        databaseInfo.setSpatialSupport( Boolean.TRUE );
     }
 
     @Test
@@ -63,7 +63,7 @@ class DatabaseInfoTest
         Assertions.assertEquals( databaseInfo.getUrl(), cloned.getUrl() );
         Assertions.assertEquals( databaseInfo.getPassword(), cloned.getPassword() );
         Assertions.assertEquals( databaseInfo.getDatabaseVersion(), cloned.getDatabaseVersion() );
-        Assertions.assertEquals( databaseInfo.isSpatialSupport(), cloned.isSpatialSupport() );
+        Assertions.assertEquals( databaseInfo.getSpatialSupport(), cloned.getSpatialSupport() );
     }
 
     @Test
@@ -75,6 +75,6 @@ class DatabaseInfoTest
         Assertions.assertNull( databaseInfo.getUrl() );
         Assertions.assertNull( databaseInfo.getPassword() );
         Assertions.assertNull( databaseInfo.getDatabaseVersion() );
-        Assertions.assertTrue( databaseInfo.isSpatialSupport() );
+        Assertions.assertNull( databaseInfo.getSpatialSupport() );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/DatabaseInfoTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/DatabaseInfoTest.java
@@ -27,8 +27,12 @@
  */
 package org.hisp.dhis.system.database;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.commons.beanutils.BeanUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,43 +42,44 @@ import org.junit.jupiter.api.Test;
  */
 class DatabaseInfoTest
 {
-
-    private DatabaseInfo databaseInfo;
-
-    @BeforeEach
-    void setUp()
-    {
-        databaseInfo = new DatabaseInfo();
-        databaseInfo.setName( "testDatabase" );
-        databaseInfo.setUser( "testUser" );
-        databaseInfo.setUrl( "theUrl" );
-        databaseInfo.setPassword( "myPassword" );
-        databaseInfo.setDatabaseVersion( "xzy 10.7" );
-        databaseInfo.setSpatialSupport( Boolean.TRUE );
-    }
-
     @Test
     void cloneDatabaseInfo()
+        throws Exception
     {
-        final DatabaseInfo cloned = databaseInfo.instance();
-        Assertions.assertNotSame( databaseInfo, cloned );
-        Assertions.assertEquals( databaseInfo.getName(), cloned.getName() );
-        Assertions.assertEquals( databaseInfo.getUser(), cloned.getUser() );
-        Assertions.assertEquals( databaseInfo.getUrl(), cloned.getUrl() );
-        Assertions.assertEquals( databaseInfo.getPassword(), cloned.getPassword() );
-        Assertions.assertEquals( databaseInfo.getDatabaseVersion(), cloned.getDatabaseVersion() );
-        Assertions.assertEquals( databaseInfo.getSpatialSupport(), cloned.getSpatialSupport() );
+        DatabaseInfo databaseInfo = getDataBaseInfo();
+        DatabaseInfo cloned = databaseInfo.instance();
+        BeanUtils.copyProperties( cloned, databaseInfo );
+        assertNotSame( databaseInfo, cloned );
+        assertEquals( databaseInfo.getName(), cloned.getName() );
+        assertEquals( databaseInfo.getUser(), cloned.getUser() );
+        assertEquals( databaseInfo.getUrl(), cloned.getUrl() );
+        assertEquals( databaseInfo.getPassword(), cloned.getPassword() );
+        assertEquals( databaseInfo.getDatabaseVersion(), cloned.getDatabaseVersion() );
+        assertEquals( databaseInfo.isSpatialSupport(), cloned.isSpatialSupport() );
     }
 
     @Test
     void clearSensitiveInfo()
     {
+        DatabaseInfo databaseInfo = getDataBaseInfo();
         databaseInfo.clearSensitiveInfo();
-        Assertions.assertNull( databaseInfo.getName() );
-        Assertions.assertNull( databaseInfo.getUser() );
-        Assertions.assertNull( databaseInfo.getUrl() );
-        Assertions.assertNull( databaseInfo.getPassword() );
-        Assertions.assertNull( databaseInfo.getDatabaseVersion() );
-        Assertions.assertNull( databaseInfo.getSpatialSupport() );
+        assertNull( databaseInfo.getName() );
+        assertNull( databaseInfo.getUser() );
+        assertNull( databaseInfo.getUrl() );
+        assertNull( databaseInfo.getPassword() );
+        assertNull( databaseInfo.getDatabaseVersion() );
+        assertFalse( databaseInfo.isSpatialSupport() );
+    }
+
+    private DatabaseInfo getDataBaseInfo()
+    {
+        DatabaseInfo databaseInfo = new DatabaseInfo();
+        databaseInfo.setName( "testDatabase" );
+        databaseInfo.setUser( "testUser" );
+        databaseInfo.setUrl( "theUrl" );
+        databaseInfo.setPassword( "myPassword" );
+        databaseInfo.setDatabaseVersion( "xzy 10.7" );
+        databaseInfo.setSpatialSupport( true );
+        return databaseInfo;
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/DatabaseInfoTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/DatabaseInfoTest.java
@@ -36,8 +36,6 @@ import org.apache.commons.beanutils.BeanUtils;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for {@link DatabaseInfo}.
- *
  * @author Volker Schmidt
  */
 class DatabaseInfoTest

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
@@ -119,6 +119,6 @@ class HibernateDatabaseInfoProviderTest
         assertEquals( "dhis", databaseInfo.getUser() );
         assertEquals( "dhisz", databaseInfo.getPassword() );
         assertEquals( "PostgreSQL 10.5", databaseInfo.getDatabaseVersion() );
-        assertTrue( databaseInfo.isSpatialSupport() );
+        assertTrue( databaseInfo.getSpatialSupport() );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/database/HibernateDatabaseInfoProviderTest.java
@@ -119,6 +119,6 @@ class HibernateDatabaseInfoProviderTest
         assertEquals( "dhis", databaseInfo.getUser() );
         assertEquals( "dhisz", databaseInfo.getPassword() );
         assertEquals( "PostgreSQL 10.5", databaseInfo.getDatabaseVersion() );
-        assertTrue( databaseInfo.getSpatialSupport() );
+        assertTrue( databaseInfo.isSpatialSupport() );
     }
 }


### PR DESCRIPTION
Removes sensitive properties from system info. Introduces Lombok annotations for get/set methods. Removes XML annotations, though XML was not supported for this endpoint anyway.

Confirmed that the About page in the UI adapts and hides null/non-existing properties.