### PR TITLE
test: add context to assertions on error and errors size

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
@@ -49,9 +49,8 @@ public class AssertTrackerValidationReport
         assertTrue( report.hasError( err -> code == err.getErrorCode() &&
             type == err.getTrackerType() &&
             uid.equals( err.getUid() ) ),
-            String.format( "error with code %s, type %s, uid %s not found in report with %d unique error(s)", code,
-                type,
-                uid, report.size() ) );
+            String.format( "error with code %s, type %s, uid %s not found in report with error(s) %s", code,
+                type, uid, report.getErrors() ) );
     }
 
     public static void assertHasWarning( TrackerValidationReport report, TrackerErrorCode code, TrackerDto dto )
@@ -66,7 +65,7 @@ public class AssertTrackerValidationReport
         assertTrue( report.hasWarning( warning -> code == warning.getWarningCode() &&
             type == warning.getTrackerType() &&
             uid.equals( warning.getUid() ) ),
-            String.format( "warning with code %s, type %s, uid %s not found in report with %d warnings(s)", code, type,
-                uid, report.getWarnings().size() ) );
+            String.format( "warning with code %s, type %s, uid %s not found in report with warnings(s) %s", code, type,
+                uid, report.getWarnings() ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/Assertions.java
@@ -27,18 +27,141 @@
  */
 package org.hisp.dhis.tracker;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.function.Supplier;
 
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
 import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
+import org.junit.jupiter.api.function.Executable;
 
+/**
+ * Collection of tracker specific assertions to help in asserting for example
+ * validation errors.
+ *
+ * While it might work to compose assertions that already use JUnit 5 assertAll
+ * <a href=
+ * "https://junit.org/junit5/docs/5.8.2/api/org.junit.jupiter.api/org/junit/jupiter/api/Assertions.html#assertAll(java.lang.String,java.util.Collection)">...</a>
+ * using assertAll its documentation does not mention that it is designed for
+ * this use. Keep that in mind when using the assertions in this class in tests.
+ *
+ * Note: some assertions are duplicates of AssertTrackerValidationReport. This
+ * is due to a constraint in our dependencies. dhis-test-integration cannot use
+ * test scope dependency on dhis-service-tracker otherwise it would not report
+ * coverage for tracker code. This means we do not have access to test code
+ * within dhis-service-tracker. Moving the assertions into dhis-support-test
+ * would need a dependency on tracker, which would make it not a generic test
+ * module. We will have to live with the duplicated assertion code until we have
+ * a better solution.
+ */
 public class Assertions
 {
+    /**
+     * assertHasErrors asserts the report contains only errors of given codes in
+     * any order.
+     *
+     * @param report import report to be asserted on
+     * @param codes expected error codes
+     */
+    public static void assertHasOnlyErrors( TrackerImportReport report, TrackerErrorCode... codes )
+    {
+        assertHasOnlyErrors( report.getValidationReport(), codes );
+    }
+
+    /**
+     * assertHasErrors asserts the report contains only errors of given codes in
+     * any order.
+     *
+     * @param report validation report to be asserted on
+     * @param codes expected error codes
+     */
+    public static void assertHasOnlyErrors( TrackerValidationReport report, TrackerErrorCode... codes )
+    {
+        assertHasErrors( report, codes.length, codes );
+    }
+
+    /**
+     * assertHasErrors asserts the report contains given count of errors and
+     * errors contain given codes in any order.<br>
+     * <em>NOTE:</em> prefer
+     * {@link #assertHasOnlyErrors(TrackerImportReport, TrackerErrorCode...)} or
+     * {@link #assertHasErrors(TrackerValidationReport, TrackerErrorCode...)}.
+     * Rethink your test if you need this assertion. If you want to make sure a
+     * certain number of errors are present, why do you not care about what
+     * errors are present? The intention of an assertion like
+     * <code>assertHasErrors(report, 13, TrackerErrorCode.E1000);</code> is not
+     * clear.
+     *
+     * @param report import report to be asserted on
+     * @param codes expected error codes
+     */
+    public static void assertHasErrors( TrackerImportReport report, int count, TrackerErrorCode... codes )
+    {
+        assertHasErrors( report.getValidationReport(), count, codes );
+    }
+
+    /**
+     * assertHasErrors asserts the report contains given count of errors and
+     * errors contain given codes in any order. <em>NOTE:</em> prefer
+     * {@link #assertHasOnlyErrors(TrackerImportReport, TrackerErrorCode...)} or
+     * {@link #assertHasErrors(TrackerValidationReport, TrackerErrorCode...)}.
+     * Rethink your test if you need this assertion. If you want to make sure a
+     * certain number of errors are present, why do you not care about what
+     * errors are present? The intention of an assertion like
+     * <code>assertHasErrors(report, 13, TrackerErrorCode.E1000);</code> is not
+     * clear.
+     *
+     * @param report validation report to be asserted on
+     * @param codes expected error codes
+     */
+    public static void assertHasErrors( TrackerValidationReport report, int count, TrackerErrorCode... codes )
+    {
+        assertTrue( report.hasErrors(), "error not found since report has no errors" );
+        ArrayList<Executable> executables = new ArrayList<>();
+        executables.add( () -> assertEquals( count, report.getErrors().size(),
+            String.format( "mismatch in number of expected error(s), got %s", report.getErrors() ) ) );
+        Arrays.stream( codes ).map( c -> ((Executable) () -> assertHasError( report, c )) ).forEach( executables::add );
+        assertAll( "assertHasErrors", executables );
+    }
+
+    /**
+     * assertHasErrors asserts the report contains errors of given codes in any
+     * order.
+     *
+     * @param report validation report to be asserted on
+     * @param codes expected error codes
+     */
+    public static void assertHasErrors( TrackerValidationReport report, TrackerErrorCode... codes )
+    {
+        assertTrue( report.hasErrors(), "error not found since report has no errors" );
+        ArrayList<Executable> executables = new ArrayList<>();
+        Arrays.stream( codes ).map( c -> ((Executable) () -> assertHasError( report, c )) ).forEach( executables::add );
+        assertAll( "assertHasErrors", executables );
+    }
+
+    public static void assertHasError( TrackerImportReport report, TrackerErrorCode code )
+    {
+        assertNotNull( report );
+        assertAll(
+            () -> assertEquals( TrackerStatus.ERROR, report.getStatus(),
+                errorMessage( "Expected import with status OK, instead got:\n", report.getValidationReport() ) ),
+            () -> assertHasError( report.getValidationReport(), code ) );
+    }
+
+    public static void assertHasError( TrackerValidationReport report, TrackerErrorCode code )
+    {
+        assertTrue( report.hasErrors(), "error not found since report has no errors" );
+        assertTrue( report.hasError( err -> code == err.getErrorCode() ),
+            String.format( "error with code %s not found in report with error(s) %s", code, report.getErrors() ) );
+    }
 
     public static void assertNoErrors( TrackerImportReport report )
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/AssertionsTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/AssertionsTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker;
+
+import static org.hisp.dhis.tracker.Assertions.assertHasError;
+import static org.hisp.dhis.tracker.Assertions.assertHasErrors;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+import org.hisp.dhis.tracker.report.TrackerValidationReport;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link Assertions}. Uncomment the commented assertions in each test
+ * if you want to iterate on the assertion messages. They are a copy of the
+ * {@link org.junit.jupiter.api.function.Executable} in the
+ * <code>assertThrows</code> statements.
+ *
+ */
+public class AssertionsTest
+{
+    @Test
+    void testAssertHasOnlyErrorsFailsIfReportHasNoErrors()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+
+        assertThrows( AssertionError.class, () -> assertHasOnlyErrors( report, TrackerErrorCode.E1000 ) );
+        // assertHasOnlyErrors(report, TrackerErrorCode.E1000);
+    }
+
+    @Test
+    void testAssertHasOnlyErrorsFailsIfReportHasMoreErrors()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1019 ).build() );
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1041 ).build() );
+
+        assertThrows( AssertionError.class,
+            () -> assertHasOnlyErrors( report, TrackerErrorCode.E1000, TrackerErrorCode.E1019 ) );
+        // assertHasOnlyErrors( report, TrackerErrorCode.E1000,
+        // TrackerErrorCode.E1019 );
+    }
+
+    @Test
+    void testAssertHasOnlyErrorsFailsIfReportHasLessErrors()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+
+        assertThrows( AssertionError.class,
+            () -> assertHasOnlyErrors( report, TrackerErrorCode.E1000, TrackerErrorCode.E1003 ) );
+        // assertHasOnlyErrors( report, TrackerErrorCode.E1000,
+        // TrackerErrorCode.E1003 );
+    }
+
+    @Test
+    void testAssertHasOnlyErrorsSucceeds()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+
+        assertHasOnlyErrors( report, TrackerErrorCode.E1000 );
+    }
+
+    @Test
+    void testAssertHasErrorsFailsIfReportHasLessErrors()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1001 ).build() );
+
+        assertThrows( AssertionError.class, () -> assertHasErrors( report, 3, TrackerErrorCode.E1000 ) );
+        // assertHasErrors( report,3, TrackerErrorCode.E1000 );
+    }
+
+    @Test
+    void testAssertHasErrorsSucceeds()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1001 ).build() );
+
+        assertHasErrors( report, 2, TrackerErrorCode.E1000 );
+    }
+
+    @Test
+    void testAssertHasErrorFailsIfReportDoesNotHaveError()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1041 ).build() );
+
+        assertThrows( AssertionError.class, () -> assertHasError( report, TrackerErrorCode.E1019 ) );
+        // assertHasError( report, TrackerErrorCode.E1019 );
+    }
+
+    @Test
+    void testAssertHasErrorFailsIfReportDoesNotHaveErrors()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+
+        assertThrows( AssertionError.class, () -> assertHasError( report, TrackerErrorCode.E1019 ) );
+        // assertHasError( report, TrackerErrorCode.E1019 );
+    }
+
+    @Test
+    void testAssertHasErrorSucceeds()
+    {
+
+        TrackerValidationReport report = new TrackerValidationReport();
+        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
+
+        assertHasError( report, TrackerErrorCode.E1000 );
+    }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/OwnershipTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertHasError;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -250,8 +251,7 @@ class OwnershipTest extends TrackerTest
         enrollmentParams.getEnrollments().get( 0 ).setEnrollment( CodeGenerator.generateUid() );
         updatedReport = trackerImportService.importTracker( enrollmentParams );
         assertEquals( 1, updatedReport.getStats().getIgnored() );
