### PR TITLE
refactor: Clean up program rule code in tracker module [DHIS2-13468]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EnrollmentActionRule.java
@@ -45,8 +45,6 @@ public class EnrollmentActionRule
 {
     private final String ruleUid;
 
-    private final String enrollment;
-
     private final String data;
 
     private final String field;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EventActionRule.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/EventActionRule.java
@@ -45,8 +45,6 @@ public class EventActionRule
 {
     private final String ruleUid;
 
-    private final String event;
-
     private final String data;
 
     private final String field;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionImplementer.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.tracker.programrule;
 
 import java.util.List;
 
+import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
@@ -43,12 +44,13 @@ public interface RuleActionImplementer
      *
      * @return list of issues
      */
-    List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, Enrollment enrollment );
+    List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, List<RuleEffect> ruleEffects,
+        Enrollment enrollment );
 
     /**
      * Get the validation for event evaluated by rule engine
      *
      * @return A map of events and list of issues
      */
-    List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, Event event );
+    List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, List<RuleEffect> ruleEffects, Event event );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/RuleActionImplementer.java
@@ -28,9 +28,10 @@
 package org.hisp.dhis.tracker.programrule;
 
 import java.util.List;
-import java.util.Map;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
 
 /**
  * @author Enrico Colasante
@@ -40,16 +41,14 @@ public interface RuleActionImplementer
     /**
      * Get the validation for enrollment evaluated by rule engine
      *
-     * @param bundle
-     * @return A map of enrollment and list of issues
+     * @return list of issues
      */
-    Map<String, List<ProgramRuleIssue>> validateEnrollments( TrackerBundle bundle );
+    List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, Enrollment enrollment );
 
     /**
      * Get the validation for event evaluated by rule engine
      *
-     * @param bundle
      * @return A map of events and list of issues
      */
-    Map<String, List<ProgramRuleIssue>> validateEvents( TrackerBundle bundle );
+    List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, Event event );
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -112,7 +112,7 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
     public List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, Event event )
     {
         List<EventActionRule> eventEffects = getEventEffects( event,
-            bundle.getEventRuleEffects().get( event.getEvent() ), bundle );
+            bundle.getEventRuleEffects().getOrDefault( event.getEvent(), Collections.emptyList() ), bundle );
 
         return applyToEvents( event, eventEffects, bundle );
     }
@@ -120,8 +120,9 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
     @Override
     public List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, Enrollment enrollment )
     {
-        List<EnrollmentActionRule> enrollmentEffects = getEnrollmentEffects(
-            enrollment, bundle.getEnrollmentRuleEffects().get( enrollment.getEnrollment() ), bundle );
+        List<EnrollmentActionRule> enrollmentEffects = getEnrollmentEffects( enrollment,
+            bundle.getEnrollmentRuleEffects().getOrDefault( enrollment.getEnrollment(), Collections.emptyList() ),
+            bundle );
 
         return applyToEnrollments( enrollment, enrollmentEffects, bundle );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -109,20 +109,18 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
     }
 
     @Override
-    public List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, Event event )
+    public List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, List<RuleEffect> ruleEffects, Event event )
     {
-        List<EventActionRule> eventEffects = getEventEffects( event,
-            bundle.getEventRuleEffects().getOrDefault( event.getEvent(), Collections.emptyList() ), bundle );
+        List<EventActionRule> eventEffects = getEventEffects( event, ruleEffects, bundle );
 
         return applyToEvents( event, eventEffects, bundle );
     }
 
     @Override
