### PR TITLE
test: use assertNoErrors instead of assert on size and content

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -28,27 +28,36 @@
 package org.hisp.dhis.tracker;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.function.Supplier;
 
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
+import org.hisp.dhis.tracker.report.TrackerValidationReport;
 
 public class Assertions
 {
 
-    public static void assertNoImportErrors( TrackerImportReport report )
+    public static void assertNoErrors( TrackerImportReport report )
     {
         assertNotNull( report );
-        assertEquals( TrackerStatus.OK, report.getStatus(), errorMessage( report ) );
+        assertEquals( TrackerStatus.OK, report.getStatus(),
+            errorMessage( "Expected import with status OK, instead got:\n", report.getValidationReport() ) );
     }
 
-    private static Supplier<String> errorMessage( TrackerImportReport report )
+    public static void assertNoErrors( TrackerValidationReport report )
+    {
+        assertNotNull( report );
+        assertFalse( report.hasErrors(), errorMessage( "Expected no validation errors, instead got:\n", report ) );
+    }
+
+    private static Supplier<String> errorMessage( String errorTitle, TrackerValidationReport report )
     {
         return () -> {
-            StringBuilder msg = new StringBuilder( "Expected import with status OK, instead got:\n" );
-            report.getValidationReport().getErrors()
+            StringBuilder msg = new StringBuilder( errorTitle );
+            report.getErrors()
                 .forEach( e -> {
                     msg.append( e.getErrorCode() );
                     msg.append( ": " );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -69,7 +69,7 @@ class EventExporterTest extends TrackerTest
     {
         setUpMetadata( "tracker/simple_metadata.json" );
         userA = userService.getUser( "M5zQapPyTZI" );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/event_and_enrollment.json", userA.getUid() ) ) );
         orgUnit = manager.get( OrganisationUnit.class, "h4w96yEMlzO" );
         manager.flush();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/EventDataValueTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.tracker.bundle;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -74,9 +74,9 @@ class EventDataValueTest extends TrackerTest
         injectSecurityContext( userA );
 
         TrackerImportParams teiParams = fromJson( "tracker/single_tei.json", userA.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( teiParams ) );
+        assertNoErrors( trackerImportService.importTracker( teiParams ) );
         TrackerImportParams enrollmentParams = fromJson( "tracker/single_enrollment.json", userA.getUid() );
-        assertNoImportErrors( trackerImportService.importTracker( enrollmentParams ) );
+        assertNoErrors( trackerImportService.importTracker( enrollmentParams ) );
         manager.flush();
     }
 
@@ -87,7 +87,7 @@ class EventDataValueTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/validations/events-with_no_program.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -97,7 +97,7 @@ class EventDataValueTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/event_with_data_values.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         List<ProgramStageInstance> events = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, events.size() );
         ProgramStageInstance psi = events.get( 0 );
@@ -112,7 +112,7 @@ class EventDataValueTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/event_with_data_values.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         List<ProgramStageInstance> events = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, events.size() );
         ProgramStageInstance psi = events.get( 0 );
@@ -126,7 +126,7 @@ class EventDataValueTest extends TrackerTest
         trackerImportParams.getEvents().get( 0 ).setEvent( trackerImportParams.getEvents().get( 0 ).getEvent() );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         List<ProgramStageInstance> updatedEvents = manager.getAll( ProgramStageInstance.class );
         assertEquals( 1, updatedEvents.size() );
         ProgramStageInstance updatedPsi = programStageInstanceService

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/LastUpdateImportTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -70,9 +70,9 @@ class LastUpdateImportTest extends TrackerTest
         setUpMetadata( "tracker/simple_metadata.json" );
         injectAdminUser();
         TrackerImportParams trackerImportParams = fromJson( "tracker/single_tei.json" );
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
+        assertNoErrors( trackerImportService.importTracker( trackerImportParams ) );
         trackedEntity = trackerImportParams.getTrackedEntities().get( 0 );
-        assertNoImportErrors( trackerImportService.importTracker( fromJson( "tracker/single_enrollment.json" ) ) );
+        assertNoErrors( trackerImportService.importTracker( fromJson( "tracker/single_enrollment.json" ) ) );
         manager.flush();
     }
 
@@ -89,7 +89,7 @@ class LastUpdateImportTest extends TrackerTest
         trackedEntity.setAttributes( Collections.singletonList( attribute ) );
         Date lastUpdateBefore = trackedEntityInstanceService
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() ).getLastUpdated();
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
+        assertNoErrors( trackerImportService.importTracker( trackerImportParams ) );
         assertTrue( manager.get( TrackedEntityInstance.class, trackedEntity.getTrackedEntity() ).getLastUpdated()
             .getTime() > lastUpdateBefore.getTime() );
     }
