### PR TITLE
chore: use CurrentUserDetails in HibernateIdentifiableObjectStore

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/Sharing_.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/Sharing_.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common.adapter;
+
+/**
+ * This class defines metadata model property's names of
+ * {@link org.hisp.dhis.user.sharing.Sharing}
+ */
+public class Sharing_
+{
+    public static final String PUBLIC = "public";
+
+    public static final String OWNER = "owner";
+
+    public static final String EXTERNAL = "external";
+
+    public static final String USERS = "users";
+
+    public static final String USER_GROUPS = "userGroups";
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserDetails.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.user;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -58,7 +59,16 @@ public interface CurrentUserDetails extends UserDetails
     @Override
     boolean isEnabled();
 
+    boolean isSuper();
+
     String getUid();
+
+    /**
+     * Set of UserGroup UID which current User belongs to.
+     *
+     * @return
+     */
+    Set<String> getUserGroupIds();
 
     Map<String, Serializable> getUserSettings();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserDetailsImpl.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserDetailsImpl.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.user;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -59,4 +60,8 @@ public class CurrentUserDetailsImpl implements CurrentUserDetails
     private final Collection<GrantedAuthority> authorities;
 
     private final Map<String, Serializable> userSettings;
+
+    private final Set<String> userGroupIds;
+
+    private final boolean isSuper;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/CurrentUserService.java
@@ -108,47 +108,28 @@ public class CurrentUserService
     @Transactional( readOnly = true )
     public CurrentUserGroupInfo getCurrentUserGroupsInfo()
     {
-        return getCurrentUserGroupsInfo( getCurrentUser() );
+        CurrentUserDetails user = CurrentUserUtil.getCurrentUserDetails();
+
+        return user == null ? null : getCurrentUserGroupsInfo( user.getUid() );
     }
 
     @Transactional( readOnly = true )
-    public CurrentUserGroupInfo getCurrentUserGroupsInfo( User user )
+    public CurrentUserGroupInfo getCurrentUserGroupsInfo( String userUID )
     {
-        if ( user == null )
-        {
-            return null;
-        }
-
         return currentUserGroupInfoCache
-            .get( user.getUsername(), this::getCurrentUserGroupsInfo );
+            .get( userUID, key -> userStore.getCurrentUserGroupInfo( key ) );
     }
 
     @Transactional( readOnly = true )
-    public void invalidateUserGroupCache( String username )
+    public void invalidateUserGroupCache( String userUID )
     {
         try
         {
-            currentUserGroupInfoCache.invalidate( username );
+            currentUserGroupInfoCache.invalidate( userUID );
         }
         catch ( NullPointerException exception )
         {
             // Ignore if key doesn't exist
         }
-    }
-
-    private CurrentUserGroupInfo getCurrentUserGroupsInfo( String username )
-    {
-        if ( username == null )
-        {
-            return null;
-        }
-
-        User currentUser = getCurrentUser();
-        if ( currentUser == null )
-        {
-            log.warn( "User is null, this should only happen at startup!" );
-            return null;
-        }
-        return userStore.getCurrentUserGroupInfo( currentUser );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserStore.java
@@ -114,7 +114,7 @@ public interface UserStore
      * @param user
      * @return
      */
-    CurrentUserGroupInfo getCurrentUserGroupInfo( User user );
+    CurrentUserGroupInfo getCurrentUserGroupInfo( String userUID );
 
     /**
      * Sets {@link User#setDisabled(boolean)} to {@code true} for all users

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.common.hibernate;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -54,22 +52,17 @@ import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.GenericDimensionalObjectStore;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.hibernate.HibernateProxyUtils;
-import org.hisp.dhis.hibernate.InternalHibernateGenericStore;
 import org.hisp.dhis.hibernate.JpaQueryParameters;
 import org.hisp.dhis.hibernate.exception.CreateAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.DeleteAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.ReadAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.UpdateAccessDeniedException;
-import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
 import org.hisp.dhis.query.JpaQueryUtils;
 import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.security.acl.AclService;
-import org.hisp.dhis.user.CurrentUserGroupInfo;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
@@ -83,15 +76,11 @@ import org.springframework.jdbc.core.JdbcTemplate;
  */
 @Slf4j
 public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
-    extends HibernateGenericStore<T>
-    implements GenericDimensionalObjectStore<T>, InternalHibernateGenericStore<T>, CurrentUserServiceTarget
+    extends SharingHibernateGenericStoreImpl<T>
+    implements GenericDimensionalObjectStore<T>, CurrentUserServiceTarget
 {
     @Autowired
     protected DbmsManager dbmsManager;
-
-    protected CurrentUserService currentUserService;
-
-    protected AclService aclService;
 
     protected boolean transientIdentifiableProperties = false;
 
@@ -99,13 +88,8 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         ApplicationEventPublisher publisher, Class<T> clazz, CurrentUserService currentUserService,
         AclService aclService, boolean cacheable )
     {
-        super( sessionFactory, jdbcTemplate, publisher, clazz, cacheable );
+        super( sessionFactory, jdbcTemplate, publisher, clazz, aclService, currentUserService, cacheable );
 
-        checkNotNull( currentUserService );
-        checkNotNull( aclService );
-
-        this.currentUserService = currentUserService;
-        this.aclService = aclService;
         this.cacheable = cacheable;
     }
 
@@ -891,119 +875,6 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, parameters );
     }
 
