### PR TITLE
fix: Do not delete analyticsdataexchange table

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -177,7 +177,12 @@ public class DefaultAnalyticsTableService
     {
         Set<String> tables = tableManager.getExistingDatabaseTables();
 
-        tables.forEach( tableManager::dropTableCascade );
+        // The filter is a quick fix to not drop `analyticsdataexchange`
+        // that is not part of the analytics table.
+        // It was getting drop only because of the name.
+        tables.stream()
+            .filter( tableName -> !"analyticsdataexchange".equals( tableName ) )
+            .forEach( tableManager::dropTableCascade );
 
         log.info( "Analytics tables dropped" );
     }


### PR DESCRIPTION
This PR https://github.com/dhis2/dhis2-core/pull/10775 created `analyticsdataexchange` table.
The naming of the table conflicts with the naming of analytics tables that are created at some point and can also be dropped.
Depending on the order of the tests, `analyticsdataexchange` is dropped and then other tests need it to run.

In this PR I just prevent the deletion of this specific table, maybe we will need to think of something more organic to prevent this from happening again as this kind of bugs in the tests are quite difficult to find.