### PR TITLE
ci: use jib to build DHIS2 Docker image [TECH-1279]

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:    
   api-test:
     env:
-      CORE_IMAGE_NAME: "dhis2/core-dev:jib-2.39-SNAPSHOT"
+      CORE_IMAGE_NAME: "dhis2/core-dev:jib-2.40-SNAPSHOT"
       TEST_IMAGE_NAME: "dhis2/tests:local"
       PR_NUMBER: ${{ github.event.number }}
       DOCKER_CHANNEL: "dhis2/core-pr"

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -36,21 +36,21 @@ jobs:
           mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/pom.xml
           mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
 
-      # - name: Login to Docker Hub
-      #   if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}
-      #     password: ${{ secrets.DHIS2_BOT_DOCKER_HUB_PASSWORD }}
+      - name: Login to Docker Hub
+        # if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DHIS2_BOT_DOCKER_HUB_PASSWORD }}
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
        
-      # - name: Publish docker image
-      #   if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
-      #   run: |
-      #     docker tag $CORE_IMAGE_NAME $DOCKER_CHANNEL:$PR_NUMBER
-      #     docker push $DOCKER_CHANNEL:$PR_NUMBER
+      - name: Publish docker image
+        # if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
+        run: |
+          # docker tag $CORE_IMAGE_NAME $DOCKER_CHANNEL:$PR_NUMBER
+          docker push $CORE_IMAGE_NAME
 
       - name: Build test image
         uses: docker/build-push-action@v3

--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:    
   api-test:
     env:
-      CORE_IMAGE_NAME: "dhis2/core:local"
+      CORE_IMAGE_NAME: "dhis2/core-dev:jib-2.39-SNAPSHOT"
       TEST_IMAGE_NAME: "dhis2/tests:local"
       PR_NUMBER: ${{ github.event.number }}
       DOCKER_CHANNEL: "dhis2/core-pr"
@@ -32,23 +32,25 @@ jobs:
           cache: maven
       - name: Build core image
         run: |
-          bash ./dhis-2/build-dev.sh
+          mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f dhis-2/pom.xml -pl -dhis-web-embedded-jetty,-dhis-test-integration,-dhis-test-coverage
+          mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/pom.xml
+          mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
 
-      - name: Login to Docker Hub
-        if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DHIS2_BOT_DOCKER_HUB_PASSWORD }}
+      # - name: Login to Docker Hub
+      #   if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}
+      #     password: ${{ secrets.DHIS2_BOT_DOCKER_HUB_PASSWORD }}
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        
-      - name: Publish docker image
-        if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
-        run: |
-          docker tag $CORE_IMAGE_NAME $DOCKER_CHANNEL:$PR_NUMBER
-          docker push $DOCKER_CHANNEL:$PR_NUMBER
+       
+      # - name: Publish docker image
+      #   if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
+      #   run: |
+      #     docker tag $CORE_IMAGE_NAME $DOCKER_CHANNEL:$PR_NUMBER
+      #     docker push $DOCKER_CHANNEL:$PR_NUMBER
 
       - name: Build test image
         uses: docker/build-push-action@v3