-    // ----------------------------------------------------------------------
-    // JPA support methods
-    // ----------------------------------------------------------------------
-
-    @Override
-    public final List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder )
-    {
-        return getDataSharingPredicates( builder, currentUserService.getCurrentUser(),
-            currentUserService.getCurrentUserGroupsInfo(), AclService.LIKE_READ_DATA );
-    }
-
-    @Override
-    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user )
-    {
-        return getDataSharingPredicates( builder, user, currentUserService.getCurrentUserGroupsInfo( user ),
-            AclService.LIKE_READ_DATA );
-    }
-
-    @Override
-    public final List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, String access )
-    {
-        User currentUser = currentUserService.getCurrentUser();
-        return getDataSharingPredicates( builder, currentUser,
-            currentUserService.getCurrentUserGroupsInfo(), access );
-    }
-
-    @Override
-    public final List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder )
-    {
-        CurrentUserGroupInfo currentUserGroupsInfo = currentUserService.getCurrentUserGroupsInfo();
-        return getSharingPredicates( builder, currentUserService.getCurrentUser(),
-            currentUserGroupsInfo, AclService.LIKE_READ_METADATA );
-    }
-
-    @Override
-    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user )
-    {
-        CurrentUserGroupInfo currentUserGroupsInfo = currentUserService.getCurrentUserGroupsInfo( user );
-        return getSharingPredicates( builder, user, currentUserGroupsInfo,
-            AclService.LIKE_READ_METADATA );
-    }
-
-    /**
-     * Get sharing predicates based on Access string and current user
-     *
-     * @param builder CriteriaBuilder
-     * @param access Access String
-     *
-     * @return List of Function<Root<T>, Predicate>
-     */
-    @Override
-    public final List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, String access )
-    {
-        User user = currentUserService.getCurrentUser();
-        return getSharingPredicates( builder, user, currentUserService.getCurrentUserGroupsInfo( user ),
-            access );
-    }
-
-    @Override
-    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user,
-        CurrentUserGroupInfo groupInfo, String access )
-    {
-        if ( user == null || groupInfo == null || !sharingEnabled( user ) )
-        {
-            return new ArrayList<>( 0 );
-        }
-
-        return getSharingPredicates( builder, groupInfo.getUserUID(), groupInfo.getUserGroupUIDs(), access );
-    }
-
-    @Override
-    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user, String access )
-    {
-        if ( !sharingEnabled( user ) || user == null )
-        {
-            return new ArrayList<>();
-        }
-
-        Set<String> groupIds = user.getGroups().stream().map( g -> g.getUid() ).collect( Collectors.toSet() );
-
-        return getSharingPredicates( builder, user.getUid(), groupIds, access );
-    }
-
-    @Override
-    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user,
-        CurrentUserGroupInfo groupInfo, String access )
-    {
-        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
-
-        if ( user == null || !dataSharingEnabled( user ) || groupInfo == null )
-        {
-            return predicates;
-        }
-
-        return getDataSharingPredicates( builder, groupInfo.getUserUID(), groupInfo.getUserGroupUIDs(), access );
-    }
-
-    @Override
-    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user,
-        String access )
-    {
-        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
-
-        if ( user == null || !dataSharingEnabled( user ) )
-        {
-            return predicates;
-        }
-
-        Set<String> groupIds = user.getGroups().stream().map( g -> g.getUid() ).collect( Collectors.toSet() );
-
-        return getDataSharingPredicates( builder, user.getUid(), groupIds, access );
-    }
-
     /**
      * Remove given UserGroup UID from all sharing records in given tableName
      */
