### PR TITLE
fix: Backwards compatible clause in boundaries [DHIS2-12309]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -122,7 +122,7 @@ public class JdbcEventAnalyticsTableManager
         new AnalyticsTableColumn( quote( "ao" ), CHARACTER_11, NOT_NULL, "ao.uid" ),
         new AnalyticsTableColumn( quote( "enrollmentdate" ), TIMESTAMP, "pi.enrollmentdate" ),
         new AnalyticsTableColumn( quote( "incidentdate" ), TIMESTAMP, "pi.incidentdate" ),
-        new AnalyticsTableColumn( quote( "executiondate" ), TIMESTAMP, getDateLinkedToStatus() ),
+        new AnalyticsTableColumn( quote( "executiondate" ), TIMESTAMP, "psi.executiondate" ),
         new AnalyticsTableColumn( quote( "duedate" ), TIMESTAMP, "psi.duedate" ),
         new AnalyticsTableColumn( quote( "completeddate" ), TIMESTAMP, "psi.completeddate" ),
         new AnalyticsTableColumn( quote( "created" ), TIMESTAMP, "psi.created" ),

--- a/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/statementbuilder/AbstractStatementBuilder.java
+++ b/dhis-2/dhis-support/dhis-support-jdbc/src/main/java/org/hisp/dhis/jdbc/statementbuilder/AbstractStatementBuilder.java
@@ -466,6 +466,11 @@ public abstract class AbstractStatementBuilder
     private String getBoundaryColumn( final AnalyticsPeriodBoundary boundary, final ProgramIndicator programIndicator,
         final String timeField, final Date reportingStartDate, final Date reportingEndDate )
     {
+        if ( boundary == null )
+        {
+            return DB_EVENT_DATE;
+        }
+
         return boundary.isEventDateBoundary()
             ? Optional.ofNullable( timeField ).orElse( DB_EVENT_DATE )
             : boundary.isEnrollmentDateBoundary() ? DB_ENROLLMENT_DATE


### PR DESCRIPTION
As part of `SCHEDULE` events support we need to make sure the current code is backwards compatible, as we never used statuses and assumed only ACTIVE/COMPLETED events. Most of the logic is based on `executiondate`.

This code fixes a missing clause to make it backwards compatible with the boundaries feature.

Basically, we are now using the `duedate` column for SCHEDULE events and `executiondate` for the rest (backwards compatible).