-    public List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, Enrollment enrollment )
+    public List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, List<RuleEffect> ruleEffects,
+        Enrollment enrollment )
     {
-        List<EnrollmentActionRule> enrollmentEffects = getEnrollmentEffects( enrollment,
-            bundle.getEnrollmentRuleEffects().getOrDefault( enrollment.getEnrollment(), Collections.emptyList() ),
-            bundle );
+        List<EnrollmentActionRule> enrollmentEffects = getEnrollmentEffects( enrollment, ruleEffects, bundle );
 
         return applyToEnrollments( enrollment, enrollmentEffects, bundle );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AbstractRuleActionImplementer.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.needsToVali
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -54,13 +53,14 @@ import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.programrule.EnrollmentActionRule;
 import org.hisp.dhis.tracker.programrule.EventActionRule;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
+import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 // TODO: Verify if we can remove checks on ProgramStage when Program Rule
 // validation is in place
 public abstract class AbstractRuleActionImplementer<T extends RuleAction>
+    implements RuleActionImplementer
 {
     /**
      * @return the class of the action that the implementer work with
@@ -83,7 +83,7 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
      * @return A list of program rule issues that can be either warnings or
      *         errors
      */
-    abstract List<ProgramRuleIssue> applyToEvents( Map.Entry<String, List<EventActionRule>> eventActionRules,
+    abstract List<ProgramRuleIssue> applyToEvents( Event event, List<EventActionRule> eventActionRules,
         TrackerBundle bundle );
 
     /**
@@ -94,8 +94,8 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
      * @return A list of program rule issues that can be either warnings or
      *         errors
      */
-    abstract List<ProgramRuleIssue> applyToEnrollments(
-        Map.Entry<String, List<EnrollmentActionRule>> enrollmentActionRules, TrackerBundle bundle );
+    abstract List<ProgramRuleIssue> applyToEnrollments( Enrollment enrollment,
+        List<EnrollmentActionRule> enrollmentActionRules, TrackerBundle bundle );
 
     /**
      * Get the content from the action.
@@ -108,29 +108,22 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
         return null;
     }
 
-    public Map<String, List<ProgramRuleIssue>> validateEvents( TrackerBundle bundle )
+    @Override
+    public List<ProgramRuleIssue> validateEvent( TrackerBundle bundle, Event event )
     {
-        Map<String, List<EventActionRule>> eventEffects = getEventEffects( bundle.getEventRuleEffects(), bundle );
+        List<EventActionRule> eventEffects = getEventEffects( event,
+            bundle.getEventRuleEffects().get( event.getEvent() ), bundle );
 
-        return eventEffects
-            .entrySet()
-            .stream()
-            .map( entry -> Maps.immutableEntry( entry.getKey(), applyToEvents( entry, bundle ) ) )
-            .filter( entry -> !entry.getValue().isEmpty() )
-            .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+        return applyToEvents( event, eventEffects, bundle );
     }
 
-    public Map<String, List<ProgramRuleIssue>> validateEnrollments( TrackerBundle bundle )
+    @Override
+    public List<ProgramRuleIssue> validateEnrollment( TrackerBundle bundle, Enrollment enrollment )
     {
-        Map<String, List<EnrollmentActionRule>> enrollmentEffects = getEnrollmentEffects(
-            bundle.getEnrollmentRuleEffects(), bundle );
+        List<EnrollmentActionRule> enrollmentEffects = getEnrollmentEffects(
+            enrollment, bundle.getEnrollmentRuleEffects().get( enrollment.getEnrollment() ), bundle );
 
-        return enrollmentEffects
-            .entrySet()
-            .stream()
-            .map( entry -> Maps.immutableEntry( entry.getKey(), applyToEnrollments( entry, bundle ) ) )
-            .filter( entry -> !entry.getValue().isEmpty() )
-            .collect( Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+        return applyToEnrollments( enrollment, enrollmentEffects, bundle );
     }
 
     /**
@@ -142,35 +135,25 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
      * @param bundle
      * @return A map of actions by event
      */
-    public Map<String, List<EventActionRule>> getEventEffects(
-        Map<String, List<RuleEffect>> effects, TrackerBundle bundle )
+    public List<EventActionRule> getEventEffects( Event event, List<RuleEffect> effects, TrackerBundle bundle )
     {
+        ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
+        Set<DataValue> dataValues = event.getDataValues();
         return effects
-            .entrySet()
             .stream()
-            .filter( entry -> getEvent( bundle, entry.getKey() ).isPresent() )
-            .collect( Collectors.toMap( Map.Entry::getKey,
-                e -> {
-                    Event event = getEvent( bundle, e.getKey() ).get();
-                    ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
-                    Set<DataValue> dataValues = event.getDataValues();
-
-                    return e.getValue()
-                        .stream()
-                        .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
-                        .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
-                            getAttributeType( effect.ruleAction() ) == DATA_ELEMENT )
-                        .map( effect -> new EventActionRule( effect.ruleId(), event.getEvent(), effect.data(),
-                            getField( (T) effect.ruleAction() ),
-                            getAttributeType( effect.ruleAction() ),
-                            getContent( (T) effect.ruleAction() ), dataValues ) )
-                        .filter( effect -> effect.getAttributeType() != DATA_ELEMENT ||
-                            isDataElementPartOfProgramStage( effect.getField(), programStage ) )
-                        .filter(
-                            effect -> effect.getAttributeType() != DATA_ELEMENT ||
-                                needsToValidateDataValues( event, programStage ) )
-                        .collect( Collectors.toList() );
-                } ) );
+            .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
+            .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
+                getAttributeType( effect.ruleAction() ) == DATA_ELEMENT )
+            .map( effect -> new EventActionRule( effect.ruleId(), effect.data(),
+                getField( (T) effect.ruleAction() ),
+                getAttributeType( effect.ruleAction() ),
+                getContent( (T) effect.ruleAction() ), dataValues ) )
+            .filter( effect -> effect.getAttributeType() != DATA_ELEMENT ||
+                isDataElementPartOfProgramStage( effect.getField(), programStage ) )
+            .filter(
+                effect -> effect.getAttributeType() != DATA_ELEMENT ||
+                    needsToValidateDataValues( event, programStage ) )
+            .collect( Collectors.toList() );
     }
 
     /**
@@ -181,36 +164,25 @@ public abstract class AbstractRuleActionImplementer<T extends RuleAction>
      * @return A map of actions by enrollment
      */
     @SuppressWarnings( "unchecked" )
-    public Map<String, List<EnrollmentActionRule>> getEnrollmentEffects(
-        Map<String, List<RuleEffect>> effects, TrackerBundle bundle )
+    public List<EnrollmentActionRule> getEnrollmentEffects( Enrollment enrollment, List<RuleEffect> effects,
+        TrackerBundle bundle )
     {
+        List<Attribute> payloadTeiAttributes = getTrackedEntity( bundle, enrollment.getTrackedEntity() )
+            .map( TrackedEntity::getAttributes )
+            .orElse( Collections.emptyList() );
+        List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
+            payloadTeiAttributes );
+
         return effects
-            .entrySet()
             .stream()
-            .filter( entry -> getEnrollment( bundle, entry.getKey() ).isPresent() )
-            .collect( Collectors.toMap( Map.Entry::getKey,
-                e -> {
-                    Enrollment enrollment = getEnrollment( bundle, e.getKey() ).get();
-
-                    List<Attribute> payloadTeiAttributes = getTrackedEntity( bundle, enrollment.getTrackedEntity() )
-                        .map( TrackedEntity::getAttributes )
-                        .orElse( Collections.emptyList() );
-
-                    List<Attribute> attributes = mergeAttributes( enrollment.getAttributes(),
-                        payloadTeiAttributes );
-
-                    return e.getValue()
-                        .stream()
-                        .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
-                        .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
-                            getAttributeType( effect.ruleAction() ) == TRACKED_ENTITY_ATTRIBUTE )
-                        .map( effect -> new EnrollmentActionRule( effect.ruleId(),
-                            enrollment.getEnrollment(), effect.data(),
-                            getField( (T) effect.ruleAction() ),
-                            getAttributeType( effect.ruleAction() ),
-                            getContent( (T) effect.ruleAction() ), attributes ) )
-                        .collect( Collectors.toList() );
-                } ) );
+            .filter( effect -> getActionClass().isAssignableFrom( effect.ruleAction().getClass() ) )
+            .filter( effect -> getAttributeType( effect.ruleAction() ) == UNKNOWN ||
+                getAttributeType( effect.ruleAction() ) == TRACKED_ENTITY_ATTRIBUTE )
+            .map( effect -> new EnrollmentActionRule( effect.ruleId(), effect.data(),
+                getField( (T) effect.ruleAction() ),
+                getAttributeType( effect.ruleAction() ),
+                getContent( (T) effect.ruleAction() ), attributes ) )
+            .collect( Collectors.toList() );
     }
 
     private List<Attribute> mergeAttributes( List<Attribute> enrollmentAttributes, List<Attribute> attributes )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -216,8 +216,8 @@ public class AssignValueImplementer
     private void addOrOverwriteDataValue( Event event, EventActionRule actionRule, TrackerBundle bundle )
     {
         DataElement dataElement = bundle.getPreheat().getDataElement( actionRule.getField() );
-        Event eventFromBundle = bundle.getEvent( event.getEvent() ).get();
-        Optional<DataValue> dataValue = eventFromBundle.getDataValues().stream()
+
+        Optional<DataValue> dataValue = event.getDataValues().stream()
             .filter( dv -> dv.getDataElement().isEqualTo( dataElement ) )
             .findAny();
 
@@ -227,7 +227,7 @@ public class AssignValueImplementer
         }
         else
         {
-            eventFromBundle.getDataValues()
+            event.getDataValues()
                 .add( createDataValue( bundle.getPreheat().getIdSchemes().toMetadataIdentifier( dataElement ),
                     actionRule.getValue() ) );
         }
@@ -236,7 +236,6 @@ public class AssignValueImplementer
     private void addOrOverwriteAttribute( Enrollment enrollment, EnrollmentActionRule actionRule, TrackerBundle bundle )
     {
         TrackedEntityAttribute attribute = bundle.getPreheat().getTrackedEntityAttribute( actionRule.getField() );
-        Enrollment enrollmentFromBundle = bundle.getEnrollment( enrollment.getEnrollment() ).get();
         Optional<TrackedEntity> trackedEntity = bundle.getTrackedEntity( enrollment.getTrackedEntity() );
         List<Attribute> attributes;
 
@@ -253,7 +252,7 @@ public class AssignValueImplementer
             }
         }
 
-        attributes = enrollmentFromBundle.getAttributes();
+        attributes = enrollment.getAttributes();
         Optional<Attribute> optionalAttribute = attributes.stream()
             .filter( at -> at.getAttribute().isEqualTo( attribute ) )
             .findAny();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/ErrorWarningImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/ErrorWarningImplementer.java
@@ -27,10 +27,9 @@
  */
 package org.hisp.dhis.tracker.programrule.implementers;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -73,39 +72,25 @@ public abstract class ErrorWarningImplementer<T extends RuleActionMessage>
     }
 
     @Override