@@ -1024,108 +895,6 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     /**
-     * Get Predicate for checking Sharing access for given User's uid and
-     * UserGroup Uids
-     *
-     * @param builder CriteriaBuilder
-     * @param userUid User Uid for checking access
-     * @param userGroupUids List of UserGroup Uid which given user belong to
-     * @param access Access String for checking
-     *
-     * @return Predicate
-     */
-    private List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, String userUid,
-        Set<String> userGroupUids,
-        String access )
-    {
-        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
-
-        Function<Root<T>, Predicate> userGroupPredicate = JpaQueryUtils.checkUserGroupsAccess( builder, userGroupUids,
-            access );
-
-        Function<Root<T>, Predicate> userPredicate = JpaQueryUtils.checkUserAccess( builder, userUid, access );
-
-        predicates.add( root -> {
-            Predicate disjunction = builder.or(
-                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), access ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), "null" ),
-                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ) ),
-                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "owner" ) ) ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "owner" ) ), "null" ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "owner" ) ), userUid ),
-                userPredicate.apply( root ) );
-
-            Predicate ugPredicateWithRoot = userGroupPredicate.apply( root );
-
-            if ( ugPredicateWithRoot != null )
-            {
-                return builder.or( disjunction, ugPredicateWithRoot );
-            }
-
-            return disjunction;
-        } );
-
-        return predicates;
-    }
-
-    /**
-     * Get Predicate for checking Data Sharing access for given User's uid and
-     * UserGroup Uids
-     *
-     * @param builder CriteriaBuilder
-     * @param userUid User Uid for checking access
-     * @param userGroupUids List of UserGroup Uid which given user belong to
-     * @param access Access String for checking
-     *
-     * @return Predicate
-     */
-    private List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, String userUid,
-        Set<String> userGroupUids,
-        String access )
-    {
-        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
-
-        preProcessPredicates( builder, predicates );
-
-        Function<Root<T>, Predicate> userGroupPredicate = JpaQueryUtils.checkUserGroupsAccess( builder, userGroupUids,
-            access );
-
-        Function<Root<T>, Predicate> userPredicate = JpaQueryUtils.checkUserAccess( builder, userUid, access );
-
-        predicates.add( root -> {
-            Predicate disjunction = builder.or(
-                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), access ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), "null" ),
-                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ) ),
-                userPredicate.apply( root ) );
-
-            Predicate ugPredicateWithRoot = userGroupPredicate.apply( root );
-
-            if ( ugPredicateWithRoot != null )
-            {
-                return builder.or( disjunction, ugPredicateWithRoot );
-            }
-
-            return disjunction;
-        } );
-
-        return predicates;
-    }
-
-    // ----------------------------------------------------------------------
-    // JPA Implementations
-    // ----------------------------------------------------------------------
-
-    /**
      * Checks whether the given user has public access to the given identifiable
      * object.
      *
@@ -1140,30 +909,6 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         boolean b2 = aclService.canMakePrivate( user, identifiableObject );
         boolean b3 = AccessStringHelper.canReadOrWrite( identifiableObject.getSharing().getPublicAccess() );
         return b1 || (b2 && !b3);
-    }
-
-    private boolean forceAcl()
-    {
-        return Dashboard.class.isAssignableFrom( clazz );
-    }
-
-    private boolean sharingEnabled( User user )
-    {
-        boolean b = forceAcl();
-
-        if ( b )
-        {
-            return b;
-        }
-        else
-        {
-            return (aclService.isClassShareable( clazz ) && !(user == null || user.isSuper()));
-        }
-    }
-
-    private boolean dataSharingEnabled( User user )
-    {
-        return aclService.isDataClassShareable( clazz ) && !user.isSuper();
     }
 
     private boolean isReadAllowed( T object, User user )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
@@ -43,6 +43,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.adapter.BaseIdentifiableObject_;
+import org.hisp.dhis.common.adapter.Sharing_;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.hibernate.HibernateGenericStore;
 import org.hisp.dhis.hibernate.InternalHibernateGenericStore;
@@ -105,18 +107,24 @@ public class InternalHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
 
         predicates.add( root -> {
             Predicate disjunction = builder.or(
-                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), access ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), "null" ),
-                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ) ),
-                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "owner" ) ) ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "owner" ) ), "null" ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "owner" ) ), userUid ),
+                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.PUBLIC ) ), access ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.PUBLIC ) ), "null" ),
+                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.PUBLIC ) ) ),
+                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.OWNER ) ) ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.OWNER ) ), "null" ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.OWNER ) ), userUid ),
                 userPredicate.apply( root ) );
 
             Predicate ugPredicateWithRoot = userGroupPredicate.apply( root );
@@ -157,12 +165,15 @@ public class InternalHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
 
         predicates.add( root -> {
             Predicate disjunction = builder.or(
-                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), access ),
-                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ), "null" ),
-                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
-                    builder.literal( "public" ) ) ),
+                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.PUBLIC ) ), access ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.PUBLIC ) ), "null" ),
+                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class,
+                    root.get( BaseIdentifiableObject_.SHARING ),
+                    builder.literal( Sharing_.PUBLIC ) ) ),
                 userPredicate.apply( root ) );
 
             Predicate ugPredicateWithRoot = userGroupPredicate.apply( root );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common.hibernate;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.hibernate.HibernateGenericStore;
+import org.hisp.dhis.hibernate.InternalHibernateGenericStore;
+import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
+import org.hisp.dhis.query.JpaQueryUtils;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserDetails;
+import org.hisp.dhis.user.CurrentUserGroupInfo;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * This class contains methods for generating predicates which are used for
+ * validating sharing access permission.
+ */
+@Slf4j
+public class InternalHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
+    extends HibernateGenericStore<T>
+    implements InternalHibernateGenericStore<T>
+{
+    protected AclService aclService;
+
+    protected CurrentUserService currentUserService;
+
+    public InternalHibernateGenericStoreImpl( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
+        ApplicationEventPublisher publisher, Class<T> clazz, AclService aclService,
+        CurrentUserService currentUserService, boolean cacheable )
+    {
+        super( sessionFactory, jdbcTemplate, publisher, clazz, cacheable );
+
+        checkNotNull( aclService );
+        checkNotNull( currentUserService );
+        this.aclService = aclService;
+        this.currentUserService = currentUserService;
+    }
+
+    /**
+     * Get Predicate for checking Sharing access for given User's uid and
+     * UserGroup Uids
+     *
+     * @param builder CriteriaBuilder
+     * @param userUid User Uid for checking access
+     * @param userGroupUids List of UserGroup Uid which given user belong to
+     * @param access Access String for checking
+     *
+     * @return List of {@link Predicate}
+     */
+    protected List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, String userUid,
+        Set<String> userGroupUids,
+        String access )
+    {
+        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
+
+        Function<Root<T>, Predicate> userGroupPredicate = JpaQueryUtils.checkUserGroupsAccess( builder, userGroupUids,
+            access );
+
+        Function<Root<T>, Predicate> userPredicate = JpaQueryUtils.checkUserAccess( builder, userUid, access );
+
+        predicates.add( root -> {
+            Predicate disjunction = builder.or(
+                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "public" ) ), access ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "public" ) ), "null" ),
+                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "public" ) ) ),
+                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "owner" ) ) ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "owner" ) ), "null" ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "owner" ) ), userUid ),
+                userPredicate.apply( root ) );
+
+            Predicate ugPredicateWithRoot = userGroupPredicate.apply( root );
+
+            if ( ugPredicateWithRoot != null )
+            {
+                return builder.or( disjunction, ugPredicateWithRoot );
+            }
+
+            return disjunction;
+        } );
+
+        return predicates;
+    }
+
+    /**
+     * Get Predicate for checking Data Sharing access for given User's uid and
+     * UserGroup Uids
+     *
+     * @param builder CriteriaBuilder
+     * @param userUid User Uid for checking access
+     * @param userGroupUids List of UserGroup Uid which given user belong to
+     * @param access Access String for checking
+     *
+     * @return List of {@link Predicate}
+     */
+    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, String userUid,
+        Set<String> userGroupUids, String access )
+    {
+        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
+
+        preProcessPredicates( builder, predicates );
+
+        Function<Root<T>, Predicate> userGroupPredicate = JpaQueryUtils.checkUserGroupsAccess( builder, userGroupUids,
+            access );
+
+        Function<Root<T>, Predicate> userPredicate = JpaQueryUtils.checkUserAccess( builder, userUid, access );
+
+        predicates.add( root -> {
+            Predicate disjunction = builder.or(
+                builder.like( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "public" ) ), access ),
+                builder.equal( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "public" ) ), "null" ),
+                builder.isNull( builder.function( JsonbFunctions.EXTRACT_PATH_TEXT, String.class, root.get( "sharing" ),
+                    builder.literal( "public" ) ) ),
+                userPredicate.apply( root ) );
+
+            Predicate ugPredicateWithRoot = userGroupPredicate.apply( root );
+
+            if ( ugPredicateWithRoot != null )
+            {
+                return builder.or( disjunction, ugPredicateWithRoot );
+            }
+
+            return disjunction;
+        } );
+
+        return predicates;
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user )
+    {
+        return getDataSharingPredicates( builder, user, currentUserService.getCurrentUserGroupsInfo( user ),
+            AclService.LIKE_READ_DATA );
+    }
+
+    @Override
+    public final List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder )
+    {
+        CurrentUserGroupInfo currentUserGroupsInfo = currentUserService.getCurrentUserGroupsInfo();
+        return getSharingPredicates( builder, currentUserService.getCurrentUser(),
+            currentUserGroupsInfo, AclService.LIKE_READ_METADATA );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user )
+    {
+        CurrentUserGroupInfo currentUserGroupsInfo = currentUserService.getCurrentUserGroupsInfo( user );
+        return getSharingPredicates( builder, user, currentUserGroupsInfo,
+            AclService.LIKE_READ_METADATA );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user, String access )
+    {
+        if ( !sharingEnabled( user ) || user == null )
+        {
+            return new ArrayList<>();
+        }
+
+        Set<String> groupIds = user.getGroups().stream().map( g -> g.getUid() ).collect( Collectors.toSet() );
+
+        return getSharingPredicates( builder, user.getUid(), groupIds, access );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user,
+        CurrentUserGroupInfo groupInfo, String access )
+    {
+        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
+
+        if ( user == null || !dataSharingEnabled( user ) || groupInfo == null )
+        {
+            return predicates;
+        }
+
+        return getDataSharingPredicates( builder, groupInfo.getUserUID(), groupInfo.getUserGroupUIDs(), access );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user,
+        String access )
+    {
+        List<Function<Root<T>, Predicate>> predicates = new ArrayList<>();
+
+        if ( user == null || !dataSharingEnabled( user ) )
+        {
+            return predicates;
+        }
+
+        Set<String> groupIds = user.getGroups().stream().map( g -> g.getUid() ).collect( Collectors.toSet() );
+
+        return getDataSharingPredicates( builder, user.getUid(), groupIds, access );
+    }
+
+    protected boolean forceAcl()
+    {
+        return Dashboard.class.isAssignableFrom( clazz );
+    }
+
+    /**
+     * @deprecated use {@link #sharingEnabled( CurrentUserDetails )} instead.
+     */
+    @Deprecated
+    protected boolean sharingEnabled( User user )
+    {
+        boolean b = forceAcl();
+
+        if ( b )
+        {
+            return b;
+        }
+        else
+        {
+            return (aclService.isClassShareable( clazz ) && !(user == null || user.isSuper()));
+        }
+    }
+
+    protected boolean sharingEnabled( CurrentUserDetails user )
+    {
+        boolean b = forceAcl();
+
+        if ( b )
+        {
+            return b;
+        }
+        else
+        {
+            return (aclService.isClassShareable( clazz ) && !(user == null || user.isSuper()));
+        }
+    }
+
+    protected boolean dataSharingEnabled( CurrentUserDetails user )
+    {
+        return aclService.isDataClassShareable( clazz ) && !user.isSuper();
+    }
+
+    /**
+     * @deprecated use {@link #dataSharingEnabled( CurrentUserDetails )}
+     *             instead.
+     */
+    @Deprecated
+    private boolean dataSharingEnabled( User user )
+    {
+        return aclService.isDataClassShareable( clazz ) && !user.isSuper();
+    }
+
+    private List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user,
+        CurrentUserGroupInfo groupInfo, String access )
+    {
+        if ( user == null || groupInfo == null || !sharingEnabled( user ) )
+        {
+            return new ArrayList<>( 0 );
+        }
+
+        return getSharingPredicates( builder, groupInfo.getUserUID(), groupInfo.getUserGroupUIDs(), access );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/InternalHibernateGenericStoreImpl.java
@@ -181,35 +181,28 @@ public class InternalHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
     @Override
     public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user )
     {
-        return getDataSharingPredicates( builder, user, currentUserService.getCurrentUserGroupsInfo( user ),
-            AclService.LIKE_READ_DATA );
-    }
-
-    @Override
-    public final List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder )
-    {
-        CurrentUserGroupInfo currentUserGroupsInfo = currentUserService.getCurrentUserGroupsInfo();
-        return getSharingPredicates( builder, currentUserService.getCurrentUser(),
-            currentUserGroupsInfo, AclService.LIKE_READ_METADATA );
+        return user == null ? List.of()
+            : getDataSharingPredicates( builder, user, currentUserService.getCurrentUserGroupsInfo( user.getUid() ),
+                AclService.LIKE_READ_DATA );
     }
 
     @Override
     public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user )
     {
-        CurrentUserGroupInfo currentUserGroupsInfo = currentUserService.getCurrentUserGroupsInfo( user );
-        return getSharingPredicates( builder, user, currentUserGroupsInfo,
-            AclService.LIKE_READ_METADATA );
+        return user == null ? List.of()
+            : getSharingPredicates( builder, user, currentUserService.getCurrentUserGroupsInfo( user.getUid() ),
+                AclService.LIKE_READ_METADATA );
     }
 
     @Override
     public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user, String access )
     {
-        if ( !sharingEnabled( user ) || user == null )
+        if ( user == null || !sharingEnabled( user ) )
         {
-            return new ArrayList<>();
+            return List.of();
         }
 
-        Set<String> groupIds = user.getGroups().stream().map( g -> g.getUid() ).collect( Collectors.toSet() );
+        Set<String> groupIds = currentUserService.getCurrentUserGroupsInfo( user.getUid() ).getUserGroupUIDs();
 
         return getSharingPredicates( builder, user.getUid(), groupIds, access );
     }
