### PR TITLE
Feat: Refactor Event SQL to use named parameters - Complex bindings [ Dhis2-13455 ]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryFilter.java
@@ -167,6 +167,31 @@ public class QueryFilter
         return "'" + encodedFilter + "'";
     }
 
+    public String getSqlFilter()
+    {
+        if ( LIKE == operator || NLIKE == operator || ILIKE == operator || NILIKE == operator )
+        {
+            return "%" + this.filter + "%";
+        }
+        else if ( EQ == operator || NE == operator || NEQ == operator || IEQ == operator || NIEQ == operator )
+        {
+            if ( this.filter.equals( NV ) )
+            {
+                return "null";
+            }
+        }
+        else if ( SW == operator )
+        {
+            return this.filter + "%";
+        }
+        else if ( EW == operator )
+        {
+            return "%" + this.filter + "";
+        }
+
+        return this.filter;
+    }
+
     public String getSqlFilter( final String encodedFilter, final ValueType valueType )
     {
         final String sqlFilter = getSqlFilter( encodedFilter );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/JpaQueryUtils.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.hibernate.jsonb.type.JsonbFunctions;
 import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.user.User;
 import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 /**
  * @author Viet Nguyen <viet@dhis2.org>
@@ -375,24 +376,42 @@ public class JpaQueryUtils
     public static String generateSQlQueryForSharingCheck( String sharingColumn, User user, String access )
     {
         return generateSQlQueryForSharingCheck( sharingColumn, access, user.getUid(),
-            user.getGroups().stream().map( BaseIdentifiableObject::getUid ).collect( toList() ) );
+            getGroupsIds( user ) );
     }
 
     private static String generateSQlQueryForSharingCheck( String sharingColumn, String access, String userId,
-        List<String> userGroupIds )
+        String groupsIds )
     {
-        String groupsIds = CollectionUtils.isEmpty( userGroupIds )
-            ? null
-            : "{" + String.join( ",", userGroupIds ) + "}";
+        return String.format( generateSQlQueryForSharingCheck( groupsIds ), sharingColumn, userId, groupsIds, access );
+    }
 
-        String sql = " ( %1$s->>'owner' is null or %1$s->>'owner' = '%2$s') "
+    public static String generateSQlQueryForSharingCheck( String sharingColumn, User user, String access,
+        MapSqlParameterSource mapSqlParameterSource )
+    {
+        String groupsIds = getGroupsIds( user );
+
+        mapSqlParameterSource
+            .addValue( "user_sharing", user.getUid() )
+            .addValue( "user_access", user.getUid() );
+
+        return String
+            .format( generateSQlQueryForSharingCheck( groupsIds )
+                .replace( "'%2$s'", "%2$s" )
+                .replace( "'%4$s'", "%4$s" ),
+                sharingColumn,
+                ":user_sharing", groupsIds,
+                ":user_access" );
+    }
+
+    private static String generateSQlQueryForSharingCheck( String groupsIds )
+    {
+        return " ( %1$s->>'owner' is null or %1$s->>'owner' = '%2$s') "
             + " or %1$s->>'public' like '%4$s' or %1$s->>'public' is null "
             + " or (" + JsonbFunctions.HAS_USER_ID + "( %1$s, '%2$s') = true "
             + " and " + JsonbFunctions.CHECK_USER_ACCESS + "( %1$s, '%2$s', '%4$s' ) = true )  "
             + (StringUtils.isEmpty( groupsIds ) ? ""
                 : " or ( " + JsonbFunctions.HAS_USER_GROUP_IDS + "( %1$s, '%3$s') = true "
                     + " and " + JsonbFunctions.CHECK_USER_GROUPS_ACCESS + "( %1$s, '%4$s', '%3$s') = true )");
-        return String.format( sql, sharingColumn, userId, groupsIds, access );
     }
 
     public static String generateHqlQueryForSharingCheck( String tableName, User user, String access )
@@ -410,7 +429,20 @@ public class JpaQueryUtils
         List<String> userGroupIds )
     {
         return "(" + sqlToHql( tableName,
-            generateSQlQueryForSharingCheck( tableName + ".sharing", access, userId, userGroupIds ) ) + ")";
+            generateSQlQueryForSharingCheck( tableName + ".sharing", access, userId, getGroupsIds( userGroupIds ) ) )
+            + ")";
+    }
+
+    private static String getGroupsIds( User user )
+    {
+        return getGroupsIds( user.getGroups().stream().map( BaseIdentifiableObject::getUid ).collect( toList() ) );
+    }
+
+    private static String getGroupsIds( List<String> userGroupIds )
+    {
+        return CollectionUtils.isEmpty( userGroupIds )
+            ? null
+            : "{" + String.join( ",", userGroupIds ) + "}";
     }
 
     private static String sqlToHql( String tableName, String sql )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1022,7 +1022,8 @@ public class JdbcEventStore implements EventStore
         StringBuilder sqlBuilder = new StringBuilder().append( "select " )
             .append( getEventSelectIdentifiersByIdScheme( params.getIdSchemes() ) )
             .append( " psi.uid as psi_uid, " )
-            .append( "ou.uid as ou_uid, p.uid as p_uid, ps.uid as ps_uid, coc.uid as coc_uid, " )
+            .append( "ou.uid as ou_uid, p.uid as p_uid, ps.uid as ps_uid, " )
+            .append( "coc.uid as coc_uid, " )
             .append(
                 "psi.programstageinstanceid as psi_id, psi.status as psi_status, psi.executiondate as psi_executiondate, " )
             .append(
@@ -1034,7 +1035,8 @@ public class JdbcEventStore implements EventStore
                 "ST_AsText( psi.geometry ) as psi_geometry, au.uid as user_assigned, (au.firstName || ' ' || au.surName) as user_assigned_name," )
             .append( "au.firstName as user_assigned_first_name, au.surName as user_assigned_surname, " )
             .append(
-                "au.username as user_assigned_username, cocco.categoryoptionid AS cocco_categoryoptionid, deco.uid AS deco_uid, " );
+                "au.username as user_assigned_username," )
+            .append( "cocco.categoryoptionid AS cocco_categoryoptionid, deco.uid AS deco_uid, " );
 
         if ( (params.getCategoryOptionCombo() == null || params.getCategoryOptionCombo().isDefault())
             && !isSuper( user ) )
@@ -1062,10 +1064,13 @@ public class JdbcEventStore implements EventStore
             .append( "inner join programinstance pi on pi.programinstanceid=psi.programinstanceid " )
             .append( "inner join program p on p.programid=pi.programid " )
             .append( "inner join programstage ps on ps.programstageid=psi.programstageid " )
-            .append( "inner join categoryoptioncombo coc on coc.categoryoptioncomboid=psi.attributeoptioncomboid " )
+            .append(
+                "inner join categoryoptioncombo coc on coc.categoryoptioncomboid=psi.attributeoptioncomboid " )
             .append(
                 "inner join categoryoptioncombos_categoryoptions cocco on psi.attributeoptioncomboid=cocco.categoryoptioncomboid " )
-            .append( "inner join dataelementcategoryoption deco on cocco.categoryoptionid=deco.categoryoptionid " )
+            .append(
+                "inner join dataelementcategoryoption deco on cocco.categoryoptionid=deco.categoryoptionid " )
+
             .append(
                 "left join trackedentityprogramowner po on (pi.trackedentityinstanceid=po.trackedentityinstanceid) " )
             .append(
@@ -1078,6 +1083,7 @@ public class JdbcEventStore implements EventStore
 
         StringBuilder eventDataValuesWhereSql = new StringBuilder();
 
+        int filterCount = 0;
         for ( QueryItem item : params.getDataElementsAndFilters() )
         {
             final String col = item.getItemId();
@@ -1110,73 +1116,66 @@ public class JdbcEventStore implements EventStore
             {
                 for ( QueryFilter filter : item.getFilters() )
                 {
-                    final String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
+                    if ( eventDataValuesWhereSql.length() > 0 )
+                    {
+                        eventDataValuesWhereSql.append( " and " );
+                    }
 
-                    final String queryCol = item.isNumeric() ? " CAST( " + dataValueValueSql + " AS NUMERIC)"
-                        : "lower( " + dataValueValueSql + " )";
+                    final String queryCol = " lower( " + dataValueValueSql + " )";
+
+                    String bindParameter = "parameter_" + ++filterCount;
 
                     if ( !item.hasOptionSet() )
                     {
-                        if ( eventDataValuesWhereSql.length() > 0 )
+                        if ( QueryOperator.IN.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
                         {
-                            eventDataValuesWhereSql.append( " and " );
-                        }
+                            mapSqlParameterSource.addValue( bindParameter, QueryFilter.getFilterItems( StringUtils
+                                .lowerCase( filter.getFilter() ) ) );
 
-                        if ( QueryOperator.LIKE.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
-                        {
-                            eventDataValuesWhereSql.append( " " )
-                                .append( queryCol )
-                                .append( " " )
-                                .append( filter.getSqlOperator() )
-                                .append( " " )
-                                .append( StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) )
-                                .append( " " );
+                            eventDataValuesWhereSql.append(
+                                inCondition( filter, bindParameter, queryCol ) );
                         }
                         else
                         {
+                            mapSqlParameterSource.addValue( bindParameter,
+                                StringUtils.lowerCase( filter.getSqlFilter() ) );
+
                             eventDataValuesWhereSql.append( " " )
                                 .append( queryCol )
                                 .append( " " )
                                 .append( filter.getSqlOperator() )
                                 .append( " " )
-                                .append( StringUtils.lowerCase(
-                                    item.isNumeric() ? encodedFilter : filter.getSqlFilter( encodedFilter ) ) )
+                                .append( ":" )
+                                .append( bindParameter )
                                 .append( " " );
                         }
                     }
-                    else if ( QueryOperator.IN.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
-                    {
-                        sqlBuilder.append( "and " )
-                            .append( queryCol )
-                            .append( " " )
-                            .append( filter.getSqlOperator() )
-                            .append( " " )
-                            .append( StringUtils
-                                .lowerCase( item.isNumeric() ? encodedFilter : filter.getSqlFilter( encodedFilter ) ) )
-                            .append( " " );
-                    }
-                    else if ( QueryOperator.LIKE.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
-                    {
-                        sqlBuilder.append( "and lower(" )
-                            .append( optCol )
-                            .append( DOT_NAME )
-                            .append( " " )
-                            .append( filter.getSqlOperator() )
-                            .append( " " )
-                            .append( StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) )
-                            .append( " " );
-                    }
                     else
                     {
-                        sqlBuilder.append( "and lower(" )
-                            .append( optCol )
-                            .append( DOT_NAME )
-                            .append( " " )
-                            .append( filter.getSqlOperator() )
-                            .append( " " )
-                            .append( StringUtils
-                                .lowerCase( item.isNumeric() ? encodedFilter : filter.getSqlFilter( encodedFilter ) ) )
-                            .append( " " );
+                        if ( QueryOperator.IN.getValue().equalsIgnoreCase( filter.getSqlOperator() ) )
+                        {
+                            mapSqlParameterSource.addValue( bindParameter, QueryFilter.getFilterItems( StringUtils
+                                .lowerCase( filter.getFilter() ) ) );
+
+                            sqlBuilder.append( " and " );
+                            sqlBuilder.append(
+                                inCondition( filter, bindParameter, queryCol ) );
+                        }
+                        else
+                        {
+                            mapSqlParameterSource.addValue( bindParameter,
+                                StringUtils.lowerCase( filter.getSqlFilter() ) );
+
+                            sqlBuilder.append( "and lower(" )
+                                .append( optCol )
+                                .append( DOT_NAME )
+                                .append( " " )
+                                .append( filter.getSqlOperator() )
+                                .append( " " )
+                                .append( ":" )
+                                .append( bindParameter )
+                                .append( " " );
+                        }
                     }
                 }
             }
@@ -1185,7 +1184,7 @@ public class JdbcEventStore implements EventStore
         if ( (params.getCategoryOptionCombo() == null || params.getCategoryOptionCombo().isDefault())
             && !isSuper( user ) )
         {
-            sqlBuilder.append( getCategoryOptionSharingForUser( user ) );
+            sqlBuilder.append( getCategoryOptionSharingForUser( user, mapSqlParameterSource ) );
         }
 
         if ( eventDataValuesWhereSql.length() > 0 )
@@ -1247,15 +1246,19 @@ public class JdbcEventStore implements EventStore
 
         if ( params.getCategoryOptionCombo() != null )
         {
-            mapSqlParameterSource.addValue( "attributeoptioncomboid", params.getCategoryOptionCombo().getId() );
+            mapSqlParameterSource.addValue( "attributeoptioncomboid",
+                params.getCategoryOptionCombo().getId() );
 
-            sqlBuilder.append( hlp.whereAnd() ).append( " psi.attributeoptioncomboid = " )
-                .append( ":attributeoptioncomboid" ).append( " " );
+            sqlBuilder.append( hlp.whereAnd() )
+                .append( " psi.attributeoptioncomboid = " )
+                .append( ":attributeoptioncomboid" )
+                .append( " " );
         }
 
         if ( !CollectionUtils.isEmpty( organisationUnits ) || params.getOrgUnit() != null )
         {
-            sqlBuilder.append( hlp.whereAnd() ).append( getOrgUnitSql( hlp, params, organisationUnits ) );
+            sqlBuilder.append( hlp.whereAnd() )
+                .append( getOrgUnitSql( hlp, params, mapSqlParameterSource, organisationUnits ) );
         }
 
         if ( params.getStartDate() != null )
@@ -1378,6 +1381,19 @@ public class JdbcEventStore implements EventStore
         return sqlBuilder.toString();
     }
 
+    private String inCondition( QueryFilter filter, String boundParameter, String queryCol )
+    {
+        return new StringBuilder()
+            .append( queryCol )
+            .append( " " )
+            .append( filter.getSqlOperator() )
+            .append( " " )
+            .append( "(" )
+            .append( ":" )
+            .append( boundParameter )
+            .append( ") " ).toString();
+    }
+
     /**
      * From, join and where clause. For dataElement params, restriction is set
      * in inner join. For query params, restriction is set in where clause.
@@ -1445,7 +1461,8 @@ public class JdbcEventStore implements EventStore
                     {
                         sqlBuilder.append( "and lower( " ).append( optCol ).append( DOT_NAME ).append( " " )
                             .append( filter.getSqlOperator() ).append( " " )
-                            .append( StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) ).append( " " );
+                            .append( StringUtils.lowerCase( filter.getSqlFilter( encodedFilter ) ) )
+                            .append( " " );
                     }
                 }
             }
@@ -1458,7 +1475,8 @@ public class JdbcEventStore implements EventStore
 
         if ( !organisationUnits.isEmpty() || params.getOrgUnit() != null )
         {
-            sqlBuilder.append( hlp.whereAnd() ).append( getOrgUnitSql( hlp, params, organisationUnits ) );
+            sqlBuilder.append( hlp.whereAnd() )
+                .append( getOrgUnitSql( hlp, params, new MapSqlParameterSource(), organisationUnits ) );
         }
 
         if ( params.getProgramStage() != null )
@@ -1605,7 +1623,7 @@ public class JdbcEventStore implements EventStore
         return sqlBuilder.toString();
     }
 
-    private String getCategoryOptionSharingForUser( User user )
+    private String getCategoryOptionSharingForUser( User user, MapSqlParameterSource mapSqlParameterSource )
     {
         StringBuilder sqlBuilder = new StringBuilder().append( " left join ( " );
 
@@ -1615,7 +1633,7 @@ public class JdbcEventStore implements EventStore
             + "left join ("
             + "select deco.categoryoptionid as deco_id, deco.uid as deco_uid , "
             + "( select ( " + JpaQueryUtils.generateSQlQueryForSharingCheck( "deco.sharing",
-                user, AclService.LIKE_READ_DATA )
+                user, AclService.LIKE_READ_DATA, mapSqlParameterSource )
             + " ) ) as can_access "
             + "from dataelementcategoryoption deco " );
 
@@ -2038,49 +2056,55 @@ public class JdbcEventStore implements EventStore
         return batch.stream().sorted( Comparator.comparing( ProgramStageInstance::getUid ) ).collect( toList() );
     }
 
-    private String getOrgUnitSql( SqlHelper hlp, EventSearchParams params, List<OrganisationUnit> organisationUnits )
+    private String getOrgUnitSql( SqlHelper hlp, EventSearchParams params, MapSqlParameterSource mapSqlParameterSource,
+        List<OrganisationUnit> organisationUnits )
     {
         StringBuilder orgUnitSql = new StringBuilder();
 
         if ( params.getOrgUnit() != null && !params.isPathOrganisationUnitMode() )
         {
+            mapSqlParameterSource.addValue( "organisationunitid", params.getOrgUnit()
+                .getId() );
+
             orgUnitSql.append( " ou.organisationunitid = " )
-                .append( params.getOrgUnit()
-                    .getId() )
+                .append( ":organisationunitid" )
                 .append( " " );
         }
         else
         {
             SqlHelper orHlp = new SqlHelper( true );
-            String path = "ou.path LIKE '";
+            String path = "ou.path LIKE ";
+            int count = 0;
+
             for ( OrganisationUnit organisationUnit : organisationUnits )
             {
+                String boundOuPath = ":ouPath_" + ++count;
+                String boundOuLevel = ":ouLevel:" + ++count;
+
                 OrganisationUnit unit = organisationUnitStore.getByUid( organisationUnit.getUid() );
 
-                if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) )
+                if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS )
+                    || params.isOrganisationUnitMode( OrganisationUnitSelectionMode.CHILDREN ) )
                 {
+                    mapSqlParameterSource.addValue( boundOuPath, "%" + unit.getPath() + "%" );
+                    mapSqlParameterSource.addValue( boundOuLevel,
+                        params.isOrganisationUnitMode( OrganisationUnitSelectionMode.DESCENDANTS ) ? unit.getLevel()
+                            : unit.getLevel() + 1 );
+
                     orgUnitSql.append( orHlp.or() )
                         .append( path )
-                        .append( unit.getPath() )
-                        .append( "%' " )
+                        .append( boundOuPath )
+                        .append( " " )
                         .append( hlp.whereAnd() )
                         .append( " ou.hierarchylevel > " )
-                        .append( unit.getLevel() );
-                }
-                else if ( params.isOrganisationUnitMode( OrganisationUnitSelectionMode.CHILDREN ) )
-                {
-                    orgUnitSql.append( orHlp.or() )
-                        .append( path )
-                        .append( unit.getPath() )
-                        .append( "%' " )
-                        .append( hlp.whereAnd() )
-                        .append( " ou.hierarchylevel = " )
-                        .append( unit.getLevel() + 1 );
+                        .append( boundOuLevel );
                 }
                 else
                 {
-                    orgUnitSql.append( orHlp.or() ).append( path )
-                        .append( unit.getPath() ).append( "%' " );
+                    orgUnitSql.append( orHlp.or() )
+                        .append( path )
+                        .append( boundOuPath )
+                        .append( " " );
                 }
             }
 
@@ -2091,11 +2115,13 @@ public class JdbcEventStore implements EventStore
 
                 if ( params.isPathOrganisationUnitMode() )
                 {
+                    mapSqlParameterSource.addValue( "organisationunitid", params.getOrgUnit()
+                        .getId() );
+
                     orgUnitSql.insert( 0, " (" );
                     orgUnitSql.append( orHlp.or() )
                         .append( " (ou.organisationunitid = " )
-                        .append( params.getOrgUnit()
-                            .getId() )
+                        .append( ":organisationunitid" )
                         .append( ")) " );
                 }
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1222,9 +1222,9 @@ public class JdbcEventStore implements EventStore
 
         if ( params.getProgramStatus() != null )
         {
-            mapSqlParameterSource.addValue( "program_status", "'" + params.getProgramStatus() + "'" );
+            mapSqlParameterSource.addValue( "program_status", params.getProgramStatus().name() );
 
-            sqlBuilder.append( hlp.whereAnd() ).append( " pi.status = " ).append( ":program_status" );
+            sqlBuilder.append( hlp.whereAnd() ).append( " pi.status = " ).append( ":program_status " );
         }
 
         if ( params.getFollowUp() != null )
@@ -1284,7 +1284,7 @@ public class JdbcEventStore implements EventStore
 
         if ( params.getProgramType() != null )
         {
-            mapSqlParameterSource.addValue( "programType", "'" + params.getProgramType() + "'" );
+            mapSqlParameterSource.addValue( "programType", params.getProgramType().name() );
 
             sqlBuilder.append( hlp.whereAnd() ).append( " p.type = " ).append( ":programType" )
                 .append( " " );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -44,9 +44,13 @@ import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Events;
+import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -120,6 +124,43 @@ class EventExporterTest extends TrackerTest
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
         params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00001" );
+
+        params.setDataElements( Set.of(
+            new QueryItem( dataElement, QueryOperator.LIKE, "val", dataElement.getValueType(),
+                null, null ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithStatusFilter()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+        params.setProgramStatus( ProgramStatus.ACTIVE );
+
+        DataElement dataElement = dataElement( "DATAEL00001" );
+
+        params.setDataElements( Set.of(
+            new QueryItem( dataElement, QueryOperator.LIKE, "val", dataElement.getValueType(),
+                null, null ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithProgramTypeFilter()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+        params.setProgramType( ProgramType.WITH_REGISTRATION );
 
         DataElement dataElement = dataElement( "DATAEL00001" );
 
@@ -229,8 +270,8 @@ class EventExporterTest extends TrackerTest
         DataElement dataElement = dataElement( "DATAEL00005" );
 
         params.setDataElements(
-          Set.of( new QueryItem( dataElement, QueryOperator.EQ, "option1", dataElement.getValueType(),
-            null, dataElement.getOptionSet() ) ) );
+            Set.of( new QueryItem( dataElement, QueryOperator.EQ, "option1", dataElement.getValueType(),
+                null, dataElement.getOptionSet() ) ) );
 
         Events events = eventService.getEvents( params );
         assertNotNull( events );
@@ -243,13 +284,13 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u", "TvctPPhpD8z") );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u", "TvctPPhpD8z" ) );
 
         DataElement dataElement = dataElement( "DATAEL00005" );
 
         params.setDataElements(
-          Set.of( new QueryItem( dataElement, QueryOperator.IN, "option1;option2", dataElement.getValueType(),
-            null, dataElement.getOptionSet() ) ) );
+            Set.of( new QueryItem( dataElement, QueryOperator.IN, "option1;option2", dataElement.getValueType(),
+                null, dataElement.getOptionSet() ) ) );
 
         Events events = eventService.getEvents( params );
         assertNotNull( events );
@@ -266,8 +307,8 @@ class EventExporterTest extends TrackerTest
         DataElement dataElement = dataElement( "DATAEL00005" );
 
         params
-          .setDataElements( Set.of( new QueryItem( dataElement, QueryOperator.LIKE, "opt", dataElement.getValueType(),
-            null, dataElement.getOptionSet() ) ) );
+            .setDataElements( Set.of( new QueryItem( dataElement, QueryOperator.LIKE, "opt", dataElement.getValueType(),
+                null, dataElement.getOptionSet() ) ) );
 
         Events events = eventService.getEvents( params );
         assertNotNull( events );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -27,17 +27,26 @@
  */
 package org.hisp.dhis.tracker;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
+import java.util.Set;
 
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.EventSearchParams;
 import org.hisp.dhis.dxf2.events.event.EventService;
 import org.hisp.dhis.dxf2.events.event.Events;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,6 +72,13 @@ class EventExporterTest extends TrackerTest
 
     private OrganisationUnit orgUnit;
 
+    private ProgramStage programStage;
+
+    private Program program;
+
+    @Autowired
+    private DataElementService dataElementService;
+
     @Override
     protected void initTest()
         throws IOException
@@ -72,6 +88,8 @@ class EventExporterTest extends TrackerTest
         assertNoImportErrors(
             trackerImportService.importTracker( fromJson( "tracker/event_and_enrollment.json", userA.getUid() ) ) );
         orgUnit = manager.get( OrganisationUnit.class, "h4w96yEMlzO" );
+        programStage = manager.get( ProgramStage.class, "NpsdDv6kKSO" );
+        program = programStage.getProgram();
         manager.flush();
     }
 