-    List<ProgramRuleIssue> applyToEnrollments( Map.Entry<String, List<EnrollmentActionRule>> enrollmentActionRules,
+    List<ProgramRuleIssue> applyToEnrollments( Enrollment enrollment, List<EnrollmentActionRule> enrollmentActionRules,
         TrackerBundle bundle )
     {
-        List<String> filteredEnrollments = bundle.getEnrollments()
-            .stream()
-            .filter( filterEnrollment() )
-            .map( Enrollment::getEnrollment )
-            .collect( Collectors.toList() );
-
-        if ( filteredEnrollments.contains( enrollmentActionRules.getKey() ) )
+        if ( needsToRun( enrollment ) )
         {
-            return parseErrors( enrollmentActionRules.getValue() );
+            return parseErrors( enrollmentActionRules );
         }
-
-        return Lists.newArrayList();
+        return Collections.emptyList();
     }
 
     @Override
-    public List<ProgramRuleIssue> applyToEvents( Map.Entry<String, List<EventActionRule>> actionRules,
+    public List<ProgramRuleIssue> applyToEvents( Event event, List<EventActionRule> actionRules,
         TrackerBundle bundle )
     {
-        List<String> filteredEvents = bundle.getEvents()
-            .stream()
-            .filter( filterEvent() )
-            .map( Event::getEvent )
-            .collect( Collectors.toList() );
-
-        if ( filteredEvents.contains( actionRules.getKey() ) )
+        if ( needsToRun( event ) )
         {
-            return parseErrors( actionRules.getValue() );
+            return parseErrors( actionRules );
         }
-
-        return Lists.newArrayList();
+        return Collections.emptyList();
     }
 
     private <U extends ActionRule> List<ProgramRuleIssue> parseErrors( List<U> effects )
@@ -134,27 +119,27 @@ public abstract class ErrorWarningImplementer<T extends RuleActionMessage>
             .collect( Collectors.toList() );
     }
 
-    private Predicate<Event> filterEvent()
+    private boolean needsToRun( Event event )
     {
         if ( isOnComplete() )
         {
-            return e -> Objects.equals( EventStatus.COMPLETED, e.getStatus() );
+            return Objects.equals( EventStatus.COMPLETED, event.getStatus() );
         }
         else
         {
-            return e -> true;
+            return true;
         }
     }
 
-    private Predicate<Enrollment> filterEnrollment()
+    private boolean needsToRun( Enrollment enrollment )
     {
         if ( isOnComplete() )
         {
-            return e -> Objects.equals( EnrollmentStatus.COMPLETED, e.getStatus() );
+            return Objects.equals( EnrollmentStatus.COMPLETED, enrollment.getStatus() );
         }
         else
         {
-            return e -> true;
+            return true;
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidator.java
@@ -80,10 +80,9 @@ public class SetMandatoryFieldValidator
     }
 
     @Override
-    List<ProgramRuleIssue> applyToEvents( Map.Entry<String, List<EventActionRule>> eventClasses, TrackerBundle bundle )
+    List<ProgramRuleIssue> applyToEvents( Event event, List<EventActionRule> eventActions, TrackerBundle bundle )
     {
-        return checkMandatoryDataElement( getEvent( bundle, eventClasses.getKey() ).get(), eventClasses.getValue(),
-            bundle );
+        return checkMandatoryDataElement( event, eventActions, bundle );
     }
 
     private List<ProgramRuleIssue> checkMandatoryDataElement( Event event, List<EventActionRule> actionRules,
@@ -108,13 +107,12 @@ public class SetMandatoryFieldValidator
     }
 
     @Override
-    List<ProgramRuleIssue> applyToEnrollments( Map.Entry<String, List<EnrollmentActionRule>> enrollmentActionRules,
+    List<ProgramRuleIssue> applyToEnrollments( Enrollment enrollment, List<EnrollmentActionRule> enrollmentActionRules,
         TrackerBundle bundle )
     {
-        return enrollmentActionRules.getValue().stream()
+        return enrollmentActionRules.stream()
             .flatMap( actionRule -> checkMandatoryEnrollmentAttribute(
-                bundle.getEnrollment( actionRule.getEnrollment() ).get(),
-                enrollmentActionRules.getValue(), bundle.getPreheat() ).stream() )
+                enrollment, enrollmentActionRules, bundle.getPreheat() ).stream() )
             .collect( Collectors.toList() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
@@ -58,9 +59,16 @@ public class EnrollmentRuleValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
+        List<RuleEffect> ruleEffects = bundle.getEnrollmentRuleEffects().get( enrollment.getEnrollment() );
+
+        if ( ruleEffects == null || ruleEffects.isEmpty() )
+        {
+            return;
+        }
+
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()
-            .flatMap( v -> v.validateEnrollment( bundle, enrollment ).stream() )
+            .flatMap( v -> v.validateEnrollment( bundle, ruleEffects, enrollment ).stream() )
             .collect( Collectors.toList() );
 
         addIssuesToReporter( reporter, enrollment, programRuleIssues );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -40,8 +40,6 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.Lists;
-
 /**
  * @author Enrico Colasante
  */
@@ -62,8 +60,7 @@ public class EnrollmentRuleValidationHook
     {
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()
-            .flatMap( v -> v.validateEnrollments( bundle )
-                .getOrDefault( enrollment.getEnrollment(), Lists.newArrayList() ).stream() )
+            .flatMap( v -> v.validateEnrollment( bundle, enrollment ).stream() )
             .collect( Collectors.toList() );
 
         addIssuesToReporter( reporter, enrollment, programRuleIssues );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.addIssuesTo
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
@@ -58,10 +59,17 @@ public class EventRuleValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
+        List<RuleEffect> ruleEffects = bundle.getEventRuleEffects().get( event.getEvent() );
+
+        if ( ruleEffects == null || ruleEffects.isEmpty() )
+        {
+            return;
+        }
+
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()
             .flatMap(
-                v -> v.validateEvent( bundle, event ).stream() )
+                v -> v.validateEvent( bundle, ruleEffects, event ).stream() )
             .collect( Collectors.toList() );
 
         addIssuesToReporter( reporter, event, programRuleIssues );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidationHook.java
@@ -40,8 +40,6 @@ import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.google.common.collect.Lists;
-
 /**
  * @author Enrico Colasante
  */
@@ -63,8 +61,7 @@ public class EventRuleValidationHook
         List<ProgramRuleIssue> programRuleIssues = validators
             .stream()
             .flatMap(
-                v -> v.validateEvents( bundle )
-                    .getOrDefault( event.getEvent(), Lists.newArrayList() ).stream() )
+                v -> v.validateEvent( bundle, event ).stream() )
             .collect( Collectors.toList() );
 
         addIssuesToReporter( reporter, event, programRuleIssues );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
@@ -39,7 +39,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -184,7 +183,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getEventWithDataValueNOTSet() );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( SECOND_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -192,8 +191,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_NEW_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
-        assertEquals( 1, eventIssues.get( SECOND_EVENT_ID ).size() );
-        assertEquals( WARNING, eventIssues.get( SECOND_EVENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, eventIssues.size() );
+        assertEquals( WARNING, eventIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -203,12 +202,13 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle,
+            getEventWithDataValueNOTSetInDifferentProgramStage() );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( SECOND_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
             .filter( dv -> dv.getDataElement().isEqualTo( dataElementA ) ).findAny();
-        assertTrue( !newDataValue.isPresent() );
+        assertTrue( newDataValue.isEmpty() );
         assertTrue( eventIssues.isEmpty() );
     }
 
@@ -221,7 +221,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getEventWithDataValueSet() );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -229,9 +229,9 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_OLD_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
-        assertEquals( 1, eventIssues.get( FIRST_EVENT_ID ).size() );
-        assertEquals( ERROR, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueType() );
-        assertEquals( TrackerErrorCode.E1307, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueCode() );
+        assertEquals( 1, eventIssues.size() );
+        assertEquals( ERROR, eventIssues.get( 0 ).getIssueType() );
+        assertEquals( TrackerErrorCode.E1307, eventIssues.get( 0 ).getIssueCode() );
     }
 
     @Test
@@ -247,7 +247,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle,
+            getEventWithDataValueSet( idSchemes ) );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -255,9 +256,9 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_OLD_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
-        assertEquals( 1, eventIssues.get( FIRST_EVENT_ID ).size() );
-        assertEquals( TrackerErrorCode.E1307, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueCode() );
-        assertEquals( ERROR, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, eventIssues.size() );
+        assertEquals( TrackerErrorCode.E1307, eventIssues.get( 0 ).getIssueCode() );
+        assertEquals( ERROR, eventIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -269,7 +270,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEvents( events );
         bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle,
+            getEventWithDataValueSetSameValue() );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -277,8 +279,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_NEW_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
-        assertEquals( 1, eventIssues.get( FIRST_EVENT_ID ).size() );
-        assertEquals( WARNING, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, eventIssues.size() );
+        assertEquals( WARNING, eventIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -292,7 +294,7 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.TRUE );
 
