### PR TITLE
fix: auto-complete running job progress processes [DHIS2-13489]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -272,9 +272,11 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
             jobService.getJob( type ).execute( configuration, progress );
 
             Process process = progress.getProcesses().peekLast();
-            if ( process != null && process.getStatus() != JobProgress.Status.RUNNING )
+            if ( process != null && process.getStatus() == JobProgress.Status.RUNNING )
             {
-                progress.failedProcess( (String) null );
+                // automatically complete processes that were not cleanly
+                // complected by calling completedProcess at the end of the job
+                progress.completedProcess( "(process completed implicitly)" );
             }
             if ( configuration.getLastExecutedStatus() == RUNNING )
             {


### PR DESCRIPTION
Hard to say what the original intention really was. I think the block in question:
```java
if ( process != null && process.getStatus() != JobProgress.Status.RUNNING )
{
    progress.failedProcess( (String) null );
}
```
was intended to complete not-yet completed (running) process as failed (as strictly they should have been complected by the job calling `completedProcess`). So originally I think the following was the intention, just the condition was accidentally flipped:

```java
if ( process != null && process.getStatus() == JobProgress.Status.RUNNING )
{
    progress.failedProcess( (String) null );
}
```

Considering the situation from a user perspective again I found that it is better not consider such a process as failed but complete it with a message hinting at the minor programming mistake made when not completing the process explicitly.

So the fixed version now has the intention that when a process was not completed explicitly it is complected implicitly giving a message that hints as this so we can notice it and eventually add the explicit completion to the job code.