### PR TITLE
ci: do not fail build if codecov upload fails

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           directory: ./dhis-2
           flags: unit
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
       # delete the next 2 steps once we are confident in the coverage setup
       - name: Tar jacoco coverage report to debug
@@ -84,7 +84,7 @@ jobs:
         with:
           directory: ./dhis-2
           flags: integration
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
       # delete the next 2 steps once we are confident in the coverage setup
       - name: Tar jacoco coverage report to debug
@@ -135,7 +135,7 @@ jobs:
         with:
           directory: ./dhis-2
           flags: integration-h2
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
       # delete the next 2 steps once we are confident in the coverage setup
       - name: Tar jacoco coverage report to debug


### PR DESCRIPTION
as coverage is optional for now and just informational