-        Map<String, List<ProgramRuleIssue>> eventIssues = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getEventWithDataValueSet() );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -300,8 +302,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( newDataValue.isPresent() );
         assertEquals( DATA_ELEMENT_NEW_VALUE, newDataValue.get().getValue() );
         assertEquals( 1, eventIssues.size() );
-        assertEquals( 1, eventIssues.get( FIRST_EVENT_ID ).size() );
-        assertEquals( WARNING, eventIssues.get( FIRST_EVENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, eventIssues.size() );
+        assertEquals( WARNING, eventIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -314,7 +316,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEnrollments( enrollments );
         bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeNOTSet() );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( SECOND_ENROLLMENT_ID ) ).findAny().get();
@@ -323,8 +326,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( attribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_NEW_VALUE, attribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( SECOND_ENROLLMENT_ID ).size() );
-        assertEquals( WARNING, enrollmentIssues.get( SECOND_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( WARNING, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -334,7 +337,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEnrollments( enrollments );
         bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeSet() );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -343,8 +347,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( attribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_OLD_VALUE, attribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).size() );
-        assertEquals( ERROR, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( ERROR, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -360,7 +364,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEnrollments( enrollments );
         bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeSet( idSchemes ) );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -369,8 +374,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( attribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_OLD_VALUE, attribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).size() );
-        assertEquals( ERROR, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( ERROR, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -382,7 +387,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setTrackedEntities( trackedEntities );
         bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeNOTSet() );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( SECOND_ENROLLMENT_ID ) ).findAny().get();
@@ -396,8 +402,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( teiAttribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_OLD_VALUE, teiAttribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( SECOND_ENROLLMENT_ID ).size() );
-        assertEquals( ERROR, enrollmentIssues.get( SECOND_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( ERROR, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -411,7 +417,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setTrackedEntities( trackedEntities );
         bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeNOTSet() );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( SECOND_ENROLLMENT_ID ) ).findAny().get();
@@ -425,8 +432,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( teiAttribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_NEW_VALUE, teiAttribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( SECOND_ENROLLMENT_ID ).size() );
-        assertEquals( WARNING, enrollmentIssues.get( SECOND_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( WARNING, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -436,7 +443,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         bundle.setEnrollments( enrollments );
         bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeSetSameValue() );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -445,8 +453,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( attribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_NEW_VALUE, attribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).size() );
-        assertEquals( WARNING, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( WARNING, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     @Test
@@ -458,7 +466,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.TRUE );
 
-        Map<String, List<ProgramRuleIssue>> enrollmentIssues = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithAttributeSet() );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -467,8 +476,8 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertTrue( attribute.isPresent() );
         assertEquals( TEI_ATTRIBUTE_NEW_VALUE, attribute.get().getValue() );
         assertEquals( 1, enrollmentIssues.size() );
-        assertEquals( 1, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).size() );
-        assertEquals( WARNING, enrollmentIssues.get( FIRST_ENROLLMENT_ID ).get( 0 ).getIssueType() );
+        assertEquals( 1, enrollmentIssues.size() );
+        assertEquals( WARNING, enrollmentIssues.get( 0 ).getIssueType() );
     }
 
     private Event getEventWithDataValueSet()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/AssignValueImplementerTest.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.tracker.programrule;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
-import static org.hisp.dhis.rules.models.TrackerObjectType.ENROLLMENT;
-import static org.hisp.dhis.rules.models.TrackerObjectType.EVENT;
 import static org.hisp.dhis.tracker.programrule.IssueType.ERROR;
 import static org.hisp.dhis.tracker.programrule.IssueType.WARNING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,7 +50,6 @@ import org.hisp.dhis.program.ValidationStrategy;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionAssign;
 import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -179,11 +176,12 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     {
         when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
-        List<Event> events = Lists.newArrayList( getEventWithDataValueNOTSet() );
+        Event eventWithDataValueNOTSet = getEventWithDataValueNOTSet();
+        List<Event> events = Lists.newArrayList( eventWithDataValueNOTSet );
         bundle.setEvents( events );
-        bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getEventWithDataValueNOTSet() );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getRuleEventEffects(),
+            eventWithDataValueNOTSet );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( SECOND_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -198,12 +196,12 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignDataElementValueForEventsWhenDataElementIsEmptyAndFromDifferentProgramStage()
     {
-        List<Event> events = Lists.newArrayList( getEventWithDataValueNOTSetInDifferentProgramStage() );
+        Event eventWithDataValueNOTSetInDifferentProgramStage = getEventWithDataValueNOTSetInDifferentProgramStage();
+        List<Event> events = Lists.newArrayList( eventWithDataValueNOTSetInDifferentProgramStage );
         bundle.setEvents( events );
-        bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle,
-            getEventWithDataValueNOTSetInDifferentProgramStage() );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getRuleEventEffects(),
+            eventWithDataValueNOTSetInDifferentProgramStage );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( SECOND_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -217,11 +215,12 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     {
         when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
-        List<Event> events = Lists.newArrayList( getEventWithDataValueSet() );
+        Event eventWithDataValueSet = getEventWithDataValueSet();
+        List<Event> events = Lists.newArrayList( eventWithDataValueSet );
         bundle.setEvents( events );
-        bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getEventWithDataValueSet() );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getRuleEventEffects(),
+            eventWithDataValueSet );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -243,12 +242,12 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         when( preheat.getIdSchemes() ).thenReturn( idSchemes );
         when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
 
-        List<Event> events = Lists.newArrayList( getEventWithDataValueSet( idSchemes ) );
+        Event eventWithDataValueSet = getEventWithDataValueSet( idSchemes );
+        List<Event> events = Lists.newArrayList( eventWithDataValueSet );
         bundle.setEvents( events );
-        bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle,
-            getEventWithDataValueSet( idSchemes ) );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getRuleEventEffects(),
+            eventWithDataValueSet );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -266,12 +265,12 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     {
         when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
-        List<Event> events = Lists.newArrayList( getEventWithDataValueSetSameValue() );
+        Event eventWithDataValueSetSameValue = getEventWithDataValueSetSameValue();
+        List<Event> events = Lists.newArrayList( eventWithDataValueSetSameValue );
         bundle.setEvents( events );
-        bundle.setRuleEffects( getRuleEventEffects( events ) );
 
-        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle,
-            getEventWithDataValueSetSameValue() );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getRuleEventEffects(),
+            eventWithDataValueSetSameValue );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -288,13 +287,14 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     {
         when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         when( preheat.getDataElement( dataElementA.getUid() ) ).thenReturn( dataElementA );
-        List<Event> events = Lists.newArrayList( getEventWithDataValueSet() );
+        Event eventWithDataValueSet = getEventWithDataValueSet();
+        List<Event> events = Lists.newArrayList( eventWithDataValueSet );
         bundle.setEvents( events );
-        bundle.setRuleEffects( getRuleEventEffects( events ) );
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.TRUE );
 
