### PR TITLE
feat: improved progress tracking of password expiry alert job [DHIS2-8150]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.SecondaryMetadataObject;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
+import org.hisp.dhis.scheduling.parameters.CredentialsExpiryAlertJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
@@ -333,6 +334,7 @@ public class JobConfiguration
         @JsonSubTypes.Type( value = TrackerProgramsDataSynchronizationJobParameters.class, name = "TRACKER_PROGRAMS_DATA_SYNC" ),
         @JsonSubTypes.Type( value = DataSynchronizationJobParameters.class, name = "DATA_SYNC" ),
         @JsonSubTypes.Type( value = DisableInactiveUsersJobParameters.class, name = "DISABLE_INACTIVE_USERS" ),
+        @JsonSubTypes.Type( value = CredentialsExpiryAlertJobParameters.class, name = "CREDENTIALS_EXPIRY_ALERT" ),
         @JsonSubTypes.Type( value = TrackerTrigramIndexJobParameters.class, name = "TRACKER_SEARCH_OPTIMIZATION" ),
         @JsonSubTypes.Type( value = DataIntegrityJobParameters.class, name = "DATA_INTEGRITY" )
     } )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
+import org.hisp.dhis.scheduling.parameters.CredentialsExpiryAlertJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataIntegrityJobParameters;
 import org.hisp.dhis.scheduling.parameters.DataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.DisableInactiveUsersJobParameters;
@@ -78,7 +79,7 @@ public enum JobType
     SEND_SCHEDULED_MESSAGE( true ),
     PROGRAM_NOTIFICATIONS( true ),
     VALIDATION_RESULTS_NOTIFICATION( false ),