@@ -101,11 +101,11 @@ class LastUpdateImportTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_with_data_values.json" );
         Date lastUpdateBefore = trackedEntityInstanceService
             .getTrackedEntityInstance( trackedEntity.getTrackedEntity() ).getLastUpdated();
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
+        assertNoErrors( trackerImportService.importTracker( trackerImportParams ) );
 
         trackerImportParams = fromJson( "tracker/event_with_updated_data_values.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.UPDATE );
-        assertNoImportErrors( trackerImportService.importTracker( trackerImportParams ) );
+        assertNoErrors( trackerImportService.importTracker( trackerImportParams ) );
         manager.clear();
         assertTrue( manager.get( TrackedEntityInstance.class, trackedEntity.getTrackedEntity() ).getLastUpdated()
             .getTime() > lastUpdateBefore.getTime() );
@@ -122,7 +122,7 @@ class LastUpdateImportTest extends TrackerTest
         enrollment.setStatus( EnrollmentStatus.COMPLETED );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.UPDATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         manager.clear();
         assertTrue( manager.get( TrackedEntityInstance.class, trackedEntity.getTrackedEntity() ).getLastUpdated()
             .getTime() > lastUpdateBefore.getTime() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -87,9 +87,9 @@ class OwnershipTest extends TrackerTest
         injectSecurityContext( superUser );
 
         nonSuperUser = userService.getUser( "Tu9fv8ezgHl" );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/ownership_tei.json", superUser.getUid() ) ) );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/ownership_enrollment.json", superUser.getUid() ) ) );
     }
 
@@ -129,7 +129,7 @@ class OwnershipTest extends TrackerTest
         manager.flush();
         TrackerImportParams teiParams = fromJson( "tracker/ownership_tei.json", nonSuperUser );
         TrackerImportParams enrollmentParams = fromJson( "tracker/ownership_enrollment.json", nonSuperUser );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> teis = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, teis.size() );
@@ -181,7 +181,7 @@ class OwnershipTest extends TrackerTest
         enrollmentParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
         manager.flush();
-        assertNoImportErrors( updatedReport );
+        assertNoErrors( updatedReport );
         assertEquals( 1, updatedReport.getStats().getUpdated() );
         pis = manager.getAll( ProgramInstance.class );
         assertEquals( 2, pis.size() );
@@ -201,7 +201,7 @@ class OwnershipTest extends TrackerTest
         pis.stream().filter( e -> e.getUid().equals( "TvctPPhpD8u" ) ).findAny().get();
         enrollmentParams.setImportStrategy( TrackerImportStrategy.DELETE );
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
-        assertNoImportErrors( updatedReport );
+        assertNoErrors( updatedReport );
         assertEquals( 1, updatedReport.getStats().getDeleted() );
         pis = manager.getAll( ProgramInstance.class );
         assertEquals( 1, pis.size() );
@@ -217,14 +217,14 @@ class OwnershipTest extends TrackerTest
         assertEquals( 2, pis.size() );
         enrollmentParams.setImportStrategy( TrackerImportStrategy.DELETE );
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
-        assertNoImportErrors( updatedReport );
+        assertNoErrors( updatedReport );
         assertEquals( 1, updatedReport.getStats().getDeleted() );
         pis = manager.getAll( ProgramInstance.class );
         assertEquals( 1, pis.size() );
         enrollmentParams.setImportStrategy( TrackerImportStrategy.CREATE );
         enrollmentParams.getEnrollments().get( 0 ).setEnrollment( CodeGenerator.generateUid() );
         updatedReport = trackerImportService.importTracker( enrollmentParams );
-        assertNoImportErrors( updatedReport );
+        assertNoErrors( updatedReport );
         assertEquals( 1, updatedReport.getStats().getCreated() );
         pis = manager.getAll( ProgramInstance.class );
         assertEquals( 2, pis.size() );
