### PR TITLE
fix: Gist API show PeriodType as name

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -455,6 +455,10 @@ final class GistBuilder
         }
         if ( isPersistentReferenceField( property ) )
         {
+            if ( PeriodType.class.isAssignableFrom( property.getKlass() ) )
+            {
+                addTransformer( row -> row[index] = ((PeriodType) row[index]).getName() );
+            }
             return createReferenceFieldHQL( index, field );
         }
         if ( isPersistentCollectionField( property ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistBuilder.java
@@ -457,7 +457,7 @@ final class GistBuilder
         {
             if ( PeriodType.class.isAssignableFrom( property.getKlass() ) )
             {
-                addTransformer( row -> row[index] = ((PeriodType) row[index]).getName() );
+                addTransformer( row -> row[index] = row[index] == null ? null : ((PeriodType) row[index]).getName() );
             }
             return createReferenceFieldHQL( index, field );
         }


### PR DESCRIPTION
### Summary
While testing I noticed that `PeriodType` object would render as empty objects in the Gist API. This is because none of their properties is annotated with `@JsonProperty`. I checked the metadata API which usually shows the period type as name so I added a transformer to gist API that does that transformation automatically.

### Example
`/api/dataSets/gist?fields=id,name,periodType`
Gives something like:
```json
{
  "pager":{
    "page":1,
    "pageSize":50
  },
  "dataSets":[
    {
      "id":"QD9rA2Jh2ei",
      "name":"test A",
      "periodType":"Monthly"
    },
    {
      "id":"XCFR1EgHzB2",
      "name":"test B",
      "periodType":"Monthly"
    }
  ]
}
```