### PR TITLE
chore: avoid find first UID match lookup when type is known [TECH-1271]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.User;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -64,7 +65,19 @@ public interface IdentifiableObjectManager
 
     void delete( IdentifiableObject object, User user );
 
-    <T extends IdentifiableObject> T get( String uid );
+    /**
+     * Lookup objects of unknown type.
+     *
+     * If the type is known at compile time this method should not be used.
+     * Instead, use
+     * {@link org.hisp.dhis.common.IdentifiableObjectManager#get(Class, String)}.
+     *
+     * @param uid a UID of an object of unknown type
+     * @return The {@link IdentifiableObject} with the given UID or null if no
+     *         such object exists
+     */
+    @Transactional( readOnly = true )
+    IdentifiableObject find( String uid );
 
     <T extends IdentifiableObject> T get( Class<T> type, long id );
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -38,7 +38,6 @@ import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.translation.Translation;
 import org.hisp.dhis.user.User;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * @author Lars Helge Overland
@@ -76,7 +75,6 @@ public interface IdentifiableObjectManager
      * @return The {@link IdentifiableObject} with the given UID or null if no
      *         such object exists
      */
-    @Transactional( readOnly = true )
     IdentifiableObject find( String uid );
 
     <T extends IdentifiableObject> T get( Class<T> type, long id );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -82,7 +82,7 @@ import com.google.gson.internal.Primitives;
  * @author Lars Helge Overland
  */
 @Slf4j