@@ -301,7 +294,7 @@ public class InternalHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
     {
         if ( user == null || groupInfo == null || !sharingEnabled( user ) )
         {
-            return new ArrayList<>( 0 );
+            return List.of();
         }
 
         return getSharingPredicates( builder, groupInfo.getUserUID(), groupInfo.getUserGroupUIDs(), access );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/SharingHibernateGenericStoreImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/SharingHibernateGenericStoreImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common.hibernate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.SessionFactory;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.hibernate.SharingHibernateGenericStore;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUserDetails;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.CurrentUserUtil;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * This class contains methods for generating predicates which are used for
+ * validating sharing access permission. All methods should use
+ * {@link CurrentUserDetails} instead of {@link org.hisp.dhis.user.User}
+ */
+public class SharingHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
+    extends InternalHibernateGenericStoreImpl<T>
+    implements SharingHibernateGenericStore<T>
+{
+    public SharingHibernateGenericStoreImpl( SessionFactory sessionFactory, JdbcTemplate jdbcTemplate,
+        ApplicationEventPublisher publisher, Class<T> clazz, AclService aclService,
+        CurrentUserService currentUserService, boolean cacheable )
+    {
+        super( sessionFactory, jdbcTemplate, publisher, clazz, aclService, currentUserService, cacheable );
+    }
+
+    @Override
+    public final List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, String access )
+    {
+        return getSharingPredicates( builder, CurrentUserUtil.getCurrentUserDetails(), access );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder,
+        CurrentUserDetails user, String access )
+    {
+        return getDataSharingPredicates( builder, user.getUid(), user.getUserGroupIds(), access );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, CurrentUserDetails user,
+        String access )
+    {
+        if ( !sharingEnabled( user ) || user == null )
+        {
+            return new ArrayList<>();
+        }
+
+        return getSharingPredicates( builder, user.getUid(), user.getUserGroupIds(), access );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, CurrentUserDetails user )
+    {
+        return getSharingPredicates( builder, user.getUid(), user.getUserGroupIds(), AclService.LIKE_READ_METADATA );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder,
+        CurrentUserDetails user )
+    {
+        return getDataSharingPredicates( builder, user.getUid(), user.getUserGroupIds(),
+            AclService.LIKE_READ_METADATA );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/SharingHibernateGenericStoreImpl.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/SharingHibernateGenericStoreImpl.java
@@ -47,8 +47,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
  * This class contains methods for generating predicates which are used for
- * validating sharing access permission. All methods should use
- * {@link CurrentUserDetails} instead of {@link org.hisp.dhis.user.User}
+ * validating sharing access permission.
  */
 public class SharingHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
     extends InternalHibernateGenericStoreImpl<T>
@@ -84,6 +83,12 @@ public class SharingHibernateGenericStoreImpl<T extends BaseIdentifiableObject>
         }
 
         return getSharingPredicates( builder, user.getUid(), user.getUserGroupIds(), access );
+    }
+
+    @Override
+    public List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder )
+    {
+        return getSharingPredicates( builder, CurrentUserUtil.getCurrentUserDetails(), AclService.LIKE_READ_METADATA );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisOidcUser.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.security.oidc;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.user.CurrentUserDetails;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -116,10 +117,21 @@ public class DhisOidcUser
     }
 
     @Override