--- a/README.md
+++ b/README.md
@@ -33,3 +33,43 @@ This repository contains the source code for the server-side component of DHIS 2
 To build it you must first install the root `POM` file, navigate to the `dhis-web` directory and then build the web `POM` file.
 
 See the [contributing](https://github.com/dhis2/dhis2-core/blob/master/CONTRIBUTING.md) page to learn how to run locally.
+
+### Docker image
+
+The DHIS2 Docker image is built using
+[Jib](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin). To build make sure
+to build DHIS2 and the web project first
+
+```sh
+mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -f dhis-2/pom.xml -pl -dhis-web-embedded-jetty,-dhis-test-integration,-dhis-test-coverage
+mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/pom.xml
+```
+
+Then build the Docker image
+
+```sh
+mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
+```
+
+Run the image using
+
+```sh
+docker compose up
+```
+
+It should now be available at `http://localhost:8080`.
+
+#### Customizations
+
+To build using a custom tag run
+
+```sh
+mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild -Djib.to-image-tag=custom-tag
+```
+
+To deploy DHIS2 under a different context then root (`/`) configure the context path by setting the
+environment variable
+
+`JAVA_TOOL_OPTIONS: "-Dcontext.path='/dhis2'"`
+
+DHIS2 should be available at `http://localhost:8080/dhis2`.

--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -57,11 +57,11 @@ ONLY_DEFAULT=1 $ROOT/docker/build-containers.sh $IMAGE:$TAG $TAG
 
 print "Successfully created Docker image $IMAGE:$TAG"
 
-# if test -z $D2CLUSTER; then
-#     print "No cluster name specified, skipping deploy"
-# else
-#     print "Deploying to d2 cluster $D2CLUSTER..."
-#
-#     d2 cluster up $D2CLUSTER --image $IMAGE:$TAG
-#     d2 cluster logs $D2CLUSTER
-# fi
+if test -z $D2CLUSTER; then
+    print "No cluster name specified, skipping deploy"
+else
+    print "Deploying to d2 cluster $D2CLUSTER..."
+
+    d2 cluster up $D2CLUSTER --image $IMAGE:$TAG
+    d2 cluster logs $D2CLUSTER
+fi

--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -40,8 +40,8 @@ print() {
 print "Building dhis2-core..."
 
 export MAVEN_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.test.skip=true"
-mvn clean install --batch-mode --no-transfer-progress --threads 1C -Pdev -f "$DIR"/pom.xml -pl -dhis-web-embedded-jetty
-mvn clean install --batch-mode --no-transfer-progress --threads 1C -Pdev -f "$DIR"/dhis-web/pom.xml
+# mvn clean install --batch-mode --no-transfer-progress --threads 1C -Pdev -f "$DIR"/pom.xml -pl -dhis-web-embedded-jetty
+# mvn clean install --batch-mode --no-transfer-progress --threads 1C -Pdev -f "$DIR"/dhis-web/pom.xml
 
 rm -rf "$ARTIFACTS/*"
 mkdir -p "$ARTIFACTS"
@@ -57,11 +57,11 @@ ONLY_DEFAULT=1 $ROOT/docker/build-containers.sh $IMAGE:$TAG $TAG
 
 print "Successfully created Docker image $IMAGE:$TAG"
 
-if test -z $D2CLUSTER; then
-    print "No cluster name specified, skipping deploy"
-else
-    print "Deploying to d2 cluster $D2CLUSTER..."
-
-    d2 cluster up $D2CLUSTER --image $IMAGE:$TAG
-    d2 cluster logs $D2CLUSTER
-fi
+# if test -z $D2CLUSTER; then
+#     print "No cluster name specified, skipping deploy"
+# else
+#     print "Deploying to d2 cluster $D2CLUSTER..."
+#
+#     d2 cluster up $D2CLUSTER --image $IMAGE:$TAG
+#     d2 cluster logs $D2CLUSTER
+# fi

--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -3,9 +3,9 @@ services:
   redis:
     image: redis:5.0.5-alpine
     volumes:
-    - ./config/redis/redis.conf:/usr/local/etc/redis.conf
+      - ./config/redis/redis.conf:/usr/local/etc/redis.conf
     ports:
-       - "6379"
+      - "6379"
 
   db:
     restart: unless-stopped
@@ -19,11 +19,11 @@ services:
   web:
     image: "${IMAGE_NAME}"
     volumes:
-    - ./config/dhis2_home/dhis.conf:/DHIS2_home/dhis.conf
+      - ./config/dhis2_home/dhis.conf:/opt/dhis2/dhis.conf:ro
     environment:
       - WAIT_FOR_DB_CONTAINER=db:5432 -t 0
     depends_on:
-    - db
-    - redis
+      - db
+      - redis
     ports:
-    - "8080"
+      - "8080"

--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -1,57 +1,124 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.hisp.dhis</groupId>
-    <artifactId>dhis-web</artifactId>
-    <version>2.40-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>org.hisp.dhis</groupId>
+        <artifactId>dhis-web</artifactId>
+        <version>2.40-SNAPSHOT</version>
+    </parent>
 
-  <artifactId>dhis-web-portal</artifactId>
-  <packaging>war</packaging>
-  <name>DHIS Web Portal</name>
+    <artifactId>dhis-web-portal</artifactId>
+    <packaging>war</packaging>
+    <name>DHIS Web Portal</name>
 
-  <build>
-    <finalName>dhis</finalName>
-  </build>
+    <build>
+        <finalName>dhis</finalName>
+        <plugins>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>${jib.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-ownership-extension-maven</artifactId>
+                        <version>0.1.0</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <container>
+                        <user>${jib.user}</user>
+                        <appRoot>${jib.app-root}</appRoot>
+                        <environment>
+                            <!-- default DHIS2 web application context to / but allow for customization -->
+                            <JAVA_TOOL_OPTIONS>-Dcontext.path=""</JAVA_TOOL_OPTIONS>
+                        </environment>
+                    </container>
+                    <from>
+                        <image>${jib.from-image}</image>
+                        <!--
+                                                <platforms>
+                                                    <platform>
+                                                        <architecture>amd64</architecture>
+                                                        <os>linux</os>
+                                                    </platform>
+                                                    <platform>
+                                                        <architecture>arm64</architecture>
+                                                        <os>linux</os>
+                                                    </platform>
+                                                </platforms>
+                        -->
+                    </from>
+                    <to>
+                        <image>${jib.to-image}:${jib.to-image-tag}</image>
+                    </to>
+                    <pluginExtensions>
+                        <pluginExtension>
+                            <implementation>com.google.cloud.tools.jib.maven.extension.ownership.JibOwnershipExtension</implementation>
+                            <configuration implementation="com.google.cloud.tools.jib.maven.extension.ownership.Configuration">
+                                <!-- Jib will create /opt/dhis2 owned by root by default.
+                                DHIS2_HOME needs to be writeable by the process running Tomcat -->
+                                <rules>
+                                    <rule>
+                                        <glob>/opt/dhis2</glob>
+                                        <ownership>${jib.user}</ownership>
+                                    </rule>
+                                    <rule>
+                                        <glob>/opt/dhis2/**</glob>
+                                        <ownership>${jib.user}</ownership>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </pluginExtension>
+                    </pluginExtensions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-  <dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.hisp.dhis</groupId>
+            <artifactId>dhis-web-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hisp.dhis</groupId>
+            <artifactId>dhis-web-commons-resources</artifactId>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.hisp.dhis</groupId>
+            <artifactId>dhis-web-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hisp.dhis</groupId>
+            <artifactId>dhis-web-dataentry</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.hisp.dhis</groupId>
+            <artifactId>dhis-web-apps</artifactId>
+            <version>${project.version}</version>
+            <type>war</type>
+        </dependency>
 
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-web-commons</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-web-commons-resources</artifactId>
-      <type>war</type>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-web-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-web-dataentry</artifactId>
-      <version>${project.version}</version>
-      <type>war</type>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-web-apps</artifactId>
-      <version>${project.version}</version>
-      <type>war</type>
-    </dependency>
-
-  </dependencies>
-  <properties>
-    <rootDir>../../</rootDir>
-  </properties>
+    </dependencies>
+    <properties>
+        <rootDir>../../</rootDir>
+        <jib.version>3.2.1</jib.version>
+        <jib.from-image>tomcat:9.0-jdk11-openjdk-slim</jib.from-image>
+        <jib.to-image>dhis2/core-dev</jib.to-image>
+        <jib.to-image-tag>jib-${project.version}</jib.to-image-tag>
+        <!-- uid=65534(nobody) present in tomcat image -->
+        <jib.user>65534</jib.user>
+        <jib.app-root>/usr/local/tomcat/webapps/ROOT</jib.app-root>
+    </properties>
 </project>

--- a/dhis-2/dhis-web/dhis-web-portal/src/main/jib/opt/dhis2/.include
+++ b/dhis-2/dhis-web/dhis-web-portal/src/main/jib/opt/dhis2/.include
@@ -1,0 +1,2 @@
+# Used to create parent folder structure by Jib
+# Default DHIS2_HOME is /opt/dhis2 which needs to be writeable by the process running Tomcat

--- a/dhis-2/dhis-web/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/Catalina/localhost/.include
+++ b/dhis-2/dhis-web/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/Catalina/localhost/.include
@@ -1,0 +1,5 @@
+# Used to create parent folder structure by Jib
+# Tomcat is having issues when running as non-root as it tries to create this folder while it does not have permission
+# to. See
+# https://github.com/docker-library/tomcat/issues/209
+# https://github.com/docker-library/tomcat/issues/128

--- a/dhis-2/dhis-web/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/server.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/src/main/jib/usr/local/tomcat/conf/server.xml
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="-1">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443"
+               URIEncoding="UTF-8"
+               relaxedQueryChars='\ { } | [ ]'/>
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation. The default
+         SSLImplementation will depend on the presence of the APR/native
+         library and the useOpenSSL attribute of the
+         AprLifecycleListener.
+         Either JSSE or OpenSSL style configuration may be used regardless of
+         the SSLImplementation selected. JSSE style configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true">
+        <SSLHostConfig>
+            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2
+         This connector uses the APR/native implementation which always uses
+         OpenSSL for TLS.
+         Either JSSE or OpenSSL style configuration may be used. OpenSSL style
+         configuration is used below.
+    -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11AprProtocol"
+               maxThreads="150" SSLEnabled="true" >
+        <UpgradeProtocol className="org.apache.coyote.http2.Http2Protocol" />
+        <SSLHostConfig>
+            <Certificate certificateKeyFile="conf/localhost-rsa-key.pem"
+                         certificateFile="conf/localhost-rsa-cert.pem"
+                         certificateChainFile="conf/localhost-rsa-chain.pem"
+                         type="RSA" />
+        </SSLHostConfig>
+    </Connector>
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009
+    <Connector port="8009" protocol="AJP/1.3" redirectPort="8443" />
+    -->
+
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host
+          name="localhost"
+          appBase="webapps"
+          unpackWARs="false"
+          autoDeploy="false"
+          deployOnStartup="false"
+      >
+
+        <!-- ROOT of /usr/local/tomcat/webapps/ROOT-->
+        <Context path="${context.path}" docBase="ROOT/" />
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.6"
+
+services:
+  web:
+    image: dhis2/core-dev:jib-2.39-SNAPSHOT
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
+    depends_on:
+      - db
+
+  db:
+    image: postgis/postgis:10-2.5-alpine
+    environment:
+      POSTGRES_USER: dhis
+      POSTGRES_DB: dhis2
+      POSTGRES_PASSWORD: dhis
+

--- a/docker/dhis.conf
+++ b/docker/dhis.conf
@@ -1,0 +1,7 @@
+connection.dialect = org.hibernate.dialect.PostgreSQLDialect
+connection.driver_class = org.postgresql.Driver
+connection.url = jdbc:postgresql://db/dhis2
+connection.username = dhis
+connection.password = dhis
+
+tracker.import.preheat.cache.enabled=off

--- a/docker/dhis.conf
+++ b/docker/dhis.conf
@@ -5,3 +5,6 @@ connection.username = dhis
 connection.password = dhis
 
 tracker.import.preheat.cache.enabled=off
+
+flyway.migrate_out_of_order = true
+flyway.repair_before_migration = true

--- a/docker/shared/containers-list.sh
+++ b/docker/shared/containers-list.sh
@@ -26,7 +26,7 @@ TOMCAT_IMAGE="tomcat"
 DEFAULT_TOMCAT_TAG="9.0-jdk11-openjdk-slim"
 
 TOMCAT_DEBIAN_TAGS=(
-    "8.5-jdk11-openjdk-slim"
+    # "8.5-jdk11-openjdk-slim" # commenting it out for build time performance measurements TECH-1279
     "9.0-jdk11-openjdk-slim"
 )
 

--- a/docker/shared/containers-list.sh
+++ b/docker/shared/containers-list.sh
@@ -26,7 +26,7 @@ TOMCAT_IMAGE="tomcat"
 DEFAULT_TOMCAT_TAG="9.0-jdk11-openjdk-slim"
 
 TOMCAT_DEBIAN_TAGS=(
-    # "8.5-jdk11-openjdk-slim" # commenting it out for build time performance measurements TECH-1279
+    "8.5-jdk11-openjdk-slim"
     "9.0-jdk11-openjdk-slim"
 )
 


### PR DESCRIPTION
## TL;DR

* build Docker image using [Jib](https://github.com/GoogleContainerTools/jib) specifically its [Maven plugin](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#jib---containerize-your-maven-project)
* run e2e tests using the Jib image

what we gain

* no bespoke build code needed to build Docker image using best practices
* faster DHIS2 startup due to pre-exploded war. On the instance manager DHIS2 2.38.1 startup is 8.168s faster on average (or 9.189s using max startup times).
* [multi-platform support](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#platform-object) by adjusting the Jib configuration in the `pom.xml`
* reduced network traffic (pulling/pushing from/to Dockerhub) when maven dependencies stay the same between subsequent builds due to the [dependencies image layer](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-are-jib-applications-layered)

what we loose

* build time: **locally** with warm caches = 3.80 ± 0.25 times slower build; 16.742s slower on average. Note that the Jib build took 23.7s max locally, which I would still consider a fast Docker build. A sample run on GitHub on this PR took 01:09 min.
* as Jib does not provide a GitHub action and [caches its image layers differently](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#system-properties) (without Docker) we cannot use the [Docker action cache support](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#cache-backend-api). We would need to cache using the [GitHub action cache](https://github.com/actions/cache/blob/main/examples.md#examples) explicitly. The Jenkins build might also need to be changed to leverage Jib caching.

## DHIS2 startup time

I deployed [dhis2/core:2.38.1.1-tomcat-9.0-jdk11-openjdk-slim](https://hub.docker.com/layers/core/dhis2/core/2.38.1.1-tomcat-9.0-jdk11-openjdk-slim/images/sha256-d678ca68476b90a0ee360c4b75bdc6979daabf3e997d0e89d6ca741105d18c6a?context=explore) and [core-dev/jib-2.39-SNAPSHOT](https://hub.docker.com/layers/core-dev/dhis2/core-dev/jib-2.39-SNAPSHOT/images/sha256-17215ab797ad94f7c80441b1f005dc2a1c28172df9afc20aced81301a0b2df01?context=explore) 5 times using the instance manager. Then got the startup time from the tomcat log like `org.apache.catalina.startup.Catalina.start Server startup in [61209] milliseconds`. DB was [2.38.1](https://databases.dhis2.org/sierra-leone/2.38.1/dhis2-db-sierra-leone.sql.gz) and no migrations had to be run.

| | dhis2/core:2.38.1.1-tomcat-9.0-jdk11-openjdk-slim | core-dev/jib-2.39-SNAPSHOT |
| ----------- | ----------- | ----------- |
| max (seconds) | 63.166 | 53.977 |
| avg (seconds) | 61.3758 | 53.2078 |
| stdev (seconds) | 1.105682233 | 0.5268924938 |

So at least in the current configuration (core version, DB, instance manager setup (nodes, ...)) we save 8.168s on average or 9.189s using the max startup times.

## Docker image build time

### Method

The `Build core image` step in our GitHub workflow is building `dhis.war` and the Docker image. The existing Docker image build inside this step does not output any timings. Comparing a few runs of the current build and the Jib build is obviously far from scientific and prone to bias.

I therefore run benchmarks locally using https://github.com/sharkdp/hyperfine which you can rerun for yourself 🧑‍🔬 

I built images locally with [Docker BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).

Build `dhis.war`

```sh
mvn clean install -f dhis-2/pom.xml -pl -dhis-web-embedded-jetty
mvn clean install -f dhis-2/dhis-web/pom.xml
```

Then run hyperfine

#### Using warm caches

```sh
hyperfine --export-markdown docker-build-benchmark.md \
  --warmup 3 \
  'mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild' \
  'dhis-2/build-dev.sh'
```

#### Using cold caches

I am unsure if a scenario with cold caches will apply and if so how often. I added it for completeness.

Added `--no-cache` https://docs.docker.com/engine/reference/commandline/build to the `dhis-2/build-dev.sh` docker build command. Let hyperfine remove the jib cache for the application layers before running the jib build. Both approaches still leverage their caches for the base image.

```sh
hyperfine \
  --prepare 'rm -rf dhis-2/dhis-web/dhis-web-portal/target/jib-*' \
  'mvn --batch-mode --no-transfer-progress -DskipTests -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild' \
  'dhis-2/build-dev.sh'
```

### Results

#### Using warm caches

Benchmark 1: mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
  Time (mean ± σ):     22.726 s ±  0.515 s    [User: 44.002 s, System: 3.465 s]
  Range (min … max):   21.991 s … 23.700 s    10 runs

Benchmark 2: dhis-2/build-dev.sh
  Time (mean ± σ):      5.984 s ±  0.364 s    [User: 4.284 s, System: 0.863 s]
  Range (min … max):    5.626 s …  6.713 s    10 runs

Summary
  'dhis-2/build-dev.sh' ran
    3.80 ± 0.25 times faster than 'mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild'

#### Using cold caches

Benchmark 1: mvn --batch-mode --no-transfer-progress -DskipTests -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
  Time (mean ± σ):     22.039 s ±  0.190 s    [User: 42.973 s, System: 3.326 s]
  Range (min … max):   21.714 s … 22.320 s    10 runs

Benchmark 2: dhis-2/build-dev.sh
  Time (mean ± σ):     17.556 s ±  0.937 s    [User: 4.005 s, System: 0.832 s]
  Range (min … max):   16.401 s … 19.156 s    10 runs

Summary
  'dhis-2/build-dev.sh' ran
    1.26 ± 0.07 times faster than 'mvn --batch-mode --no-transfer-progress -DskipTests -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild'

## Docker image size

### Method

Compared image sizes using [dive](https://github.com/wagoodman/dive).

You can get it using `docker pull wagoodman/dive`.

Pulled and analyzed the existing DHIS2 image of 2.38.1. I don't know if we publish one for 2.39 as well. The Jib image is built using 2.39.

```sh
docker run --rm -it \
    -v /var/run/docker.sock:/var/run/docker.sock \
    wagoodman/dive:latest dhis2/core:2.38.1-tomcat-9.0-jdk11-openjdk-slim
```

```sh
docker run --rm -it \
    -v /var/run/docker.sock:/var/run/docker.sock \
    wagoodman/dive:latest dhis2/core-dev:jib-2.39-SNAPSHOT
```

### Results

The [DHIS2 war itself has ~300MB](https://dhis2.org/downloads/). Locally on master it was 280MB for me. Both images use the same base image `tomcat:9.0-jdk11-openjdk-slim`. This explains why there is not much difference in terms of total image size.

Image name: dhis2/core:2.38.1-tomcat-9.0-jdk11-openjdk-slim
Total Image size: 1.1 GB
Potential wasted space: 8.1 MB
Image efficiency score: 99 %

Image name: dhis2/core-dev:jib-2.39-SNAPSHOT
Total Image size: 1.0 GB
Potential wasted space: 5.9 MB
Image efficiency score: 99 %

Dive allows us to see how [Jib layers the image](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-does-the-war-command-work). The first layers are the base image and should thus be the same with the previous Docker images. Jib then creates a layer for the dependencies as is common best practice in Docker images.

![image](https://user-images.githubusercontent.com/4661144/179927973-136ae0be-89df-4e3d-8435-9af99de8082a.png)

It then creates a layer for the [snapshots dependencies, resources and other files](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-does-the-war-command-work). Note that it pre-explodes the war file, which is why we get faster startup times 😄 

![image](https://user-images.githubusercontent.com/4661144/179927761-563bac04-abb7-460c-bcd3-76313f4aa512.png)

See in comparison the [COPY ./artifacts/dhis.war /usr/local/tomcat/webapps/ROOT.war
](https://github.com/dhis2/dhis2-core/blob/655a95b8838f191714212c88710c2de44e3ff902/docker/tomcat-debian/Dockerfile#L32) in the previous image

![image](https://user-images.githubusercontent.com/4661144/179929060-ac4d3a70-3e60-404a-970c-3ae9e156fbf4.png)

So Jibs layering allows us to reuse the dependency or resource layer if these were not changed.

## Running as non-root

Run DHIS2

```sh
docker compose up
```

The container has its own process space. Tomcat is running as PID 1

```sh
docker compose exec web cat /proc/1/cmdline
/usr/local/openjdk-11/bin/java-Djava.util.logging.config.file=/usr/local/tomcat/conf/logging.properties-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager-Djdk.tls.ephemeralDHKeySize=2048-Djava.protocol.handler.pkgs=org.apache.catalina.webresources-Dorg.apache.catalina.security.SecurityListener.UMASK=0027-Dignore.endorsed.dirs=-classpath/usr/local/tomcat/bin/bootstrap.jar:/usr/local/tomcat/bin/tomcat-juli.jar-Dcatalina.base=/usr/local/tomcat-Dcatalina.home=/usr/local/tomcat-Djava.io.tmpdir=/usr/local/tomcat/temporg.apache.catalina.startup.Bootstrapstart
```

https://tomcat.apache.org/tomcat-9.0-doc/class-loader-howto.html

Owned by user uid=65534(nobody) gid=65534(nogroup) groups=65534(nogroup)

```sh
docker compose exec web ls -l /proc/1/
total 0
-r--r--r--   1 nobody nogroup 0 Jul 19 09:52 arch_status
dr-xr-xr-x   2 nobody nogroup 0 Jul 19 09:49 attr
-rw-r--r--   1 nobody nogroup 0 Jul 19 09:52 autogroup
-r--------   1 nobody nogroup 0 Jul 19 09:52 auxv
-r--r--r--   1 nobody nogroup 0 Jul 19 09:49 cgroup
...
```

## Understanding Jib

If you want to dig deeper in what Jib does or how a particular aspect works refer to

https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#frequently-asked-questions-faq

Adding `-X -Djib.serialize=true` to the Jib build will output useful details like layer ids you can then also find in the different cache directories like `dhis-2/dhis-web/dhis-web-portal/target/jib-cache/layers`

```sh
mvn -X -Djib.serialize=true --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
```

## What's next

If we agree on building with Jib we should

* use Jib to build the Docker images we currently publish to Dockerhub
* remove any directories/files that are not needed anymore like `docker`
* decide on what platforms we want to support and adapt our pipeline to publish those as well