### PR TITLE
fix: personal access token field filter

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenAttribute.java
@@ -27,9 +27,8 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
-
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.EmbeddedObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -45,13 +44,18 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
     @JsonSubTypes.Type( value = RefererAllowedList.class, name = "RefererAllowedList" ),
     @JsonSubTypes.Type( value = MethodAllowedList.class, name = "MethodAllowedList" ) } )
 @JacksonXmlRootElement( localName = "apiTokenAttribute", namespace = DxfNamespaces.DXF_2_0 )
-public abstract class ApiTokenAttribute implements Serializable
+public abstract class ApiTokenAttribute implements EmbeddedObject
 {
-    @JsonProperty
     protected final String type;
 
     protected ApiTokenAttribute( String type )
     {
         this.type = type;
+    }
+
+    @JsonProperty
+    public String getType()
+    {
+        return type;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/IpAllowedList.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/IpAllowedList.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -44,7 +43,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class IpAllowedList extends ApiTokenAttribute implements Serializable
+public class IpAllowedList extends ApiTokenAttribute
 {
     private Set<String> allowedIps = new HashSet<>();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/MethodAllowedList.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/MethodAllowedList.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -45,7 +44,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class MethodAllowedList extends ApiTokenAttribute implements Serializable
+public class MethodAllowedList extends ApiTokenAttribute
 {
     private Set<String> allowedMethods = new HashSet<>();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/RefererAllowedList.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/RefererAllowedList.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -45,7 +44,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class RefererAllowedList extends ApiTokenAttribute implements Serializable
+public class RefererAllowedList extends ApiTokenAttribute
 {
     private Set<String> allowedReferrers = new HashSet<>();
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
@@ -184,8 +184,7 @@ class PathContext
     private final Object currentValue;
 
     /**
-     * true if special type we do not support field filtering on. If this is
-     * true, always fully expand the property.
+     * true if special type we do not support field filtering on.
      */
     private final boolean alwaysExpand;
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
@@ -183,5 +183,9 @@ class PathContext
 
     private final Object currentValue;
 
+    /**
+     * true if special type we do not support field filtering on. If this is
+     * true, always fully expand the property.
+     */
     private final boolean alwaysExpand;
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterSimpleBeanPropertyFilter.java
@@ -35,7 +35,9 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.scheduling.JobParameters;
+import org.hisp.dhis.system.util.AnnotationUtils;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -86,7 +88,7 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
             return false;
         }
 
-        if ( ctx.isMapType() )
+        if ( ctx.isAlwaysExpand() )
         {
             return true;
         }
@@ -107,7 +109,7 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
         StringBuilder nestedPath = new StringBuilder();
         JsonStreamContext sc = jgen.getOutputContext();
         Object currentValue = null;
-        boolean mapType = false;
+        boolean alwaysExpand = false;
 
         if ( sc != null )
         {
@@ -118,10 +120,10 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
 
         while ( sc != null )
         {
-            if ( isMapType( sc.getCurrentValue() ) )
+            if ( isAlwaysExpandType( sc.getCurrentValue() ) )
             {
                 sc = sc.getParent();
-                mapType = true;
+                alwaysExpand = true;
                 continue;
             }
 
@@ -134,12 +136,12 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
             sc = sc.getParent();
         }
 
-        if ( isMapType( currentValue ) )
+        if ( isAlwaysExpandType( currentValue ) )
         {
-            mapType = true;
+            alwaysExpand = true;
         }
 
-        return new PathContext( nestedPath.toString(), currentValue, mapType );
+        return new PathContext( nestedPath.toString(), currentValue, alwaysExpand );
     }
 
     @Override
@@ -156,10 +158,17 @@ public class FieldFilterSimpleBeanPropertyFilter extends SimpleBeanPropertyFilte
         }
     }
 
-    private boolean isMapType( Object object )
+    private boolean isAlwaysExpandType( Object object )
     {
-        return object != null && (Map.class.isAssignableFrom( object.getClass() )
-            || JobParameters.class.isAssignableFrom( object.getClass() ));
+        if ( object == null )
+        {
+            return false;
+        }
+
+        Class<?> klass = object.getClass();
+
+        return Map.class.isAssignableFrom( klass ) || JobParameters.class.isAssignableFrom( klass )
+            || AnnotationUtils.isAnnotationPresent( klass, JsonTypeInfo.class );
     }
 }
 
@@ -174,5 +183,5 @@ class PathContext
 
     private final Object currentValue;
 
-    private final boolean mapType;
+    private final boolean alwaysExpand;
 }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -115,11 +115,8 @@ public class FieldPathHelper
 
         Property property = fieldPath.getProperty();
 
-        System.err.println( "1: " + property.getName() );
-
         if ( isComplex( property ) )
         {
-            System.err.println( "1: IS COMPLEX" );
             expandComplex( fieldPathMap, paths, schema );
         }
         else if ( isReference( property ) )
@@ -149,11 +146,8 @@ public class FieldPathHelper
             return;
         }
 
-        System.err.println( "2: " + property.getName() );
-
         if ( isComplex( property ) )
         {
-            System.err.println( "2: IS COMPLEX" );
             expandComplex( fieldPathMap, paths, schema );
         }
         else if ( isReference( property ) )

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -115,8 +115,11 @@ public class FieldPathHelper
 
         Property property = fieldPath.getProperty();
 
+        System.err.println( "1: " + property.getName() );
+
         if ( isComplex( property ) )
         {
+            System.err.println( "1: IS COMPLEX" );
             expandComplex( fieldPathMap, paths, schema );
         }
         else if ( isReference( property ) )
@@ -146,8 +149,11 @@ public class FieldPathHelper
             return;
         }
 
+        System.err.println( "2: " + property.getName() );
+
         if ( isComplex( property ) )
         {
+            System.err.println( "2: IS COMPLEX" );
             expandComplex( fieldPathMap, paths, schema );
         }
         else if ( isReference( property ) )


### PR DESCRIPTION
## Summary

* Change `ApiTokenAttribute` sub types to `EmbeddedObject`.
* Adds getter for `ApiTokenAttribute.type`.
* Update `FieldFilterSimpleBeanPropertyFilter` to always expand `@JsonTypeInfo` annotated classes as we do not allow field filtering on them.

[DHIS2-13437](https://jira.dhis2.org/browse/DHIS2-13437)