+    public boolean isSuper()
+    {
+        return user.isSuper();
+    }
+
+    @Override
     public String getUid()
     {
         return user.getUid();
+    }
 
+    @Override
+    public Set<String> getUserGroupIds()
+    {
+        return user.getUserGroupIds();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -839,7 +839,7 @@ public class DefaultUserService
             .credentialsNonExpired( credentialsNonExpired )
             .authorities( user.getAuthorities() )
             .userSettings( new HashMap<>() )
-            .userGroupIds( currentUserService.getCurrentUserGroupsInfo( user ).getUserGroupUIDs() )
+            .userGroupIds( currentUserService.getCurrentUserGroupsInfo( user.getUid() ).getUserGroupUIDs() )
             .isSuper( user.isSuper() )
             .build();
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -839,6 +839,8 @@ public class DefaultUserService
             .credentialsNonExpired( credentialsNonExpired )
             .authorities( user.getAuthorities() )
             .userSettings( new HashMap<>() )
+            .userGroupIds( currentUserService.getCurrentUserGroupsInfo( user ).getUserGroupUIDs() )
+            .isSuper( user.isSuper() )
             .build();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserGroupDeletionHandler.java
@@ -74,6 +74,6 @@ public class UserGroupDeletionHandler extends DeletionHandler
             idObjectManager.updateNoAcl( group );
         }
 