-        assertEquals( TrackerErrorCode.E1102,
-            updatedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
+        assertHasError( updatedReport, TrackerErrorCode.E1102 );
     }
 
     @Test
@@ -267,8 +267,7 @@ class OwnershipTest extends TrackerTest
         enrollmentParams.setImportStrategy( TrackerImportStrategy.DELETE );
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
         assertEquals( 1, updatedReport.getStats().getIgnored() );
-        assertEquals( TrackerErrorCode.E1102,
-            updatedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
+        assertHasError( updatedReport, TrackerErrorCode.E1102 );
     }
 
     @Test
@@ -284,8 +283,7 @@ class OwnershipTest extends TrackerTest
         enrollmentParams.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         TrackerImportReport updatedReport = trackerImportService.importTracker( enrollmentParams );
         assertEquals( 1, updatedReport.getStats().getIgnored() );
-        assertEquals( TrackerErrorCode.E1102,
-            updatedReport.getValidationReport().getErrors().get( 0 ).getErrorCode() );
+        assertHasError( updatedReport, TrackerErrorCode.E1102 );
     }
 
     private void compareEnrollmentBasicProperties( ProgramInstance pi, Enrollment enrollment )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/bundle/ReportSummaryDeleteIntegrationTest.java
@@ -27,12 +27,12 @@
  */
 package org.hisp.dhis.tracker.bundle;
 