-        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getEventWithDataValueSet() );
+        List<ProgramRuleIssue> eventIssues = implementerToTest.validateEvent( bundle, getRuleEventEffects(),
+            eventWithDataValueSet );
 
         Event event = bundle.getEvents().stream().filter( e -> e.getEvent().equals( FIRST_EVENT_ID ) ).findAny().get();
         Optional<DataValue> newDataValue = event.getDataValues().stream()
@@ -311,13 +311,14 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     {
         when( preheat.getIdSchemes() ).thenReturn( TrackerIdSchemeParams.builder().build() );
         List<TrackedEntity> trackedEntities = Lists.newArrayList( getTrackedEntitiesWithAttributeNOTSet() );
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeNOTSet() );
+        Enrollment enrollmentWithAttributeNOTSet = getEnrollmentWithAttributeNOTSet();
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeNOTSet );
         bundle.setTrackedEntities( trackedEntities );
         bundle.setEnrollments( enrollments );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeNOTSet() );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeNOTSet );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( SECOND_ENROLLMENT_ID ) ).findAny().get();
@@ -333,12 +334,13 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignAttributeValueForEnrollmentsWhenAttributeIsAlreadyPresent()
     {
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeSet() );
+        Enrollment enrollmentWithAttributeSet = getEnrollmentWithAttributeSet();
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeSet );
         bundle.setEnrollments( enrollments );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeSet() );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeSet );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -360,12 +362,13 @@ class AssignValueImplementerTest extends DhisConvenienceTest
             .build();
         when( preheat.getIdSchemes() ).thenReturn( idSchemes );
         when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( attributeA );
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeSet( idSchemes ) );
+        Enrollment enrollmentWithAttributeSet = getEnrollmentWithAttributeSet( idSchemes );
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeSet );
         bundle.setEnrollments( enrollments );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeSet( idSchemes ) );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeSet );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -381,14 +384,15 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignAttributeValueForEnrollmentsWhenAttributeIsAlreadyPresentInTei()
     {
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeNOTSet() );
+        Enrollment enrollmentWithAttributeNOTSet = getEnrollmentWithAttributeNOTSet();
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeNOTSet );
         List<TrackedEntity> trackedEntities = Lists.newArrayList( getTrackedEntitiesWithAttributeSet() );
         bundle.setEnrollments( enrollments );
         bundle.setTrackedEntities( trackedEntities );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeNOTSet() );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeNOTSet );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( SECOND_ENROLLMENT_ID ) ).findAny().get();
@@ -411,14 +415,15 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     {
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.TRUE );
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeNOTSet() );
+        Enrollment enrollmentWithAttributeNOTSet = getEnrollmentWithAttributeNOTSet();
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeNOTSet );
         List<TrackedEntity> trackedEntities = Lists.newArrayList( getTrackedEntitiesWithAttributeSet() );
         bundle.setEnrollments( enrollments );
         bundle.setTrackedEntities( trackedEntities );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeNOTSet() );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeNOTSet );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( SECOND_ENROLLMENT_ID ) ).findAny().get();
@@ -439,12 +444,13 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignAttributeValueForEnrollmentsWhenAttributeIsAlreadyPresentAndHasTheSameValue()
     {
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeSetSameValue() );
+        Enrollment enrollmentWithAttributeSetSameValue = getEnrollmentWithAttributeSetSameValue();
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeSetSameValue );
         bundle.setEnrollments( enrollments );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeSetSameValue() );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeSetSameValue );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -460,14 +466,15 @@ class AssignValueImplementerTest extends DhisConvenienceTest
     @Test
     void testAssignAttributeValueForEnrollmentsWhenAttributeIsAlreadyPresentAndSystemSettingToOverwriteIsTrue()
     {
-        List<Enrollment> enrollments = Lists.newArrayList( getEnrollmentWithAttributeSet() );
+        Enrollment enrollmentWithAttributeSet = getEnrollmentWithAttributeSet();
+        List<Enrollment> enrollments = Lists.newArrayList( enrollmentWithAttributeSet );
         bundle.setEnrollments( enrollments );
-        bundle.setRuleEffects( getRuleEnrollmentEffects( enrollments ) );
         when( systemSettingManager.getBooleanSetting( SettingKey.RULE_ENGINE_ASSIGN_OVERWRITE ) )
             .thenReturn( Boolean.TRUE );
 
         List<ProgramRuleIssue> enrollmentIssues = implementerToTest.validateEnrollment( bundle,
-            getEnrollmentWithAttributeSet() );
+            getRuleEnrollmentEffects(),
+            enrollmentWithAttributeSet );
 
         Enrollment enrollment = bundle.getEnrollments().stream()
             .filter( e -> e.getEnrollment().equals( FIRST_ENROLLMENT_ID ) ).findAny().get();
@@ -632,27 +639,6 @@ class AssignValueImplementerTest extends DhisConvenienceTest
             .value( TEI_ATTRIBUTE_NEW_VALUE )
             .build();
         return Lists.newArrayList( attribute );
-    }
-
-    private List<RuleEffects> getRuleEventEffects( List<Event> events )
-    {
-        List<RuleEffects> ruleEffectsByEvent = Lists.newArrayList();
-        for ( Event event : events )
-        {
-            ruleEffectsByEvent.add( new RuleEffects( EVENT, event.getEvent(), getRuleEventEffects() ) );
-        }
-        return ruleEffectsByEvent;
-    }
-
-    private List<RuleEffects> getRuleEnrollmentEffects( List<Enrollment> enrollments )
-    {
-        List<RuleEffects> ruleEffectsByEnrollment = Lists.newArrayList();
-        for ( Enrollment enrollment : enrollments )
-        {
-            ruleEffectsByEnrollment
-                .add( new RuleEffects( ENROLLMENT, enrollment.getEnrollment(), getRuleEnrollmentEffects() ) );
-        }
-        return ruleEffectsByEnrollment;
     }
 
     private List<RuleEffect> getRuleEventEffects()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.tracker.programrule;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
-import static org.hisp.dhis.rules.models.TrackerObjectType.ENROLLMENT;
-import static org.hisp.dhis.rules.models.TrackerObjectType.EVENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -48,7 +46,6 @@ import org.hisp.dhis.program.ValidationStrategy;
 import org.hisp.dhis.rules.models.RuleAction;
 import org.hisp.dhis.rules.models.RuleActionSetMandatoryField;
 import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -134,7 +131,6 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         attribute.setCode( ATTRIBUTE_CODE );
 
         bundle = TrackerBundle.builder().build();
-        bundle.setRuleEffects( getRuleEventAndEnrollmentEffects() );
         bundle.setPreheat( preheat );
     }
 
@@ -147,7 +143,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet() ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueSet() );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getRuleEffects(),
+            getEventWithMandatoryValueSet() );
 
         assertTrue( errors.isEmpty() );
     }
@@ -164,7 +161,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet( idSchemes ) ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle,
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getRuleEffects(),
             getEventWithMandatoryValueSet( idSchemes ) );
 
         assertTrue( errors.isEmpty() );
@@ -179,10 +176,11 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(), getEventWithMandatoryValueNOTSet() ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueSet() );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getRuleEffects(),
+            getEventWithMandatoryValueSet() );
         assertTrue( errors.isEmpty() );
 
