### PR TITLE
perf: use select 1 limit 1 instead of select count(*) to check existence in deletion handlers [DHIS2-13506]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDimensionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDimensionDeletionHandler.java
@@ -50,13 +50,13 @@ public class CategoryDimensionDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOption( CategoryOption categoryOption )
     {
-        String sql = "select count(*) from categorydimension_items where categoryoptionid = :id";
+        String sql = "select 1 from categorydimension_items where categoryoptionid = :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", categoryOption.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategory( Category category )
     {
-        String sql = "select count(*) from categorydimension where categoryid = :id";
+        String sql = "select 1 from categorydimension where categoryid = :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", category.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionComboDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionComboDeletionHandler.java
@@ -62,23 +62,23 @@ public class CategoryOptionComboDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOption( CategoryOption categoryOption )
     {
-        final String dvSql = "select count(*) from datavalue dv " +
+        final String dvSql = "select 1 from datavalue dv " +
             "where dv.categoryoptioncomboid in ( " +
             "select cc.categoryoptioncomboid from categoryoptioncombos_categoryoptions cc " +
             "where cc.categoryoptionid = :coId ) " +
             "or dv.attributeoptioncomboid in ( " +
             "select cc.categoryoptioncomboid from categoryoptioncombos_categoryoptions cc " +
-            "where cc.categoryoptionid = :coId );";
+            "where cc.categoryoptionid = :coId ) limit 1;";
 
         if ( exists( dvSql, Map.of( "coId", categoryOption.getId() ) ) )
         {
             return VETO;
         }
 
-        final String crSql = "select count(*) from completedatasetregistration cdr " +
+        final String crSql = "select 1 from completedatasetregistration cdr " +
             "where cdr.attributeoptioncomboid in ( " +
             "select cc.categoryoptioncomboid from categoryoptioncombos_categoryoptions cc " +
-            "where cc.categoryoptionid = :coId );";
+            "where cc.categoryoptionid = :coId ) limit 1;";
 
         if ( exists( crSql, Map.of( "coId", categoryOption.getId() ) ) )
         {
@@ -90,23 +90,23 @@ public class CategoryOptionComboDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteCategoryCombo( CategoryCombo categoryCombo )
     {
-        final String dvSql = "select count(*) from datavalue dv " +
+        final String dvSql = "select 1 from datavalue dv " +
             "where dv.categoryoptioncomboid in ( " +
             "select co.categoryoptioncomboid from categorycombos_optioncombos co " +
             "where co.categorycomboid= :coId ) " +
             "or dv.attributeoptioncomboid in ( " +
             "select co.categoryoptioncomboid from categorycombos_optioncombos co " +
-            "where co.categorycomboid= :coId );";
+            "where co.categorycomboid= :coId ) limit 1;";
 
         if ( exists( dvSql, Map.of( "coId", categoryCombo.getId() ) ) )
         {
             return VETO;
         }
 
-        final String crSql = "select count(*) from completedatasetregistration cdr " +
+        final String crSql = "select 1 from completedatasetregistration cdr " +
             "where cdr.attributeoptioncomboid in ( " +
             "select co.categoryoptioncomboid from categorycombos_optioncombos co " +
-            "where co.categorycomboid= :coId );";
+            "where co.categorycomboid= :coId ) limit 1;";
 
         if ( exists( crSql, Map.of( "coId", categoryCombo.getId() ) ) )
         {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalDeletionHandler.java
@@ -52,19 +52,19 @@ public class DataApprovalDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteDataApprovalLevel( DataApprovalLevel dataApprovalLevel )
     {
-        String sql = "select count(*) from dataapproval where dataapprovallevelid=:id";
+        String sql = "select 1 from dataapproval where dataapprovallevelid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", dataApprovalLevel.getId() ) );
     }
 
     private DeletionVeto allowDeleteDataApprovalWorkflow( DataApprovalWorkflow workflow )
     {
-        String sql = "select count(*) from dataapproval where workflowid=:id";
+        String sql = "select 1 from dataapproval where workflowid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", workflow.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "select count(*) from dataapproval where attributeoptioncomboid=:id";
+        String sql = "select 1 from dataapproval where attributeoptioncomboid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevelDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevelDeletionHandler.java
@@ -51,13 +51,13 @@ public class DataApprovalLevelDeletionHandler extends JdbcDeletionHandler
 
     public DeletionVeto allowDeleteCategoryOptionGroupSet( CategoryOptionGroupSet categoryOptionGroupSet )
     {
-        String sql = "select count(*) from dataapprovallevel where categoryoptiongroupsetid=:id";
+        String sql = "select 1 from dataapprovallevel where categoryoptiongroupsetid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", categoryOptionGroupSet.getId() ) );
     }
 
     public DeletionVeto allowDeleteDataApprovalWorkflow( DataApprovalWorkflow workflow )
     {
-        String sql = "select count(*) from dataapprovalworkflowlevels where workflowid=:id";
+        String sql = "select 1 from dataapprovalworkflowlevels where workflowid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", workflow.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementDeletionHandler.java
@@ -124,7 +124,7 @@ public class DataElementDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteOptionSet( OptionSet optionSet )
     {
-        String sql = "select count(*) from dataelement where optionsetid = :id";
+        String sql = "select 1 from dataelement where optionsetid = :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", optionSet.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementOperandDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementOperandDeletionHandler.java
@@ -53,7 +53,7 @@ public class DataElementOperandDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "select count(*) from dataelementoperand where categoryoptioncomboid=:id";
+        String sql = "select 1 from dataelementoperand where categoryoptioncomboid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/CompleteDataSetRegistrationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/CompleteDataSetRegistrationDeletionHandler.java
@@ -65,7 +65,7 @@ public class CompleteDataSetRegistrationDeletionHandler extends JdbcDeletionHand
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        return vetoIfExists( VETO, "select count(*) from completedatasetregistration where periodid= :id",
+        return vetoIfExists( VETO, "select 1 from completedatasetregistration where periodid= :id limit 1",
             Map.of( "id", period.getId() ) );
     }
 
@@ -77,7 +77,7 @@ public class CompleteDataSetRegistrationDeletionHandler extends JdbcDeletionHand
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
         return vetoIfExists( VETO,
-            "select count(*) from completedatasetregistration where attributeoptioncomboid= :id",
+            "select 1 from completedatasetregistration where attributeoptioncomboid= :id limit 1",
             Map.of( "id", optionCombo.getId() ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataInputPeriodDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataInputPeriodDeletionHandler.java
@@ -50,7 +50,7 @@ public class DataInputPeriodDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        String sql = "select count(*) from datainputperiod where periodid= :id";
+        String sql = "select 1 from datainputperiod where periodid= :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", period.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueAuditDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueAuditDeletionHandler.java
@@ -53,25 +53,25 @@ public class DataValueAuditDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        String sql = "select count(*) from datavalueaudit where dataelementid=:id";
+        String sql = "select 1 from datavalueaudit where dataelementid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", dataElement.getId() ) );
     }
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        String sql = "select count(*) from datavalueaudit where periodid=:id";
+        String sql = "select 1 from datavalueaudit where periodid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", period.getId() ) );
     }
 
     private DeletionVeto allowDeleteOrganisationUnit( OrganisationUnit unit )
     {
-        String sql = "select count(*) from datavalueaudit where organisationunitid=:id";
+        String sql = "select 1 from datavalueaudit where organisationunitid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", unit.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "select count(*) from datavalueaudit where categoryoptioncomboid=:id or attributeoptioncomboid=:id";
+        String sql = "select 1 from datavalueaudit where categoryoptioncomboid=:id or attributeoptioncomboid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DataValueDeletionHandler.java
@@ -56,25 +56,26 @@ public class DataValueDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        return vetoIfExists( VETO, "select count(*) from datavalue where dataelementid=:id",
+        return vetoIfExists( VETO, "select 1 from datavalue where dataelementid=:id limit 1",
             Map.of( "id", dataElement.getId() ) );
     }
 
     private DeletionVeto allowDeletePeriod( Period period )
     {
-        return vetoIfExists( VETO, "select count(*) from datavalue where periodid=:id",
+        return vetoIfExists( VETO, "select 1 from datavalue where periodid=:id limit 1",
             Map.of( "id", period.getId() ) );
     }
 
     private DeletionVeto allowDeleteOrganisationUnit( OrganisationUnit unit )
     {
-        return vetoIfExists( VETO, "select count(*) from datavalue where sourceid=:id", Map.of( "id", unit.getId() ) );
+        return vetoIfExists( VETO, "select 1 from datavalue where sourceid=:id limit 1",
+            Map.of( "id", unit.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
         return vetoIfExists( VETO,
-            "select count(*) from datavalue where categoryoptioncomboid=:id or attributeoptioncomboid=:id",
+            "select 1 from datavalue where categoryoptioncomboid=:id or attributeoptioncomboid=:id limit 1",
             Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionItemDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dimension/DataDimensionItemDeletionHandler.java
@@ -51,7 +51,7 @@ public class DataDimensionItemDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        String sql = "select count(*) from datadimensionitem where dataelementoperand_categoryoptioncomboid=:id";
+        String sql = "select 1 from datadimensionitem where dataelementoperand_categoryoptioncomboid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", optionCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ExternalFileResourceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/ExternalFileResourceDeletionHandler.java
@@ -56,7 +56,7 @@ public class ExternalFileResourceDeletionHandler extends JdbcDeletionHandler
         {
             return ACCEPT;
         }
-        String sql = "select count(*) from externalfileresource where fileresourceid=:id";
+        String sql = "select 1 from externalfileresource where fileresourceid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/MessageAttachmentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/MessageAttachmentDeletionHandler.java
@@ -53,7 +53,7 @@ public class MessageAttachmentDeletionHandler extends JdbcDeletionHandler
         {
             return ACCEPT;
         }
-        String sql = "select count(*) from messageattachments where fileresourceid=:id";
+        String sql = "select 1 from messageattachments where fileresourceid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorDeletionHandler.java
@@ -101,15 +101,15 @@ public class PredictorDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteCategoryOptionCombo( CategoryOptionCombo optionCombo )
     {
-        return vetoIfExists( VETO, "select count(*) from predictor where generatoroutputcombo=:id",
+        return vetoIfExists( VETO, "select 1 from predictor where generatoroutputcombo=:id limit 1",
             Map.of( "id", optionCombo.getId() ) );
     }
 
     private DeletionVeto allowDeleteCategoryCombo( CategoryCombo categoryCombo )
     {
-        return vetoIfExists( VETO, "select count(*) from predictor p where exists ("
+        return vetoIfExists( VETO, "select 1 from predictor p where exists ("
             + "select 1 from categorycombos_optioncombos co"
-            + " where co.categorycomboid=:id and co.categoryoptioncomboid=p.generatoroutputcombo"
+            + " where co.categorycomboid=:id and co.categoryoptioncomboid=p.generatoroutputcombo limit 1"
             + ")", Map.of( "id", categoryCombo.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
@@ -73,7 +73,7 @@ public class ProgramInstanceDeletionHandler extends JdbcDeletionHandler
         {
             return ACCEPT;
         }
-        String sql = "select count(*) from programinstance where programid = :id";
+        String sql = "select 1 from programinstance where programid = :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", program.getId() ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDeletionHandler.java
@@ -84,7 +84,7 @@ public class ProgramStageDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        String sql = "select count(*) from programstagedataelement where dataelementid=:id";
+        String sql = "select 1 from programstagedataelement where dataelementid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", dataElement.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
@@ -59,7 +59,7 @@ public class ProgramStageInstanceDeletionHandler extends JdbcDeletionHandler
     private DeletionVeto allowDeleteProgramStage( ProgramStage programStage )
     {
         return vetoIfExists( VETO,
-            "select count(*) from programstageinstance where programstageid = :id",
+            "select 1 from programstageinstance where programstageid = :id limit 1",
             Map.of( "id", programStage.getId() ) );
     }
 
@@ -74,13 +74,13 @@ public class ProgramStageInstanceDeletionHandler extends JdbcDeletionHandler
     private DeletionVeto allowDeleteProgram( Program program )
     {
         return vetoIfExists( VETO,
-            "select count(*) from programstageinstance psi join programinstance pi on pi.programinstanceid=psi.programinstanceid where pi.programid = :id",
+            "select 1 from programstageinstance psi join programinstance pi on pi.programinstanceid=psi.programinstanceid where pi.programid = :id limit 1",
             Map.of( "id", program.getId() ) );
     }
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        return vetoIfExists( VETO, "select count(*) from programstageinstance where eventdatavalues ?? :uid",
+        return vetoIfExists( VETO, "select 1 from programstageinstance where eventdatavalues ?? :uid limit 1",
             Map.of( "uid", dataElement.getUid() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/code/SMSCodesDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/code/SMSCodesDeletionHandler.java
@@ -48,7 +48,7 @@ public class SMSCodesDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteDataElement( DataElement dataElement )
     {
-        String sql = "select count(*) from smscodes where dataelementid=:id";
+        String sql = "select 1 from smscodes where dataelementid=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", dataElement.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceDeletionHandler.java
@@ -51,13 +51,13 @@ public class TrackedEntityInstanceDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteOrganisationUnit( OrganisationUnit unit )
     {
-        String sql = "select count(*) from trackedentityinstance where organisationunitid = :id";
+        String sql = "select 1 from trackedentityinstance where organisationunitid = :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", unit.getId() ) );
     }
 
     private DeletionVeto allowDeleteTrackedEntityType( TrackedEntityType trackedEntityType )
     {
-        String sql = "select count(*) from trackedentityinstance where trackedentitytypeid = :id";
+        String sql = "select 1 from trackedentityinstance where trackedentitytypeid = :id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", trackedEntityType.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserDeletionHandler.java
@@ -105,7 +105,7 @@ public class UserDeletionHandler extends JdbcDeletionHandler
 
     private DeletionVeto allowDeleteFileResource( FileResource fileResource )
     {
-        String sql = "select count(*) from userinfo where avatar=:id";
+        String sql = "select 1 from userinfo where avatar=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/document/DocumentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/document/DocumentDeletionHandler.java
@@ -70,7 +70,7 @@ public class DocumentDeletionHandler extends JdbcDeletionHandler
         {
             return ACCEPT;
         }
-        String sql = "select count(*) from document where fileresource=:id";
+        String sql = "select 1 from document where fileresource=:id limit 1";
         return vetoIfExists( VETO, sql, Map.of( "id", fileResource.getId() ) );
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/JdbcDeletionHandler.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/deletion/JdbcDeletionHandler.java
@@ -46,8 +46,9 @@ public abstract class JdbcDeletionHandler extends DeletionHandler
 
     protected final int count( String sql, Map<String, Object> parameters )
     {
-        Integer count = npTemplate.queryForObject( sql, new MapSqlParameterSource( parameters ), Integer.class );
-        return count == null ? 0 : count;
+        // OBS! Need to use queryForList to allow no result rows
+        List<Integer> count = npTemplate.queryForList( sql, new MapSqlParameterSource( parameters ), Integer.class );
+        return count.isEmpty() ? 0 : count.get( 0 );
     }
 
     protected final boolean exists( String sql, Map<String, Object> parameters )


### PR DESCRIPTION
### Summary
Essentially replaces
```sql
select count(*) ...
```
with
```sql
select 1 ... limit 1
```
Gain should be most notable the larger tables get.

### Manual Testing
This is hard to test so **reviewers should pay extra attention** to the changes.