+import static org.hisp.dhis.tracker.Assertions.assertHasError;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
@@ -44,9 +44,7 @@ import org.hisp.dhis.tracker.TrackerTest;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.report.TrackerBundleReport;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerImportReport;
-import org.hisp.dhis.tracker.report.TrackerStatus;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -140,10 +138,7 @@ class ReportSummaryDeleteIntegrationTest extends TrackerTest
 
         TrackerImportReport importReport = trackerImportService.importTracker( params );
 
-        assertEquals( TrackerStatus.ERROR, importReport.getStatus() );
-        assertTrue( importReport.getValidationReport().hasErrors() );
-        List<TrackerErrorReport> trackerErrorReports = importReport.getValidationReport().getErrors();
-        assertEquals( TrackerErrorCode.E1081, trackerErrorReports.get( 0 ).getErrorCode() );
+        assertHasError( importReport, TrackerErrorCode.E1081 );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentAttrValidationTest.java
@@ -27,12 +27,9 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertHasErrors;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -74,9 +71,8 @@ class EnrollmentAttrValidationTest extends TrackerTest
         TrackerImportParams params = fromJson(
             "tracker/validations/enrollments_te_with_invalid_option_value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1125 );
     }
 
     @Test
@@ -100,9 +96,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
 
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1075 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1075 );
     }
 
     @Test