-        errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueNOTSet() );
+        errors = implementerToTest.validateEvent( bundle, getRuleEffects(), getEventWithMandatoryValueNOTSet() );
 
         assertFalse( errors.isEmpty() );
         errors.forEach( e -> {
@@ -205,11 +203,13 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(),
             getEventWithMandatoryValueNOTSetInDifferentProgramStage() ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueSet() );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getRuleEffects(),
+            getEventWithMandatoryValueSet() );
 
         assertTrue( errors.isEmpty() );
 
-        errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueNOTSetInDifferentProgramStage() );
+        errors = implementerToTest.validateEvent( bundle, getRuleEffects(),
+            getEventWithMandatoryValueNOTSetInDifferentProgramStage() );
 
         assertTrue( errors.isEmpty() );
     }
@@ -221,7 +221,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( attribute );
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet() ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle,
+        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle, getRuleEffects(),
             getEnrollmentWithMandatoryAttributeSet() );
 
         assertTrue( errors.isEmpty() );
@@ -237,7 +237,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( attribute );
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet( idSchemes ) ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle,
+        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle, getRuleEffects(),
             getEnrollmentWithMandatoryAttributeSet( idSchemes ) );
 
         assertTrue( errors.isEmpty() );
@@ -251,12 +251,13 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet(),
             getEnrollmentWithMandatoryAttributeNOTSet() ) );
 
-        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle,
+        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle, getRuleEffects(),
             getEnrollmentWithMandatoryAttributeSet() );
 
         assertTrue( errors.isEmpty() );
 
-        errors = implementerToTest.validateEnrollment( bundle, getEnrollmentWithMandatoryAttributeNOTSet() );
+        errors = implementerToTest.validateEnrollment( bundle, getRuleEffects(),
+            getEnrollmentWithMandatoryAttributeNOTSet() );
 
         errors.forEach( e -> {
             assertEquals( "RULE_ATTRIBUTE", e.getRuleUid() );
@@ -375,16 +376,6 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .attribute( MetadataIdentifier.ofUid( ATTRIBUTE_ID ) )
             .value( ATTRIBUTE_VALUE )
             .build();
-    }
-
-    private List<RuleEffects> getRuleEventAndEnrollmentEffects()
-    {
-        List<RuleEffects> ruleEffectsByEvent = Lists.newArrayList();
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, FIRST_EVENT_ID, getRuleEffects() ) );
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, SECOND_EVENT_ID, getRuleEffects() ) );
-        ruleEffectsByEvent.add( new RuleEffects( ENROLLMENT, ACTIVE_ENROLLMENT_ID, getRuleEffects() ) );
-        ruleEffectsByEvent.add( new RuleEffects( ENROLLMENT, COMPLETED_ENROLLMENT_ID, getRuleEffects() ) );
-        return ruleEffectsByEvent;
     }
 
     private List<RuleEffect> getRuleEffects()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/SetMandatoryFieldValidatorTest.java
@@ -36,11 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.dataelement.DataElement;
@@ -150,7 +147,7 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet() ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueSet() );
 
         assertTrue( errors.isEmpty() );
     }
@@ -167,7 +164,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet( idSchemes ) ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle,
+            getEventWithMandatoryValueSet( idSchemes ) );
 
         assertTrue( errors.isEmpty() );
     }
@@ -181,13 +179,13 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
             .thenReturn( firstProgramStage );
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(), getEventWithMandatoryValueNOTSet() ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueSet() );
+        assertTrue( errors.isEmpty() );
+
+        errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueNOTSet() );
 
         assertFalse( errors.isEmpty() );
-        List<ProgramRuleIssue> errorMessages = errors.values().stream().flatMap( Collection::stream )
-            .collect( Collectors.toList() );
-        assertFalse( errorMessages.isEmpty() );
-        errorMessages.forEach( e -> {
+        errors.forEach( e -> {
             assertEquals( "RULE_DATA_VALUE", e.getRuleUid() );
             assertEquals( TrackerErrorCode.E1301, e.getIssueCode() );
             assertEquals( IssueType.ERROR, e.getIssueType() );
@@ -207,7 +205,11 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         bundle.setEvents( Lists.newArrayList( getEventWithMandatoryValueSet(),
             getEventWithMandatoryValueNOTSetInDifferentProgramStage() ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueSet() );
+
+        assertTrue( errors.isEmpty() );
+
+        errors = implementerToTest.validateEvent( bundle, getEventWithMandatoryValueNOTSetInDifferentProgramStage() );
 
         assertTrue( errors.isEmpty() );
     }
@@ -219,7 +221,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( attribute );
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet() ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithMandatoryAttributeSet() );
 
         assertTrue( errors.isEmpty() );
     }
@@ -234,7 +237,8 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         when( preheat.getTrackedEntityAttribute( ATTRIBUTE_ID ) ).thenReturn( attribute );
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet( idSchemes ) ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithMandatoryAttributeSet( idSchemes ) );
 
         assertTrue( errors.isEmpty() );
     }
@@ -247,13 +251,14 @@ class SetMandatoryFieldValidatorTest extends DhisConvenienceTest
         bundle.setEnrollments( Lists.newArrayList( getEnrollmentWithMandatoryAttributeSet(),
             getEnrollmentWithMandatoryAttributeNOTSet() ) );
 
-        Map<String, List<ProgramRuleIssue>> errors = implementerToTest.validateEnrollments( bundle );
+        List<ProgramRuleIssue> errors = implementerToTest.validateEnrollment( bundle,
+            getEnrollmentWithMandatoryAttributeSet() );
 
-        assertFalse( errors.isEmpty() );
-        List<ProgramRuleIssue> errorMessages = errors.values().stream().flatMap( Collection::stream )
-            .collect( Collectors.toList() );
-        assertFalse( errorMessages.isEmpty() );
-        errorMessages.forEach( e -> {
+        assertTrue( errors.isEmpty() );
+
+        errors = implementerToTest.validateEnrollment( bundle, getEnrollmentWithMandatoryAttributeNOTSet() );
+
+        errors.forEach( e -> {
             assertEquals( "RULE_ATTRIBUTE", e.getRuleUid() );
             assertEquals( TrackerErrorCode.E1306, e.getIssueCode() );
             assertEquals( IssueType.ERROR, e.getIssueType() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -29,8 +29,6 @@ package org.hisp.dhis.tracker.programrule;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
-import static org.hisp.dhis.rules.models.TrackerObjectType.ENROLLMENT;
-import static org.hisp.dhis.rules.models.TrackerObjectType.EVENT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,7 +48,6 @@ import org.hisp.dhis.rules.models.RuleActionShowError;
 import org.hisp.dhis.rules.models.RuleActionShowWarning;
 import org.hisp.dhis.rules.models.RuleActionWarningOnCompletion;
 import org.hisp.dhis.rules.models.RuleEffect;
-import org.hisp.dhis.rules.models.RuleEffects;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
@@ -121,7 +118,6 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
         bundle = TrackerBundle.builder().build();
         bundle.setEvents( getEvents() );
         bundle.setEnrollments( getEnrollments() );
-        bundle.setRuleEffects( getRuleEventAndEnrollmentEffects() );
         bundle.setPreheat( preheat );
         programStage = createProgramStage( 'A', 0 );
         programStage.setValidationStrategy( ValidationStrategy.ON_UPDATE_AND_INSERT );
@@ -143,10 +139,10 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     @Test
     void testValidateShowErrorRuleActionForEvents()
     {
-        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, activeEvent() );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, getRuleEffects(), activeEvent() );
         assertErrors( errors, 1 );
 
-        errorImplementer.validateEvent( bundle, completedEvent() );
+        errorImplementer.validateEvent( bundle, getRuleEffects(), completedEvent() );
         assertErrors( errors, 1 );
     }
 
@@ -154,8 +150,8 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     void testValidateShowErrorRuleActionForEventsWithValidationStrategyOnComplete()
     {
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
-        bundle.setRuleEffects( getRuleEventEffectsLinkedToDataElement() );
-        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, completedEvent() );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, getRuleEffectsLinkedToDataElement(),
+            completedEvent() );
         assertErrors( errors, 1 );
         assertErrorsWithDataElement( errors );
     }
@@ -163,8 +159,8 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     @Test
     void testValidateShowErrorForEventsInDifferentProgramStages()
     {
-        bundle.setRuleEffects( getRuleEventEffectsLinkedTo2DataElementsIn2DifferentProgramStages() );
-        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, activeEvent() );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, getRuleEffectsLinkedToDataElement(),
+            activeEvent() );
         assertErrors( errors, 1 );
         assertErrorsWithDataElement( errors );
     }