@@ -240,7 +240,7 @@ class OwnershipTest extends TrackerTest
         assertEquals( 2, pis.size() );
         enrollmentParams.setImportStrategy( TrackerImportStrategy.DELETE );
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
-        assertNoImportErrors( updatedReport );
+        assertNoErrors( updatedReport );
         assertEquals( 1, updatedReport.getStats().getDeleted() );
         TrackedEntityInstance tei = manager.get( TrackedEntityInstance.class, "IOR1AXXl24H" );
         OrganisationUnit ou = manager.get( OrganisationUnit.class, "B1nCbRV3qtP" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/RelationshipImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/RelationshipImportTest.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.tracker.bundle;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 
 import java.io.IOException;
 
@@ -64,11 +64,11 @@ class RelationshipImportTest extends TrackerTest
     {
         setUpMetadata( "tracker/simple_metadata.json" );
         userA = userService.getUser( "M5zQapPyTZI" );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/single_tei.json", userA.getUid() ) ) );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/single_enrollment.json", userA.getUid() ) ) );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/single_event.json", userA.getUid() ) ) );
         manager.flush();
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -90,7 +90,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         assertEquals( 9, params.getTrackedEntities().size() );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertDeletedObjects( 9, trackerImportReport.getBundleReport(), TrackerType.TRACKED_ENTITY );
         // remaining
         assertEquals( 4, manager.getAll( TrackedEntityInstance.class ).size() );
@@ -107,7 +107,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
         params.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.ENROLLMENT );
         // remaining
@@ -125,7 +125,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.EVENT );
         // remaining
         assertEquals( 1, manager.getAll( ProgramStageInstance.class ).size() );
@@ -155,7 +155,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.ENROLLMENT );
         assertDeletedObjects( 1, trackerImportReport.getBundleReport(), TrackerType.TRACKED_ENTITY );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryIntegrationTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -72,7 +72,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportTeiReport );
+        assertNoErrors( trackerImportTeiReport );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getIgnored() );
@@ -94,7 +94,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportTeiReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportTeiReport );
+        assertNoErrors( trackerImportTeiReport );
         assertEquals( 1, trackerImportTeiReport.getStats().getCreated() );
         assertEquals( 1, trackerImportTeiReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportTeiReport.getStats().getIgnored() );