@@ -112,9 +106,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
         TrackerImportParams params = fromJson(
             "tracker/validations/enrollments_te_attr-missing-value.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1076 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1076 );
     }
 
     @Test
@@ -123,9 +115,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_attr-non-existing.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1006 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1006 );
     }
 
     @Test
@@ -135,9 +125,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
         TrackerImportParams params = fromJson(
             "tracker/validations/enrollments_te_attr-missing-mandatory.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1018 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1018 );
     }
 
     @Test
@@ -178,9 +166,7 @@ class EnrollmentAttrValidationTest extends TrackerTest
 
         trackerImportReport = trackerImportService.importTracker( params );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1064 );
     }
 
     @Test
@@ -188,17 +174,14 @@ class EnrollmentAttrValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data_3.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoErrors( trackerImportReport );
+        assertNoErrors( trackerImportService.importTracker( params ) );
         manager.flush();
         manager.clear();
         params = fromJson( "tracker/validations/enrollments_te_unique_attr.json" );
 
-        trackerImportReport = trackerImportService.importTracker( params );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
 
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
+        assertHasErrors( trackerImportReport, 2, TrackerErrorCode.E1064 );
     }
 
     @Test
@@ -207,9 +190,9 @@ class EnrollmentAttrValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson(
             "tracker/validations/enrollments_te_attr-only-program-attr.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1019 );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentImportValidationTest.java
@@ -27,11 +27,8 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertHasErrors;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
@@ -123,10 +120,10 @@ class EnrollmentImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_enrollments-data.json" );
         User user = userService.getUser( USER_2 );
         params.setUser( user );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
+
+        assertHasErrors( trackerImportReport, 4, TrackerErrorCode.E1000 );
     }
 
     @Test
@@ -134,10 +131,10 @@ class EnrollmentImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_error_non_program_attr.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 3, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
+
+        assertHasErrors( trackerImportReport, 3, TrackerErrorCode.E1019 );
     }
 
     @Test
@@ -151,8 +148,6 @@ class EnrollmentImportValidationTest extends TrackerTest
         assertNoErrors( trackerImportReport );
         assertEquals( 1, trackerImportReport.getBundleReport().getTypeReportMap().get( TrackerType.ENROLLMENT )
             .getObjectReportMap().values().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1019 ) ) ) );
     }
 
     @Test
@@ -171,12 +166,10 @@ class EnrollmentImportValidationTest extends TrackerTest
         User user2 = userService.getUser( USER_4 );
         params.setUser( user2 );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
+
         TrackerImportReport trackerImportDeleteReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportDeleteReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportDeleteReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1103 ) ) ) );
-        assertThat( trackerImportDeleteReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1091 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportDeleteReport, TrackerErrorCode.E1103, TrackerErrorCode.E1091 );
     }
 
     protected void importProgramStageInstances()
@@ -184,7 +177,9 @@ class EnrollmentImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/events-with-registration.json" );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
+
         assertNoErrors( trackerImportReport );
     }
 
@@ -205,9 +200,8 @@ class EnrollmentImportValidationTest extends TrackerTest
         trackerImportReport = trackerImportService.importTracker( trackerImportParams1 );
 
         TrackerValidationReport validationReport = trackerImportReport.getValidationReport();
-        assertEquals( 1, validationReport.getErrors().size() );
-        assertThat( validationReport.getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1015 ) ) ) );
+
+        assertHasOnlyErrors( validationReport, TrackerErrorCode.E1015 );
     }
 
     @Test
