### PR TITLE
fix: delete option linked with OptionGroup [DHIS2-7908-39]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionGroupStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionGroupStore.java
@@ -41,7 +41,7 @@ public interface OptionGroupStore
 {
     List<OptionGroup> getOptionGroups( OptionGroupSet groupSet );
 
-    List<OptionGroup> getOptionGroups( String optionId );
+    List<OptionGroup> getOptionGroupsByOptionId( String optionId );
 
     List<OptionGroup> getOptionGroupsNoAcl( DataDimensionType dataDimensionType, boolean dataDimension );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/OptionGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/OptionGroupDeletionHandler.java
@@ -29,19 +29,38 @@ package org.hisp.dhis.option;
 
 import java.util.List;
 
-import org.hisp.dhis.common.DataDimensionType;
-import org.hisp.dhis.common.GenericDimensionalObjectStore;
+import lombok.AllArgsConstructor;
 
-/**
- * @author Viet Nguyen <viet@dhis2.org>
- */
+import org.apache.commons.collections4.CollectionUtils;
+import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
-public interface OptionGroupStore
-    extends GenericDimensionalObjectStore<OptionGroup>
+@Component
+@AllArgsConstructor
+public class OptionGroupDeletionHandler extends DeletionHandler
 {
-    List<OptionGroup> getOptionGroups( OptionGroupSet groupSet );
+    @Autowired
+    private OptionGroupStore optionGroupStore;
 
-    List<OptionGroup> getOptionGroups( String optionId );
+    @Override
+    protected void register()
+    {
+        whenDeleting( Option.class, this::deleteOption );
+    }
 
-    List<OptionGroup> getOptionGroupsNoAcl( DataDimensionType dataDimensionType, boolean dataDimension );
+    private void deleteOption( Option option )
+    {
+        List<OptionGroup> optionGroup = optionGroupStore.getOptionGroups( option.getUid() );
+
+        if ( CollectionUtils.isEmpty( optionGroup ) )
+        {
+            return;
+        }
+
+        optionGroup.forEach( og -> {
+            og.removeOption( option );
+            optionGroupStore.update( og );
+        } );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/OptionGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/OptionGroupDeletionHandler.java
@@ -51,7 +51,7 @@ public class OptionGroupDeletionHandler extends DeletionHandler
 
     private void deleteOption( Option option )
     {
-        List<OptionGroup> optionGroup = optionGroupStore.getOptionGroups( option.getUid() );
+        List<OptionGroup> optionGroup = optionGroupStore.getOptionGroupsByOptionId( option.getUid() );
 
         if ( CollectionUtils.isEmpty( optionGroup ) )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionGroupStore.java
@@ -68,6 +68,16 @@ public class HibernateOptionGroupStore
     }
 
     @Override
+    public List<OptionGroup> getOptionGroups( String optionId )
+    {
+        CriteriaBuilder builder = getCriteriaBuilder();
+
+        return getList( builder, newJpaParameters()
+            .addPredicates( getSharingPredicates( builder ) )
+            .addPredicate( root -> builder.equal( root.join( "members" ).get( "uid" ), optionId ) ) );
+    }
+
+    @Override
     public List<OptionGroup> getOptionGroupsNoAcl( DataDimensionType dataDimensionType, boolean dataDimension )
     {
         CriteriaBuilder builder = getCriteriaBuilder();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/hibernate/HibernateOptionGroupStore.java
@@ -68,7 +68,7 @@ public class HibernateOptionGroupStore
     }
 
     @Override
-    public List<OptionGroup> getOptionGroups( String optionId )
+    public List<OptionGroup> getOptionGroupsByOptionId( String optionId )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionGroupStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionGroupStoreTest.java
@@ -34,6 +34,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 
+import org.hisp.dhis.common.IdentifiableObjectStore;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,9 +45,14 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class OptionGroupStoreTest extends SingleSetupIntegrationTestBase
 {
-
     @Autowired
     private OptionGroupStore store;
+
+    @Autowired
+    private OptionStore optionStore;
+
+    @Autowired
+    private IdentifiableObjectStore<OptionSet> optionSetStore;
 
     private OptionGroup optionGroupA;
 
@@ -101,5 +108,42 @@ class OptionGroupStoreTest extends SingleSetupIntegrationTestBase
         assertTrue( objects.contains( optionGroupA ) );
         assertTrue( objects.contains( optionGroupB ) );
         assertTrue( objects.contains( optionGroupC ) );
+    }
+
+    @Test
+    void testGetByOption()
+    {
+        OptionSet optionSet = createOptionSet( 'A' );
+        optionSet.setValueType( ValueType.TEXT );
+        optionSetStore.save( optionSet );
+
+        Option option = createOption( 'A' );
+        option.setOptionSet( optionSet );
+        optionStore.save( option );
+
+        optionGroupA.setOptionSet( optionSet );
+        optionGroupA.addOption( option );
+        store.save( optionGroupA );
+
+        assertNotNull( store.getOptionGroups( option.getUid() ) );
+    }
+
+    @Test
+    void testDeleteOption()
+    {
+        OptionSet optionSet = createOptionSet( 'A' );
+        optionSet.setValueType( ValueType.TEXT );
+        optionSetStore.save( optionSet );
+        Option option = createOption( 'A' );
+        option.setOptionSet( optionSet );
+        optionStore.save( option );
+
+        optionGroupA.setOptionSet( optionSet );
+        optionGroupA.addOption( option );
+        store.save( optionGroupA );
+
+        optionStore.delete( option );
+
+        assertTrue( optionGroupA.getMembers().isEmpty() );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionGroupStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/option/OptionGroupStoreTest.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -60,6 +61,7 @@ class OptionGroupStoreTest extends SingleSetupIntegrationTestBase
 
     private OptionGroup optionGroupC;
 
+    @BeforeEach
     public void setUpTest()
     {
         optionGroupA = new OptionGroup( "OptionGroupA" );
@@ -111,7 +113,7 @@ class OptionGroupStoreTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
-    void testGetByOption()
+    void testGetByOptionId()
     {
         OptionSet optionSet = createOptionSet( 'A' );
         optionSet.setValueType( ValueType.TEXT );
@@ -125,7 +127,7 @@ class OptionGroupStoreTest extends SingleSetupIntegrationTestBase
         optionGroupA.addOption( option );
         store.save( optionGroupA );
 
-        assertNotNull( store.getOptionGroups( option.getUid() ) );
+        assertNotNull( store.getOptionGroupsByOptionId( option.getUid() ) );
     }
 
     @Test
@@ -143,7 +145,7 @@ class OptionGroupStoreTest extends SingleSetupIntegrationTestBase
         store.save( optionGroupA );
 
         optionStore.delete( option );
-
+        optionGroupA = store.get( optionGroupA.getId() );
         assertTrue( optionGroupA.getMembers().isEmpty() );
     }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7908

- Add deletionHandler to remove `Option` from `OptionGroup` when `deleteOption()` is triggered.
- Note that `Option` is automatically removed from `OptionSet` because of cascade="all" defined in `OptionSet.hbm`. So we don't need to add deletionHandler for this association. 