### PR TITLE
fix: Backward compatible clause in boundaries [DHIS2-12309]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -245,7 +245,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
             "from analytics_event_Program000A " +
             "where analytics_event_Program000A.pi = ax.pi " +
             "and \"DataElmentA\" is not null and \"DataElmentA\" is not null " +
-            "and executiondate < cast( '2021-01-01' as date ) " +
+            "and  psistatus != 'SCHEDULE' and executiondate < cast( '2021-01-01' as date ) " +
             "and ps = 'ProgrmStagA')" ) );
     }
 
@@ -262,7 +262,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
             "from analytics_event_Program000A " +
             "where analytics_event_Program000A.pi = ax.pi " +
             "and \"DataElmentA\" is not null and \"DataElmentA\" is not null " +
-            "and executiondate >= cast( '2020-01-01' as date ) " +
+            "and  psistatus != 'SCHEDULE' and executiondate >= cast( '2020-01-01' as date ) " +
             "and ps = 'ProgrmStagA')" ) );
     }
 
@@ -278,8 +278,9 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
         assertThat( sql, is( "(select count(\"DataElmentA\") " +
             "from analytics_event_Program000A " +
             "where analytics_event_Program000A.pi = ax.pi " +
-            "and \"DataElmentA\" is not null and \"DataElmentA\" is not null " +
-            "and executiondate < cast( '2021-01-01' as date ) and executiondate >= cast( '2020-01-01' as date ) " +
+            "and \"DataElmentA\" is not null and \"DataElmentA\" is not null and  psistatus != 'SCHEDULE' " +
+            "and executiondate < cast( '2021-01-01' as date ) and  psistatus != 'SCHEDULE' and executiondate >= cast( '2020-01-01' as date ) "
+            +
             "and ps = 'ProgrmStagA')" ) );
     }
 
@@ -487,8 +488,9 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
         String sql = test( "d2:yearsBetween(V{enrollment_date}, PS_EVENTDATE:ProgrmStagA) < 1" );
         assertThat( sql, is( "(date_part('year',age(cast((select executiondate from analytics_event_Program000A " +
             "where analytics_event_Program000A.pi = ax.pi and executiondate is not null " +
-            "and executiondate < cast( '2021-01-01' as date ) and executiondate >= cast( '2020-01-01' as date ) " +
-            "and ps = 'ProgrmStagA' " +
+            "and  psistatus != 'SCHEDULE' and executiondate < cast( '2021-01-01' as date ) " +
+            "and  psistatus != 'SCHEDULE' " +
+            "and executiondate >= cast( '2020-01-01' as date ) and ps = 'ProgrmStagA' " +
             "order by executiondate desc limit 1 ) as date), cast(enrollmentdate as date)))) < 1" ) );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -536,9 +536,11 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest
         Date dateFrom = getDate( 2019, 1, 1 );
         Date dateTo = getDate( 2019, 12, 31 );
         // Generated subquery, since indicatorF is type Enrollment
-        String expected = "coalesce((select \"DataElmentA\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi and \"DataElmentA\" is not null and executiondate < cast( '"
+        String expected = "coalesce((select \"DataElmentA\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi "
+            + "and \"DataElmentA\" is not null and  psistatus != 'SCHEDULE' and executiondate < cast( '"
             + "2020-01-11" + "' as date ) and ps = 'ProgrmStagA' order by executiondate desc limit 1 )::numeric,0) - "
-            + "coalesce((select \"DataElmentC\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi and \"DataElmentC\" is not null and executiondate < cast( '"
+            + "coalesce((select \"DataElmentC\" from analytics_event_Program000B where analytics_event_Program000B.pi = axx1.pi "
+            + "and \"DataElmentC\" is not null and  psistatus != 'SCHEDULE' and executiondate < cast( '"
             + "2020-01-11" + "' as date ) and ps = 'ProgrmStagB' order by executiondate desc limit 1 )::numeric,0)";
         String expression = "#{ProgrmStagA.DataElmentA} - #{ProgrmStagB.DataElmentC}";
         assertEquals( expected,


### PR DESCRIPTION
As part of `SCHEDULE` events support we need to make sure the current code is backwards compatible, as we never used statuses and assumed only ACTIVE/COMPLETED events. Most of the logic is based on `executiondate`.

This code fixes a missing clause to make it backwards compatible with the boundaries feature.