@@ -227,6 +221,7 @@ class EnrollmentImportValidationTest extends TrackerTest
         paramsDelete.setImportStrategy( TrackerImportStrategy.DELETE );
 
         TrackerImportReport trackerImportReportDelete = trackerImportService.importTracker( paramsDelete );
+
         assertNoErrors( trackerImportReportDelete );
         assertEquals( 1, trackerImportReportDelete.getStats().getDeleted() );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EnrollmentSecurityImportValidationTest.java
@@ -27,13 +27,10 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.Assertions.assertHasErrors;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_2;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -183,10 +180,10 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         injectSecurityContext( user );
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
+
+        assertHasErrors( trackerImportReport, 4, TrackerErrorCode.E1000 );
     }
 
     @Test
@@ -206,10 +203,10 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_no-access-tei.json" );
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1104 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1104 );
     }
 
     @Test
@@ -229,10 +226,10 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_no-access-program.json" );
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1091 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1091 );
     }
 
     @Test
@@ -275,9 +272,9 @@ class EnrollmentSecurityImportValidationTest extends TrackerTest
             "tracker/validations/enrollments_program-teitype-missmatch.json" );
         params.setUser( user );
         params.setImportStrategy( TrackerImportStrategy.CREATE );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1104 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1104 );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -28,11 +28,8 @@
 package org.hisp.dhis.tracker.validation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.CREATE_AND_UPDATE;
 import static org.hisp.dhis.tracker.TrackerImportStrategy.DELETE;
@@ -105,9 +102,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events-with_invalid_option_value.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1125 );
     }
 
     @Test
@@ -165,16 +160,11 @@ class EventImportValidationTest extends TrackerTest
             "tracker/validations/events-cat-write-access.json" );
         User user = userService.getUser( USER_6 );
         trackerImportParams.setUser( user );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 4, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1099 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1104 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1096 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1095 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1099, TrackerErrorCode.E1104,
+            TrackerErrorCode.E1096, TrackerErrorCode.E1095 );
     }
 
     @Test
@@ -186,9 +176,7 @@ class EventImportValidationTest extends TrackerTest
         User user = userService.getUser( USER_2 );
         trackerBundleParams.setUser( user );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1000 );
     }
 
     @Test
@@ -206,9 +194,7 @@ class EventImportValidationTest extends TrackerTest
 
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1039 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1039 );
     }
 
     @Test
@@ -225,9 +211,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_non-default-combo.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1055 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1055 );
     }
 
     @Test
@@ -237,9 +221,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_cant-find-cat-opt-combo.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1115 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1115 );
     }
 
     @Test
@@ -249,9 +231,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_cant-find-aoc-with-subset-of-cos.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1117 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1117 );
     }
 
     @Test
@@ -261,9 +241,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_cant-find-aoc-but-co-exists.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1115 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1115 );
     }
 
     @Test
@@ -273,9 +251,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_cant-find-cat-option.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1116 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1116 );
     }
 
     @Test
@@ -285,9 +261,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events-aoc-not-in-program-cc.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1054 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1054 );
     }
 
     @Test
@@ -297,9 +271,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events-aoc-and-co-dont-match.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1117 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1117 );
     }
 
     @Test
@@ -309,9 +281,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_cant-find-cat-option-combo-for-given-cc-and-co.json" ) );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1117 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1117 );
     }
 
     @Test
@@ -321,11 +291,7 @@ class EventImportValidationTest extends TrackerTest
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( fromJson(
             "tracker/validations/events_combo-date-wrong.json" ) );
 
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1056 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1057 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1056, TrackerErrorCode.E1057 );
     }
 
     @Test
@@ -400,9 +366,8 @@ class EventImportValidationTest extends TrackerTest
         trackerBundleParams.setImportStrategy( importStrategy );
         // When
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1082 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1082 );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventSecurityImportValidationTest.java
@@ -27,15 +27,11 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
 import static org.hisp.dhis.tracker.validation.Users.USER_4;
 import static org.hisp.dhis.tracker.validation.Users.USER_5;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Calendar;