-        userGroup.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUsername() ) );
+        userGroup.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUid() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
@@ -55,13 +55,13 @@ public class HibernateUserGroupStore extends HibernateIdentifiableObjectStore<Us
     public void save( UserGroup object, boolean clearSharing )
     {
         super.save( object, clearSharing );
-        object.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUsername() ) );
+        object.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUid() ) );
     }
 
     @Override
     public void update( UserGroup object, User user )
     {
         super.update( object, user );
-        object.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUsername() ) );
+        object.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUid() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -114,7 +114,7 @@ public class HibernateUserStore
     {
         super.save( user, clearSharing );
 
-        currentUserService.invalidateUserGroupCache( user.getUsername() );
+        currentUserService.invalidateUserGroupCache( user.getUid() );
     }
 
     @Override
@@ -535,12 +535,12 @@ public class HibernateUserStore
     }
 
     @Override
-    public CurrentUserGroupInfo getCurrentUserGroupInfo( User user )
+    public CurrentUserGroupInfo getCurrentUserGroupInfo( String userUID )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
         CriteriaQuery<Object[]> query = builder.createQuery( Object[].class );
         Root<User> root = query.from( User.class );
-        query.where( builder.equal( root.get( "id" ), user.getId() ) );
+        query.where( builder.equal( root.get( "uid" ), userUID ) );
         query.select( builder.array( root.get( "uid" ), root.join( "groups", JoinType.LEFT ).get( "uid" ) ) );
 
         Session session = getSession();
@@ -550,7 +550,7 @@ public class HibernateUserStore
 
         if ( CollectionUtils.isEmpty( results ) )
         {
-            currentUserGroupInfo.setUserUID( user.getUid() );
+            currentUserGroupInfo.setUserUID( userUID );
             return currentUserGroupInfo;
         }
 

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/InternalHibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/InternalHibernateGenericStore.java
@@ -69,10 +69,38 @@ public interface InternalHibernateGenericStore<T>
      */
     List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user, String access );
 
+    /**
+     * Get List of JPA Query Predicates for checking AclService.LIKE_READ_DATA
+     * sharing access of current {@link User}.
+     *
+     * @param builder {@link CriteriaBuilder} used for generating
+     *        {@link Predicate}.
+     * @param user {@link User} for checking.
+     * @return List of {@link Predicate}
+     */
     List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user );
 
+    /**
+     * Get List of JPA Query Predicates for checking data sharing access of
+     * current {@link User} based on given access String.
+     *
+     * @param builder {@link CriteriaBuilder} used for generating
+     *        {@link Predicate}.
+     * @param user {@link User} for checking.
+     * @param groupInfo {@link CurrentUserGroupInfo}
+     * @return List of {@link Predicate}
+     */
     List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user,
         CurrentUserGroupInfo groupInfo, String access );
 
+    /**
+     * Get List of JPA Query Predicates for checking data sharing access of
+     * current {@link User} based on given access String.
+     *
+     * @param builder {@link CriteriaBuilder} used for generating
+     *        {@link Predicate}.
+     * @param user {@link User} for checking.
+     * @return List of {@link Predicate}
+     */
     List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user, String access );
 }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/InternalHibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/InternalHibernateGenericStore.java
@@ -35,7 +35,6 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.hisp.dhis.common.GenericStore;
-import org.hisp.dhis.user.CurrentUserDetails;
 import org.hisp.dhis.user.CurrentUserGroupInfo;
 import org.hisp.dhis.user.User;
 
@@ -48,17 +47,6 @@ import org.hisp.dhis.user.User;
 public interface InternalHibernateGenericStore<T>
     extends GenericStore<T>
 {
-    /**
-     * Get List of JPA Query Predicates for checking
-     * AclService.LIKE_READ_METADATA sharing access of current
-     * {@link CurrentUserDetails}.
-     *
-     * @param builder {@link CriteriaBuilder} used for generating
-     *        {@link Predicate}
-     * @return List of {@link Predicate}
-     */
-    List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder );
-
     /**
      * Get List of JPA Query Predicates for checking
      * AclService.LIKE_READ_METADATA sharing access of current {@link User}.

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/SharingHibernateGenericStore.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/SharingHibernateGenericStore.java
@@ -34,9 +34,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
-import org.hisp.dhis.common.GenericStore;
 import org.hisp.dhis.user.CurrentUserDetails;
-import org.hisp.dhis.user.CurrentUserGroupInfo;
 import org.hisp.dhis.user.User;
 
 /**
@@ -45,12 +43,12 @@ import org.hisp.dhis.user.User;
  *
  * @author Lars Helge Overland
  */
-public interface InternalHibernateGenericStore<T>
-    extends GenericStore<T>
+public interface SharingHibernateGenericStore<T>
+    extends InternalHibernateGenericStore<T>
 {
     /**
      * Get List of JPA Query Predicates for checking
-     * AclService.LIKE_READ_METADATA sharing access of current
+     * AclService.LIKE_READ_METADATA sharing access of
      * {@link CurrentUserDetails}.
      *
      * @param builder {@link CriteriaBuilder} used for generating
@@ -61,17 +59,18 @@ public interface InternalHibernateGenericStore<T>
 
     /**
      * Get List of JPA Query Predicates for checking
-     * AclService.LIKE_READ_METADATA sharing access of current {@link User}.
+     * AclService.LIKE_READ_METADATA sharing access of current
+     * {@link CurrentUserDetails}.
      *
      * @param builder {@link CriteriaBuilder} used for generating
      *        {@link Predicate}
      * @return List of {@link Predicate}
      */
-    List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user );
+    List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, CurrentUserDetails user );
 
     /**
      * Get List of JPA Query Predicates for checking sharing access of current
-     * {@link User} based on given access String.
+     * {@link CurrentUserDetails} based on given access String.
      *
      * @param builder {@link CriteriaBuilder} used for generating
      *        {@link Predicate}.
@@ -79,12 +78,40 @@ public interface InternalHibernateGenericStore<T>
      * @param access access string for checking.
      * @return List of {@link Predicate}
      */