@@ -141,7 +141,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportEnrollmentReport );
+        assertNoErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -163,7 +163,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportEnrollmentReport );
+        assertNoErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -175,7 +175,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportEnrollmentReport );
+        assertNoErrors( trackerImportEnrollmentReport );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -202,7 +202,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportEnrollmentReport );
+        assertNoErrors( trackerImportEnrollmentReport );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEnrollmentReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEnrollmentReport.getStats().getIgnored() );
@@ -259,7 +259,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportEventReport );
+        assertNoErrors( trackerImportEventReport );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 0, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEventReport.getStats().getIgnored() );
@@ -292,7 +292,7 @@ class ReportSummaryIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportEventReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportEventReport );
+        assertNoErrors( trackerImportEventReport );
         assertEquals( 1, trackerImportEventReport.getStats().getCreated() );
         assertEquals( 1, trackerImportEventReport.getStats().getUpdated() );
         assertEquals( 0, trackerImportEventReport.getStats().getIgnored() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -95,7 +95,7 @@ class TrackedEntityAttributeTest extends TrackerTest
     {
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/te_with_tea_data.json" ) );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityAttributeValueAuditTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -80,7 +80,7 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
     void testTrackedEntityAttributeValueAuditCreate()
         throws IOException
     {
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/te_program_with_tea_data.json" ) ) );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
@@ -103,7 +103,7 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         List<TrackedEntityAttributeValue> attributeValues1 = trackedEntityAttributeValueService
             .getTrackedEntityAttributeValues( manager.getAll( TrackedEntityInstance.class ).get( 0 ) );
         List<TrackedEntityAttribute> attributes1 = attributeValues1.stream()
@@ -111,7 +111,7 @@ class TrackedEntityAttributeValueAuditTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_null_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         List<TrackedEntityAttributeValueAudit> attributeValueAudits = attributeValueAuditService
             .getTrackedEntityAttributeValueAudits( attributes1, trackedEntityInstances, AuditType.DELETE );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityDataValueAuditTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,11 +79,11 @@ public class TrackedEntityDataValueAuditTest extends TrackerTest
     void testTrackedEntityDataValueAuditCreate()
         throws IOException
     {
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/event_and_enrollment_with_data_values.json" ) ) );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/event_with_data_values_for_update_audit.json" ) ) );
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/event_with_data_values_for_delete_audit.json" ) ) );
 
         DataElement dataElement = manager.search( DataElement.class, DE );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeEncryptionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeEncryptionTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -78,7 +78,7 @@ class TrackedEntityProgramAttributeEncryptionTest extends TrackerTest
     {
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/te_program_with_tea_encryption_data.json" ) );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeFileResourceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeFileResourceTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,7 +87,7 @@ class TrackedEntityProgramAttributeFileResourceTest extends TrackerTest
         assertFalse( fileResource.isAssigned() );
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/te_program_with_tea_fileresource_data.json" ) );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackedEntityProgramAttributeTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -74,7 +74,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -90,7 +90,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -103,7 +103,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_update_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -118,7 +118,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson( "tracker/te_program_with_tea_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -131,7 +131,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_update_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 1, trackedEntityInstances.size() );
@@ -143,7 +143,7 @@ class TrackedEntityProgramAttributeTest extends TrackerTest
         trackerImportParams = fromJson( "tracker/te_program_with_tea_delete_data.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.DELETE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 0, trackedEntityInstances.size() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackerEventBundleServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackerEventBundleServiceTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -69,7 +69,7 @@ class TrackerEventBundleServiceTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_events_and_enrollment.json" );
         assertEquals( 8, trackerImportParams.getEvents().size() );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<ProgramStageInstance> programStageInstances = programStageInstanceStore.getAll();
         assertEquals( 8, programStageInstances.size() );
@@ -82,11 +82,11 @@ class TrackerEventBundleServiceTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson( "tracker/event_events_and_enrollment.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertEquals( 8, programStageInstanceStore.getAll().size() );
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         assertEquals( 8, programStageInstanceStore.getAll().size() );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/TrackerSideEffectHandlerServiceTest.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -69,7 +69,7 @@ class TrackerSideEffectHandlerServiceTest extends TrackerTest
     {
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/enrollment_data_with_program_rule_side_effects.json" ) );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         List<ProgramNotificationInstance> instances = manager.getAll( ProgramNotificationInstance.class );
         assertFalse( instances.isEmpty() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleIntegrationTest.java
@@ -28,8 +28,11 @@
 package org.hisp.dhis.tracker.programrule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -148,7 +151,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/program_event.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertEquals( 1, trackerImportReport.getValidationReport().getWarnings().size() );
     }
 
@@ -160,7 +163,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
         params.getEvents().clear();
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         params = fromJson( "tracker/tei_enrollment_event.json" );
         params.getTrackedEntities().clear();
@@ -170,7 +173,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
         params.getEvents().forEach( e -> e.setOccurredAt( oneWeekFromNow ) );
         trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertEquals( 4, trackerImportReport.getValidationReport().getWarnings().size() );
         // TODO: Review this test when DHIS2-13468 is fixed
         assertThat( trackerImportReport.getValidationReport().getWarnings(),
@@ -183,12 +186,12 @@ class ProgramRuleIntegrationTest extends TrackerTest
     {
         TrackerImportReport trackerImportTeiReport = trackerImportService
             .importTracker( fromJson( "tracker/single_tei.json" ) );
-        assertNoImportErrors( trackerImportTeiReport );
+        assertNoErrors( trackerImportTeiReport );
 
         TrackerImportReport trackerImportEnrollmentReport = trackerImportService
             .importTracker( fromJson( "tracker/single_enrollment.json" ) );
 
-        assertNoImportErrors( trackerImportEnrollmentReport );
+        assertNoErrors( trackerImportEnrollmentReport );
         assertEquals( 2, trackerImportEnrollmentReport.getValidationReport().getWarnings().size() );
     }
 
@@ -200,7 +203,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         List<TrackerWarningReport> warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 6, warningReports.size() );
         assertEquals( 4,
@@ -213,7 +216,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 4, warningReports.size() );
         assertThat( trackerImportReport.getValidationReport().getWarnings(),
@@ -226,7 +229,7 @@ class ProgramRuleIntegrationTest extends TrackerTest
 
         trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         warningReports = trackerImportReport.getValidationReport().getWarnings();
         assertEquals( 4, warningReports.size() );
         assertThat( trackerImportReport.getValidationReport().getWarnings(),

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -62,7 +62,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata_mandatory_attr.json" );
         injectAdminUser();
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/validations/enrollments_te_te-data_2.json" ) ) );
         manager.flush();
     }
@@ -85,8 +85,10 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson(
             "tracker/validations/enrollments_te_with_valid_option_value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -144,8 +146,10 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson(
             "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -153,17 +157,27 @@ class EnrollmentAttrValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+
+        assertNoErrors( trackerImportReport );
+
         manager.flush();
         manager.clear();
+
         params = fromJson( "tracker/validations/enrollments_te_unique_attr_same_tei.json" );
+
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
+
         manager.flush();
         manager.clear();
+
         params = fromJson( "tracker/validations/enrollments_te_unique_attr_in_db.json" );
+
         trackerImportReport = trackerImportService.importTracker( params );
+
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
@@ -175,7 +189,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         manager.flush();
         manager.clear();
         params = fromJson( "tracker/validations/enrollments_te_unique_attr.json" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,7 +77,7 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/validations/enrollments_te_te-data.json" ) ) );
         manager.flush();
     }
@@ -88,7 +88,7 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -97,7 +97,7 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         TrackerImportParams secondParams = fromJson(
             "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerPreheat preheat = trackerPreheatService.preheat( secondParams );
@@ -145,10 +145,12 @@ class EnrollmentImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_attr-data.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
+
+        assertNoErrors( trackerImportReport );
         assertEquals( 1, trackerImportReport.getBundleReport().getTypeReportMap().get( TrackerType.ENROLLMENT )
             .getObjectReportMap().values().size() );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
             everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
     }
@@ -161,7 +163,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_attr-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         manager.flush();
         importProgramStageInstances();
         manager.flush();
@@ -183,7 +185,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/events-with-registration.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -192,13 +194,17 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/enrollments_double-tei-enrollment_part1.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        TrackerValidationReport validationReport = trackerImportReport.getValidationReport();
-        assertEquals( 0, validationReport.getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
+
         TrackerImportParams trackerImportParams1 = fromJson(
             "tracker/validations/enrollments_double-tei-enrollment_part2.json" );
+
         trackerImportReport = trackerImportService.importTracker( trackerImportParams1 );
-        validationReport = trackerImportReport.getValidationReport();
+
+        TrackerValidationReport validationReport = trackerImportReport.getValidationReport();
         assertEquals( 1, validationReport.getErrors().size() );
         assertThat( validationReport.getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
@@ -211,7 +217,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams paramsCreate = fromJson(
             "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( paramsCreate );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         manager.flush();
         manager.clear();
@@ -221,7 +227,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
-        assertNoImportErrors( trackerImportReportDelete );
+        assertNoErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }
 
@@ -233,7 +239,9 @@ class EnrollmentImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_bad-note-no-value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -170,7 +170,7 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        assertNoImportErrors(
+        assertNoErrors(
             trackerImportService.importTracker( fromJson( "tracker/validations/enrollments_te_te-data.json" ) ) );
     }
 
@@ -252,8 +252,10 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_no-access-program.json" );
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Every.everyItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.DELETE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.UPDATE;
@@ -92,9 +92,9 @@ class EventImportValidationTest extends TrackerTest
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
 
-        assertNoImportErrors( trackerImportService.importTracker( fromJson(
+        assertNoErrors( trackerImportService.importTracker( fromJson(
             "tracker/validations/enrollments_te_te-data.json" ) ) );
-        assertNoImportErrors( trackerImportService
+        assertNoErrors( trackerImportService
             .importTracker( fromJson( "tracker/validations/enrollments_te_enrollments-data.json" ) ) );
     }
 
@@ -117,7 +117,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/validations/events-with_valid_option_value.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -127,7 +127,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/validations/events-with-registration.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -137,7 +137,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events-without-attribute-option-combo.json" ) );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -149,12 +149,12 @@ class EventImportValidationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         trackerBundleParams.setImportStrategy( UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -197,10 +197,15 @@ class EventImportValidationTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/events_non-repeatable-programstage_part1.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
+
         trackerImportParams = fromJson( "tracker/validations/events_non-repeatable-programstage_part2.json" );
+
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
+
         assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
         assertThat( trackerImportReport.getValidationReport().getErrors(),
             hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1039 ) ) ) );
@@ -409,7 +414,7 @@ class EventImportValidationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         manager.flush();
         manager.clear();
@@ -419,7 +424,7 @@ class EventImportValidationTest extends TrackerTest
         paramsDelete.setImportStrategy( DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
-        assertNoImportErrors( trackerImportReportDelete );
+        assertNoErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }
 
@@ -432,7 +437,7 @@ class EventImportValidationTest extends TrackerTest
         // When
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
         // Then
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         return trackerImportReport;
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.validation.Users.USER_5;
@@ -139,9 +139,9 @@ class EventSecurityImportValidationTest extends TrackerTest
     {
         setUpMetadata( "tracker/tracker_basic_metadata.json" );
         injectAdminUser();
-        assertNoImportErrors( trackerImportService.importTracker( fromJson(
+        assertNoErrors( trackerImportService.importTracker( fromJson(
             "tracker/validations/enrollments_te_te-data.json" ) ) );
-        assertNoImportErrors( trackerImportService
+        assertNoErrors( trackerImportService
             .importTracker( fromJson( "tracker/validations/enrollments_te_enrollments-data.json" ) ) );
         manager.flush();
     }
@@ -253,7 +253,7 @@ class EventSecurityImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/events_error-no-uncomplete.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         // Change just inserted Event to status COMPLETED...
         ProgramStageInstance zwwuwNp6gVd = programStageServiceInstance.getProgramStageInstance( "ZwwuwNp6gVd" );
         zwwuwNp6gVd.setStatus( EventStatus.COMPLETED );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -65,17 +65,17 @@ class TeTaEncryptionValidationTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_country.json" );
         trackerImportParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data_in_region.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -85,7 +85,7 @@ class TeTaEncryptionValidationTest extends TrackerTest
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_unique_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         trackerImportParams = fromJson( "tracker/validations/te-program_with_tea_unique_data2.json" );
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.core.Every.everyItem;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
-import static org.hisp.dhis.tracker.Assertions.assertNoImportErrors;
+import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_1;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
@@ -91,8 +91,10 @@ class TrackedEntityImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-with_valid_option_value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 0, trackerImportReport.getValidationReport().getErrors().size() );
+
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -111,8 +113,10 @@ class TrackedEntityImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -137,7 +141,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertEquals( 3, trackerImportReport.getStats().getCreated() );
         // For some reason teiSearchOrgunits is not created properly from
         // metadata
@@ -152,7 +156,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         params.setAtomicMode( AtomicMode.OBJECT );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertEquals( 3, trackerImportReport.getStats().getUpdated() );
     }
 
@@ -162,7 +166,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         assertEquals( 3, trackerImportReport.getStats().getCreated() );
         dbmsManager.clearSession();
         params = fromJson( "tracker/validations/te-data_with_different_ou.json" );
@@ -202,7 +206,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         user.setPassword( "user4password" );
         injectSecurityContext( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -211,7 +215,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_error_geo-ok.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 
     @Test
@@ -231,7 +235,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
         importProgramInstances();
         manager.flush();
         manager.clear();
@@ -251,7 +255,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
 
         manager.flush();
         manager.clear();
@@ -261,7 +265,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
-        assertNoImportErrors( trackerImportReportDelete );
+        assertNoErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }
 
@@ -270,6 +274,6 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoImportErrors( trackerImportReport );
+        assertNoErrors( trackerImportReport );
     }
 }


### PR DESCRIPTION
in case the expected and actual size differs, we do not get more context other than that they are not equal. Using our own `assertNoErrors` assertion we do also get the list of errors. This context is especially helpful in integration tests which take long to run and/or with flaky tests only failing in CI.

* renamed `assertNoImportErrors` with `assertNoErrors` to overload it, so we can now call it with `TrackerImportReport` and `TrackerValidationReport`
* replaced (hopefully) any `assertEquals` for `errors.size() == 0` with assertNoErrors