@@ -237,12 +233,10 @@ class EventSecurityImportValidationTest extends TrackerTest
         trackerBundleParams.setUser( user );
         user.addOrganisationUnit( organisationUnitA );
         manager.update( user );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1095 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1096 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1095, TrackerErrorCode.E1096 );
     }
 
     @Test
@@ -274,8 +268,6 @@ class EventSecurityImportValidationTest extends TrackerTest
         trackerBundleParams.setUserId( user.getUid() );
         trackerBundleParams.setImportStrategy( TrackerImportStrategy.UPDATE );
         trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1083 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1083 );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TeTaEncryptionValidationTest.java
@@ -27,12 +27,8 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
@@ -88,9 +84,9 @@ class TeTaEncryptionValidationTest extends TrackerTest
         assertNoErrors( trackerImportReport );
 
         trackerImportParams = fromJson( "tracker/validations/te-program_with_tea_unique_data2.json" );
+
         trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1064 );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TeTaValidationTest.java
@@ -27,11 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.core.Every.everyItem;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -126,9 +122,7 @@ class TeTaValidationTest extends TrackerTest
         assertTrue( fileResource.isAssigned() );
         trackerImportParams = fromJson( "tracker/validations/te-program_with_tea_fileresource_data2.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1009 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1009 );
     }
 
     @Test
@@ -139,9 +133,7 @@ class TeTaValidationTest extends TrackerTest
             "tracker/validations/te-program_with_tea_fileresource_data.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
 
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1084 ) ) ) );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1084 );
         List<TrackedEntityInstance> trackedEntityInstances = manager.getAll( TrackedEntityInstance.class );
         assertEquals( 0, trackedEntityInstances.size() );
     }
@@ -152,10 +144,10 @@ class TeTaValidationTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_too_long_text_value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1077 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1077 );
     }
 
     @Test
@@ -164,10 +156,10 @@ class TeTaValidationTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_invalid_format_value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1085 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1085 );
     }
 
     @Test
@@ -176,12 +168,10 @@ class TeTaValidationTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_invalid_image_value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1085 ) ) ) );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1007 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1085, TrackerErrorCode.E1007 );
     }
 
     @Test
@@ -190,9 +180,9 @@ class TeTaValidationTest extends TrackerTest
     {
         TrackerImportParams trackerImportParams = fromJson(
             "tracker/validations/te-program_with_tea_invalid_value_isnull.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerImportParams );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1076 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1076 );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/TrackedEntityImportValidationTest.java
@@ -27,12 +27,8 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.core.Every.everyItem;
-import static org.hamcrest.core.IsIterableContaining.hasItem;
+import static org.hisp.dhis.tracker.Assertions.assertHasErrors;
+import static org.hisp.dhis.tracker.Assertions.assertHasOnlyErrors;
 import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.tracker.validation.Users.USER_1;
 import static org.hisp.dhis.tracker.validation.Users.USER_3;
@@ -80,10 +76,10 @@ class TrackedEntityImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-with_invalid_option_value.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1125 ) ) ) );
+
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1125 );
     }
 
     @Test
@@ -102,10 +98,10 @@ class TrackedEntityImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-with_unique_attributes.json" );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1064 ) ) ) );
+
+        assertHasErrors( trackerImportReport, 2, TrackerErrorCode.E1064 );
     }
 
     @Test
@@ -128,11 +124,9 @@ class TrackedEntityImportValidationTest extends TrackerTest
         params.setUser( user );
         params.setAtomicMode( AtomicMode.OBJECT );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1000 );
         assertEquals( 2, trackerImportReport.getStats().getCreated() );
         assertEquals( 1, trackerImportReport.getStats().getIgnored() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            contains( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1000 ) ) ) );
     }
 
     @Test
@@ -175,11 +169,9 @@ class TrackedEntityImportValidationTest extends TrackerTest
         params.setImportStrategy( TrackerImportStrategy.CREATE_AND_UPDATE );
         params.setAtomicMode( AtomicMode.OBJECT );
         trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 1, trackerImportReport.getValidationReport().getErrors().size() );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1003 );
         assertEquals( 2, trackerImportReport.getStats().getUpdated() );
         assertEquals( 1, trackerImportReport.getStats().getIgnored() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            hasItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1003 ) ) ) );
     }
 
     @Test
