### PR TITLE
fix: Backport paging for events/enroll. [DHIS2-13512]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Pager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Pager.java
@@ -177,4 +177,17 @@ public class Pager
     {
         this.prevPage = prevPage;
     }
+
+    /**
+     * Method used when we don't need any pagination logic. We just want to
+     * simply set the current page and page size.
+     *
+     * @param page
+     * @param pageSize
+     */
+    public void force( int page, int pageSize )
+    {
+        this.page = page;
+        this.pageSize = pageSize;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
@@ -45,7 +45,7 @@ public class SlimPager extends Pager
 {
     public static final int FIRST_PAGE = 1;
 
-    private Boolean lastPage;
+    private final Boolean lastPage;
 
     public SlimPager( final int page, final int pageSize, final Boolean lastPage )
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Represents a light version of the Pager object. This should be used in cases
+ * where we do not need to represent page count and total of pages.
+ */
+@JsonIgnoreProperties( value = { "total", "pageCount" } )
+@JsonInclude( NON_NULL )
+public class SlimPager extends Pager
+{
+    public static final int FIRST_PAGE = 1;
+
+    private Boolean lastPage;
+
+    public SlimPager( final int page, final int pageSize, final Boolean lastPage )
+    {
+        // Total is always ZERO, as the main goal of this object it to never
+        // count the total of pages.
+        force( page, pageSize );
+        this.lastPage = lastPage;
+    }
+
+    /**
+     * Store a boolean value to indicate if this is the last page or not.
+     *
+     * @return true if this is the last page, false otherwise
+     */
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
+    public Boolean isLastPage()
+    {
+        return lastPage;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -131,6 +131,15 @@ public class HibernateProgramInstanceStore
             query.setMaxResults( params.getPageSizeWithDefault() );
         }
 
+        // When the clients choose to not show the total of pages.
+        if ( !params.isTotalPages() )
+        {
+            // Get pageSize + 1, so we are able to know if there is another
+            // page available. It adds one additional element into the list,
+            // as consequence. The caller needs to remove the last element.
+            query.setMaxResults( params.getPageSizeWithDefault() + 1 );
+        }
+
         return query.list();
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.dxf2.events.enrollment;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.trackedentity.TrackedEntityAttributeService.TEA_VALUE_MAX_LENGTH;
 
@@ -53,6 +56,7 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.exception.InvalidIdentifierReferenceException;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.collection.CollectionUtils;
@@ -193,7 +197,8 @@ public abstract class AbstractEnrollmentService
     @Override
     public Enrollments getEnrollments( ProgramInstanceQueryParams params )
     {
-        Enrollments enrollments = new Enrollments();
+        final Enrollments enrollments = new Enrollments();
+        final List<ProgramInstance> programInstances = new ArrayList<>();
 
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
@@ -202,22 +207,65 @@ public abstract class AbstractEnrollmentService
 
         if ( params.isPaging() )
         {
-            int count = 0;
+            final Pager pager;
 
             if ( params.isTotalPages() )
             {
-                count = programInstanceService.countProgramInstances( params );
-            }
+                programInstances.addAll( programInstanceService.getProgramInstances( params ) );
 
-            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+                final int count = programInstanceService.countProgramInstances( params );
+                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            }
+            else
+            {
+                pager = handleLastPageFlag( params, programInstances );
+            }
 
             enrollments.setPager( pager );
         }
 
-        List<ProgramInstance> programInstances = programInstanceService.getProgramInstances( params );
         enrollments.setEnrollments( getEnrollments( programInstances ) );
 
         return enrollments;
+    }
+
+    /**
+     * This method will apply the logic related to the parameter
+     * 'totalPages=false'. This works in conjunction with the method:
+     * {@link org.hisp.dhis.program.hibernate.HibernateProgramInstanceStore#getProgramInstances(ProgramInstanceQueryParams)}
+     *
+     * This is needed because we need to query (pageSize + 1) at DB level. The
+     * resulting query will allow us to evaluate if we are in the last page or
+     * not. And this is what his method does, returning the respective Pager
+     * object.
+     *
+     * @param params the request params
+     * @param programInstances the reference to the list of ProgramInstance
+     * @return the populated SlimPager instance
+     */
+    private Pager handleLastPageFlag( final ProgramInstanceQueryParams params,
+        final List<ProgramInstance> programInstances )
+    {
+        final int originalPage = params.getPage();
+        final int originalPageSize = params.getPageSize();
+        boolean isLastPage = false;
+
+        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
+
+        if ( isNotEmpty( programInstances ) )
+        {
+            isLastPage = programInstances.size() <= originalPageSize;
+            if ( !isLastPage )
+            {
+                // Get the same number of elements of the pageSize, forcing
+                // the removal of the last additional element added at querying
+                // time.
+                programInstances.retainAll( programInstances.subList( 0, originalPageSize ) );
+            }
+        }
+
+        return new SlimPager( defaultIfNull( originalPage, FIRST_PAGE ), originalPageSize,
+            isLastPage );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.dxf2.events.event;
 
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
+import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_BY_ID;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_DATE_ID;
@@ -50,6 +55,7 @@ import static org.hisp.dhis.dxf2.events.event.EventSearchParams.PAGER_META_KEY;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,6 +85,7 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -293,21 +300,26 @@ public abstract class AbstractEventService implements EventService
         }
 
         Events events = new Events();
+        List<Event> eventList = new ArrayList<>();
 
         if ( params.isPaging() )
         {
-            int count = 0;
+            final Pager pager;
 
             if ( params.isTotalPages() )
             {
-                count = eventStore.getEventCount( params, organisationUnits );
+                eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
+
+                int count = eventStore.getEventCount( params, organisationUnits );
+                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            }
+            else
+            {
+                pager = handleLastPageFlag( params, eventList, organisationUnits );
             }
 
-            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             events.setPager( pager );
         }
-
-        List<Event> eventList = eventStore.getEvents( params, organisationUnits, Collections.emptyMap() );
 
         events.setEvents( eventList );
 
@@ -407,20 +419,98 @@ public abstract class AbstractEventService implements EventService
 
         if ( params.isPaging() )
         {
-            int count = 0;
+            final Pager pager;
 
             if ( params.isTotalPages() )
             {
-                count = eventStore.getEventCount( params, organisationUnits );
+                int count = eventStore.getEventCount( params, organisationUnits );
+                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            }
+            else
+            {
+                pager = handleLastPageFlag( params, grid );
             }
 
-            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             metaData.put( PAGER_META_KEY, pager );
         }
 
         grid.setMetaData( metaData );
 
         return grid;
+    }
+
+    /**
+     * This method will apply the logic related to the parameter
+     * 'totalPages=false'. This works in conjunction with the method:
+     * {@link EventStore#getEvents(EventSearchParams,List<OrganisationUnit>,Map<String,Set<String>>)}
+     *
+     * This is needed because we need to query (pageSize + 1) at DB level. The
+     * resulting query will allow us to evaluate if we are in the last page or
+     * not. And this is what his method does, returning the respective Pager
+     * object.
+     *
+     * @param params the request params
+     * @param eventList the reference to the list of Event
+     * @return the populated SlimPager instance
+     */
+    private Pager handleLastPageFlag( final EventSearchParams params,
+        final List<Event> eventList, final List<OrganisationUnit> organisationUnits )
+    {
+        final Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        final Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
+        boolean isLastPage = false;
+
+        eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
+
+        if ( isNotEmpty( eventList ) )
+        {
+            isLastPage = eventList.size() <= originalPageSize;
+            if ( !isLastPage )
+            {
+                // Get the same number of elements of the pageSize, forcing
+                // the removal of the last additional element added at querying
+                // time.
+                eventList.retainAll( eventList.subList( 0, originalPageSize ) );
+            }
+        }
+
+        return new SlimPager( originalPage, originalPageSize, isLastPage );
+    }
+
+    /**
+     * This method will apply the logic related to the parameter
+     * 'totalPages=false'. This works in conjunction with the method:
+     * {@link org.hisp.dhis.dxf2.events.event.JdbcEventStore#getEventPagingQuery(EventSearchParams)}
+     *
+     * This is needed because we need to query (pageSize + 1) at DB level. The
+     * resulting query will allow us to evaluate if we are in the last page or
+     * not. And this is what his method does, returning the respective Pager
+     * object.
+     *
+     * @param params the request params
+     * @param grid the populated Grid object
+     * @return the populated SlimPager instance
+     */
+    private Pager handleLastPageFlag( final EventSearchParams params, final Grid grid )
+    {
+        final int originalPage = params.getPage();
+        final int originalPageSize = params.getPageSize();
+        boolean isLastPage = false;
+
+        if ( isNotEmpty( grid.getRows() ) )
+        {
+            isLastPage = grid.getRows().size() <= originalPageSize;
+            if ( !isLastPage )
+            {
+                // Get the same number of elements of the pageSize, forcing
+                // the removal of the last additional element added at querying
+                // time.
+                grid.getRows().retainAll( grid.getRows().subList( 0, originalPageSize ) );
+            }
+        }
+
+        return new SlimPager( defaultIfNull( originalPage, FIRST_PAGE ), originalPageSize,
+            isLastPage );
     }
 
     @Transactional( readOnly = true )

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1468,11 +1468,21 @@ public class JdbcEventStore implements EventStore
 
     private String getEventPagingQuery( EventSearchParams params )
     {
-        StringBuilder sqlBuilder = new StringBuilder().append( " " );
+        final StringBuilder sqlBuilder = new StringBuilder().append( " " );
+        int pageSize = params.getPageSizeWithDefault();
+
+        // When the clients choose to not show the total of pages.
+        if ( !params.isTotalPages() )
+        {
+            // Get pageSize + 1, so we are able to know if there is another
+            // page available. It adds one additional element into the list,
+            // as consequence. The caller needs to remove the last element.
+            pageSize++;
+        }
 
         if ( !params.isSkipPaging() )
         {
-            sqlBuilder.append( "limit " ).append( params.getPageSizeWithDefault() ).append( " offset " )
+            sqlBuilder.append( "limit " ).append( pageSize ).append( " offset " )
                 .append( params.getOffset() ).append( " " );
         }
 

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/NodeUtils.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/NodeUtils.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.node.types.ComplexNode;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.node.types.SimpleNode;
@@ -97,6 +98,17 @@ public final class NodeUtils
         pagerNode.addChild( new SimpleNode( "pageSize", pager.getPageSize() ) );
         pagerNode.addChild( new SimpleNode( "nextPage", pager.getNextPage() ) );
         pagerNode.addChild( new SimpleNode( "prevPage", pager.getPrevPage() ) );
+
+        return pagerNode;
+    }
+
+    public static Node createSlimPager( final SlimPager pager )
+    {
+        final ComplexNode pagerNode = new ComplexNode( "pager" );
+        pagerNode.setMetadata( true );
+        pagerNode.addChild( new SimpleNode( "page", pager.getPage() ) );
+        pagerNode.addChild( new SimpleNode( "pageSize", pager.getPageSize() ) );
+        pagerNode.addChild( new SimpleNode( "isLastPage", pager.isLastPage() ) );
 
         return pagerNode;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -47,6 +47,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.hisp.dhis.common.AsyncTaskExecutor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.PagerUtils;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dxf2.common.ImportOptions;
@@ -165,7 +166,14 @@ public class EnrollmentController
 
             if ( enrollments.getPager() != null )
             {
-                rootNode.addChild( NodeUtils.createPager( enrollments.getPager() ) );
+                if ( params.isTotalPages() )
+                {
+                    rootNode.addChild( NodeUtils.createPager( enrollments.getPager() ) );
+                }
+                else
+                {
+                    rootNode.addChild( NodeUtils.createSlimPager( (SlimPager) enrollments.getPager() ) );
+                }
             }
 
             listEnrollments = enrollments.getEnrollments();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -68,6 +68,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.PagerUtils;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -542,10 +543,7 @@ public class EventController
 
         RootNode rootNode = NodeUtils.createMetadata();
 
-        if ( events.getPager() != null )
-        {
-            rootNode.addChild( NodeUtils.createPager( events.getPager() ) );
-        }
+        addPager( params, events, rootNode );
 
         if ( !StringUtils.isEmpty( eventCriteria.getAttachment() ) )
         {
@@ -595,10 +593,7 @@ public class EventController
 
         RootNode rootNode = NodeUtils.createEvents();
 
-        if ( events.getPager() != null )
-        {
-            rootNode.addChild( NodeUtils.createPager( events.getPager() ) );
-        }
+        addPager( params, events, rootNode );
 
         if ( !StringUtils.isEmpty( eventCriteria.getAttachment() ) )
         {
@@ -1006,6 +1001,28 @@ public class EventController
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------
+
+    /**
+     * Adds a pager object to the root node respecting the given params.
+     *
+     * @param params
+     * @param events
+     * @param rootNode
+     */
+    private void addPager( final EventSearchParams params, final Events events, final RootNode rootNode )
+    {
+        if ( events.getPager() != null )
+        {
+            if ( params.isTotalPages() )
+            {
+                rootNode.addChild( NodeUtils.createPager( events.getPager() ) );
+            }
+            else
+            {
+                rootNode.addChild( NodeUtils.createSlimPager( (SlimPager) events.getPager() ) );
+            }
+        }
+    }
 
     /**
      * Starts an asynchronous import task.


### PR DESCRIPTION
[Backport from 2.38]

This fixes the pager object for the cases when `totalPages=false` is set as a parameter in the GET request.

Example for events.:
```
http://localhost:8080/dhis/api/events.json?fields=enrollment&ou=ImspTQPwCqd
&page=201&pageSize=100&program=ur1Edk5Oe2n&programEndDate=2021-05-24
&programStartDate=2021-05-02&totalPages=false
```
Before this fix the page object returned was always:
```
"pager": {
"page": 1,
"total": 0,
"pageSize": 50,
"pageCount": 1
}
```

Now it will look like this:
```
"pager": {
"page": 4,
"pageSize": 50,
"isLastPage": true
}

``` 

Another example, for enrollments, could be:
```
http://localhost:8080/dhis/api/enrollments.json?fields=enrollment&ou=ImspTQPwCqd
&ouMode=DESCENDANTS&page=3&pageSize=20&program=ur1Edk5Oe2n
&programEndDate=2021-05-24&programStartDate=2021-05-02&totalPages=false
```
