### PR TITLE
fix: Lombok dep error in dhis-web-embedded-jetty

### DIFF
--- a/dhis-2/dhis-web-embedded-jetty/pom.xml
+++ b/dhis-2/dhis-web-embedded-jetty/pom.xml
@@ -264,6 +264,10 @@
       <groupId>javax.media</groupId>
       <artifactId>jai_imageio</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The module `dhis-web-embedded-jetty` does not build.
It raises this warning and the job fails:

```
[INFO] --- maven-dependency-plugin:3.3.0:analyze-only (analyze) @ dhis-web-embedded-jetty ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.projectlombok:lombok:jar:1.18.24:provided
```

Adding the Lombok dep fixes the problem.