### PR TITLE
feat: Add headers param support in CPL [DHIS2-13511]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/common/CommonQueryRequest.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/common/CommonQueryRequest.java
@@ -27,9 +27,11 @@
  */
 package org.hisp.dhis.analytics.common;
 
-import java.util.Collection;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import lombok.Builder;
@@ -39,24 +41,43 @@ import lombok.Setter;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 
+/**
+ * This object wraps the common params/request attributes used across analytics
+ * requests.
+ *
+ * Some objects are specified as Set/LinkedHashSet as they might require
+ * enforcing ordering and avoid duplications.
+ */
 @Getter
 @Setter
 @Builder( toBuilder = true )
 public class CommonQueryRequest
 {
+
     @Builder.Default
-    private Collection<String> program = new HashSet<>();
+    private Set<String> program = new LinkedHashSet<>();
 
     private String userOrgUnit;
 
+    /**
+     * The dimensions to be returned/filtered at.
+     */
     @Builder.Default
-    private Set<String> dimension = new HashSet<>();
+    private Set<String> dimension = new LinkedHashSet<>();
 
+    /**
+     * The filters to be applied at querying time.
+     */
     @Builder.Default
     private Set<String> filter = new HashSet<>();
 
+    /**
+     * When set, the headers in the response object will match the specified
+     * headers in the respective order. As the headers should not be duplicated,
+     * this is represented as Set.
+     */
     @Builder.Default
-    private Set<String> headers = new HashSet<>();
+    private Set<String> headers = new LinkedHashSet<>();
 
     private OrganisationUnitSelectionMode ouMode;
 
@@ -66,16 +87,37 @@ public class CommonQueryRequest
     @Builder.Default
     private Set<String> desc = new HashSet<>();
 
-    private boolean skipMeta;
-
-    private boolean skipData;
-
     @Builder.Default
     private IdScheme dataIdScheme = IdScheme.UID;
 
+    /**
+     * When set to true, this will count the total of pages related to the
+     * current query. If enabled this might cause performance issues depending
+     * on the result size.
+     */
     private boolean totalPages;
 
     private Date relativePeriodDate;
+
+    /**
+     * Indicates if the metadata element should be omitted from the response.
+     */
+    private boolean skipMeta;
+
+    /**
+     * Indicates if the data should be omitted from the response.
+     */
+    private boolean skipData;
+
+    /**
+     * Indicates if the headers should be omitted from the response.
+     */
+    private boolean skipHeaders;
+
+    /**
+     * Indicates if full precision should be provided for numeric values.
+     */
+    private boolean skipRounding;
 
     /**
      * Custom date filters
@@ -90,4 +132,8 @@ public class CommonQueryRequest
 
     private String lastUpdated;
 
+    public boolean hasHeaders()
+    {
+        return isNotEmpty( getHeaders() );
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenAttribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiTokenAttribute.java
@@ -27,9 +27,8 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
-
 import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.common.EmbeddedObject;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -45,13 +44,18 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
     @JsonSubTypes.Type( value = RefererAllowedList.class, name = "RefererAllowedList" ),
     @JsonSubTypes.Type( value = MethodAllowedList.class, name = "MethodAllowedList" ) } )
 @JacksonXmlRootElement( localName = "apiTokenAttribute", namespace = DxfNamespaces.DXF_2_0 )
-public abstract class ApiTokenAttribute implements Serializable
+public abstract class ApiTokenAttribute implements EmbeddedObject
 {
-    @JsonProperty
     protected final String type;
 
     protected ApiTokenAttribute( String type )
     {
         this.type = type;
+    }
+
+    @JsonProperty
+    public String getType()
+    {
+        return type;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/IpAllowedList.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/IpAllowedList.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -44,7 +43,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class IpAllowedList extends ApiTokenAttribute implements Serializable
+public class IpAllowedList extends ApiTokenAttribute
 {
     private Set<String> allowedIps = new HashSet<>();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/MethodAllowedList.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/MethodAllowedList.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -45,7 +44,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class MethodAllowedList extends ApiTokenAttribute implements Serializable
+public class MethodAllowedList extends ApiTokenAttribute
 {
     private Set<String> allowedMethods = new HashSet<>();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/RefererAllowedList.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/RefererAllowedList.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.security.apikey;
 
-import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -45,7 +44,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class RefererAllowedList extends ApiTokenAttribute implements Serializable
+public class RefererAllowedList extends ApiTokenAttribute
 {
     private Set<String> allowedReferrers = new HashSet<>();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CommonQueryRequestMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CommonQueryRequestMapper.java
@@ -113,7 +113,7 @@ public class CommonQueryRequestMapper
 
             List<String> missingProgramUids = Optional.of( queryRequest )
                 .map( CommonQueryRequest::getProgram )
-                .orElse( Collections.emptyList() ).stream()
+                .orElse( Collections.emptySet() ).stream()
                 .filter( uidFromRequest -> !foundProgramUids.contains( uidFromRequest ) )
                 .collect( toList() );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CommonQueryRequestProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/CommonQueryRequestProcessor.java
@@ -60,5 +60,4 @@ public class CommonQueryRequestProcessor implements Processor<CommonQueryRequest
                         commonQueryRequest ) ) )
             .build();
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/Processor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/Processor.java
@@ -35,5 +35,6 @@ package org.hisp.dhis.analytics.common;
  */
 public interface Processor<T>
 {
+
     T process( T object );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/Validator.java
@@ -28,11 +28,12 @@
 package org.hisp.dhis.analytics.common;
 
 /**
- * Simple interface that enables validation capabilities to the implementer.
+ * Simple interface that enables validation capabilities.
  *
  * @param <T>
  */
 public interface Validator<T>
 {
+
     void validate( T object );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -136,7 +136,9 @@ public class EventQueryParams
     private List<QueryItem> itemFilters = new ArrayList<>();
 
     /**
-     * TODO Change to List? TODO Add Javadoc
+     * When set, the headers in the response object will match the specified
+     * headers in the respective order. As the headers should not be duplicated,
+     * this is represented as Set.
      */
     protected Set<String> headers = new LinkedHashSet<>();
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsDimensionsService.java
@@ -53,7 +53,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-class DefaultEnrollmentAnalyticsDimensionsService implements EnrollmentAnalyticsDimensionsService
+public class DefaultEnrollmentAnalyticsDimensionsService implements EnrollmentAnalyticsDimensionsService
 {
     @NonNull
     private final ProgramService programService;
@@ -114,5 +114,4 @@ class DefaultEnrollmentAnalyticsDimensionsService implements EnrollmentAnalytics
     {
         return !trackedEntityAttribute.isConfidentialBool();
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DimensionsServiceCommon.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DimensionsServiceCommon.java
@@ -85,7 +85,7 @@ public class DimensionsServiceCommon
         DataElement.class, pd -> ((DataElement) pd.getItem()).getValueType(),
         ProgramStageDataElement.class, pd -> ((ProgramStageDataElement) pd.getItem()).getDataElement().getValueType() );
 
-    enum OperationType
+    public enum OperationType
     {
         QUERY,
         AGGREGATE

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/GridHeaders.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/GridHeaders.java
@@ -31,14 +31,18 @@ import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.hisp.dhis.analytics.shared.LabelMapper.getLabelOf;
 import static org.springframework.util.Assert.noNullElements;
 import static org.springframework.util.Assert.notEmpty;
+import static org.springframework.util.Assert.notNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
+import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 
 /**
- * This class is responsible for encapsulating the grid header creation.
+ * This class is responsible for encapsulating the grid header creation and
+ * provide supportive methods related to headers.
  *
  * @author maikel arabori
  */
@@ -73,5 +77,26 @@ public class GridHeaders
         }
 
         return headers;
+    }
+
+    /**
+     * This method will retain the given headers in the give Grid. If the set of
+     * headers provided is null or empty, no changes will be made to the Grid.
+     * Its headers will remain as is.
+     *
+     * @param grid
+     * @param headersToRetain
+     */
+    public static void retainHeadersOnGrid( final Grid grid, final Set<String> headersToRetain )
+    {
+        notNull( grid, "The 'grid' cannot be null" );
+
+        final boolean hasHeadersToRetain = isNotEmpty( headersToRetain );
+
+        if ( hasHeadersToRetain )
+        {
+            grid.retainColumns( headersToRetain );
+            grid.repositionColumns( grid.repositionHeaders( new ArrayList<>( headersToRetain ) ) );
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/DefaultTeiAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/DefaultTeiAnalyticsDimensionsService.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.analytics.event.data;
+package org.hisp.dhis.analytics.tei;
 
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.OperationType.QUERY;
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.filterByValueType;
@@ -44,7 +44,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsDimensionsService;
-import org.hisp.dhis.analytics.event.TeiAnalyticsDimensionsService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.program.Program;
@@ -62,6 +61,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 class DefaultTeiAnalyticsDimensionsService implements TeiAnalyticsDimensionsService
 {
+
     @NonNull
     private final TrackedEntityTypeService trackedEntityTypeService;
 
@@ -71,12 +71,6 @@ class DefaultTeiAnalyticsDimensionsService implements TeiAnalyticsDimensionsServ
     @NonNull
     private final ProgramService programService;
 
-    /**
-     * Retrieve all Dimensions that can be used on a given Tracked Entity Type.
-     *
-     * @param trackedEntityTypeId the uid of a tracked entity type
-     * @return list of dimension
-     */
     @Override
     public List<PrefixedDimension> getQueryDimensionsByTrackedEntityTypeId( String trackedEntityTypeId )
     {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsService.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.analytics.event;
+package org.hisp.dhis.analytics.tei;
 
 import java.util.List;
 
@@ -33,5 +33,12 @@ import org.hisp.dhis.common.PrefixedDimension;
 
 public interface TeiAnalyticsDimensionsService
 {
+
+    /**
+     * Retrieve all Dimensions that can be used on a given Tracked Entity Type.
+     *
+     * @param trackedEntityTypeId the uid of a tracked entity type
+     * @return list of dimensions
+     */
     List<PrefixedDimension> getQueryDimensionsByTrackedEntityTypeId( String trackedEntityTypeId );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiAnalyticsQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiAnalyticsQueryService.java
@@ -69,7 +69,7 @@ public class TeiAnalyticsQueryService
      * @return the populated Grid object
      * @throws IllegalArgumentException if the given teiParams is null
      */
-    public Grid getTeiGrid( final TeiQueryParams teiQueryParams )
+    public Grid getGrid( final TeiQueryParams teiQueryParams )
     {
         notNull( teiQueryParams, "The 'teiParams' must not be null" );
 
@@ -79,5 +79,4 @@ public class TeiAnalyticsQueryService
 
         return gridAdaptor.createGrid( headers, result.result() );
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/AnalyticsDimensionsTestSupport.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/AnalyticsDimensionsTestSupport.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.analytics.event.data;
+package org.hisp.dhis.analytics.common;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,7 +43,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeAttribute;
 public class AnalyticsDimensionsTestSupport
 {
 
-    static TrackedEntityType trackedEntityType()
+    public static TrackedEntityType trackedEntityType()
     {
         TrackedEntityType trackedEntityType = new TrackedEntityType();
         trackedEntityType.setTrackedEntityTypeAttributes(
@@ -54,7 +54,7 @@ public class AnalyticsDimensionsTestSupport
         return trackedEntityType;
     }
 
-    static List<TrackedEntityAttribute> allValueTypeTEAs()
+    public static List<TrackedEntityAttribute> allValueTypeTEAs()
     {
         return buildWithAllValueTypes( valueType -> {
             TrackedEntityAttribute trackedEntityAttribute = new TrackedEntityAttribute();
@@ -64,7 +64,7 @@ public class AnalyticsDimensionsTestSupport
         } ).collect( Collectors.toList() );
     }
 
-    static Set<DataElement> allValueTypeDataElements()
+    public static Set<DataElement> allValueTypeDataElements()
     {
         return buildWithAllValueTypes( valueType -> {
             DataElement dataElement = new DataElement();
@@ -74,7 +74,7 @@ public class AnalyticsDimensionsTestSupport
         } ).collect( Collectors.toSet() );
     }
 
-    static <T> Stream<T> buildWithAllValueTypes( Function<ValueType, T> mapper )
+    public static <T> Stream<T> buildWithAllValueTypes( Function<ValueType, T> mapper )
     {
         return Arrays.stream( ValueType.values() )
             .map( mapper );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/CommonQueryRequestMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/common/CommonQueryRequestMapperTest.java
@@ -120,7 +120,7 @@ class CommonQueryRequestMapperTest
 
         final CommonQueryRequest aCommonQueryRequest = CommonQueryRequest.builder()
             .userOrgUnit( "PEZNsGbZaVJ" )
-            .program( List.of( "ur1Edk5Oe2n", "lxAQ7Zs9VYR" ) )
+            .program( Set.of( "ur1Edk5Oe2n", "lxAQ7Zs9VYR" ) )
             .dimension( Set.of( dimension + ":" + queryItem ) )
             .build();
 
@@ -187,7 +187,7 @@ class CommonQueryRequestMapperTest
 
         final CommonQueryRequest aCommonQueryRequest = CommonQueryRequest.builder()
             .userOrgUnit( orgUnitUid )
-            .program( List.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
+            .program( Set.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
             .filter( Set.of( "ur1Edk5Oe2n.OU:PEZNsGbZaVJ" ) )
             .build();
 
@@ -259,7 +259,7 @@ class CommonQueryRequestMapperTest
 
         final CommonQueryRequest aCommonQueryRequest = CommonQueryRequest.builder()
             .userOrgUnit( queryItemFilter )
-            .program( List.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
+            .program( Set.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
             .dimension( Set.of( dimension + ":" + queryItemDimension ) )
             .filter( Set.of( "ur1Edk5Oe2n.OU:PEZNsGbZaVJ" ) )
             .build();
@@ -330,7 +330,7 @@ class CommonQueryRequestMapperTest
             .userOrgUnit( "PEZNsGbZaVJ" )
             .dimension( Set.of( dimension + ":" + queryItem ) )
             // Two programs, where "ur1Edk5Oe2n" does not exist.
-            .program( List.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
+            .program( Set.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
             .build();
 
         when( dataQueryService.getUserOrgUnits( null, aCommonQueryRequest.getUserOrgUnit() ) )
@@ -374,7 +374,7 @@ class CommonQueryRequestMapperTest
 
         final CommonQueryRequest aCommonQueryRequest = CommonQueryRequest.builder()
             .userOrgUnit( "PEZNsGbZaVJ" )
-            .program( List.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
+            .program( Set.of( "lxAQ7Zs9VYR", "ur1Edk5Oe2n" ) )
             .dimension( Set.of( dimension + ":" + queryItem ) )
             .build();
 
@@ -485,7 +485,7 @@ class CommonQueryRequestMapperTest
 
         final CommonQueryRequest aCommonQueryRequest = CommonQueryRequest.builder()
             .userOrgUnit( "PEZNsGbZaVJ" )
-            .program( List.of( "ur1Edk5Oe2n", "lxAQ7Zs9VYR" ) )
+            .program( Set.of( "ur1Edk5Oe2n", "lxAQ7Zs9VYR" ) )
             .dimension(
                 Set.of( dimension + ":" + queryItem_1 + DIMENSION_OR_SEPARATOR + dimension + ":" + queryItem_2 ) )
             .build();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsDimensionsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsDimensionsServiceTest.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.allValueTypeDataElements;
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.allValueTypeTEAs;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.allValueTypeDataElements;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.allValueTypeTEAs;
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.AGGREGATE_ALLOWED_VALUE_TYPES;
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.QUERY_DISALLOWED_VALUE_TYPES;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsDimensionsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsDimensionsServiceTest.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.allValueTypeDataElements;
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.allValueTypeTEAs;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.allValueTypeDataElements;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.allValueTypeTEAs;
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.AGGREGATE_ALLOWED_VALUE_TYPES;
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.QUERY_DISALLOWED_VALUE_TYPES;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/shared/GridHeadersTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/shared/GridHeadersTest.java
@@ -27,18 +27,23 @@
  */
 package org.hisp.dhis.analytics.shared;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.analytics.ColumnDataType.TEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
+import org.hisp.dhis.system.grid.ListGrid;
 import org.junit.jupiter.api.Test;
 
 /**
- * // TODO: Improve unit tests and coverage
- *
  * Unit tests for {@link GridHeaders}
  *
  * @author maikel arabori
@@ -57,5 +62,93 @@ class GridHeadersTest
         // Then
         assertNotNull( headers, "Should not be null: headers" );
         assertEquals( 1, headers.size(), "Should have size of 1: headers" );
+    }
+
+    @Test
+    void testFromWhenColumnsIsNull()
+    {
+        // Given
+        final List<Column> columns = null;
+
+        // When
+        final IllegalArgumentException thrown = assertThrows( IllegalArgumentException.class,
+            () -> GridHeaders.from( columns ) );
+
+        // Then
+        assertEquals( "The 'columns' must not be null/empty", thrown.getMessage(),
+            "Exception message does not match." );
+    }
+
+    @Test
+    void testFromWhenColumnsIsEmpty()
+    {
+        // Given
+        final List<Column> columns = emptyList();
+
+        // When
+        final IllegalArgumentException thrown = assertThrows( IllegalArgumentException.class,
+            () -> GridHeaders.from( columns ) );
+
+        // Then
+        assertEquals( "The 'columns' must not be null/empty", thrown.getMessage(),
+            "Exception message does not match." );
+    }
+
+    @Test
+    void testFromWhenColumnsHasNullElement()
+    {
+        // Given
+        final List<Column> columns = new ArrayList<>();
+        columns.add( Column.builder().value( "name" ).type( TEXT ).build() );
+        columns.add( null ); // null element
+
+        // When
+        final IllegalArgumentException thrown = assertThrows( IllegalArgumentException.class,
+            () -> GridHeaders.from( columns ) );
+
+        // Then
+        assertEquals( "The 'columns' must not contain null elements", thrown.getMessage(),
+            "Exception message does not match." );
+    }
+
+    @Test
+    void testRetainHeadersOnGrid()
+    {
+        // Given
+        final GridHeader headerA = new GridHeader( "headerA", "Header A" );
+        final GridHeader headerB = new GridHeader( "headerB", "Header B" );
+        final GridHeader headerC = new GridHeader( "headerC", "Header C" );
+
+        final Grid grid = new ListGrid();
+        grid.addHeader( headerA );
+        grid.addHeader( headerB );
+        grid.addHeader( headerC );
+        grid.addRow().addValue( 1 ).addValue( "a" ).addValue( "a-1" );
+        grid.addRow().addValue( 2 ).addValue( "b" ).addValue( "b-1" );
+        grid.addRow().addValue( 3 ).addValue( "c" ).addValue( "c-1" );
+
+        final Set<String> headers = new LinkedHashSet<>( List.of( "headerA", "headerB" ) );
+
+        // When
+        GridHeaders.retainHeadersOnGrid( grid, headers );
+
+        // Then
+        assertEquals( 2, grid.getHeaderWidth(), "Should have size of 2: getHeaderWidth()" );
+        assertEquals( "headerA", grid.getHeaders().get( 0 ).getName(), "Should be named 'headerA': getName()" );
+        assertEquals( "headerB", grid.getHeaders().get( 1 ).getName(), "Should be named 'headerB': getName()" );
+    }
+
+    @Test
+    void testRetainHeadersOnGridWhenGridIsNull()
+    {
+        // Given
+        final Set<String> headers = new LinkedHashSet<>( List.of( "headerA", "headerB" ) );
+
+        // When
+        final IllegalArgumentException thrown = assertThrows( IllegalArgumentException.class,
+            () -> GridHeaders.retainHeadersOnGrid( null, headers ) );
+
+        // Then
+        assertEquals( "The 'grid' cannot be null", thrown.getMessage(), "Exception message does not match." );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsServiceTest.java
@@ -25,11 +25,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.analytics.event.data;
+package org.hisp.dhis.analytics.tei;
 
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.allValueTypeDataElements;
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.allValueTypeTEAs;
-import static org.hisp.dhis.analytics.event.data.AnalyticsDimensionsTestSupport.trackedEntityType;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.allValueTypeDataElements;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.allValueTypeTEAs;
+import static org.hisp.dhis.analytics.common.AnalyticsDimensionsTestSupport.trackedEntityType;
 import static org.hisp.dhis.analytics.event.data.DimensionsServiceCommon.QUERY_DISALLOWED_VALUE_TYPES;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,7 +40,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import org.hisp.dhis.analytics.event.TeiAnalyticsDimensionsService;
+import org.hisp.dhis.analytics.event.data.DefaultEnrollmentAnalyticsDimensionsService;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.PrefixedDimension;
 import org.hisp.dhis.dataelement.DataElement;

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/TeiAnalyticsPrefixStrategy.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/TeiAnalyticsPrefixStrategy.java
@@ -43,5 +43,4 @@ public class TeiAnalyticsPrefixStrategy implements PrefixStrategy
     {
         return pDimension.getPrefix();
     }
-
 }


### PR DESCRIPTION
This feature aims to add support for the `headers` request param.

When this param is set, the response should respect the `headers` specified, returning only the defined ones in the respective order. The main change is the code related to this class `dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/shared/GridHeaders.java`

I also did a small code clean-up as part of this PR.

_You will notice a small commit from "mortenoh", that can be ignored. This is because I merged `master` into my commit._