### PR TITLE
fix: datastore integration test setup

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreIntegrationTest.java
@@ -78,6 +78,13 @@ class DatastoreIntegrationTest extends IntegrationTestBase
         addPet( "pig", "Oink", 6, List.of( "carrots", "potatoes" ) );
     }
 
+    @Override
+    protected void tearDownTest()
+        throws Exception
+    {
+        datastore.deleteNamespace( "pets" );
+    }
+
     private DatastoreEntry addEntry( String key, String value )
     {
         DatastoreEntry entry = new DatastoreEntry( "pets", key, value.replace( '\'', '"' ), false );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1164,7 +1164,6 @@ class AclServiceTest extends TransactionalIntegrationTest
         manager.save( de, false );
         User userA = makeUser( "A" );
         manager.save( userA );
-        dbmsManager.flushSession();
         de = manager.get( de.getUid() );
         assertEquals( AccessStringHelper.DEFAULT, de.getPublicAccess() );
         assertEquals( null, de.getSharing().getOwner() );


### PR DESCRIPTION
The existence of the `pets` namespace from `DatastoreIntegrationTest` messed up the expectations in `DatastoreEntryStoreTest` so the test now cleans the namespace in its tear-down.