@@ -172,61 +168,66 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     @Test
     void testValidateShowErrorRuleActionForEnrollment()
     {
-        List<ProgramRuleIssue> errors = errorImplementer.validateEnrollment( bundle, activeEnrollment() );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEnrollment( bundle, getRuleEffects(),
+            activeEnrollment() );
         assertErrors( errors, 1 );
 
-        errorImplementer.validateEnrollment( bundle, completedEnrollment() );
+        errorImplementer.validateEnrollment( bundle, getRuleEffects(), completedEnrollment() );
         assertErrors( errors, 1 );
     }
 
     @Test
     void testValidateShowWarningRuleActionForEvents()
     {
-        List<ProgramRuleIssue> warnings = warningImplementer.validateEvent( bundle, activeEvent() );
+        List<ProgramRuleIssue> warnings = warningImplementer.validateEvent( bundle, getRuleEffects(), activeEvent() );
         assertWarnings( warnings, 1 );
 
-        warnings = warningImplementer.validateEvent( bundle, completedEvent() );
+        warnings = warningImplementer.validateEvent( bundle, getRuleEffects(), completedEvent() );
         assertWarnings( warnings, 1 );
     }
 
     @Test
     void testValidateShowWarningRuleActionForEnrollment()
     {
-        List<ProgramRuleIssue> warnings = warningImplementer.validateEnrollment( bundle, activeEnrollment() );
+        List<ProgramRuleIssue> warnings = warningImplementer.validateEnrollment( bundle, getRuleEffects(),
+            activeEnrollment() );
         assertWarnings( warnings, 1 );
 
-        warningImplementer.validateEnrollment( bundle, completedEnrollment() );
+        warningImplementer.validateEnrollment( bundle, getRuleEffects(), completedEnrollment() );
         assertWarnings( warnings, 1 );
     }
 
     @Test
     void testValidateShowErrorOnCompleteRuleActionForEvents()
     {
-        List<ProgramRuleIssue> errors = errorOnCompleteImplementer.validateEvent( bundle, activeEvent() );
+        List<ProgramRuleIssue> errors = errorOnCompleteImplementer.validateEvent( bundle, getRuleEffects(),
+            activeEvent() );
         assertTrue( errors.isEmpty() );
 
-        errors = errorOnCompleteImplementer.validateEvent( bundle, completedEvent() );
+        errors = errorOnCompleteImplementer.validateEvent( bundle, getRuleEffects(), completedEvent() );
         assertErrors( errors, 1 );
     }
 
     @Test
     void testValidateShowErrorOnCompleteRuleActionForEnrollment()
     {
-        List<ProgramRuleIssue> errors = errorOnCompleteImplementer.validateEnrollment( bundle, completedEnrollment() );
+        List<ProgramRuleIssue> errors = errorOnCompleteImplementer.validateEnrollment( bundle, getRuleEffects(),
+            completedEnrollment() );
         assertErrors( errors, 1 );
     }
 
     @Test
     void testValidateShowWarningOnCompleteRuleActionForEvents()
     {
-        List<ProgramRuleIssue> warnings = warningOnCompleteImplementer.validateEvent( bundle, completedEvent() );
+        List<ProgramRuleIssue> warnings = warningOnCompleteImplementer.validateEvent( bundle, getRuleEffects(),
+            completedEvent() );
         assertWarnings( warnings, 1 );
     }
 
     @Test
     void testValidateShowWarningOnCompleteRuleActionForEnrollment()
     {
-        List<ProgramRuleIssue> warnings = warningOnCompleteImplementer.validateEnrollment( bundle,
+        List<ProgramRuleIssue> warnings = warningOnCompleteImplementer.validateEnrollment( bundle, getRuleEffects(),
             completedEnrollment() );
         assertWarnings( warnings, 1 );
     }
@@ -306,33 +307,6 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
         completedEnrollment.setEnrollment( COMPLETED_ENROLLMENT_ID );
         completedEnrollment.setStatus( EnrollmentStatus.COMPLETED );
         return completedEnrollment;
-    }
-
-    private List<RuleEffects> getRuleEventEffectsLinkedToDataElement()
-    {
-        List<RuleEffects> ruleEffectsByEvent = Lists.newArrayList();
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, ACTIVE_EVENT_ID, getRuleEffectsLinkedToDataElement() ) );
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, COMPLETED_EVENT_ID, getRuleEffectsLinkedToDataElement() ) );
-        return ruleEffectsByEvent;
-    }
-
-    private List<RuleEffects> getRuleEventEffectsLinkedTo2DataElementsIn2DifferentProgramStages()
-    {
-        List<RuleEffects> ruleEffectsByEvent = Lists.newArrayList();
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, ACTIVE_EVENT_ID, getRuleEffectsLinkedToDataElement() ) );
-        ruleEffectsByEvent
-            .add( new RuleEffects( EVENT, COMPLETED_EVENT_ID, getRuleEffectsLinkedToDataAnotherElement() ) );
-        return ruleEffectsByEvent;
-    }
-
-    private List<RuleEffects> getRuleEventAndEnrollmentEffects()
-    {
-        List<RuleEffects> ruleEffectsByEvent = Lists.newArrayList();
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, ACTIVE_EVENT_ID, getRuleEffects() ) );
-        ruleEffectsByEvent.add( new RuleEffects( EVENT, COMPLETED_EVENT_ID, getRuleEffects() ) );
-        ruleEffectsByEvent.add( new RuleEffects( ENROLLMENT, ACTIVE_ENROLLMENT_ID, getRuleEffects() ) );
-        ruleEffectsByEvent.add( new RuleEffects( ENROLLMENT, COMPLETED_ENROLLMENT_ID, getRuleEffects() ) );
-        return ruleEffectsByEvent;
     }
 
     private List<RuleEffect> getRuleEffects()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/ShowErrorWarningImplementerTest.java
@@ -36,9 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.dataelement.DataElement;
@@ -145,8 +143,11 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     @Test
     void testValidateShowErrorRuleActionForEvents()
     {
-        Map<String, List<ProgramRuleIssue>> errors = errorImplementer.validateEvents( bundle );
-        assertErrors( errors, 2 );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, activeEvent() );
+        assertErrors( errors, 1 );
+
+        errorImplementer.validateEvent( bundle, completedEvent() );
+        assertErrors( errors, 1 );
     }
 
     @Test
@@ -154,7 +155,7 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     {
         programStage.setValidationStrategy( ValidationStrategy.ON_COMPLETE );
         bundle.setRuleEffects( getRuleEventEffectsLinkedToDataElement() );
-        Map<String, List<ProgramRuleIssue>> errors = errorImplementer.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, completedEvent() );
         assertErrors( errors, 1 );
         assertErrorsWithDataElement( errors );
     }