-@Component( "org.hisp.dhis.common.IdentifiableObjectManager" )
+@Component
 public class DefaultIdentifiableObjectManager
     implements IdentifiableObjectManager
 {
@@ -245,19 +245,17 @@ public class DefaultIdentifiableObjectManager
 
     @Override
     @Transactional( readOnly = true )
-    @SuppressWarnings( "unchecked" )
-    public <T extends IdentifiableObject> T get( String uid )
+    public IdentifiableObject find( String uid )
     {
         for ( IdentifiableObjectStore<? extends IdentifiableObject> store : identifiableObjectStores )
         {
-            T object = (T) store.getByUid( uid );
+            IdentifiableObject object = store.getByUid( uid );
 
             if ( object != null )
             {
                 return object;
             }
         }
-
         return null;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/DefaultIdentifiableObjectManager.java
@@ -82,7 +82,7 @@ import com.google.gson.internal.Primitives;
  * @author Lars Helge Overland
  */
 @Slf4j
-@Component
+@Component( "org.hisp.dhis.common.IdentifiableObjectManager" )
 public class DefaultIdentifiableObjectManager
     implements IdentifiableObjectManager
 {

--- a/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
+++ b/dhis-2/dhis-services/dhis-service-metadata-workflow/src/main/java/org/hisp/dhis/metadata/DefaultMetadataWorkflowService.java
@@ -251,7 +251,8 @@ public class DefaultMetadataWorkflowService implements MetadataWorkflowService
     private ImportReport acceptRemove( MetadataProposal proposal, ObjectBundleMode mode )
     {
         return importService.importMetadata(
-            createImportParams( mode, ImportStrategy.DELETE, objectManager.get( proposal.getTargetId() ) ) );
+            createImportParams( mode, ImportStrategy.DELETE, objectManager.get(
+                proposal.getTarget().getType(), proposal.getTargetId() ) ) );
     }
 
     private MetadataImportParams createImportParams( ObjectBundleMode mode, ImportStrategy strategy,

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -665,12 +665,12 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
         sharing.setUserGroupAccess( Set.of( new UserGroupAccess( "rw------", userGroupA.getUid() ) ) );
         de.setSharing( sharing );
         idObjectManager.save( de, false );
-        de = idObjectManager.get( de.getUid() );
+        de = idObjectManager.get( DataElement.class, de.getUid() );
         assertEquals( 1, de.getSharing().getUserGroups().size() );
         idObjectManager.delete( userGroupA );
         idObjectManager.removeUserGroupFromSharing( userGroupUid );
         dbmsManager.clearSession();
-        de = idObjectManager.get( de.getUid() );
+        de = idObjectManager.get( DataElement.class, de.getUid() );
         assertEquals( 0, de.getSharing().getUserGroups().size() );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreIntegrationTest.java
@@ -78,6 +78,13 @@ class DatastoreIntegrationTest extends IntegrationTestBase
         addPet( "pig", "Oink", 6, List.of( "carrots", "potatoes" ) );
     }
 
+    @Override
+    protected void tearDownTest()
+        throws Exception
+    {
+        datastore.deleteNamespace( "pets" );
+    }
+
     private DatastoreEntry addEntry( String key, String value )
     {
         DatastoreEntry entry = new DatastoreEntry( "pets", key, value.replace( '\'', '"' ), false );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -888,7 +888,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( Status.OK, report.getStatus() );
         ProgramStage programStage = programStageService.getProgramStage( "oORy3Rg9hLE" );
         assertEquals( 1, programStage.getSharing().getUserGroups().size() );
-        Program program = manager.get( "QIHW6CBdLsP" );
+        Program program = manager.get( Program.class, "QIHW6CBdLsP" );
         assertEquals( 1, program.getSharing().getUserGroups().size() );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1165,7 +1165,7 @@ class AclServiceTest extends TransactionalIntegrationTest
         User userA = makeUser( "A" );
         manager.save( userA );
         dbmsManager.flushSession();
-        de = manager.get( de.getUid() );
+        de = manager.get( DataElement.class, de.getUid() );
         assertEquals( AccessStringHelper.DEFAULT, de.getPublicAccess() );
         assertEquals( null, de.getSharing().getOwner() );
         assertTrue( de.getSharing().getUsers().isEmpty() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.config.ConfigProviderConfiguration;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
@@ -188,7 +189,7 @@ public abstract class DhisControllerConvenienceTest extends DhisMockMvcControlle
     protected void switchToUserWithOrgUnitDataView( String userName, String orgUnitId )
     {
         User user = makeUser( userName, Collections.singletonList( "ALL" ) );
-        user.getDataViewOrganisationUnits().add( manager.get( orgUnitId ) );
+        user.getDataViewOrganisationUnits().add( manager.get( OrganisationUnit.class, orgUnitId ) );
         userService.addUser( user );
         switchContextToUser( user );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractDataValueControllerTest.java
@@ -73,7 +73,7 @@ abstract class AbstractDataValueControllerTest
         dataElementId = addDataElement( "My data element", "DE1", ValueType.INTEGER, null );
 
         // Add the newly created org unit to the superuser's hierarchy
-        OrganisationUnit unit = manager.get( orgUnitId );
+        OrganisationUnit unit = manager.get( OrganisationUnit.class, orgUnitId );
         User user = userService.getUser( getSuperUser().getUid() );
         user.addOrganisationUnit( unit );
         userService.updateUser( user );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataApprovalControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataApprovalControllerTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
@@ -81,7 +82,7 @@ class DataApprovalControllerTest extends DhisControllerConvenienceTest
             POST( "/dataSets/", "{'name':'My data set', 'periodType':'Monthly', " + "'workflow': {'id':'" + wfId + "'},"
                 + "'organisationUnits':[{'id':'" + ou1Id + "'},{'id':'" + ouId + "'}]" + "}" ) );
 
-        getSuperUser().addOrganisationUnit( manager.get( ouId ) );
+        getSuperUser().addOrganisationUnit( manager.get( OrganisationUnit.class, ouId ) );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/IdentifiableObjectController.java
@@ -59,7 +59,7 @@ public class IdentifiableObjectController
     public List<IdentifiableObject> getEntity( String uid, WebOptions options )
     {
         List<IdentifiableObject> identifiableObjects = Lists.newArrayList();
-        Optional<IdentifiableObject> optional = Optional.ofNullable( manager.get( uid ) );
+        Optional<IdentifiableObject> optional = Optional.ofNullable( manager.find( uid ) );
         optional.ifPresent( identifiableObjects::add );
 
         return identifiableObjects;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/organisationunit/OrganisationUnitController.java
@@ -214,7 +214,7 @@ public class OrganisationUnitController
 
         IdentifiableObject member;
 
-        if ( memberObject != null && memberCollection != null && (member = manager.get( memberObject )) != null )
+        if ( memberObject != null && memberCollection != null && (member = manager.find( memberObject )) != null )
         {
             for ( OrganisationUnit unit : list )
             {


### PR DESCRIPTION
Noticed the get by only UID (without type) method in `IdentifiableObjectManager`

```java
<T extends IdentifiableObject> T get( String uid );
```
The implementation loops though all stores and returns the first match.
Such lookup should be limited to the few places where this is really needed which were 2 out of 10.
To better communicate the complexity of the process the method got renamed to `find` and also the overly convenient cast to any type `T` that extends `IdentifiableObject` was replaced with just `IdentifiableObject`.

All usages that knew the type of object they wanted to load instead use:
```java
<T extends IdentifiableObject> T get( Class<T> type, String uid );
```

