### PR TITLE
fix: DSet indicators /dataEntry/metadata TECH-1265

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -80,7 +80,7 @@ public class DefaultDataSetMetadataExportService
     private static final String PROPERTY_ORGANISATION_UNITS = "organisationUnits";
 
     private static final String FIELDS_DATA_SETS = ":simple,categoryCombo[id],formType,dataEntryForm[id]," +
-        "dataSetElements[dataElement[id],categoryCombo[id]]," +
+        "dataSetElements[dataElement[id],categoryCombo[id]],indicators~pluck[id]," +
         "compulsoryDataElementOperands[dataElement[id],categoryOptionCombo[id]]," +
         "dataInputPeriods[period,openingDate,closingDate]," +
         "sections[:simple,dataElements~pluck[id],indicators~pluck[id]," +


### PR DESCRIPTION

See [TECH-1265](https://dhis2.atlassian.net/browse/TECH-1265). Endpoint `/dataEntry/metadata` was returning indicators within data set sections, but was not returning indicators for data sets with no sections (default forms). The problem was that in the dataSets query `indicators~pluck[id]` was present within `sections`, but was not also present within the data set as a whole. This has been added.

Now `/dataEntry/metadata` will still return indicators inside sections when they are referenced inside sections, and it will also return all indicators for a data set in the main body of the data set, whether or not the data set has sections. When indicators are listed in sections, they are also listed in the main body of the data set. This follows the pattern for data elements, which are likewise listed in sections when they appear, but are always listed in the main body of the data set.

Before:

```{
    "dataSets": [
        ...
        {
            "code": "DS_1149441",
            "name": "EPI Stock",
            ...
        },
        ...
        {
            "code": "DS_359593",
            "name": "Reproductive Health",
            ...
            "sections": [
                {
                    "name": "Antenatal Care",
                    ...
                    "indicators": [
                        "dy1a1mseGR7",
                        "W7MxOZjZ1VC"
                    ],
                    ...
                },
                {
                    "name": "Postnatal Care",
                    ...
                    "indicators": [
                        "n3fzCxYk3k3"
                    ],
                    ...
                },
                {
                    "name": "Delivery",
                    ...
                    "indicators": [
                        "po1QxztD1K1"
                    ],
                    ...
                },
                {
                    "name": "Tetanus Toxoid",
                    ...
                    "indicators": [
                        "aEtcFtcJjtZ"
                    ],
                    ...
                },
                {
                    "name": "Births",
                    ...
                    "indicators": [
                        "gNAXtpqAqW2"
                    ],
                    ...
                }
            ],
            ...
```
After:
```
{
    "dataSets": [
        ...
        {
            "code": "DS_1149441",
            "name": "EPI Stock",
            ...
            "indicators": [
                "OEWO2PpiUKx",
                "bASXd9ukRGD",
                "loEBZlcsTlx"
            ],
            ...
        },
        ...
        {
            "code": "DS_359593",
            "name": "Reproductive Health",
            ...
            "indicators": [
                "n3fzCxYk3k3",
                "gNAXtpqAqW2",
                "W7MxOZjZ1VC",
                "dy1a1mseGR7",
                "po1QxztD1K1",
                "aEtcFtcJjtZ"
            ],
            ...
            "sections": [
                {
                    "name": "Antenatal Care",
                    ...
                    "indicators": [
                        "dy1a1mseGR7",
                        "W7MxOZjZ1VC"
                    ],
                    ...
                },
                {
                    "name": "Postnatal Care",
                    ...
                    "indicators": [
                        "n3fzCxYk3k3"
                    ],
                    ...
                },
                {
                    "name": "Delivery",
                    ...
                    "indicators": [
                        "po1QxztD1K1"
                    ],
                    ...
                },
                {
                    "name": "Tetanus Toxoid",
                    ...
                    "indicators": [
                        "aEtcFtcJjtZ"
                    ],
                    ...
                },
                {
                    "name": "Births",
                    ...
                    "indicators": [
                        "gNAXtpqAqW2"
                    ],
                    ...
                }
            ],
            ...
```