### PR TITLE
fix: Sql parsing issue in PI expression [DHIS2-13487]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramExpressionItem.java
@@ -146,6 +146,6 @@ public abstract class ProgramExpressionItem
             }
         }
 
-        return COALESCE + column + ",'')";
+        return COALESCE + column + "::text,'')";
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -306,10 +306,10 @@ public class ProgramIndicatorServiceVariableTest
         assertEquals( "0", getSqlEnrollment( "V{value_count}" ) );
 
         assertEquals(
-            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" is not null then 1 else 0 end) as double),0)",
+            "coalesce(\"TEAttribute\"::text,'') + nullif(cast((case when \"TEAttribute\" is not null then 1 else 0 end) as double),0)",
             getSql( "A{TEAttribute} + V{value_count}" ) );
         assertEquals(
-            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" is not null then 1 else 0 end) as double),0)",
+            "coalesce(\"TEAttribute\"::text,'') + nullif(cast((case when \"TEAttribute\" is not null then 1 else 0 end) as double),0)",
             getSqlEnrollment( "A{TEAttribute} + V{value_count}" ) );
     }
 
@@ -320,10 +320,10 @@ public class ProgramIndicatorServiceVariableTest
         assertEquals( "0", getSqlEnrollment( "V{zero_pos_value_count}" ) );
 
         assertEquals(
-            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
+            "coalesce(\"TEAttribute\"::text,'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
             getSql( "A{TEAttribute} + V{zero_pos_value_count}" ) );
         assertEquals(
-            "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
+            "coalesce(\"TEAttribute\"::text,'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
             getSqlEnrollment( "A{TEAttribute} + V{zero_pos_value_count}" ) );
     }
 }


### PR DESCRIPTION
_[Backport from master/2.39]_

When setting a Program Indicator expression using a Data Element as type "Date", it does not evaluate correctly at querying time. It causes an error in the backend that propagates to the front end.

The error happens during the execution of the SQL at DB level:
```
org.springframework.dao.DataIntegrityViolationException:
StatementCallback; SQL [
select count(psi) as value,ax.“uidlevel3” from analytics_event_fxpgw6evdvb as ax where ax.“yearly” in (‘2021’, ‘2022’) and ax.“uidlevel3” in (‘JEhqFsfXxTt’,‘VSxknPhjR6o’,‘M7qFOnwmE3A’,‘Qq4jYe5tHnl’,‘mNzjvxYEHkq’,‘nFPxXeZftGm’,‘eWjt9Zl76FS’,‘HqJwxVQhfyM’,‘uqh2OI3no6W’,‘aeBwvrjdh7m’,‘hfal93WttYV’,‘qnw9ul9mgww’,‘Kts15CHhP3h’,‘Er2eXRYQ5kD’,‘mdpCE7IYau0’,‘HR8JDs4Sae5’,‘GBeQB9YNmP4’,‘L4FwAUd37Wp’,‘KlCB0HQHtbg’,‘dJssgIzIiL4’,‘TBh00t5LnBZ’,‘lpjb08mkXcY’,‘soweCPFSM7L’,‘isI5LRdu80m’) and (coalesce(“IaiCT78oIaU”,‘’) >= ‘2019-07-01’ and coalesce(“IaiCT78oIaU”,‘’) <= ‘2019-07-31’) and ax.“yearly” in (‘2021’, ‘2022’) group by ax.“uidlevel3”
];

ERROR: invalid input syntax for type timestamp: “”
Position: 508; nested exception is org.postgresql.util.PSQLException: ERROR: invalid input syntax for type timestamp: “”
```

This relates to an issue raised by the Community:
`
https://community.dhis2.org/t/challenge-with-generating-line-listing-event-reports/48272
`