@@ -94,5 +112,170 @@ class EventExporterTest extends TrackerTest
         Events events = eventService.getEvents( params );
         assertNotNull( events );
         assertEquals( 1, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsLike()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00001" );
+
+        params.setDataElements( Set.of(
+            new QueryItem( dataElement, QueryOperator.LIKE, "val", dataElement.getValueType(),
+                null, null ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsEqual()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00001" );
+
+        params.setDataElements( Set.of(
+            new QueryItem( dataElement, QueryOperator.EQ, "value00001", dataElement.getValueType(),
+                null,
+                null ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsIn()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u", "TvctPPhpD8z" ) );
+
+        DataElement datael00001 = dataElement( "DATAEL00001" );
+
+        params.setDataElements( Set.of(
+            new QueryItem( datael00001, QueryOperator.IN, "value00001;value00002", datael00001.getValueType(),
+                null,
+                null ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 2, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithCategoryOptionSuperUser()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+        params.setProgramStage( programStage );
+        params.setProgram( program );
+
+        params.setCategoryOptionCombo( manager.get( CategoryOptionCombo.class, "HllvX50cXC0" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00001" );
+
+        params
+            .setDataElements(
+                Set.of( new QueryItem( dataElement, QueryOperator.EQ, "value00001", dataElement.getValueType(),
+                    null, dataElement.getOptionSet() ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithCategoryOptionNotSuperUser()
+    {
+        injectSecurityContext( createAndAddUser( false, "user", newHashSet( orgUnit ), newHashSet( orgUnit ),
+            "F_EXPORT_DATA" ) );
+
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8z" ) );
+        params.setProgramStage( programStage );
+        params.setProgram( program );
+
+        params.setCategoryOptionCombo( manager.get( CategoryOptionCombo.class, "HllvX50cXC0" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00002" );
+
+        params
+            .setDataElements(
+                Set.of( new QueryItem( dataElement, QueryOperator.EQ, "value00002", dataElement.getValueType(),
+                    null, dataElement.getOptionSet() ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithOptionSetEqual()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00005" );
+
+        params.setDataElements(
+          Set.of( new QueryItem( dataElement, QueryOperator.EQ, "option1", dataElement.getValueType(),
+            null, dataElement.getOptionSet() ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    // TODO
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithOptionSetIn()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u", "TvctPPhpD8z") );
+
+        DataElement dataElement = dataElement( "DATAEL00005" );
+
+        params.setDataElements(
+          Set.of( new QueryItem( dataElement, QueryOperator.IN, "option1;option2", dataElement.getValueType(),
+            null, dataElement.getOptionSet() ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 2, events.getEvents().size() );
+    }
+
+    @Test
+    void testExportEventsWhenFilteringByDataElementsWithOptionSetLike()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setProgramInstances( Sets.newHashSet( "TvctPPhpD8u" ) );
+
+        DataElement dataElement = dataElement( "DATAEL00005" );
+
+        params
+          .setDataElements( Set.of( new QueryItem( dataElement, QueryOperator.LIKE, "opt", dataElement.getValueType(),
+            null, dataElement.getOptionSet() ) ) );
+
+        Events events = eventService.getEvents( params );
+        assertNotNull( events );
+        assertEquals( 1, events.getEvents().size() );
+    }
+
+    private DataElement dataElement( String uid )
+    {
+        return dataElementService.getDataElement( uid );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -155,7 +155,30 @@
       ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "dataValues": [],
+      "dataValues": [
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          },
+          "value": "value00001",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
+        },
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00005"
+          },
+          "value": "option1",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
+        }
+      ],
       "notes": []
     },
     {
@@ -194,7 +217,41 @@
       ],
       "completedBy": "admin",
       "completedAt": "2019-01-28T00:00:00.000",
-      "dataValues": [],
+      "dataValues": [
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00001"
+          },
+          "value": "value00002",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
+        },
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00002"
+          },
+          "value": "value00002",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
+        },
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00005"
+          },
+          "value": "option2",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
+        }
+      ],
       "notes": []
     }
   ],

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
@@ -188,6 +188,94 @@
       "userAccesses": [],
       "legendSets": [],
       "aggregationLevels": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.404",
+      "id": "DATAEL00005",
+      "created": "2020-05-31T08:58:48.406",
+      "name": "with-option-set",
+      "shortName": "with-option-set",
+      "aggregationType": "SUM",
+      "domainType": "TRACKER",
+      "publicAccess": "rw------",
+      "valueType": "TEXT",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "optionSet": {
+        "id": "VWzgQENmzPK"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": [],
+      "aggregationLevels": []
+    }
+  ],
+  "options": [
+    {
+      "attributeValues": [],
+      "code": "option1",
+      "displayFormName": "option1",
+      "displayName": "option1",
+      "externalAccess": false,
+      "favorite": false,
+      "favorites": [],
+      "id": "IHYwYAtvjCY",
+      "name": "option1",
+      "optionSet": {
+        "id": "VWzgQENmzPK"
+      },
+      "sortOrder": 3,
+      "userAccesses": [],
+      "userGroupAccesses": []
+    },
+    {
+      "attributeValues": [],
+      "code": "option2",
+      "displayFormName": "option2",
+      "displayName": "option2",
+      "externalAccess": false,
+      "favorite": false,
+      "favorites": [],
+      "id": "HxFNfoxk7ac",
+      "name": "option2",
+      "optionSet": {
+        "id": "VWzgQENmzPK"
+      },
+      "sortOrder": 4,
+      "userAccesses": [],
+      "userGroupAccesses": []
+    }
+  ],
+  "optionSets": [
+    {
+      "attributeValues": [],
+      "code": "options",
+      "displayName": "options",
+      "externalAccess": false,
+      "favorite": false,
+      "favorites": [],
+      "id": "VWzgQENmzPK",
+      "name": "options",
+      "options": [
+        {
+          "id": "IHYwYAtvjCY"
+        },
+        {
+          "id": "HxFNfoxk7ac"
+        }
+      ],
+      "publicAccess": "rw------",
+      "userAccesses": [],
+      "userGroupAccesses": [],
+      "valueType": "TEXT",
+      "version": 5
     }
   ],
   "userGroups": [
@@ -223,7 +311,7 @@
       "name": "test-program-stage",
       "allowGenerateNextVisit": false,
       "preGenerateUID": false,
-      "publicAccess": "--------",
+      "publicAccess": "rwrw----",
       "description": "test-program-stage",
       "openAfterEnrollment": false,
       "repeatable": true,
@@ -382,6 +470,39 @@
           },
           "dataElement": {
             "id": "DATAEL00004"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2019-01-28T11:23:20.855",
+          "id": "PSDE0000005",
+          "created": "2019-01-28T11:23:20.855",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "NpsdDv6kKSO"
+          },
+          "dataElement": {
+            "id": "DATAEL00005"
           },
           "favorites": [],
           "translations": [],


### PR DESCRIPTION
[DHIS2-13455](https://jira.dhis2.org/browse/DHIS2-13455)

Add named parameters to events query for :
- filters
- sharing

Filters are used for data values that are in JSON so now the data type is no longer relevant.
Also, the events grid will be fixed later with [DHIS2-13508](https://jira.dhis2.org/browse/DHIS2-13508). For now, there is an empty map in case we use the same methods.