-    CREDENTIALS_EXPIRY_ALERT( false ),
+    CREDENTIALS_EXPIRY_ALERT( false, SchedulingType.CRON, CredentialsExpiryAlertJobParameters.class, null ),
     MONITORING( true, SchedulingType.CRON, MonitoringJobParameters.class, Map.of(
         "relativePeriods", "/api/periodTypes/relativePeriodTypes",
         "validationRuleGroups", "/api/validationRuleGroups" ) ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/CredentialsExpiryAlertJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/CredentialsExpiryAlertJobParameters.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.scheduling.parameters;
 
 import java.util.Optional;
 
+import lombok.NoArgsConstructor;
+
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
@@ -41,36 +43,13 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 /**
  * @author Jan Bernitt
  */
+@NoArgsConstructor
 @JacksonXmlRootElement( localName = "jobParameters", namespace = DxfNamespaces.DXF_2_0 )
-public class DisableInactiveUsersJobParameters implements JobParameters
+public class CredentialsExpiryAlertJobParameters implements JobParameters
 {
-    private static final long serialVersionUID = -5877578172615705990L;
-
-    private int inactiveMonths;
+    private static final long serialVersionUID = 1474076005450145410L;
 
     private Integer reminderDaysBefore;
-
-    public DisableInactiveUsersJobParameters()
-    {
-
-    }
-
-    public DisableInactiveUsersJobParameters( int inactiveMonths )
-    {
-        this.inactiveMonths = inactiveMonths;
-    }
-
-    @JsonProperty( required = true )
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public int getInactiveMonths()
-    {
-        return inactiveMonths;
-    }
-
-    public void setInactiveMonths( int inactiveMonths )
-    {
-        this.inactiveMonths = inactiveMonths;
-    }
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
@@ -87,11 +66,6 @@ public class DisableInactiveUsersJobParameters implements JobParameters
     @Override
     public Optional<ErrorReport> validate()
     {
-        if ( inactiveMonths < 1 || inactiveMonths > 24 )
-        {
-            return Optional.of(
-                new ErrorReport( getClass(), ErrorCode.E4008, "inactiveMonths", 1, 24, inactiveMonths ) );
-        }
         if ( reminderDaysBefore != null && (reminderDaysBefore < 1 || reminderDaysBefore > 28) )
         {
             return Optional.of(

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/CredentialsExpiryAlertJobParametersDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/CredentialsExpiryAlertJobParametersDeserializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling.parameters.jackson;
+
+import org.hisp.dhis.scheduling.parameters.CredentialsExpiryAlertJobParameters;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * @author Jan Bernitt
+ */
+public class CredentialsExpiryAlertJobParametersDeserializer
+    extends AbstractJobParametersDeserializer<CredentialsExpiryAlertJobParameters>
+{
+    public CredentialsExpiryAlertJobParametersDeserializer()
+    {
+        super( CredentialsExpiryAlertJobParameters.class, CustomJobParameters.class );
+    }
+
+    @JsonDeserialize
+    public static class CustomJobParameters extends CredentialsExpiryAlertJobParameters
+    {
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -422,6 +422,19 @@ public interface UserService
     Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
 
     /**
+     * Selects all not disabled users where the
+     * {@link User#getPasswordLastUpdated()} ()} is within the given time-frame
+     * and which have an email address.
+     *
+     * @param from start of the selected time-frame (inclusive)
+     * @param to end of the selected time-frame (exclusive)
+     * @return user emails having a password last updated within the given
+     *         time-frame as keys and if available their preferred locale as
+     *         value
+     */
+    Map<String, Optional<Locale>> findNotifiableUsersWithPasswordLastUpdatedBetween( Date from, Date to );
+
+    /**
      * Get user display name by concat( firstname,' ', surname ) Return null if
      * User doesn't exist
      */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -368,13 +368,6 @@ public interface UserService
     List<ErrorReport> validateUser( User user, User currentUser );
 
     /**
-     * Returns list of active users who are expiring with in few days.
-     *
-     * @return list of active users who are expiring with in few days.
-     */
-    List<User> getExpiringUsers();
-
-    /**
      * @param inDays number of days to include
      * @return list of those users that are about to expire in the provided
      *         number of days (or less) and which have an email configured

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -110,9 +110,6 @@ public interface UserStore
     /**
      * Return CurrentUserGroupInfo used for ACL check in
      * {@link IdentifiableObjectStore}
-     *
-     * @param user
-     * @return
      */
     CurrentUserGroupInfo getCurrentUserGroupInfo( String userUID );
 
@@ -137,6 +134,19 @@ public interface UserStore
      *         keys and if available their preferred locale as value
      */
     Map<String, Optional<Locale>> findNotifiableUsersWithLastLoginBetween( Date from, Date to );
+
+    /**
+     * Selects all not disabled users where the
+     * {@link User#getPasswordLastUpdated()} ()} is within the given time-frame
+     * and which have an email address.
+     *
+     * @param from start of the selected time-frame (inclusive)
+     * @param to end of the selected time-frame (exclusive)
+     * @return user emails having a password last updated within the given
+     *         time-frame as keys and if available their preferred locale as
+     *         value
+     */
+    Map<String, Optional<Locale>> findNotifiableUsersWithPasswordLastUpdatedBetween( Date from, Date to );
 
     String getDisplayName( String userUid );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -791,6 +791,13 @@ public class DefaultUserService
     }
 
     @Override
+    @Transactional( readOnly = true )
+    public Map<String, Optional<Locale>> findNotifiableUsersWithPasswordLastUpdatedBetween( Date from, Date to )
+    {
+        return userStore.findNotifiableUsersWithPasswordLastUpdatedBetween( from, to );
+    }
+
+    @Override
     public String getDisplayName( String userUid )
     {
         return userDisplayNameCache.get( userUid, c -> userStore.getDisplayName( userUid ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -72,7 +72,6 @@ import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.filter.UserRoleCanIssueFilter;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
-import org.joda.time.DateTime;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
@@ -729,23 +728,6 @@ public class DefaultUserService
         } );
 
         return errors;
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public List<User> getExpiringUsers()
-    {
-        int daysBeforePasswordChangeRequired = systemSettingManager
-            .getIntSetting( SettingKey.CREDENTIALS_EXPIRES ) * 30;
-
-        Date daysPassed = new DateTime( new Date() ).minusDays( daysBeforePasswordChangeRequired - EXPIRY_THRESHOLD )
-            .toDate();
-
-        UserQueryParams userQueryParams = new UserQueryParams()
-            .setDisabled( false )
-            .setPasswordLastUpdated( daysPassed );
-
-        return userStore.getExpiringUsers( userQueryParams );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -591,6 +591,21 @@ public class HibernateUserStore
             "from User u " +
             "left outer join UserSetting s on u.id = s.user and s.name = 'keyUiLocale' " +
             "where u.email is not null and u.disabled = false and u.lastLogin >= :from and u.lastLogin < :to";
+        return toLocaleMap( hql, from, to );
+    }
+
+    @Override
+    public Map<String, Optional<Locale>> findNotifiableUsersWithPasswordLastUpdatedBetween( Date from, Date to )
+    {
+        String hql = "select u.email, s.value " +
+            "from User u " +
+            "left outer join UserSetting s on u.id = s.user and s.name = 'keyUiLocale' " +
+            "where u.email is not null and u.disabled = false and u.passwordLastUpdated >= :from and u.passwordLastUpdated < :to";
+        return toLocaleMap( hql, from, to );
+    }
+
+    private Map<String, Optional<Locale>> toLocaleMap( String hql, Date from, Date to )
+    {
         return getSession().createQuery( hql, Object[].class )
             .setParameter( "from", from )
             .setParameter( "to", to )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/i18n_global.properties
@@ -1966,3 +1966,6 @@ data_integrity.program_rule_actions_without_stage.description=Lists program rule
 # disable inactive users job notification texts
 notification.user_inactive.subject=Your DHIS2 account will be disabled soon.
 notification.user_inactive.body=Your DHIS2 user account was inactive for a while. Login during the next {0} days to prevent your account from being disabled.
+# notify user that need to change their password soon
+notification.password_change_required.subject=Password Expiry Alert
+notification.password_change_required.body=Please change your password. It will expire in {0} day(s).

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
@@ -114,10 +114,15 @@ public class CredentialsExpiryAlertJob implements Job
         progress.startingProcess( "User password expiry alerts" );
         CredentialsExpiryAlertJobParameters parameters = (CredentialsExpiryAlertJobParameters) jobConfiguration
             .getJobParameters();
-        Integer reminderDaysBefore = parameters.getReminderDaysBefore();
+        Integer reminderDaysBefore = parameters == null ? null : parameters.getReminderDaysBefore();
         int daysUntilDisable = reminderDaysBefore == null ? 28 : reminderDaysBefore;
         int daysBeforePasswordChangeRequired = systemSettingManager
             .getIntSetting( SettingKey.CREDENTIALS_EXPIRES ) * 30;
+        if ( daysBeforePasswordChangeRequired <= 0 )
+        {
+            progress.completedProcess( "Passwords expire after n months is configured to zero (feature disabled)" );
+            return;
+        }
         LocalDate lastUpdatedBefore = LocalDate.now().minusDays( daysBeforePasswordChangeRequired );
         do
         {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/credentials/CredentialsExpiryAlertJob.java
@@ -27,33 +27,41 @@
  */
 package org.hisp.dhis.credentials;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static java.lang.Math.abs;
 import static java.lang.String.format;
-import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM;
+import static java.time.ZoneId.systemDefault;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.email.EmailResponse;
+import org.hisp.dhis.email.EmailService;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorReport;
-import org.hisp.dhis.message.MessageSender;
+import org.hisp.dhis.i18n.I18n;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.i18n.locale.LocaleManager;
 import org.hisp.dhis.outboundmessage.OutboundMessageResponse;
 import org.hisp.dhis.scheduling.Job;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.JobType;
+import org.hisp.dhis.scheduling.parameters.CredentialsExpiryAlertJobParameters;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.util.DateUtils;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -61,37 +69,22 @@ import org.springframework.stereotype.Component;
  * have a chance to update their credentials.
  *
  * @author zubair (original)
- * @author Jan Bernitt (job progress tracking)
+ * @author Jan Bernitt (job progress tracking, sending on specific days only)
  */
 @Slf4j
 @Component
+@AllArgsConstructor
 public class CredentialsExpiryAlertJob implements Job
 {
-    private static final String SUBJECT = "Password Expiry Alert";
-
-    private static final String TEXT_EXPIRES_SOON = "Dear %s, Please change your password. It will expire in %d days.";
-
-    private static final String TEXT_EXPIRED = "Dear %s, Please change your password. It expired %d days ago.";
-
-    private static final String KEY_TASK = "credentialsExpiryAlertTask";
-
     private final UserService userService;
 
-    private final MessageSender emailMessageSender;
+    private final EmailService emailService;
+
+    private final LocaleManager localeManager;
+
+    private final I18nManager i18nManager;
 
     private final SystemSettingManager systemSettingManager;
-
-    public CredentialsExpiryAlertJob( UserService userService,
-        @Qualifier( "emailMessageSender" ) MessageSender emailMessageSender, SystemSettingManager systemSettingManager )
-    {
-        checkNotNull( userService );
-        checkNotNull( emailMessageSender );
-        checkNotNull( systemSettingManager );
-
-        this.userService = userService;
-        this.emailMessageSender = emailMessageSender;
-        this.systemSettingManager = systemSettingManager;
-    }
 
     @Override
     public JobType getJobType()
@@ -100,26 +93,9 @@ public class CredentialsExpiryAlertJob implements Job
     }
 
     @Override
-    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
-    {
-        if ( !systemSettingManager.getBoolSetting( SettingKey.CREDENTIALS_EXPIRY_ALERT ) )
-        {
-            log.info( format( "%s aborted. Expiry alerts are disabled", KEY_TASK ) );
-            return;
-        }
-
-        progress.startingProcess( "User account expire alerts" );
-        progress.startingStage( "finding and preparing email recipients" );
-        List<User> users = progress.runStage( List.of(),
-            recipients -> format( "%d recipients", recipients.size() ), userService::getExpiringUsers );
-        sendExpiryAlert( users, progress );
-        progress.completedProcess( null );
-    }
-
-    @Override
     public ErrorReport validate()
     {
-        if ( !emailMessageSender.isConfigured() )
+        if ( !emailService.emailConfigured() )
         {
             return new ErrorReport( CredentialsExpiryAlertJob.class, ErrorCode.E7010,
                 "EMAIL gateway configuration does not exist" );
@@ -127,49 +103,81 @@ public class CredentialsExpiryAlertJob implements Job
         return Job.super.validate();
     }
 
-    private void sendExpiryAlert( List<User> users, JobProgress progress )
+    @Override
+    public void execute( JobConfiguration jobConfiguration, JobProgress progress )
     {
-        progress.startingStage( "sending expiry alert emails", users.size(), SKIP_ITEM );
-        if ( emailMessageSender.isConfigured() )
+        if ( !systemSettingManager.getBoolSetting( SettingKey.CREDENTIALS_EXPIRY_ALERT ) )
         {
-            progress.runStage( users, this::createItemDescription, this::sendEmail );
+            log.info( "credentialsExpiryAlertTask aborted. Expiry alerts are disabled" );
+            return;
         }
-        else
+        progress.startingProcess( "User password expiry alerts" );
+        CredentialsExpiryAlertJobParameters parameters = (CredentialsExpiryAlertJobParameters) jobConfiguration
+            .getJobParameters();
+        Integer reminderDaysBefore = parameters.getReminderDaysBefore();
+        int daysUntilDisable = reminderDaysBefore == null ? 28 : reminderDaysBefore;
+        int daysBeforePasswordChangeRequired = systemSettingManager
+            .getIntSetting( SettingKey.CREDENTIALS_EXPIRES ) * 30;
+        LocalDate lastUpdatedBefore = LocalDate.now().minusDays( daysBeforePasswordChangeRequired );
+        do
         {
-            progress.failedStage( "Email service is not configured" );
+            sendReminderEmail( lastUpdatedBefore, daysUntilDisable, progress );
+            daysUntilDisable = daysUntilDisable / 2;
         }
+        while ( daysUntilDisable > 0 );
+        progress.completedProcess( null );
     }
 
-    private void sendEmail( User user )
+    private void sendReminderEmail( LocalDate lastUpdatedBefore, int daysUntilChangeRequired, JobProgress progress )
     {
-        OutboundMessageResponse response = emailMessageSender.sendMessage( SUBJECT,
-            createEmailBodyText( user ), user.getEmail() );
+        LocalDate referenceDay = lastUpdatedBefore.plusDays( daysUntilChangeRequired );
+        ZonedDateTime nDaysPriorToChangeRequired = referenceDay.atStartOfDay( systemDefault() );
+        ZonedDateTime nDaysPriorToChangeRequiredEod = referenceDay.plusDays( 1 ).atStartOfDay( systemDefault() );
+
+        progress.startingStage(
+            format( "Fetching users for reminder, %d days until password change is required", daysUntilChangeRequired ),
+            SKIP_STAGE );
+        Map<String, Optional<Locale>> receivers = progress.runStage( Map.of(),
+            map -> format( "Found %d receivers", map.size() ),
+            () -> userService.findNotifiableUsersWithPasswordLastUpdatedBetween(
+                Date.from( nDaysPriorToChangeRequired.toInstant() ),
+                Date.from( nDaysPriorToChangeRequiredEod.toInstant() ) ) );
+        if ( receivers.isEmpty() )
+        {
+            return;
+        }
+        // send reminders by language
+        Locale fallback = localeManager.getFallbackLocale();
+        Map<Locale, Set<String>> receiversByLocale = new HashMap<>();
+        for ( Map.Entry<String, Optional<Locale>> e : receivers.entrySet() )
+        {
+            receiversByLocale.computeIfAbsent( e.getValue().orElse( fallback ), key -> new HashSet<>() )
+                .add( e.getKey() );
+        }
+        progress.startingStage(
+            format( "Sending reminder for %d days until password change is required", daysUntilChangeRequired ),
+            receiversByLocale.size(), JobProgress.FailurePolicy.SKIP_ITEM );
+        progress.runStage( receiversByLocale.entrySet().stream(),
+            e -> format( "Sending email to %d user(s) in %s", e.getValue().size(), e.getKey().getDisplayLanguage() ),
+            OutboundMessageResponse::getDescription,
+            e -> sendReminderEmailInLanguage( e.getKey(), e.getValue(), daysUntilChangeRequired ), null );
+    }
+
+    private OutboundMessageResponse sendReminderEmailInLanguage( Locale language, Set<String> receiverEmails,
+        int daysUntilChangeRequired )
+    {
+        I18n i18n = i18nManager.getI18n( language );
+        String subject = i18n.getString( "notification.password_change_required.subject",
+            "Password Expiry Alert" );
+        String body = i18n.getString( "notification.password_change_required.body",
+            "Please change your password. It will expire in {0} day(s)." );
+        OutboundMessageResponse response = emailService.sendEmail( subject,
+            format( body.replace( "{0}", "%d" ), daysUntilChangeRequired ), receiverEmails );
+
         if ( response.getResponseObject() != EmailResponse.SENT )
         {
             throw new UncheckedIOException( response.getDescription(), new IOException() );
         }
-    }
-
-    private String createItemDescription( User user )
-    {
-        int remainingDays = getRemainingDays( user );
-        return remainingDays < 0
-            ? format( "to: %s, expired since %d days", user.getUsername(), abs( remainingDays ) )
-            : format( "to: %s, %d days until expiry", user.getUsername(), remainingDays );
-    }
-
-    private String createEmailBodyText( User user )
-    {
-        int remainingDays = getRemainingDays( user );
-        return remainingDays < 0
-            ? format( TEXT_EXPIRED, user.getUsername(), abs( remainingDays ) )
-            : format( TEXT_EXPIRES_SOON, user.getUsername(), remainingDays );
-    }
-
-    private int getRemainingDays( User user )
-    {
-        int daysBeforeChangeRequired = systemSettingManager.getIntSetting( SettingKey.CREDENTIALS_EXPIRES ) * 30;
-        Date passwordLastUpdated = user.getPasswordLastUpdated();
-        return (daysBeforeChangeRequired - DateUtils.daysBetween( passwordLastUpdated, new Date() ));
+        return response;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -100,7 +100,7 @@ public enum SettingKey
     ACCOUNT_RECOVERY( "keyAccountRecovery", Boolean.FALSE, Boolean.class ),
     LOCK_MULTIPLE_FAILED_LOGINS( "keyLockMultipleFailedLogins", Boolean.FALSE, Boolean.class ),
     GOOGLE_ANALYTICS_UA( "googleAnalyticsUA" ),
-    CREDENTIALS_EXPIRES( "credentialsExpires", 12, Integer.class ),
+    CREDENTIALS_EXPIRES( "credentialsExpires", 0, Integer.class ),
     CREDENTIALS_EXPIRY_ALERT( "credentialsExpiryAlert", false, Boolean.class ),
     ACCOUNT_EXPIRES_IN_DAYS( "accountExpiresInDays", 7, Integer.class ),
     ACCOUNT_EXPIRY_ALERT( "accountExpiryAlert", false, Boolean.class ),

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -100,7 +100,7 @@ public enum SettingKey
     ACCOUNT_RECOVERY( "keyAccountRecovery", Boolean.FALSE, Boolean.class ),
     LOCK_MULTIPLE_FAILED_LOGINS( "keyLockMultipleFailedLogins", Boolean.FALSE, Boolean.class ),
     GOOGLE_ANALYTICS_UA( "googleAnalyticsUA" ),
-    CREDENTIALS_EXPIRES( "credentialsExpires", 0, Integer.class ),
+    CREDENTIALS_EXPIRES( "credentialsExpires", 12, Integer.class ),
     CREDENTIALS_EXPIRY_ALERT( "credentialsExpiryAlert", false, Boolean.class ),
     ACCOUNT_EXPIRES_IN_DAYS( "accountExpiresInDays", 7, Integer.class ),
     ACCOUNT_EXPIRY_ALERT( "accountExpiryAlert", false, Boolean.class ),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -478,16 +478,6 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
-    void testGetExpiringUser()
-    {
-        User userA = addUser( "A" );
-        addUser( "B", User::setDisabled, true );
-        User userC = addUser( "C" );
-        addUser( "D", User::setDisabled, true );
-        assertContainsOnly( userService.getExpiringUsers(), userA, userC );
-    }
-
-    @Test
     void testGetExpiringUserAccounts()
     {
         ZonedDateTime now = ZonedDateTime.now();


### PR DESCRIPTION
### Summary
The existing job was functional but had unintended behaviour:
* job did process with a month setting of `0` (feature is not used)
* job did email users every day for at least 14 days 
* job would keep sending emails to already expired users (as long as they were not disabled)

The progress tracking would not be as useful as it could be because, ...

* items (sending an email) would always be considered a success independent of the `OutboundMessageResponse` status
* the days remaining was not included in the item description
* already expired passwords would show as negative "days until expiry" (now excluded)

Overall failure policy was changed from `SKIP_ITEM_OUTLIER` to `SKIP_ITEM` to try sending as much emails as possible even if some fail. This is also important now because the outcome of `OutboundMessageResponse` is considered and any outcome that is not `EmailResponse.SENT` causes the item to be considered having status "ERROR".
An item here is sending emails to all users for the same language and the same number of days before expiry. 


### Other Jobs
This PR also makes the two jobs that use the email on specific days before expiry pattern similar.
Both now recognise items as ERROR if the send response was not OK. 
Also there is the fix for the correct set of emails so that not each languages sends to all users.

### Manual Testing
* use `/api/jobConfigurations` to find the ID of the credentials expiry alert
* use `POST` for `/api/jobConfigurations/{uid}/execute` to trigger the job
* check the outcome using `/api/scheduling/completed/CREDENTIALS_EXPIRY_ALERT`

Adjust the database to have users with a `passwordLastUpdated` date that matches on of the days picked by the job.
Rerun the above steps. This might then require to setup email in server email settings to have them send successful. 
But also without email being configured the job should run successful but just skip the items that wanted to actually send emails.

### Example Output
```json
[
  {
    "status":"SUCCESS",
    "completedTime":"2022-07-21T11:14:02.242",
    "startedTime":"2022-07-21T11:14:00.558",
    "description":"User password expiry alerts",
    "stages":[
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-07-21T11:14:00.564",
        "startedTime":"2022-07-21T11:14:00.560",
        "description":"Fetching users for reminder, 28 days until password change is required",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":4,
        "complete":true
      },
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-07-21T11:14:00.567",
        "startedTime":"2022-07-21T11:14:00.564",
        "description":"Fetching users for reminder, 14 days until password change is required",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":3,
        "complete":true
      },
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-07-21T11:14:00.571",
        "startedTime":"2022-07-21T11:14:00.568",
        "description":"Fetching users for reminder, 7 days until password change is required",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":3,
        "complete":true
      },
      {
        "summary":"Found 0 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-07-21T11:14:00.574",
        "startedTime":"2022-07-21T11:14:00.572",
        "description":"Fetching users for reminder, 3 days until password change is required",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":2,
        "complete":true
      },
      {
        "summary":"Found 1 receivers",
        "status":"SUCCESS",
        "completedTime":"2022-07-21T11:14:00.580",
        "startedTime":"2022-07-21T11:14:00.575",
        "description":"Fetching users for reminder, 1 days until password change is required",
        "totalItems":0,
        "onFailure":"SKIP_STAGE",
        "items":[
          
        ],
        "duration":5,
        "complete":true
      },
      {
        "status":"SUCCESS",
        "completedTime":"2022-07-21T11:14:02.241",
        "startedTime":"2022-07-21T11:14:00.582",
        "description":"Sending reminder for 1 days until password change is required",
        "totalItems":1,
        "onFailure":"SKIP_ITEM",
        "items":[
          {
            "summary":"Email sent",
            "status":"SUCCESS",
            "completedTime":"2022-07-21T11:14:02.241",
            "startedTime":"2022-07-21T11:14:00.588",
            "description":"Sending email to 1 user(s) in English",
            "onFailure":"SKIP_ITEM",
            "duration":1653,
            "complete":true
          }
        ],
        "duration":1659,
        "complete":true
      }
    ],
    "jobId":"sHMedQF7VYa",
    "duration":1684,
    "complete":true
  }
]
```