### PR TITLE
fix: abort deletion on exception in handlers [DHIS2-13499]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -228,6 +228,9 @@ public enum ErrorCode
     E4052( "For program rule variable with name `{0}` following keywords are forbidden : and , or , not" ),
     E4053( "Program stage `{0}` must reference a program." ),
 
+    /* Metadata Validation (continued) */
+    E4060( "Object could not be deleted: {0}" ),
+
     /* SQL views */
     E4300( "SQL query is null" ),
     E4301( "SQL query must be a select query" ),

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DefaultDeletionManager.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/DefaultDeletionManager.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.system.deletion;
 
+import static java.lang.String.format;
+
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -137,7 +139,7 @@ public class DefaultDeletionManager
                 {
                     ErrorMessage errorMessage = new ErrorMessage( ErrorCode.E4030, veto.getMessage() );
 
-                    log.debug( "Delete was not allowed by " + handlerName + ": " + errorMessage.toString() );
+                    log.debug( "Delete was not allowed by " + handlerName + ": " + errorMessage );
 
                     throw new DeleteNotAllowedException( errorMessage );
                 }
@@ -150,7 +152,9 @@ public class DefaultDeletionManager
         catch ( Exception ex )
         {
             log.error( "Deletion failed, veto handler '" + handlerName + "' threw an exception: ", ex );
-            return;
+            throw new DeleteNotAllowedException( new ErrorMessage( ErrorCode.E4060,
+                format( "handler '%s' threw an exception while trying to find related objects: %s", handlerName,
+                    ex.getMessage() ) ) );
         }
 
         // ---------------------------------------------------------------------
@@ -172,7 +176,9 @@ public class DefaultDeletionManager
         catch ( Exception ex )
         {
             log.error( "Deletion failed, deletion handler '" + handlerName + "' threw an exception: ", ex );
-            return;
+            throw new DeleteNotAllowedException( new ErrorMessage( ErrorCode.E4060,
+                format( "handler '%s' threw an exception while removing related objects: %s", handlerName,
+                    ex.getMessage() ) ) );
         }
 
         log.debug( "Deleted objects associated with object of type " + className );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/SchemaBasedControllerTest.java
@@ -79,6 +79,7 @@ class SchemaBasedControllerTest extends DhisControllerConvenienceTest
         "programRuleAction", // needs DataElement and TrackedEntityAttribute
         "validationRule", // generator insufficient (embedded fields)
         "programStage", // presumably server errors/bugs
+        "dataElement", // non-postgres SQL in deletion handler
         "trackedEntityInstance", // conflict (no details)
         "predictor", // NPE in preheat when creating objects
         "analyticsDataExchange" // required JSONB objects not working


### PR DESCRIPTION
### Summary
Current behaviour is:

* if a deletion veto handler throws an exception (that is not the `DeleteNotAllowedException`) during veto phase the deletion handling is aborted effectively skipping other veto handler and certainly skipping all deletion handler (that change/remove linkage)
* if a deletion handler throws an exception (any) deletion handling is aborted and all further deletion handlers are skipped
Since no exception is re-thrown the code triggering the deletion event will continue and delete the object triggering the deletion event (unless this fails due to a FK constraint in the DB).

This can leave the DB in an inconsistent state that is mostly unpredictable and certainly undesirable. 

The target behaviour is:

* if an exception is thrown (not `DeleteNotAllowedException`) either during veto or deletion loop the manager will throw a `DeleteNotAllowedException` to effectively prevent the deletion to keep the database in an consistent state. 

This is certainly not ideal either as any issue in one of the deletion handler will prevent deletion from happening. This might cause situations where deletion is not possible to perform because the reasons of the exception are due to an programming error or a database state that cannot be repaired using the UI.