### PR TITLE
fix: Restore debezium-connector-postgres TECH-1259

### DIFF
--- a/dhis-2/dhis-support/dhis-support-cache-invalidation/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-cache-invalidation/pom.xml
@@ -43,6 +43,10 @@
       <groupId>io.debezium</groupId>
       <artifactId>debezium-embedded</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.debezium</groupId>
+      <artifactId>debezium-connector-postgres</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/dhis-2/dhis-support/dhis-support-cache-invalidation/src/test/java/org/hisp/dhis/cacheinvalidation/DebeziumPostgresConnectorTest.java
+++ b/dhis-2/dhis-support/dhis-support-cache-invalidation/src/test/java/org/hisp/dhis/cacheinvalidation/DebeziumPostgresConnectorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.cacheinvalidation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import io.debezium.connector.postgresql.PostgresConnector;
+
+/**
+ * Test to make sure that the Debezium Postgres connector is available. It is
+ * needed for PostgreSQL cache invalidation in a DHIS2 cluster configuration.
+ *
+ * @author Jim Grace
+ */
+class DebeziumPostgresConnectorTest
+{
+    @Test
+    void testDebeziumPostgresConnectorPresent()
+    {
+        assertEquals( "PostgresConnector", PostgresConnector.class.getSimpleName() );
+    }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -2253,6 +2253,11 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>io.debezium</groupId>
+        <artifactId>debezium-connector-postgres</artifactId>
+        <version>${version.debezium}</version>
+      </dependency>
 
       <!-- Test -->
       <dependency>


### PR DESCRIPTION
See [TECH-1259](https://dhis2.atlassian.net/browse/TECH-1259).

debezium-connector-postgres was removed from pom.xml in [pull/10436](https://github.com/dhis2/dhis2-core/pull/10436). However, it is needed for PostgreSQL cache invalidation in a DHIS2 cluster.

This PR adds it back in along with a test that will break if it is removed again.