### PR TITLE
fix: always propagate end of process to delegate progress trackers [DHIS2-13474]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
@@ -149,12 +149,12 @@ public class ControlledJobProgress implements JobProgress
     @Override
     public void failedProcess( String error )
     {
+        tracker.failedProcess( error );
         Process process = processes.peekLast();
         if ( process == null || process.getCompletedTime() != null )
         {
             return;
         }
-        tracker.failedProcess( error );
         if ( process.getStatus() != Status.CANCELLED )
         {
             automaticAbort( false, error, null );
@@ -170,12 +170,12 @@ public class ControlledJobProgress implements JobProgress
     @Override
     public void failedProcess( Exception cause )
     {
+        tracker.failedProcess( cause );
         Process process = processes.peekLast();
         if ( process == null || process.getCompletedTime() != null )
         {
             return;
         }
-        tracker.failedProcess( cause );
         if ( process.getStatus() != Status.CANCELLED )
         {
             cause = cancellationAsAbort( cause );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/NotifierJobProgress.java
@@ -103,7 +103,7 @@ public class NotifierJobProgress implements JobProgress
     {
         if ( isNotEmpty( summary ) )
         {
-            notifier.notify( jobId, NotificationLevel.INFO, summary, isCancellationRequested() );
+            notifier.notify( jobId, NotificationLevel.INFO, summary, false );
         }
     }
 
@@ -112,7 +112,7 @@ public class NotifierJobProgress implements JobProgress
     {
         if ( isNotEmpty( error ) )
         {
-            notifier.notify( jobId, NotificationLevel.ERROR, error, isCancellationRequested() );
+            notifier.notify( jobId, NotificationLevel.ERROR, error, false );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -83,7 +83,6 @@ import org.springframework.util.concurrent.SuccessCallback;
  */
 class SchedulingManagerTest
 {
-
     private final TaskScheduler taskScheduler = mock( TaskScheduler.class );
 
     private final JobConfigurationService jobConfigurationService = mock( JobConfigurationService.class );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaControllerTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
  */
 class SchemaControllerTest extends DhisControllerConvenienceTest
 {
-
     @Test
     void testValidateSchema()
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.descriptors.JobConfigurationSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
+import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.webdomain.JobTypes;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -91,8 +92,14 @@ public class JobConfigurationController
 
     @PostMapping( value = "{uid}/execute", produces = { APPLICATION_JSON_VALUE, "application/javascript" } )
     public ObjectReport executeJobConfiguration( @PathVariable( "uid" ) String uid )
+        throws NotFoundException
     {
         JobConfiguration jobConfiguration = jobConfigurationService.getJobConfigurationByUid( uid );
+
+        if ( jobConfiguration == null )
+        {
+            throw NotFoundException.notFoundUid( uid );
+        }
 
         ObjectReport objectReport = new ObjectReport( JobConfiguration.class, 0 );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulingController.java
@@ -69,6 +69,13 @@ public class SchedulingController
 {
     private final SchedulingManager schedulingManager;
 
+    @GetMapping( value = { "/running/types", "/running/types/" }, produces = APPLICATION_JSON_VALUE )
+    @ResponseBody
+    public Collection<JobType> getRunningProgressTypesOnly()
+    {
+        return schedulingManager.getRunningTypes();
+    }
+
     @GetMapping( value = { "/running", "/running/" }, produces = APPLICATION_JSON_VALUE )
     @ResponseBody
     public Map<JobType, Collection<ProcessInfo>> getRunningProgressTypes()


### PR DESCRIPTION
### Summary
The main issue was that the completing of the process (outer bracket) was not propagated in case of automatic cancellation as the `Process` record was already completed (the `process.getCompletedTime() != null` check was true).
The forwarding call `tracker.failedProcess( error );` is now simply always done first. It was placed later before to protect against wrongly calling `failedProcess` multiple times (from the outside) but that is a programming error and should not happen.

In addition I added a new controller method so the UI can query for the running types without getting the full status.

I also noticed that the `/api/jobConfigurations/{uid}/execute` endpoint does not check if the configuration exists and return a proper error code for that, instead it would cause a 500 internal server error.

The use of `isCancellationRequested()` that I changed to `false` for stages was just a mistake in my thinking. 
This would be correct if the method would have been called on the progress tracker that delegated to `NotifierJobProgress` but the `NotifierJobProgress` itself will always return `false` anyhow for `isCancellationRequested()`. I concluded that it is more correct anyhow to never consider a stage to complete the notifications - that should happen by one of the process level methods.

### Manual Testing

* check that `POST` to http://localhost:8080/api/jobConfigurations/XXXXXXXXXXX/execute results in 404 NOT FOUND

To check that an error in the process terminates properly one would need a reproducer causing an exception in the job.
With that in place run _Apps > Data administration > Analytics tables_

### Example Output
`/api/scheduling/running/types`:
```json
[
  "ANALYTICS_TABLE"
]
```