@@ -189,10 +181,10 @@ class TrackedEntityImportValidationTest extends TrackerTest
         TrackerImportParams params = fromJson( "tracker/validations/te-data_ok.json" );
         User user = userService.getUser( USER_1 );
         params.setUser( user );
+
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 13, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1001 ) ) ) );
+
+        assertHasErrors( trackerImportReport, 13, TrackerErrorCode.E1001 );
     }
 
     @Test
@@ -224,9 +216,8 @@ class TrackedEntityImportValidationTest extends TrackerTest
     {
         TrackerImportParams params = fromJson( "tracker/validations/te-data_error_attr-non-existing.json" );
         TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1006 ) ) ) );
+
+        assertHasErrors( trackerImportReport, 2, TrackerErrorCode.E1006 );
     }
 
     @Test
@@ -234,8 +225,7 @@ class TrackedEntityImportValidationTest extends TrackerTest
         throws IOException
     {
         TrackerImportParams params = fromJson( "tracker/validations/enrollments_te_te-data.json" );
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
-        assertNoErrors( trackerImportReport );
+        assertNoErrors( trackerImportService.importTracker( params ) );
         importProgramInstances();
         manager.flush();
         manager.clear();
@@ -243,10 +233,10 @@ class TrackedEntityImportValidationTest extends TrackerTest
         User user2 = userService.getUser( USER_4 );
         params.setUser( user2 );
         params.setImportStrategy( TrackerImportStrategy.DELETE );
-        trackerImportReport = trackerImportService.importTracker( params );
-        assertEquals( 2, trackerImportReport.getValidationReport().getErrors().size() );
-        assertThat( trackerImportReport.getValidationReport().getErrors(),
-            everyItem( hasProperty( "errorCode", equalTo( TrackerErrorCode.E1100 ) ) ) );
+
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( params );
+
+        assertHasErrors( trackerImportReport, 2, TrackerErrorCode.E1100 );
     }
 
     @Test


### PR DESCRIPTION
in case the expected and actual size differs, we do not get more context
other than that they are not equal. We usually have such assertions
before the assertions checking for error codes within the list of errors
which will then not get executed. Add context using JUnit 5 assertAll
and some custom assertions so both the check for size and content are
executed and the full list of validation errors is printed in case of a
failing assertion.

This context is especially helpful in integration (flaky) tests which take long
to run and/or only fail in CI.

* added a AssertionsTest so we ensure the actually fail when we want to and so we can iterate on the Assertions locally especially the assertion messages.

## Example errors

```java
        TrackerValidationReport report = new TrackerValidationReport();
        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );
        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1019 ).build() );
        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1041 ).build() );

        assertHasOnlyErrors( report, TrackerErrorCode.E1000, TrackerErrorCode.E1019 );
```

leads to an error message like

```
org.opentest4j.MultipleFailuresError: assertHasOnlyErrors (1 failure)
	org.opentest4j.AssertionFailedError: mismatch in number of expected error(s), got [TrackerErrorReport{message=null, errorCode=E1000, trackerEntityType=null, uid=null}, TrackerErrorReport{message=null, errorCode=E1019, trackerEntityType=null, uid=null}, TrackerErrorReport{message=null, errorCode=E1041, trackerEntityType=null, uid=null}] ==> expected: <2> but was: <3>
```


```java
        TrackerValidationReport report = new TrackerValidationReport();
        report.addError( TrackerErrorReport.builder().errorCode( TrackerErrorCode.E1000 ).build() );

        assertHasOnlyErrors( report, TrackerErrorCode.E1000, TrackerErrorCode.E1003 );
```

```
org.opentest4j.MultipleFailuresError: assertHasOnlyErrors (2 failures)
	org.opentest4j.AssertionFailedError: mismatch in number of expected error(s), got [TrackerErrorReport{message=null, errorCode=E1000, trackerEntityType=null, uid=null}] ==> expected: <2> but was: <1>
	org.opentest4j.AssertionFailedError: error with code E1003 not found in report with error(s) [TrackerErrorReport{message=null, errorCode=E1000, trackerEntityType=null, uid=null}] ==> expected: <true> but was: <false>
```