### PR TITLE
fix: NPE when getting tracker/events CSV

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
@@ -151,7 +151,7 @@ public class MvcTestConfig implements WebMvcConfigurer
         .put( "pdf", MediaType.APPLICATION_PDF )
         .put( "xls", parseMediaType( "application/vnd.ms-excel" ) )
         .put( "xlsx", parseMediaType( "application/vnd.ms-excel" ) )
-        .put( "csv", parseMediaType( "application/csv" ) )
+        .put( "csv", parseMediaType( "text/csv" ) )
         .put( "csv.gz", parseMediaType( "application/csv+gzip" ) )
         .put( "csv.zip", parseMediaType( "application/csv+zip" ) )
         .put( "adx.xml", parseMediaType( "application/adx+xml" ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/csv/TrackerCsvEventService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/csv/TrackerCsvEventService.java
@@ -98,14 +98,15 @@ public class TrackerCsvEventService
                 event.getUpdatedAtClient() == null ? null : event.getUpdatedAtClient().toString() );
             templateDataValue
                 .setCompletedAt( event.getCompletedAt() == null ? null : event.getCompletedAt().toString() );
-            templateDataValue.setUpdatedBy( event.getUpdatedBy().getUsername() );
+            templateDataValue.setUpdatedBy( event.getUpdatedBy() == null ? null : event.getUpdatedBy().getUsername() );
             templateDataValue.setStoredBy( event.getStoredBy() );
             templateDataValue
                 .setCompletedAt( event.getCompletedAt() == null ? null : event.getCompletedAt().toString() );
             templateDataValue.setCompletedBy( event.getCompletedBy() );
             templateDataValue.setAttributeOptionCombo( event.getAttributeOptionCombo() );
             templateDataValue.setAttributeCategoryOptions( event.getAttributeCategoryOptions() );
-            templateDataValue.setAssignedUser( event.getAssignedUser().getUsername() );
+            templateDataValue
+                .setAssignedUser( event.getAssignedUser() == null ? null : event.getAssignedUser().getUsername() );
 
             if ( event.getGeometry() != null )
             {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/csv/TrackerCsvEventServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/csv/TrackerCsvEventServiceTest.java
@@ -32,14 +32,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 
 import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.webapi.controller.tracker.view.DataValue;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.hisp.dhis.webapi.controller.tracker.view.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.io.ParseException;
 
@@ -48,7 +52,52 @@ import com.google.common.io.Files;
 class TrackerCsvEventServiceTest
 {
 
-    private TrackerCsvEventService serviceToTest = new TrackerCsvEventService();
+    private TrackerCsvEventService service;
+
+    @BeforeEach
+    void setUp()
+    {
+        service = new TrackerCsvEventService();
+    }
+
+    @Test
+    void writeEventsHandlesEventsWithNullEventFields()
+        throws IOException
+    {
+        // this is not to say Events will ever be defined in such a way, just to
+        // prevent any further NPEs from slipping through
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        service.writeEvents( out, Collections.singletonList( new Event() ), false );
+
+        assertEquals( "", out.toString() );
+    }
+
+    @Test
+    void writeEvents()
+        throws IOException
+    {
+
+        DataValue dataValue = DataValue.builder()
+            .dataElement( "color" )
+            .value( "red" )
+            .providedElsewhere( true )
+            .build();
+        Event event = Event.builder()
+            .event( "BuA2R2Gr4vt" )
+            .followup( true )
+            .deleted( false )
+            .status( EventStatus.ACTIVE )
+            .dataValues( Collections.singleton( dataValue ) )
+            .build();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        service.writeEvents( out, Collections.singletonList( event ), false );
+
+        assertEquals( "BuA2R2Gr4vt,ACTIVE,,,,,,,,,,,true,false,,,,,,,,,,,color,red,,true,,,\n", out.toString() );
+    }
 
     @Test
     void testReadEventsFromFileWithHeader()
@@ -57,7 +106,9 @@ class TrackerCsvEventServiceTest
     {
         File event = new File( "src/test/resources/controller/tracker/csv/event.csv" );
         InputStream inputStream = Files.asByteSource( event ).openStream();
-        List<Event> events = serviceToTest.readEvents( inputStream, true );
+
+        List<Event> events = service.readEvents( inputStream, true );
+
         assertFalse( events.isEmpty() );
         assertEquals( 1, events.size() );
         assertEquals( "eventId", events.get( 0 ).getEvent() );
@@ -90,7 +141,9 @@ class TrackerCsvEventServiceTest
     {
         File event = new File( "src/test/resources/controller/tracker/csv/completeEvent.csv" );
         InputStream inputStream = Files.asByteSource( event ).openStream();
-        List<Event> events = serviceToTest.readEvents( inputStream, false );
+
+        List<Event> events = service.readEvents( inputStream, false );
+
         assertFalse( events.isEmpty() );
         assertEquals( 1, events.size() );
         assertEquals( "eventId", events.get( 0 ).getEvent() );
@@ -120,7 +173,7 @@ class TrackerCsvEventServiceTest
             assertEquals( "2020-02-26T23:08:00Z", dv.getUpdatedAt().toString() );
             assertEquals( "dataElement", dv.getDataElement() );
             assertEquals( "admin", dv.getStoredBy() );
-            assertEquals( false, dv.isProvidedElsewhere() );
+            assertFalse( dv.isProvidedElsewhere() );
         } );
     }
 }


### PR DESCRIPTION
* copied WebMvcConfig over to MvcTestConfig as prod and test configs for
media types should be the same.
* fix NPE and another potential NPE
* added tests to protect us against future NPEs at least in the event itself
* added test for a happy `writeEvents` case

Note: this does not address that when navigating to https://play.dhis2.org/2.38.0/api/tracker/events using the browser the CSV endpoint is chosen. Making a curl command like `curl -u admin:district https://play.dhis2.org/2.38.1/api/tracker/events` does return JSON. More on that in https://jira.dhis2.org/browse/DHIS2-13413?focusedCommentId=51667&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-51667