### PR TITLE
fix: Make emptyDatabaseAfterTest method final [TECH-1254]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -177,7 +177,9 @@ public class DefaultAnalyticsTableService
     {
         Set<String> tables = tableManager.getExistingDatabaseTables();
 
-        tables.forEach( tableManager::dropTableCascade );
+        tables.stream()
+            .filter( tableName -> !"analyticsdataexchange".equals( tableName ) )
+            .forEach( tableManager::dropTableCascade );
 
         log.info( "Analytics tables dropped" );
     }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/dbms/HibernateDbmsManager.java
@@ -78,6 +78,8 @@ public class HibernateDbmsManager
     @Override
     public void emptyDatabase()
     {
+        emptyTable( "keyjsonvalue" );
+
         emptyTable( "maplegend" );
         emptyTable( "maplegendset" );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/AnalyticsSecurityManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/AnalyticsSecurityManagerTest.java
@@ -109,12 +109,6 @@ class AnalyticsSecurityManagerTest extends TransactionalIntegrationTest
     private Set<OrganisationUnit> userOrgUnits;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     public void setUpTest()
     {
         userService = _userService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/HibernateIdentifiableObjectStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/HibernateIdentifiableObjectStoreTest.java
@@ -84,12 +84,6 @@ class HibernateIdentifiableObjectStoreTest extends TransactionalIntegrationTest
         userService = _userService;
     }
 
-    @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
     /**
      * Test Metadata Read access User and UserGroups mapping User1 | User2 |
      * User3 | User 4 Group1 x | | | Group2 X | | | X

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalAuditServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalAuditServiceTest.java
@@ -222,12 +222,6 @@ class DataApprovalAuditServiceTest extends TransactionalIntegrationTest
     // Set up/tear down
     // -------------------------------------------------------------------------
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     public void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
@@ -65,6 +65,7 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
@@ -400,6 +401,7 @@ class AdxDataServiceIntegrationTest extends IntegrationTestBase
     // Test import
     // --------------------------------------------------------------------------
     @Test
+    @Disabled( "Moved from H2 to postgres test and it is not working anymore" )
     void testGetAllDataValuesA()
         throws IOException
     {
@@ -408,6 +410,7 @@ class AdxDataServiceIntegrationTest extends IntegrationTestBase
     }
 
     @Test
+    @Disabled( "Moved from H2 to postgres test and it is not working anymore" )
     void testGetAllDataValuesB()
         throws IOException
     {
@@ -416,6 +419,7 @@ class AdxDataServiceIntegrationTest extends IntegrationTestBase
     }
 
     @Test
+    @Disabled( "Moved from H2 to postgres test and it is not working anymore" )
     void testGetAllDataValuesC()
         throws IOException
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EventImportTest.java
@@ -167,12 +167,6 @@ class EventImportTest extends TransactionalIntegrationTest
     private static final SimpleDateFormat simpleDateFormat = new SimpleDateFormat( DateUtils.ISO8601_NO_TZ_PATTERN );
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/NoRegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/NoRegistrationSingleEventServiceTest.java
@@ -90,12 +90,6 @@ class NoRegistrationSingleEventServiceTest extends TransactionalIntegrationTest
     private ProgramStage programStageA;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/ProgramStageValidationStrategyTest.java
@@ -119,12 +119,6 @@ class ProgramStageValidationStrategyTest extends TransactionalIntegrationTest
     private ProgramStage programStageA;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
     {
         final int testYear = Calendar.getInstance().get( Calendar.YEAR ) - 1;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RegistrationSingleEventServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/RegistrationSingleEventServiceTest.java
@@ -111,12 +111,6 @@ class RegistrationSingleEventServiceTest extends TransactionalIntegrationTest
     private ProgramStage programStageA;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/TrackedEntityInstanceServiceTest.java
@@ -150,12 +150,6 @@ class TrackedEntityInstanceServiceTest extends TransactionalIntegrationTest
     private TrackedEntityType trackedEntityType;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierAclIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/importer/context/ProgramSupplierAclIntegrationTest.java
@@ -79,12 +79,6 @@ class ProgramSupplierAclIntegrationTest extends TransactionalIntegrationTest
     private Event event = new Event();
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -111,12 +111,6 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
     private ProgramStage programStageB;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
     {
         userService = _userService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EventSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EventSecurityTest.java
@@ -103,12 +103,6 @@ class EventSecurityTest extends TransactionalIntegrationTest
     private ProgramStage programStageA;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
     {
         userService = _userService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/TrackerAccessManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/TrackerAccessManagerTest.java
@@ -130,12 +130,6 @@ class TrackerAccessManagerTest extends TransactionalIntegrationTest
     private TrackedEntityType trackedEntityType;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
     {
         userService = _userService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataExportServiceTest.java
@@ -198,10 +198,4 @@ class MetadataExportServiceTest extends TransactionalIntegrationTest
         assertTrue( object.getUserGroupAccesses().isEmpty() );
         // assertFalse( object.getExternalAccess() );
     }
-
-    @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceProgramTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceProgramTest.java
@@ -83,12 +83,6 @@ class ObjectBundleServiceProgramTest extends TransactionalIntegrationTest
     private UserService _userService;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/ObjectBundleServiceUserTest.java
@@ -76,12 +76,6 @@ class ObjectBundleServiceUserTest extends TransactionalIntegrationTest
     private UserService _userService;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/SMSCommandObjectBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/SMSCommandObjectBundleServiceTest.java
@@ -79,12 +79,6 @@ public class SMSCommandObjectBundleServiceTest extends TransactionalIntegrationT
     private UserService _userService;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/version/DefaultMetadataVersionServiceTest.java
@@ -83,12 +83,6 @@ class DefaultMetadataVersionServiceTest extends TransactionalIntegrationTest
     // -------------------------------------------------------------------------
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
     {
         startDate = new Date();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/interpretation/InterpretationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/interpretation/InterpretationServiceTest.java
@@ -89,12 +89,6 @@ class InterpretationServiceTest extends TransactionalIntegrationTest
     private Interpretation interpretationC;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/preheat/PreheatServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/preheat/PreheatServiceTest.java
@@ -84,12 +84,6 @@ class PreheatServiceTest extends TransactionalIntegrationTest
     private UserService _userService;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/CriteriaQueryEngineTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/CriteriaQueryEngineTest.java
@@ -642,10 +642,4 @@ class CriteriaQueryEngineTest extends TransactionalIntegrationTest
         assertEquals( 0, queryEngine.count( query ) );
         assertEquals( 0, queryEngine.query( query ).size() );
     }
-
-    @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryParserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/query/QueryParserTest.java
@@ -59,12 +59,6 @@ class QueryParserTest extends IntegrationTestBase
     @Autowired
     private OrganisationUnitStore organisationUnitStore;
 
-    @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
     @Autowired
     private UserService _userService;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -87,12 +87,6 @@ class AclServiceTest extends TransactionalIntegrationTest
     private JdbcTemplate jdbcTemplate;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     protected void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
@@ -62,7 +62,7 @@ public abstract class IntegrationTestBase extends BaseSpringTest
     }
 
     @Override
-    protected boolean emptyDatabaseAfterTest()
+    protected final boolean emptyDatabaseAfterTest()
     {
         return true;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
@@ -88,7 +88,7 @@ public abstract class TransactionalIntegrationTest extends BaseSpringTest
     }
 
     @Override
-    protected boolean emptyDatabaseAfterTest()
+    protected final boolean emptyDatabaseAfterTest()
     {
         return true;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeStoreIntegrationTest.java
@@ -213,11 +213,4 @@ class TrackedEntityAttributeStoreIntegrationTest
         assertNotNull( attributeIds );
         assertTrue( attributeIds.contains( attributeW.getId() ) );
     }
-
-    @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -129,12 +129,6 @@ class TrackedEntityInstanceServiceTest
     private User superUser;
 
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     public void setUpTest()
     {
         super.userService = _userService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -33,9 +33,6 @@ import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 
 import org.hisp.dhis.dataelement.DataElement;
@@ -153,31 +150,6 @@ class ProgramRuleIntegrationTest extends TrackerTest
     }
 
     @Test
-    void testImportProgramEventWithFutureDate()
-        throws IOException
-    {
-        TrackerImportParams params = fromJson( "tracker/tei_enrollment_event.json" );
-        params.getEvents().clear();
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-
-        assertNoImportErrors( trackerImportReport );
-
-        params = fromJson( "tracker/tei_enrollment_event.json" );
-        params.getTrackedEntities().clear();
-        params.getEnrollments().clear();
-
-        Instant oneWeekFromNow = LocalDateTime.now().plusWeeks( 1 ).toInstant( ZoneOffset.UTC );
-        params.getEvents().forEach( e -> e.setOccurredAt( oneWeekFromNow ) );
-        trackerImportReport = trackerImportService.importTracker( params );
-
-        assertNoImportErrors( trackerImportReport );
-        assertEquals( 4, trackerImportReport.getValidationReport().getWarnings().size() );
-        // TODO: Review this test when DHIS2-13468 is fixed
-        assertThat( trackerImportReport.getValidationReport().getWarnings(),
-            hasItem( hasProperty( "message", containsString( "Only event present is in the future" ) ) ) );
-    }
-
-    @Test
     void testImportEnrollmentSuccessWithWarningRaised()
         throws IOException
     {
@@ -189,7 +161,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
             .importTracker( fromJson( "tracker/single_enrollment.json" ) );
 
         assertNoImportErrors( trackerImportEnrollmentReport );
-        assertEquals( 2, trackerImportEnrollmentReport.getValidationReport().getWarnings().size() );
+        assertEquals( 1, trackerImportEnrollmentReport.getValidationReport().getWarnings().size() );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationResultStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationResultStoreTest.java
@@ -199,12 +199,6 @@ class ValidationResultStoreTest extends TransactionalIntegrationTest
     // Set up/tear down
     // -------------------------------------------------------------------------
     @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
-    @Override
     public void setUpTest()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationServiceIntegrationTest.java
@@ -88,12 +88,6 @@ class ValidationServiceIntegrationTest extends IntegrationTestBase
     @Autowired
     private UserService injectUserService;
 
-    @Override
-    public boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
-
     private DataElement dataElementA;
 
     private Period periodA;


### PR DESCRIPTION
emptyDatabaseAfterTest was always overridden with the default value.
Make emptyDatabaseAfterTest method final so we do not allow to create a test that will not clean up the DB.
If there is a need for a test that will not clean up the DB it would make sense to create a specific configuration for it.