-    List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, User user, String access );
+    List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, CurrentUserDetails user,
+        String access );
 
-    List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user );
+    /**
+     * Get List of JPA Query Predicates for checking sharing access of current
+     * {@link CurrentUserDetails} based on given access String.
+     *
+     * @param builder {@link CriteriaBuilder} used for generating
+     *        {@link Predicate}
+     * @param access access string for checking.
+     * @return List of {@link Predicate}
+     */
+    List<Function<Root<T>, Predicate>> getSharingPredicates( CriteriaBuilder builder, String access );
 
-    List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user,
-        CurrentUserGroupInfo groupInfo, String access );
+    /**
+     * Get List of JPA Query Predicates for checking AclService.LIKE_DATA_READ
+     * data sharing access of current {@link CurrentUserDetails}.
+     *
+     * @param builder {@link CriteriaBuilder} used for generating
+     *        {@link Predicate}
+     * @return List of {@link Predicate}
+     */
+    List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, CurrentUserDetails user );
 
-    List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, User user, String access );
+    /**
+     * Get List of JPA Query Predicates for checking data sharing access of
+     * current {@link CurrentUserDetails} based on given access String.
+     *
+     * @param builder {@link CriteriaBuilder} used for generating
+     *        {@link Predicate}.
+     * @param user {@link User} for checking.
+     * @param access access string for checking.
+     * @return List of {@link Predicate}
+     */
+    List<Function<Root<T>, Predicate>> getDataSharingPredicates( CriteriaBuilder builder, CurrentUserDetails user,
+        String access );
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/HibernateIdentifiableObjectStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/HibernateIdentifiableObjectStoreTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -62,7 +63,6 @@ import com.google.common.collect.Sets;
 
 class HibernateIdentifiableObjectStoreTest extends TransactionalIntegrationTest
 {
-
     @Autowired
     private DataElementStore dataElementStore;
 
@@ -101,21 +101,21 @@ class HibernateIdentifiableObjectStoreTest extends TransactionalIntegrationTest
     void testMetadataRead()
     {
         User admin = createAndInjectAdminUser();
-        User user1 = new User();
-        user1.setAutoFields();
-        User user2 = new User();
-        user2.setAutoFields();
-        User user3 = new User();
-        user3.setAutoFields();
-        User user4 = new User();
-        user4.setAutoFields();
-        UserGroup userGroup1 = new UserGroup();
-        userGroup1.setAutoFields();
-        UserGroup userGroup2 = new UserGroup();
-        userGroup2.setAutoFields();
-        user1.getGroups().add( userGroup1 );
-        user1.getGroups().add( userGroup2 );
-        user4.getGroups().add( userGroup2 );
+        User user1 = createAndAddUser( "A" );
+        User user2 = createAndAddUser( "B" );
+        User user3 = createAndAddUser( "C" );
+        User user4 = createAndAddUser( "D" );
+        manager.save( user1 );
+        manager.save( user2 );
+        manager.save( user3 );
+        manager.save( user4 );
+
+        UserGroup userGroup1 = createUserGroup( 'A', Set.of( user1 ) );
+        UserGroup userGroup2 = createUserGroup( 'B', Set.of( user1, user4 ) );
+        manager.save( userGroup1 );
+        manager.save( userGroup2 );
+
+        // Create sharing settings
         Map<String, UserAccess> userSharing = new HashMap<>();
         userSharing.put( user1.getUid(), new UserAccess( user1, AccessStringHelper.DEFAULT ) );
         userSharing.put( user2.getUid(), new UserAccess( user2, AccessStringHelper.READ ) );
@@ -124,18 +124,21 @@ class HibernateIdentifiableObjectStoreTest extends TransactionalIntegrationTest
         Map<String, UserGroupAccess> userGroupSharing = new HashMap<>();
         userGroupSharing.put( userGroup1.getUid(), new UserGroupAccess( userGroup1, AccessStringHelper.READ_WRITE ) );
         userGroupSharing.put( userGroup2.getUid(), new UserGroupAccess( userGroup2, AccessStringHelper.DEFAULT ) );
+
+        // Create DataElement with given sharing settings
         DataElement dataElement = createDataElement( 'A' );
         String dataElementUid = "deabcdefghA";
         dataElement.setUid( dataElementUid );
         dataElement.setCreatedBy( admin );
-        Sharing sharing = Sharing.builder().external( false ).publicAccess( AccessStringHelper.DEFAULT )
-            .owner( "testOwner" ).userGroups( userGroupSharing ).users( userSharing ).build();
-        dataElement.setSharing( sharing );
+        dataElement.setSharing( Sharing.builder().external( false ).publicAccess( AccessStringHelper.DEFAULT )
+            .owner( "testOwner" ).userGroups( userGroupSharing ).users( userSharing ).build() );
         dataElementStore.save( dataElement, false );
+
         dataElement = dataElementStore.getByUidNoAcl( dataElementUid );
         assertNotNull( dataElement.getSharing() );
         assertEquals( 2, dataElement.getSharing().getUserGroups().size() );
         assertEquals( 4, dataElement.getSharing().getUsers().size() );
+
         // User1 can't access but it belong to UserGroup1 which has access
         assertNotNull( dataElementStore.getDataElement( dataElement.getUid(), user1 ) );
         // User2 has access to DEA

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -409,29 +409,35 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
             "F_USERGROUP_PUBLIC_ADD" );
         User user = makeUser( "B" );
         idObjectManager.save( user );
+        idObjectManager.save( loginUser );
+
+        // Create userGroupA contains loginUser
         UserGroup userGroup = createUserGroup( 'A', Sets.newHashSet( loginUser ) );
         idObjectManager.save( userGroup );
-        user.getGroups().add( userGroup );
-        loginUser.getGroups().add( userGroup );
-        idObjectManager.save( loginUser );
-        idObjectManager.save( user );
-        idObjectManager.save( createDataElement( 'A' ) );
-        idObjectManager.save( createDataElement( 'B' ) );
-        idObjectManager.save( createDataElement( 'C' ) );
-        idObjectManager.save( createDataElement( 'D' ) );
+
+        // Create sharing with publicAccess = '--------' and shared to
+        // userGroupA
+        Sharing sharing = Sharing.builder().owner( user.getUid() ).publicAccess( AccessStringHelper.DEFAULT ).build();
+        sharing.addUserGroupAccess( new UserGroupAccess( userGroup, AccessStringHelper.READ ) );
+
+        DataElement dataElementA = createDataElement( 'A' );
+        dataElementA.setSharing( sharing );
+        DataElement dataElementB = createDataElement( 'B' );
+        dataElementA.setSharing( sharing );
+        DataElement dataElementC = createDataElement( 'C' );
+        dataElementA.setSharing( sharing );
+        DataElement dataElementD = createDataElement( 'D' );
+        dataElementA.setSharing( sharing );
+
+        idObjectManager.save( dataElementA );
+        idObjectManager.save( dataElementB );
+        idObjectManager.save( dataElementC );
+        idObjectManager.save( dataElementD );
+
+        // query with loginUser
         assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
         assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
-        List<DataElement> dataElements = new ArrayList<>( idObjectManager.getAll( DataElement.class ) );
-        for ( DataElement dataElement : dataElements )
-        {
-            dataElement.getSharing().setOwner( user );
-            dataElement.getSharing().setPublicAccess( AccessStringHelper.newInstance().build() );
-            dataElement.getSharing().addUserGroupAccess( new UserGroupAccess( userGroup, AccessStringHelper.READ ) );
-            sessionFactory.getCurrentSession().update( dataElement );
-        }
-        idObjectManager.flush();
-        assertEquals( 4, idObjectManager.getCount( DataElement.class ) );
-        assertEquals( 4, idObjectManager.getAll( DataElement.class ).size() );
+
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserStoreTest.java
@@ -169,7 +169,7 @@ class UserStoreTest extends SingleSetupIntegrationTestBase
         userGroupService.addUserGroup( userGroupB );
         userA.getGroups().add( userGroupA );
         userA.getGroups().add( userGroupB );
-        CurrentUserGroupInfo currentUserGroupInfo = userStore.getCurrentUserGroupInfo( userA );
+        CurrentUserGroupInfo currentUserGroupInfo = userStore.getCurrentUserGroupInfo( userA.getUid() );
         assertNotNull( currentUserGroupInfo );
         assertEquals( 2, currentUserGroupInfo.getUserGroupUIDs().size() );
         assertEquals( userA.getUid(), currentUserGroupInfo.getUserUID() );
@@ -180,7 +180,7 @@ class UserStoreTest extends SingleSetupIntegrationTestBase
     {
         User userA = makeUser( "A" );
         userStore.save( userA );
-        CurrentUserGroupInfo currentUserGroupInfo = userStore.getCurrentUserGroupInfo( userA );
+        CurrentUserGroupInfo currentUserGroupInfo = userStore.getCurrentUserGroupInfo( userA.getUid() );
         assertNotNull( currentUserGroupInfo );
         assertEquals( 0, currentUserGroupInfo.getUserGroupUIDs().size() );
         assertEquals( userA.getUid(), currentUserGroupInfo.getUserUID() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/apikey/ApiTokenAuthenticationToken.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/apikey/ApiTokenAuthenticationToken.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.security.apikey;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.security.apikey.ApiToken;
 import org.hisp.dhis.user.CurrentUserDetails;
@@ -123,9 +124,21 @@ public class ApiTokenAuthenticationToken extends AbstractAuthenticationToken imp
     }
 
     @Override
+    public boolean isSuper()
+    {
+        return user.isSuper();
+    }
+
+    @Override
     public String getUid()
     {
         return user.getUid();
+    }
+
+    @Override
+    public Set<String> getUserGroupIds()
+    {
+        return user.getUserGroupIds();
     }
 
     @Override


### PR DESCRIPTION
This PR aims to replace the use of `currentUserService.getCurrentUser()` with `CurrentUserUtil.getCurrentUserDetails()`. This helps to avoid using the hibernate `User` object which contains lazy collections.
Some necessary  changes were made:
- Add `userGroupIds` and `isSuper` to `CurrentUserDetails` interface
- Create a new interface `SharingHibernateGenericStore` which contains methods for generating predicates which are used for validating sharing access permission. This interface will only use `CurrentUserDetails` instead of `User` object as in `InternalHibernateGenericStore`.
- The `InternalHibernateGenericStore` still contains methods accepting `User` object. Will create another PR to remove those them.