@@ -163,7 +164,7 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     void testValidateShowErrorForEventsInDifferentProgramStages()
     {
         bundle.setRuleEffects( getRuleEventEffectsLinkedTo2DataElementsIn2DifferentProgramStages() );
-        Map<String, List<ProgramRuleIssue>> errors = errorImplementer.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEvent( bundle, activeEvent() );
         assertErrors( errors, 1 );
         assertErrorsWithDataElement( errors );
     }
@@ -171,68 +172,80 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
     @Test
     void testValidateShowErrorRuleActionForEnrollment()
     {
-        Map<String, List<ProgramRuleIssue>> errors = errorImplementer.validateEnrollments( bundle );
-        assertErrors( errors, 2 );
+        List<ProgramRuleIssue> errors = errorImplementer.validateEnrollment( bundle, activeEnrollment() );
+        assertErrors( errors, 1 );
+
+        errorImplementer.validateEnrollment( bundle, completedEnrollment() );
+        assertErrors( errors, 1 );
     }
 
     @Test
     void testValidateShowWarningRuleActionForEvents()
     {
-        Map<String, List<ProgramRuleIssue>> warnings = warningImplementer.validateEvents( bundle );
-        assertWarnings( warnings, 2 );
+        List<ProgramRuleIssue> warnings = warningImplementer.validateEvent( bundle, activeEvent() );
+        assertWarnings( warnings, 1 );
+
+        warnings = warningImplementer.validateEvent( bundle, completedEvent() );
+        assertWarnings( warnings, 1 );
     }
 
     @Test
     void testValidateShowWarningRuleActionForEnrollment()
     {
-        Map<String, List<ProgramRuleIssue>> warnings = warningImplementer.validateEnrollments( bundle );
-        assertWarnings( warnings, 2 );
+        List<ProgramRuleIssue> warnings = warningImplementer.validateEnrollment( bundle, activeEnrollment() );
+        assertWarnings( warnings, 1 );
+
+        warningImplementer.validateEnrollment( bundle, completedEnrollment() );
+        assertWarnings( warnings, 1 );
     }
 
     @Test
     void testValidateShowErrorOnCompleteRuleActionForEvents()
     {
-        Map<String, List<ProgramRuleIssue>> errors = errorOnCompleteImplementer.validateEvents( bundle );
+        List<ProgramRuleIssue> errors = errorOnCompleteImplementer.validateEvent( bundle, activeEvent() );
+        assertTrue( errors.isEmpty() );
+
+        errors = errorOnCompleteImplementer.validateEvent( bundle, completedEvent() );
         assertErrors( errors, 1 );
     }
 
     @Test
     void testValidateShowErrorOnCompleteRuleActionForEnrollment()
     {
-        Map<String, List<ProgramRuleIssue>> errors = errorOnCompleteImplementer.validateEnrollments( bundle );
+        List<ProgramRuleIssue> errors = errorOnCompleteImplementer.validateEnrollment( bundle, completedEnrollment() );
         assertErrors( errors, 1 );
     }
 
     @Test
     void testValidateShowWarningOnCompleteRuleActionForEvents()
     {
-        Map<String, List<ProgramRuleIssue>> warnings = warningOnCompleteImplementer.validateEvents( bundle );
+        List<ProgramRuleIssue> warnings = warningOnCompleteImplementer.validateEvent( bundle, completedEvent() );
         assertWarnings( warnings, 1 );
     }
 
     @Test
     void testValidateShowWarningOnCompleteRuleActionForEnrollment()
     {
-        Map<String, List<ProgramRuleIssue>> warnings = warningOnCompleteImplementer.validateEnrollments( bundle );
+        List<ProgramRuleIssue> warnings = warningOnCompleteImplementer.validateEnrollment( bundle,
+            completedEnrollment() );
         assertWarnings( warnings, 1 );
     }
 
-    public void assertErrors( Map<String, List<ProgramRuleIssue>> errors, int numberOfErrors )
+    public void assertErrors( List<ProgramRuleIssue> errors, int numberOfErrors )
     {
         assertIssues( errors, numberOfErrors, IssueType.ERROR );
     }
 
-    public void assertWarnings( Map<String, List<ProgramRuleIssue>> warnings, int numberOfWarnings )
+    public void assertWarnings( List<ProgramRuleIssue> warnings, int numberOfWarnings )
     {
         assertIssues( warnings, numberOfWarnings, IssueType.WARNING );
     }
 
-    private void assertIssues( Map<String, List<ProgramRuleIssue>> errors, int numberOfErrors, IssueType issueType )
+    private void assertIssues( List<ProgramRuleIssue> errors, int numberOfErrors, IssueType issueType )
     {
         assertFalse( errors.isEmpty() );
         assertEquals( numberOfErrors, errors.size() );
-        errors.forEach( ( key, value ) -> assertEquals( 1, value.size() ) );
-        errors.values().stream().flatMap( Collection::stream ).forEach( e -> {
+        errors.forEach( e -> {
             assertEquals( "", e.getRuleUid() );
             assertEquals( issueType, e.getIssueType() );
             assertEquals( TrackerErrorCode.E1300, e.getIssueCode() );
@@ -240,9 +253,9 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
         } );
     }
 
-    public void assertErrorsWithDataElement( Map<String, List<ProgramRuleIssue>> errors )
+    public void assertErrorsWithDataElement( List<ProgramRuleIssue> errors )
     {
-        errors.values().stream().flatMap( Collection::stream ).forEach( e -> {
+        errors.forEach( e -> {
             assertEquals( "", e.getRuleUid() );
             assertEquals( IssueType.ERROR, e.getIssueType() );
             assertEquals( TrackerErrorCode.E1300, e.getIssueCode() );
@@ -253,26 +266,46 @@ class ShowErrorWarningImplementerTest extends DhisConvenienceTest
 
     private List<Event> getEvents()
     {
+        return Lists.newArrayList( activeEvent(), completedEvent() );
+    }
+
+    private Event activeEvent()
+    {
         Event activeEvent = new Event();
         activeEvent.setEvent( ACTIVE_EVENT_ID );
         activeEvent.setStatus( EventStatus.ACTIVE );
         activeEvent.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) );
+        return activeEvent;
+    }
+
+    private Event completedEvent()
+    {
         Event completedEvent = new Event();
         completedEvent.setEvent( COMPLETED_EVENT_ID );
         completedEvent.setStatus( EventStatus.COMPLETED );
         completedEvent.setProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) );
-        return Lists.newArrayList( activeEvent, completedEvent );
+        return completedEvent;
     }
 
     private List<Enrollment> getEnrollments()
     {
+        return Lists.newArrayList( activeEnrollment(), completedEnrollment() );
+    }
+
+    private Enrollment activeEnrollment()
+    {
         Enrollment activeEnrollment = new Enrollment();
         activeEnrollment.setEnrollment( ACTIVE_ENROLLMENT_ID );
         activeEnrollment.setStatus( EnrollmentStatus.ACTIVE );
+        return activeEnrollment;
+    }
+
+    private Enrollment completedEnrollment()
+    {
         Enrollment completedEnrollment = new Enrollment();
         completedEnrollment.setEnrollment( COMPLETED_ENROLLMENT_ID );
         completedEnrollment.setStatus( EnrollmentStatus.COMPLETED );
-        return Lists.newArrayList( activeEnrollment, completedEnrollment );
+        return completedEnrollment;
     }
 
     private List<RuleEffects> getRuleEventEffectsLinkedToDataElement()


### PR DESCRIPTION
This is a refactor that needs to be done before tackling the real issue in rule-engine library.
Just removing all unneeded maps and explicitly passing the related Event/Enrollment 