### PR TITLE
fix: Indicator type: /dataEntry/metadata TECH-1266

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -89,7 +89,7 @@ public class DefaultDataSetMetadataExportService
     private static final String FIELDS_DATA_ELEMENTS = ":identifiable,displayName,displayShortName,displayFormName," +
         "zeroIsSignificant,valueType,aggregationType,categoryCombo[id],optionSet[id],commentOptionSet";
 
-    private static final String FIELDS_INDICATORS = ":simple,explodedNumerator,explodedDenominator";
+    private static final String FIELDS_INDICATORS = ":simple,explodedNumerator,explodedDenominator,indicatorType[factor]";
 
     private static final String FIELDS_DATA_ELEMENT_CAT_COMBOS = ":simple,isDefault,categories~pluck[id]," +
         "categoryOptionCombos[id,code,name,displayName,categoryOptions~pluck[id]]";


### PR DESCRIPTION
See [TECH-1265](https://dhis2.atlassian.net/browse/TECH-1265). The endpoint api/dataEntry/metadata needs to include indicator factor from indicatorType, in order for the new data entry frontend code to correctly compute indicator values. Without this fix, indicators are returned like:

```
    "indicators": [
        {
            "name": "Postnatal contact total ",
            "created": "2014-10-10T17:33:20.071",
            "lastUpdated": "2014-10-10T17:33:20.077",
            "shortName": "Postnatal contact total ",
            "dimensionItemType": "INDICATOR",
            "annualized": false,
            "numerator": "#{LhoRsqtRn4r}+#{k1vnEuKnRYE}",
            "numeratorDescription": "Postnatal contact total",
            "explodedNumerator": "#{LhoRsqtRn4r}+#{k1vnEuKnRYE}",
            "denominator": "1",
            "denominatorDescription": "",
            "explodedDenominator": "1",
            "url": "",
            "displayNumeratorDescription": "Postnatal contact total",
            "displayDenominatorDescription": "",
            "dimensionItem": "n3fzCxYk3k3",
            "displayShortName": "Postnatal contact total ",
            "favorite": false,
            "displayName": "Postnatal contact total ",
            "displayFormName": "Postnatal contact total ",
            "id": "n3fzCxYk3k3"
        },
        ...
```

With the fix, they are returned like:

```
    "indicators": [
        {
            "name": "Postnatal contact total ",
            "created": "2014-10-10T17:33:20.071",
            "lastUpdated": "2014-10-10T17:33:20.077",
            "shortName": "Postnatal contact total ",
            "dimensionItemType": "INDICATOR",
            "annualized": false,
            "indicatorType": {
                "factor": 1
            },
            "numerator": "#{LhoRsqtRn4r}+#{k1vnEuKnRYE}",
            "numeratorDescription": "Postnatal contact total",
            "explodedNumerator": "#{LhoRsqtRn4r}+#{k1vnEuKnRYE}",
            "denominator": "1",
            "denominatorDescription": "",
            "explodedDenominator": "1",
            "url": "",
            "displayNumeratorDescription": "Postnatal contact total",
            "displayDenominatorDescription": "",
            "dimensionItem": "n3fzCxYk3k3",
            "displayShortName": "Postnatal contact total ",
            "favorite": false,
            "displayName": "Postnatal contact total ",
            "displayFormName": "Postnatal contact total ",
            "id": "n3fzCxYk3k3"
        },
        ...
```






