### PR TITLE
fix: Backport paging for events/enroll. [DHIS2-13512]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Pager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/Pager.java
@@ -177,4 +177,17 @@ public class Pager
     {
         this.prevPage = prevPage;
     }
+
+    /**
+     * Method used when we don't need any pagination logic. We just want to
+     * simply set the current page and page size.
+     *
+     * @param page
+     * @param pageSize
+     */
+    public void force( int page, int pageSize )
+    {
+        this.page = page;
+        this.pageSize = pageSize;
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
@@ -45,7 +45,7 @@ public class SlimPager extends Pager
 {
     public static final int FIRST_PAGE = 1;
 
-    private Boolean lastPage;
+    private final Boolean lastPage;
 
     public SlimPager( final int page, final int pageSize, final Boolean lastPage )
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SlimPager.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.common;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Represents a light version of the Pager object. This should be used in cases
+ * where we do not need to represent page count and total of pages.
+ */
+@JsonIgnoreProperties( value = { "total", "pageCount" } )
+@JsonInclude( NON_NULL )
+public class SlimPager extends Pager
+{
+    public static final int FIRST_PAGE = 1;
+
+    private Boolean lastPage;
+
+    public SlimPager( final int page, final int pageSize, final Boolean lastPage )
+    {
+        // Total is always ZERO, as the main goal of this object it to never
+        // count the total of pages.
+        force( page, pageSize );
+        this.lastPage = lastPage;
+    }
+
+    /**
+     * Store a boolean value to indicate if this is the last page or not.
+     *
+     * @return true if this is the last page, false otherwise
+     */
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
+    public Boolean isLastPage()
+    {
+        return lastPage;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -124,6 +124,15 @@ public class HibernateProgramInstanceStore
             query.setMaxResults( params.getPageSizeWithDefault() );
         }
 
+        // When the clients choose to not show the total of pages.
+        if ( !params.isTotalPages() )
+        {
+            // Get pageSize + 1, so we are able to know if there is another
+            // page available. It adds one additional element into the list,
+            // as consequence. The caller needs to remove the last element.
+            query.setMaxResults( params.getPageSizeWithDefault() + 1 );
+        }
+
         return query.list();
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -27,6 +27,11 @@
  */
 package org.hisp.dhis.dxf2.events.event;
 
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
+import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_BY_ID;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_COMPLETED_DATE_ID;
@@ -50,6 +55,7 @@ import static org.hisp.dhis.dxf2.events.event.EventSearchParams.PAGER_META_KEY;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -78,6 +84,7 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.commons.collection.CachingMap;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.dataelement.DataElement;
@@ -292,21 +299,26 @@ public abstract class AbstractEventService implements EventService
         }
 
         Events events = new Events();
+        List<Event> eventList = new ArrayList<>();
 
         if ( params.isPaging() )
         {
-            int count = 0;
+            final Pager pager;
 
             if ( params.isTotalPages() )
             {
-                count = eventStore.getEventCount( params, organisationUnits );
+                eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
+
+                int count = eventStore.getEventCount( params, organisationUnits );
+                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            }
+            else
+            {
+                pager = handleLastPageFlag( params, eventList, organisationUnits );
             }
 
-            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             events.setPager( pager );
         }
-
-        List<Event> eventList = eventStore.getEvents( params, organisationUnits, Collections.emptyMap() );
 
         events.setEvents( eventList );
 
@@ -406,14 +418,18 @@ public abstract class AbstractEventService implements EventService
 
         if ( params.isPaging() )
         {
-            int count = 0;
+            final Pager pager;
 
             if ( params.isTotalPages() )
             {
-                count = eventStore.getEventCount( params, organisationUnits );
+                int count = eventStore.getEventCount( params, organisationUnits );
+                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+            }
+            else
+            {
+                pager = handleLastPageFlag( params, grid );
             }
 
-            Pager pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             metaData.put( PAGER_META_KEY, pager );
         }
 
@@ -810,6 +826,80 @@ public abstract class AbstractEventService implements EventService
     // -------------------------------------------------------------------------
     // HELPERS
     // -------------------------------------------------------------------------
+
+    /**
+     * This method will apply the logic related to the parameter
+     * 'totalPages=false'. This works in conjunction with the method:
+     * {@link EventStore#getEvents(EventSearchParams,List<OrganisationUnit>,Map<String,Set<String>>)}
+     *
+     * This is needed because we need to query (pageSize + 1) at DB level. The
+     * resulting query will allow us to evaluate if we are in the last page or
+     * not. And this is what his method does, returning the respective Pager
+     * object.
+     *
+     * @param params the request params
+     * @param eventList the reference to the list of Event
+     * @return the populated SlimPager instance
+     */
+    private Pager handleLastPageFlag( final EventSearchParams params,
+        final List<Event> eventList, final List<OrganisationUnit> organisationUnits )
+    {
+        final Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        final Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
+        boolean isLastPage = false;
+
+        eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
+
+        if ( isNotEmpty( eventList ) )
+        {
+            isLastPage = eventList.size() <= originalPageSize;
+            if ( !isLastPage )
+            {
+                // Get the same number of elements of the pageSize, forcing
+                // the removal of the last additional element added at querying
+                // time.
+                eventList.retainAll( eventList.subList( 0, originalPageSize ) );
+            }
+        }
+
+        return new SlimPager( originalPage, originalPageSize, isLastPage );
+    }
+
+    /**
+     * This method will apply the logic related to the parameter
+     * 'totalPages=false'. This works in conjunction with the method:
+     * {@link org.hisp.dhis.dxf2.events.event.JdbcEventStore#getEventPagingQuery(EventSearchParams)}
+     *
+     * This is needed because we need to query (pageSize + 1) at DB level. The
+     * resulting query will allow us to evaluate if we are in the last page or
+     * not. And this is what his method does, returning the respective Pager
+     * object.
+     *
+     * @param params the request params
+     * @param grid the populated Grid object
+     * @return the populated SlimPager instance
+     */
+    private Pager handleLastPageFlag( final EventSearchParams params, final Grid grid )
+    {
+        final int originalPage = params.getPage();
+        final int originalPageSize = params.getPageSize();
+        boolean isLastPage = false;
+
+        if ( isNotEmpty( grid.getRows() ) )
+        {
+            isLastPage = grid.getRows().size() <= originalPageSize;
+            if ( !isLastPage )
+            {
+                // Get the same number of elements of the pageSize, forcing
+                // the removal of the last additional element added at querying
+                // time.
+                grid.getRows().retainAll( grid.getRows().subList( 0, originalPageSize ) );
+            }
+        }
+
+        return new SlimPager( defaultIfNull( originalPage, FIRST_PAGE ), originalPageSize,
+            isLastPage );
+    }
 
     private List<OrganisationUnit> getOrganisationUnits( EventSearchParams params, User user )
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1480,11 +1480,21 @@ public class JdbcEventStore implements EventStore
 
     private String getEventPagingQuery( EventSearchParams params )
     {
-        StringBuilder sqlBuilder = new StringBuilder().append( " " );
+        final StringBuilder sqlBuilder = new StringBuilder().append( " " );
+        int pageSize = params.getPageSizeWithDefault();
+
+        // When the clients choose to not show the total of pages.
+        if ( !params.isTotalPages() )
+        {
+            // Get pageSize + 1, so we are able to know if there is another
+            // page available. It adds one additional element into the list,
+            // as consequence. The caller needs to remove the last element.
+            pageSize++;
+        }
 
         if ( !params.isSkipPaging() )
         {
-            sqlBuilder.append( "limit " ).append( params.getPageSizeWithDefault() ).append( " offset " )
+            sqlBuilder.append( "limit " ).append( pageSize ).append( " offset " )
                 .append( params.getOffset() ).append( " " );
         }
 

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/NodeUtils.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/NodeUtils.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.node.types.ComplexNode;
 import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.node.types.SimpleNode;
@@ -97,6 +98,17 @@ public final class NodeUtils
         pagerNode.addChild( new SimpleNode( "pageSize", pager.getPageSize() ) );
         pagerNode.addChild( new SimpleNode( "nextPage", pager.getNextPage() ) );
         pagerNode.addChild( new SimpleNode( "prevPage", pager.getPrevPage() ) );
+
+        return pagerNode;
+    }
+
+    public static Node createSlimPager( final SlimPager pager )
+    {
+        final ComplexNode pagerNode = new ComplexNode( "pager" );
+        pagerNode.setMetadata( true );
+        pagerNode.addChild( new SimpleNode( "page", pager.getPage() ) );
+        pagerNode.addChild( new SimpleNode( "pageSize", pager.getPageSize() ) );
+        pagerNode.addChild( new SimpleNode( "isLastPage", pager.isLastPage() ) );
 
         return pagerNode;
     }

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -128,42 +128,24 @@ public class EnrollmentController
 
     @RequestMapping( value = "", method = RequestMethod.GET )
     public @ResponseBody RootNode getEnrollments(
-        @RequestParam( required = false )
-        String ou,
-        @RequestParam( required = false )
-        OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false )
-        String program,
-        @RequestParam( required = false )
-        ProgramStatus programStatus,
-        @RequestParam( required = false )
-        Boolean followUp,
-        @RequestParam( required = false )
-        Date lastUpdated,
-        @RequestParam( required = false )
-        String lastUpdatedDuration,
-        @RequestParam( required = false )
-        Date programStartDate,
-        @RequestParam( required = false )
-        Date programEndDate,
-        @RequestParam( required = false )
-        String trackedEntityType,
-        @RequestParam( required = false )
-        String trackedEntityInstance,
-        @RequestParam( required = false )
-        String enrollment,
-        @RequestParam( required = false )
-        Integer page,
-        @RequestParam( required = false )
-        Integer pageSize,
-        @RequestParam( required = false )
-        boolean totalPages,
-        @RequestParam( required = false )
-        Boolean skipPaging,
-        @RequestParam( required = false )
-        Boolean paging,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeDeleted )
+        @RequestParam( required = false ) String ou,
+        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) String program,
+        @RequestParam( required = false ) ProgramStatus programStatus,
+        @RequestParam( required = false ) Boolean followUp,
+        @RequestParam( required = false ) Date lastUpdated,
+        @RequestParam( required = false ) String lastUpdatedDuration,
+        @RequestParam( required = false ) Date programStartDate,
+        @RequestParam( required = false ) Date programEndDate,
+        @RequestParam( required = false ) String trackedEntityType,
+        @RequestParam( required = false ) String trackedEntityInstance,
+        @RequestParam( required = false ) String enrollment,
+        @RequestParam( required = false ) Integer page,
+        @RequestParam( required = false ) Integer pageSize,
+        @RequestParam( required = false ) boolean totalPages,
+        @RequestParam( required = false ) Boolean skipPaging,
+        @RequestParam( required = false ) Boolean paging,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted )
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
 
@@ -218,10 +200,8 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "/{id}", method = RequestMethod.GET )
-    public @ResponseBody Enrollment getEnrollment( @PathVariable
-    String id,
-        @RequestParam
-        Map<String, String> parameters, Model model )
+    public @ResponseBody Enrollment getEnrollment( @PathVariable String id,
+        @RequestParam Map<String, String> parameters, Model model )
         throws NotFoundException
     {
         return getEnrollment( id );
@@ -232,8 +212,7 @@ public class EnrollmentController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
-    public void postEnrollmentJson( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
-    ImportStrategy strategy,
+    public void postEnrollmentJson( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -278,8 +257,7 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
-    public void postEnrollmentXml( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
-    ImportStrategy strategy,
+    public void postEnrollmentXml( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -328,8 +306,7 @@ public class EnrollmentController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/{id}/note", method = RequestMethod.POST, consumes = "application/json" )
-    public void updateEnrollmentForNoteJson( @PathVariable
-    String id, HttpServletRequest request,
+    public void updateEnrollmentForNoteJson( @PathVariable String id, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
     {
@@ -339,8 +316,7 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
-    public void updateEnrollmentXml( @PathVariable
-    String id, ImportOptions importOptions, HttpServletRequest request,
+    public void updateEnrollmentXml( @PathVariable String id, ImportOptions importOptions, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
     {
@@ -352,8 +328,7 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
-    public void updateEnrollmentJson( @PathVariable
-    String id, ImportOptions importOptions, HttpServletRequest request,
+    public void updateEnrollmentJson( @PathVariable String id, ImportOptions importOptions, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
     {
@@ -366,8 +341,7 @@ public class EnrollmentController
 
     @RequestMapping( value = "/{id}/cancelled", method = RequestMethod.PUT )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void cancelEnrollment( @PathVariable
-    String id )
+    public void cancelEnrollment( @PathVariable String id )
         throws WebMessageException
     {
         if ( !programInstanceService.programInstanceExists( id ) )
@@ -380,8 +354,7 @@ public class EnrollmentController
 
     @RequestMapping( value = "/{id}/completed", method = RequestMethod.PUT )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void completeEnrollment( @PathVariable
-    String id )
+    public void completeEnrollment( @PathVariable String id )
         throws WebMessageException
     {
         if ( !programInstanceService.programInstanceExists( id ) )
@@ -394,8 +367,7 @@ public class EnrollmentController
 
     @RequestMapping( value = "/{id}/incompleted", method = RequestMethod.PUT )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void incompleteEnrollment( @PathVariable
-    String id )
+    public void incompleteEnrollment( @PathVariable String id )
         throws WebMessageException
     {
         if ( !programInstanceService.programInstanceExists( id ) )
@@ -411,8 +383,7 @@ public class EnrollmentController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/{id}", method = RequestMethod.DELETE )
-    public void deleteEnrollment( @PathVariable
-    String id, HttpServletRequest request, HttpServletResponse response )
+    public void deleteEnrollment( @PathVariable String id, HttpServletRequest request, HttpServletResponse response )
     {
         ImportSummary importSummary = enrollmentService.deleteEnrollment( id );
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -44,6 +44,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.PagerUtils;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dxf2.common.ImportOptions;
@@ -127,24 +128,42 @@ public class EnrollmentController
 
     @RequestMapping( value = "", method = RequestMethod.GET )
     public @ResponseBody RootNode getEnrollments(
-        @RequestParam( required = false ) String ou,
-        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false ) String program,
-        @RequestParam( required = false ) ProgramStatus programStatus,
-        @RequestParam( required = false ) Boolean followUp,
-        @RequestParam( required = false ) Date lastUpdated,
-        @RequestParam( required = false ) String lastUpdatedDuration,
-        @RequestParam( required = false ) Date programStartDate,
-        @RequestParam( required = false ) Date programEndDate,
-        @RequestParam( required = false ) String trackedEntityType,
-        @RequestParam( required = false ) String trackedEntityInstance,
-        @RequestParam( required = false ) String enrollment,
-        @RequestParam( required = false ) Integer page,
-        @RequestParam( required = false ) Integer pageSize,
-        @RequestParam( required = false ) boolean totalPages,
-        @RequestParam( required = false ) Boolean skipPaging,
-        @RequestParam( required = false ) Boolean paging,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted )
+        @RequestParam( required = false )
+        String ou,
+        @RequestParam( required = false )
+        OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false )
+        String program,
+        @RequestParam( required = false )
+        ProgramStatus programStatus,
+        @RequestParam( required = false )
+        Boolean followUp,
+        @RequestParam( required = false )
+        Date lastUpdated,
+        @RequestParam( required = false )
+        String lastUpdatedDuration,
+        @RequestParam( required = false )
+        Date programStartDate,
+        @RequestParam( required = false )
+        Date programEndDate,
+        @RequestParam( required = false )
+        String trackedEntityType,
+        @RequestParam( required = false )
+        String trackedEntityInstance,
+        @RequestParam( required = false )
+        String enrollment,
+        @RequestParam( required = false )
+        Integer page,
+        @RequestParam( required = false )
+        Integer pageSize,
+        @RequestParam( required = false )
+        boolean totalPages,
+        @RequestParam( required = false )
+        Boolean skipPaging,
+        @RequestParam( required = false )
+        Boolean paging,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeDeleted )
     {
         List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
 
@@ -172,7 +191,14 @@ public class EnrollmentController
 
             if ( enrollments.getPager() != null )
             {
-                rootNode.addChild( NodeUtils.createPager( enrollments.getPager() ) );
+                if ( params.isTotalPages() )
+                {
+                    rootNode.addChild( NodeUtils.createPager( enrollments.getPager() ) );
+                }
+                else
+                {
+                    rootNode.addChild( NodeUtils.createSlimPager( (SlimPager) enrollments.getPager() ) );
+                }
             }
 
             listEnrollments = enrollments.getEnrollments();
@@ -192,8 +218,10 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "/{id}", method = RequestMethod.GET )
-    public @ResponseBody Enrollment getEnrollment( @PathVariable String id,
-        @RequestParam Map<String, String> parameters, Model model )
+    public @ResponseBody Enrollment getEnrollment( @PathVariable
+    String id,
+        @RequestParam
+        Map<String, String> parameters, Model model )
         throws NotFoundException
     {
         return getEnrollment( id );
@@ -204,7 +232,8 @@ public class EnrollmentController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
-    public void postEnrollmentJson( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
+    public void postEnrollmentJson( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
+    ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -249,7 +278,8 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "", method = RequestMethod.POST, consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
-    public void postEnrollmentXml( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
+    public void postEnrollmentXml( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
+    ImportStrategy strategy,
         ImportOptions importOptions, HttpServletRequest request, HttpServletResponse response )
         throws IOException
     {
@@ -298,7 +328,8 @@ public class EnrollmentController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/{id}/note", method = RequestMethod.POST, consumes = "application/json" )
-    public void updateEnrollmentForNoteJson( @PathVariable String id, HttpServletRequest request,
+    public void updateEnrollmentForNoteJson( @PathVariable
+    String id, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
     {
@@ -308,7 +339,8 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_XML_VALUE, produces = MediaType.APPLICATION_XML_VALUE )
-    public void updateEnrollmentXml( @PathVariable String id, ImportOptions importOptions, HttpServletRequest request,
+    public void updateEnrollmentXml( @PathVariable
+    String id, ImportOptions importOptions, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
     {
@@ -320,7 +352,8 @@ public class EnrollmentController
     }
 
     @RequestMapping( value = "/{id}", method = RequestMethod.PUT, consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE )
-    public void updateEnrollmentJson( @PathVariable String id, ImportOptions importOptions, HttpServletRequest request,
+    public void updateEnrollmentJson( @PathVariable
+    String id, ImportOptions importOptions, HttpServletRequest request,
         HttpServletResponse response )
         throws IOException
     {
@@ -333,7 +366,8 @@ public class EnrollmentController
 
     @RequestMapping( value = "/{id}/cancelled", method = RequestMethod.PUT )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void cancelEnrollment( @PathVariable String id )
+    public void cancelEnrollment( @PathVariable
+    String id )
         throws WebMessageException
     {
         if ( !programInstanceService.programInstanceExists( id ) )
@@ -346,7 +380,8 @@ public class EnrollmentController
 
     @RequestMapping( value = "/{id}/completed", method = RequestMethod.PUT )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void completeEnrollment( @PathVariable String id )
+    public void completeEnrollment( @PathVariable
+    String id )
         throws WebMessageException
     {
         if ( !programInstanceService.programInstanceExists( id ) )
@@ -359,7 +394,8 @@ public class EnrollmentController
 
     @RequestMapping( value = "/{id}/incompleted", method = RequestMethod.PUT )
     @ResponseStatus( HttpStatus.NO_CONTENT )
-    public void incompleteEnrollment( @PathVariable String id )
+    public void incompleteEnrollment( @PathVariable
+    String id )
         throws WebMessageException
     {
         if ( !programInstanceService.programInstanceExists( id ) )
@@ -375,7 +411,8 @@ public class EnrollmentController
     // -------------------------------------------------------------------------
 
     @RequestMapping( value = "/{id}", method = RequestMethod.DELETE )
-    public void deleteEnrollment( @PathVariable String id, HttpServletRequest request, HttpServletResponse response )
+    public void deleteEnrollment( @PathVariable
+    String id, HttpServletRequest request, HttpServletResponse response )
     {
         ImportSummary importSummary = enrollmentService.deleteEnrollment( id );
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -47,8 +47,6 @@ import java.util.zip.GZIPOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.SneakyThrows;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
@@ -57,6 +55,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.PagerUtils;
+import org.hisp.dhis.common.SlimPager;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.commons.util.StreamUtils;
 import org.hisp.dhis.commons.util.TextUtils;
@@ -127,6 +126,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+
+import lombok.SneakyThrows;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -228,39 +229,72 @@ public class EventController
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_JAVASCRIPT } )
     public @ResponseBody Grid queryEventsJson(
-        @RequestParam( required = false ) String program,
-        @RequestParam( required = false ) String programStage,
-        @RequestParam( required = false ) ProgramStatus programStatus,
-        @RequestParam( required = false ) Boolean followUp,
-        @RequestParam( required = false ) String trackedEntityInstance,
-        @RequestParam( required = false ) String orgUnit,
-        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false ) String assignedUser,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) Date dueDateStart,
-        @RequestParam( required = false ) Date dueDateEnd,
-        @RequestParam( required = false ) Date lastUpdated,
-        @RequestParam( required = false ) Date lastUpdatedStartDate,
-        @RequestParam( required = false ) Date lastUpdatedEndDate,
-        @RequestParam( required = false ) EventStatus status,
-        @RequestParam( required = false ) String attributeCc,
-        @RequestParam( required = false ) String attributeCos,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) Integer page,
-        @RequestParam( required = false ) Integer pageSize,
-        @RequestParam( required = false ) boolean totalPages,
-        @RequestParam( required = false ) Boolean skipPaging,
-        @RequestParam( required = false ) Boolean paging,
-        @RequestParam( required = false ) List<OrderCriteria> order,
-        @RequestParam( required = false ) String attachment,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
-        @RequestParam( required = false ) String event,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
-        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false )
+        String program,
+        @RequestParam( required = false )
+        String programStage,
+        @RequestParam( required = false )
+        ProgramStatus programStatus,
+        @RequestParam( required = false )
+        Boolean followUp,
+        @RequestParam( required = false )
+        String trackedEntityInstance,
+        @RequestParam( required = false )
+        String orgUnit,
+        @RequestParam( required = false )
+        OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false )
+        AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false )
+        String assignedUser,
+        @RequestParam( required = false )
+        Date startDate,
+        @RequestParam( required = false )
+        Date endDate,
+        @RequestParam( required = false )
+        Date dueDateStart,
+        @RequestParam( required = false )
+        Date dueDateEnd,
+        @RequestParam( required = false )
+        Date lastUpdated,
+        @RequestParam( required = false )
+        Date lastUpdatedStartDate,
+        @RequestParam( required = false )
+        Date lastUpdatedEndDate,
+        @RequestParam( required = false )
+        EventStatus status,
+        @RequestParam( required = false )
+        String attributeCc,
+        @RequestParam( required = false )
+        String attributeCos,
+        @RequestParam( required = false )
+        boolean skipMeta,
+        @RequestParam( required = false )
+        Integer page,
+        @RequestParam( required = false )
+        Integer pageSize,
+        @RequestParam( required = false )
+        boolean totalPages,
+        @RequestParam( required = false )
+        Boolean skipPaging,
+        @RequestParam( required = false )
+        Boolean paging,
+        @RequestParam( required = false )
+        List<OrderCriteria> order,
+        @RequestParam( required = false )
+        String attachment,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeDeleted,
+        @RequestParam( required = false )
+        String event,
+        @RequestParam( required = false )
+        Set<String> filter,
+        @RequestParam( required = false )
+        Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeAllDataElements,
+        @RequestParam
+        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws WebMessageException
     {
@@ -302,39 +336,72 @@ public class EventController
 
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_XML )
     public void queryEventsXml(
-        @RequestParam( required = false ) String program,
-        @RequestParam( required = false ) String programStage,
-        @RequestParam( required = false ) ProgramStatus programStatus,
-        @RequestParam( required = false ) Boolean followUp,
-        @RequestParam( required = false ) String trackedEntityInstance,
-        @RequestParam( required = false ) String orgUnit,
-        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false ) String assignedUser,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) Date dueDateStart,
-        @RequestParam( required = false ) Date dueDateEnd,
-        @RequestParam( required = false ) Date lastUpdated,
-        @RequestParam( required = false ) Date lastUpdatedStartDate,
-        @RequestParam( required = false ) Date lastUpdatedEndDate,
-        @RequestParam( required = false ) EventStatus status,
-        @RequestParam( required = false ) String attributeCc,
-        @RequestParam( required = false ) String attributeCos,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) Integer page,
-        @RequestParam( required = false ) Integer pageSize,
-        @RequestParam( required = false ) boolean totalPages,
-        @RequestParam( required = false ) Boolean skipPaging,
-        @RequestParam( required = false ) Boolean paging,
-        @RequestParam( required = false ) List<OrderCriteria> order,
-        @RequestParam( required = false ) String attachment,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
-        @RequestParam( required = false ) String event,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
-        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false )
+        String program,
+        @RequestParam( required = false )
+        String programStage,
+        @RequestParam( required = false )
+        ProgramStatus programStatus,
+        @RequestParam( required = false )
+        Boolean followUp,
+        @RequestParam( required = false )
+        String trackedEntityInstance,
+        @RequestParam( required = false )
+        String orgUnit,
+        @RequestParam( required = false )
+        OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false )
+        AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false )
+        String assignedUser,
+        @RequestParam( required = false )
+        Date startDate,
+        @RequestParam( required = false )
+        Date endDate,
+        @RequestParam( required = false )
+        Date dueDateStart,
+        @RequestParam( required = false )
+        Date dueDateEnd,
+        @RequestParam( required = false )
+        Date lastUpdated,
+        @RequestParam( required = false )
+        Date lastUpdatedStartDate,
+        @RequestParam( required = false )
+        Date lastUpdatedEndDate,
+        @RequestParam( required = false )
+        EventStatus status,
+        @RequestParam( required = false )
+        String attributeCc,
+        @RequestParam( required = false )
+        String attributeCos,
+        @RequestParam( required = false )
+        boolean skipMeta,
+        @RequestParam( required = false )
+        Integer page,
+        @RequestParam( required = false )
+        Integer pageSize,
+        @RequestParam( required = false )
+        boolean totalPages,
+        @RequestParam( required = false )
+        Boolean skipPaging,
+        @RequestParam( required = false )
+        Boolean paging,
+        @RequestParam( required = false )
+        List<OrderCriteria> order,
+        @RequestParam( required = false )
+        String attachment,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeDeleted,
+        @RequestParam( required = false )
+        String event,
+        @RequestParam( required = false )
+        Set<String> filter,
+        @RequestParam( required = false )
+        Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeAllDataElements,
+        @RequestParam
+        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws Exception
     {
@@ -375,39 +442,72 @@ public class EventController
 
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_EXCEL )
     public void queryEventsXls(
-        @RequestParam( required = false ) String program,
-        @RequestParam( required = false ) String programStage,
-        @RequestParam( required = false ) ProgramStatus programStatus,
-        @RequestParam( required = false ) Boolean followUp,
-        @RequestParam( required = false ) String trackedEntityInstance,
-        @RequestParam( required = false ) String orgUnit,
-        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false ) String assignedUser,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) Date dueDateStart,
-        @RequestParam( required = false ) Date dueDateEnd,
-        @RequestParam( required = false ) Date lastUpdated,
-        @RequestParam( required = false ) Date lastUpdatedStartDate,
-        @RequestParam( required = false ) Date lastUpdatedEndDate,
-        @RequestParam( required = false ) EventStatus status,
-        @RequestParam( required = false ) String attributeCc,
-        @RequestParam( required = false ) String attributeCos,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) Integer page,
-        @RequestParam( required = false ) Integer pageSize,
-        @RequestParam( required = false ) boolean totalPages,
-        @RequestParam( required = false ) Boolean skipPaging,
-        @RequestParam( required = false ) Boolean paging,
-        @RequestParam( required = false ) List<OrderCriteria> order,
-        @RequestParam( required = false ) String attachment,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
-        @RequestParam( required = false ) String event,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
-        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false )
+        String program,
+        @RequestParam( required = false )
+        String programStage,
+        @RequestParam( required = false )
+        ProgramStatus programStatus,
+        @RequestParam( required = false )
+        Boolean followUp,
+        @RequestParam( required = false )
+        String trackedEntityInstance,
+        @RequestParam( required = false )
+        String orgUnit,
+        @RequestParam( required = false )
+        OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false )
+        AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false )
+        String assignedUser,
+        @RequestParam( required = false )
+        Date startDate,
+        @RequestParam( required = false )
+        Date endDate,
+        @RequestParam( required = false )
+        Date dueDateStart,
+        @RequestParam( required = false )
+        Date dueDateEnd,
+        @RequestParam( required = false )
+        Date lastUpdated,
+        @RequestParam( required = false )
+        Date lastUpdatedStartDate,
+        @RequestParam( required = false )
+        Date lastUpdatedEndDate,
+        @RequestParam( required = false )
+        EventStatus status,
+        @RequestParam( required = false )
+        String attributeCc,
+        @RequestParam( required = false )
+        String attributeCos,
+        @RequestParam( required = false )
+        boolean skipMeta,
+        @RequestParam( required = false )
+        Integer page,
+        @RequestParam( required = false )
+        Integer pageSize,
+        @RequestParam( required = false )
+        boolean totalPages,
+        @RequestParam( required = false )
+        Boolean skipPaging,
+        @RequestParam( required = false )
+        Boolean paging,
+        @RequestParam( required = false )
+        List<OrderCriteria> order,
+        @RequestParam( required = false )
+        String attachment,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeDeleted,
+        @RequestParam( required = false )
+        String event,
+        @RequestParam( required = false )
+        Set<String> filter,
+        @RequestParam( required = false )
+        Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeAllDataElements,
+        @RequestParam
+        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws Exception
     {
@@ -449,39 +549,72 @@ public class EventController
 
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_CSV )
     public void queryEventsCsv(
-        @RequestParam( required = false ) String program,
-        @RequestParam( required = false ) String programStage,
-        @RequestParam( required = false ) ProgramStatus programStatus,
-        @RequestParam( required = false ) Boolean followUp,
-        @RequestParam( required = false ) String trackedEntityInstance,
-        @RequestParam( required = false ) String orgUnit,
-        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false ) String assignedUser,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) Date dueDateStart,
-        @RequestParam( required = false ) Date dueDateEnd,
-        @RequestParam( required = false ) Date lastUpdated,
-        @RequestParam( required = false ) Date lastUpdatedStartDate,
-        @RequestParam( required = false ) Date lastUpdatedEndDate,
-        @RequestParam( required = false ) EventStatus status,
-        @RequestParam( required = false ) String attributeCc,
-        @RequestParam( required = false ) String attributeCos,
-        @RequestParam( required = false ) boolean skipMeta,
-        @RequestParam( required = false ) Integer page,
-        @RequestParam( required = false ) Integer pageSize,
-        @RequestParam( required = false ) boolean totalPages,
-        @RequestParam( required = false ) Boolean skipPaging,
-        @RequestParam( required = false ) Boolean paging,
-        @RequestParam( required = false ) List<OrderCriteria> order,
-        @RequestParam( required = false ) String attachment,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
-        @RequestParam( required = false ) String event,
-        @RequestParam( required = false ) Set<String> filter,
-        @RequestParam( required = false ) Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
-        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false )
+        String program,
+        @RequestParam( required = false )
+        String programStage,
+        @RequestParam( required = false )
+        ProgramStatus programStatus,
+        @RequestParam( required = false )
+        Boolean followUp,
+        @RequestParam( required = false )
+        String trackedEntityInstance,
+        @RequestParam( required = false )
+        String orgUnit,
+        @RequestParam( required = false )
+        OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false )
+        AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false )
+        String assignedUser,
+        @RequestParam( required = false )
+        Date startDate,
+        @RequestParam( required = false )
+        Date endDate,
+        @RequestParam( required = false )
+        Date dueDateStart,
+        @RequestParam( required = false )
+        Date dueDateEnd,
+        @RequestParam( required = false )
+        Date lastUpdated,
+        @RequestParam( required = false )
+        Date lastUpdatedStartDate,
+        @RequestParam( required = false )
+        Date lastUpdatedEndDate,
+        @RequestParam( required = false )
+        EventStatus status,
+        @RequestParam( required = false )
+        String attributeCc,
+        @RequestParam( required = false )
+        String attributeCos,
+        @RequestParam( required = false )
+        boolean skipMeta,
+        @RequestParam( required = false )
+        Integer page,
+        @RequestParam( required = false )
+        Integer pageSize,
+        @RequestParam( required = false )
+        boolean totalPages,
+        @RequestParam( required = false )
+        Boolean skipPaging,
+        @RequestParam( required = false )
+        Boolean paging,
+        @RequestParam( required = false )
+        List<OrderCriteria> order,
+        @RequestParam( required = false )
+        String attachment,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeDeleted,
+        @RequestParam( required = false )
+        String event,
+        @RequestParam( required = false )
+        Set<String> filter,
+        @RequestParam( required = false )
+        Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeAllDataElements,
+        @RequestParam
+        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws Exception
     {
@@ -527,7 +660,8 @@ public class EventController
 
     @RequestMapping( method = RequestMethod.GET )
     public @ResponseBody RootNode getEvents(
-        EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
+        EventCriteria eventCriteria, @RequestParam
+        Map<String, String> parameters, Model model,
         HttpServletResponse response,
         HttpServletRequest request )
     {
@@ -562,10 +696,7 @@ public class EventController
 
         RootNode rootNode = NodeUtils.createMetadata();
 
-        if ( events.getPager() != null )
-        {
-            rootNode.addChild( NodeUtils.createPager( events.getPager() ) );
-        }
+        addPager( params, events, rootNode );
 
         if ( !StringUtils.isEmpty( eventCriteria.getAttachment() ) )
         {
@@ -582,7 +713,8 @@ public class EventController
 
     @RequestMapping( method = RequestMethod.GET, produces = { "application/xml", "application/xml+gzip", "text/xml" } )
     public @ResponseBody RootNode getXmlEvents(
-        EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
+        EventCriteria eventCriteria, @RequestParam
+        Map<String, String> parameters, Model model,
         HttpServletResponse response,
         HttpServletRequest request )
         throws WebMessageException
@@ -615,10 +747,7 @@ public class EventController
 
         RootNode rootNode = NodeUtils.createEvents();
 
-        if ( events.getPager() != null )
-        {
-            rootNode.addChild( NodeUtils.createPager( events.getPager() ) );
-        }
+        addPager( params, events, rootNode );
 
         if ( !StringUtils.isEmpty( eventCriteria.getAttachment() ) )
         {
@@ -637,7 +766,8 @@ public class EventController
     @RequestMapping( method = RequestMethod.GET, produces = { "application/csv", "application/csv+gzip", "text/csv" } )
     public void getCsvEvents(
         EventCriteria eventCriteria,
-        @RequestParam( required = false, defaultValue = "false" ) boolean skipHeader,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean skipHeader,
         HttpServletResponse response, HttpServletRequest request )
         throws IOException,
         WebMessageException
@@ -670,24 +800,42 @@ public class EventController
 
     @RequestMapping( value = "/eventRows", method = RequestMethod.GET )
     public @ResponseBody EventRows getEventRows(
-        @RequestParam( required = false ) String program,
-        @RequestParam( required = false ) String orgUnit,
-        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false ) ProgramStatus programStatus,
-        @RequestParam( required = false ) EventStatus eventStatus,
-        @RequestParam( required = false ) Date startDate,
-        @RequestParam( required = false ) Date endDate,
-        @RequestParam( required = false ) String attributeCc,
-        @RequestParam( required = false ) String attributeCos,
-        @RequestParam( required = false ) Integer page,
-        @RequestParam( required = false ) Integer pageSize,
-        @RequestParam( required = false ) boolean totalPages,
-        @RequestParam( required = false ) Boolean skipPaging,
-        @RequestParam( required = false ) Boolean paging,
-        @RequestParam( required = false ) List<OrderCriteria> order,
-        @RequestParam( required = false ) Boolean skipEventId,
-        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
-        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model )
+        @RequestParam( required = false )
+        String program,
+        @RequestParam( required = false )
+        String orgUnit,
+        @RequestParam( required = false )
+        OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false )
+        ProgramStatus programStatus,
+        @RequestParam( required = false )
+        EventStatus eventStatus,
+        @RequestParam( required = false )
+        Date startDate,
+        @RequestParam( required = false )
+        Date endDate,
+        @RequestParam( required = false )
+        String attributeCc,
+        @RequestParam( required = false )
+        String attributeCos,
+        @RequestParam( required = false )
+        Integer page,
+        @RequestParam( required = false )
+        Integer pageSize,
+        @RequestParam( required = false )
+        boolean totalPages,
+        @RequestParam( required = false )
+        Boolean skipPaging,
+        @RequestParam( required = false )
+        Boolean paging,
+        @RequestParam( required = false )
+        List<OrderCriteria> order,
+        @RequestParam( required = false )
+        Boolean skipEventId,
+        @RequestParam( required = false, defaultValue = "false" )
+        boolean includeDeleted,
+        @RequestParam
+        Map<String, String> parameters, IdSchemes idSchemes, Model model )
         throws WebMessageException
     {
         CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo( attributeCc, attributeCos,
@@ -706,8 +854,10 @@ public class EventController
     }
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
-    public @ResponseBody Event getEvent( @PathVariable( "uid" ) String uid,
-        @RequestParam Map<String, String> parameters,
+    public @ResponseBody Event getEvent( @PathVariable( "uid" )
+    String uid,
+        @RequestParam
+        Map<String, String> parameters,
         Model model, HttpServletRequest request )
         throws Exception
     {
@@ -725,8 +875,11 @@ public class EventController
     }
 
     @RequestMapping( value = "/files", method = RequestMethod.GET )
-    public void getEventDataValueFile( @RequestParam String eventUid, @RequestParam String dataElementUid,
-        @RequestParam( required = false ) ImageFileDimension dimension,
+    public void getEventDataValueFile( @RequestParam
+    String eventUid, @RequestParam
+    String dataElementUid,
+        @RequestParam( required = false )
+        ImageFileDimension dimension,
         HttpServletResponse response, HttpServletRequest request )
         throws Exception
     {
@@ -818,7 +971,8 @@ public class EventController
     // -------------------------------------------------------------------------
 
     @RequestMapping( method = RequestMethod.POST, consumes = "application/xml" )
-    public void postXmlEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
+    public void postXmlEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
+    ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
     {
         postEvent( strategy, response, request, importOptions, this::safeAddEventsXml, this::safeGetEventsXml );
@@ -837,7 +991,8 @@ public class EventController
     }
 
     @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
-    public void postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
+    public void postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
+    ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
     {
         postEvent( strategy, response, request, importOptions, this::safeAddEventsJson, this::safeGetEventsJson );
@@ -906,7 +1061,8 @@ public class EventController
     }
 
     @RequestMapping( value = "/{uid}/note", method = RequestMethod.POST, consumes = "application/json" )
-    public void postJsonEventForNote( @PathVariable( "uid" ) String uid,
+    public void postJsonEventForNote( @PathVariable( "uid" )
+    String uid,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
         throws IOException,
         WebMessageException
@@ -925,7 +1081,8 @@ public class EventController
     }
 
     @RequestMapping( method = RequestMethod.POST, consumes = { "application/csv", "text/csv" } )
-    public void postCsvEvents( @RequestParam( required = false, defaultValue = "false" ) boolean skipFirst,
+    public void postCsvEvents( @RequestParam( required = false, defaultValue = "false" )
+    boolean skipFirst,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
         throws IOException,
         ParseException
@@ -952,7 +1109,8 @@ public class EventController
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = { "application/xml", "text/xml" } )
     public void putXmlEvent( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" ) String uid, ImportOptions importOptions )
+        @PathVariable( "uid" )
+        String uid, ImportOptions importOptions )
         throws IOException
     {
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -964,7 +1122,8 @@ public class EventController
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = "application/json" )
     public void putJsonEvent( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" ) String uid, ImportOptions importOptions )
+        @PathVariable( "uid" )
+        String uid, ImportOptions importOptions )
         throws IOException
     {
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -984,7 +1143,9 @@ public class EventController
 
     @RequestMapping( value = "/{uid}/{dataElementUid}", method = RequestMethod.PUT, consumes = "application/json" )
     public void putJsonEventSingleValue( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" ) String uid, @PathVariable( "dataElementUid" ) String dataElementUid )
+        @PathVariable( "uid" )
+        String uid, @PathVariable( "dataElementUid" )
+        String dataElementUid )
         throws IOException,
         WebMessageException
     {
@@ -1005,7 +1166,8 @@ public class EventController
 
     @RequestMapping( value = "/{uid}/eventDate", method = RequestMethod.PUT, consumes = "application/json" )
     public void putJsonEventForEventDate( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" ) String uid, ImportOptions importOptions )
+        @PathVariable( "uid" )
+        String uid, ImportOptions importOptions )
         throws IOException,
         WebMessageException
     {
@@ -1028,7 +1190,8 @@ public class EventController
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE )
     public void deleteEvent( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" ) String uid )
+        @PathVariable( "uid" )
+        String uid )
     {
         ImportSummary importSummary = eventService.deleteEvent( uid );
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );
@@ -1037,6 +1200,28 @@ public class EventController
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------
+
+    /**
+     * Adds a pager object to the root node respecting the given params.
+     *
+     * @param params
+     * @param events
+     * @param rootNode
+     */
+    private void addPager( final EventSearchParams params, final Events events, final RootNode rootNode )
+    {
+        if ( events.getPager() != null )
+        {
+            if ( params.isTotalPages() )
+            {
+                rootNode.addChild( NodeUtils.createPager( events.getPager() ) );
+            }
+            else
+            {
+                rootNode.addChild( NodeUtils.createSlimPager( (SlimPager) events.getPager() ) );
+            }
+        }
+    }
 
     /**
      * Starts an asynchronous import task.

--- a/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -47,6 +47,8 @@ import java.util.zip.GZIPOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import lombok.SneakyThrows;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
@@ -126,8 +128,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
-
-import lombok.SneakyThrows;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -229,72 +229,39 @@ public class EventController
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = { ContextUtils.CONTENT_TYPE_JSON,
         ContextUtils.CONTENT_TYPE_JAVASCRIPT } )
     public @ResponseBody Grid queryEventsJson(
-        @RequestParam( required = false )
-        String program,
-        @RequestParam( required = false )
-        String programStage,
-        @RequestParam( required = false )
-        ProgramStatus programStatus,
-        @RequestParam( required = false )
-        Boolean followUp,
-        @RequestParam( required = false )
-        String trackedEntityInstance,
-        @RequestParam( required = false )
-        String orgUnit,
-        @RequestParam( required = false )
-        OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false )
-        AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false )
-        String assignedUser,
-        @RequestParam( required = false )
-        Date startDate,
-        @RequestParam( required = false )
-        Date endDate,
-        @RequestParam( required = false )
-        Date dueDateStart,
-        @RequestParam( required = false )
-        Date dueDateEnd,
-        @RequestParam( required = false )
-        Date lastUpdated,
-        @RequestParam( required = false )
-        Date lastUpdatedStartDate,
-        @RequestParam( required = false )
-        Date lastUpdatedEndDate,
-        @RequestParam( required = false )
-        EventStatus status,
-        @RequestParam( required = false )
-        String attributeCc,
-        @RequestParam( required = false )
-        String attributeCos,
-        @RequestParam( required = false )
-        boolean skipMeta,
-        @RequestParam( required = false )
-        Integer page,
-        @RequestParam( required = false )
-        Integer pageSize,
-        @RequestParam( required = false )
-        boolean totalPages,
-        @RequestParam( required = false )
-        Boolean skipPaging,
-        @RequestParam( required = false )
-        Boolean paging,
-        @RequestParam( required = false )
-        List<OrderCriteria> order,
-        @RequestParam( required = false )
-        String attachment,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeDeleted,
-        @RequestParam( required = false )
-        String event,
-        @RequestParam( required = false )
-        Set<String> filter,
-        @RequestParam( required = false )
-        Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeAllDataElements,
-        @RequestParam
-        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false ) String program,
+        @RequestParam( required = false ) String programStage,
+        @RequestParam( required = false ) ProgramStatus programStatus,
+        @RequestParam( required = false ) Boolean followUp,
+        @RequestParam( required = false ) String trackedEntityInstance,
+        @RequestParam( required = false ) String orgUnit,
+        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) Date startDate,
+        @RequestParam( required = false ) Date endDate,
+        @RequestParam( required = false ) Date dueDateStart,
+        @RequestParam( required = false ) Date dueDateEnd,
+        @RequestParam( required = false ) Date lastUpdated,
+        @RequestParam( required = false ) Date lastUpdatedStartDate,
+        @RequestParam( required = false ) Date lastUpdatedEndDate,
+        @RequestParam( required = false ) EventStatus status,
+        @RequestParam( required = false ) String attributeCc,
+        @RequestParam( required = false ) String attributeCos,
+        @RequestParam( required = false ) boolean skipMeta,
+        @RequestParam( required = false ) Integer page,
+        @RequestParam( required = false ) Integer pageSize,
+        @RequestParam( required = false ) boolean totalPages,
+        @RequestParam( required = false ) Boolean skipPaging,
+        @RequestParam( required = false ) Boolean paging,
+        @RequestParam( required = false ) List<OrderCriteria> order,
+        @RequestParam( required = false ) String attachment,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
+        @RequestParam( required = false ) String event,
+        @RequestParam( required = false ) Set<String> filter,
+        @RequestParam( required = false ) Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
+        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws WebMessageException
     {
@@ -336,72 +303,39 @@ public class EventController
 
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_XML )
     public void queryEventsXml(
-        @RequestParam( required = false )
-        String program,
-        @RequestParam( required = false )
-        String programStage,
-        @RequestParam( required = false )
-        ProgramStatus programStatus,
-        @RequestParam( required = false )
-        Boolean followUp,
-        @RequestParam( required = false )
-        String trackedEntityInstance,
-        @RequestParam( required = false )
-        String orgUnit,
-        @RequestParam( required = false )
-        OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false )
-        AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false )
-        String assignedUser,
-        @RequestParam( required = false )
-        Date startDate,
-        @RequestParam( required = false )
-        Date endDate,
-        @RequestParam( required = false )
-        Date dueDateStart,
-        @RequestParam( required = false )
-        Date dueDateEnd,
-        @RequestParam( required = false )
-        Date lastUpdated,
-        @RequestParam( required = false )
-        Date lastUpdatedStartDate,
-        @RequestParam( required = false )
-        Date lastUpdatedEndDate,
-        @RequestParam( required = false )
-        EventStatus status,
-        @RequestParam( required = false )
-        String attributeCc,
-        @RequestParam( required = false )
-        String attributeCos,
-        @RequestParam( required = false )
-        boolean skipMeta,
-        @RequestParam( required = false )
-        Integer page,
-        @RequestParam( required = false )
-        Integer pageSize,
-        @RequestParam( required = false )
-        boolean totalPages,
-        @RequestParam( required = false )
-        Boolean skipPaging,
-        @RequestParam( required = false )
-        Boolean paging,
-        @RequestParam( required = false )
-        List<OrderCriteria> order,
-        @RequestParam( required = false )
-        String attachment,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeDeleted,
-        @RequestParam( required = false )
-        String event,
-        @RequestParam( required = false )
-        Set<String> filter,
-        @RequestParam( required = false )
-        Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeAllDataElements,
-        @RequestParam
-        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false ) String program,
+        @RequestParam( required = false ) String programStage,
+        @RequestParam( required = false ) ProgramStatus programStatus,
+        @RequestParam( required = false ) Boolean followUp,
+        @RequestParam( required = false ) String trackedEntityInstance,
+        @RequestParam( required = false ) String orgUnit,
+        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) Date startDate,
+        @RequestParam( required = false ) Date endDate,
+        @RequestParam( required = false ) Date dueDateStart,
+        @RequestParam( required = false ) Date dueDateEnd,
+        @RequestParam( required = false ) Date lastUpdated,
+        @RequestParam( required = false ) Date lastUpdatedStartDate,
+        @RequestParam( required = false ) Date lastUpdatedEndDate,
+        @RequestParam( required = false ) EventStatus status,
+        @RequestParam( required = false ) String attributeCc,
+        @RequestParam( required = false ) String attributeCos,
+        @RequestParam( required = false ) boolean skipMeta,
+        @RequestParam( required = false ) Integer page,
+        @RequestParam( required = false ) Integer pageSize,
+        @RequestParam( required = false ) boolean totalPages,
+        @RequestParam( required = false ) Boolean skipPaging,
+        @RequestParam( required = false ) Boolean paging,
+        @RequestParam( required = false ) List<OrderCriteria> order,
+        @RequestParam( required = false ) String attachment,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
+        @RequestParam( required = false ) String event,
+        @RequestParam( required = false ) Set<String> filter,
+        @RequestParam( required = false ) Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
+        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws Exception
     {
@@ -442,72 +376,39 @@ public class EventController
 
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_EXCEL )
     public void queryEventsXls(
-        @RequestParam( required = false )
-        String program,
-        @RequestParam( required = false )
-        String programStage,
-        @RequestParam( required = false )
-        ProgramStatus programStatus,
-        @RequestParam( required = false )
-        Boolean followUp,
-        @RequestParam( required = false )
-        String trackedEntityInstance,
-        @RequestParam( required = false )
-        String orgUnit,
-        @RequestParam( required = false )
-        OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false )
-        AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false )
-        String assignedUser,
-        @RequestParam( required = false )
-        Date startDate,
-        @RequestParam( required = false )
-        Date endDate,
-        @RequestParam( required = false )
-        Date dueDateStart,
-        @RequestParam( required = false )
-        Date dueDateEnd,
-        @RequestParam( required = false )
-        Date lastUpdated,
-        @RequestParam( required = false )
-        Date lastUpdatedStartDate,
-        @RequestParam( required = false )
-        Date lastUpdatedEndDate,
-        @RequestParam( required = false )
-        EventStatus status,
-        @RequestParam( required = false )
-        String attributeCc,
-        @RequestParam( required = false )
-        String attributeCos,
-        @RequestParam( required = false )
-        boolean skipMeta,
-        @RequestParam( required = false )
-        Integer page,
-        @RequestParam( required = false )
-        Integer pageSize,
-        @RequestParam( required = false )
-        boolean totalPages,
-        @RequestParam( required = false )
-        Boolean skipPaging,
-        @RequestParam( required = false )
-        Boolean paging,
-        @RequestParam( required = false )
-        List<OrderCriteria> order,
-        @RequestParam( required = false )
-        String attachment,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeDeleted,
-        @RequestParam( required = false )
-        String event,
-        @RequestParam( required = false )
-        Set<String> filter,
-        @RequestParam( required = false )
-        Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeAllDataElements,
-        @RequestParam
-        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false ) String program,
+        @RequestParam( required = false ) String programStage,
+        @RequestParam( required = false ) ProgramStatus programStatus,
+        @RequestParam( required = false ) Boolean followUp,
+        @RequestParam( required = false ) String trackedEntityInstance,
+        @RequestParam( required = false ) String orgUnit,
+        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) Date startDate,
+        @RequestParam( required = false ) Date endDate,
+        @RequestParam( required = false ) Date dueDateStart,
+        @RequestParam( required = false ) Date dueDateEnd,
+        @RequestParam( required = false ) Date lastUpdated,
+        @RequestParam( required = false ) Date lastUpdatedStartDate,
+        @RequestParam( required = false ) Date lastUpdatedEndDate,
+        @RequestParam( required = false ) EventStatus status,
+        @RequestParam( required = false ) String attributeCc,
+        @RequestParam( required = false ) String attributeCos,
+        @RequestParam( required = false ) boolean skipMeta,
+        @RequestParam( required = false ) Integer page,
+        @RequestParam( required = false ) Integer pageSize,
+        @RequestParam( required = false ) boolean totalPages,
+        @RequestParam( required = false ) Boolean skipPaging,
+        @RequestParam( required = false ) Boolean paging,
+        @RequestParam( required = false ) List<OrderCriteria> order,
+        @RequestParam( required = false ) String attachment,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
+        @RequestParam( required = false ) String event,
+        @RequestParam( required = false ) Set<String> filter,
+        @RequestParam( required = false ) Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
+        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws Exception
     {
@@ -549,72 +450,39 @@ public class EventController
 
     @RequestMapping( value = "/query", method = RequestMethod.GET, produces = ContextUtils.CONTENT_TYPE_CSV )
     public void queryEventsCsv(
-        @RequestParam( required = false )
-        String program,
-        @RequestParam( required = false )
-        String programStage,
-        @RequestParam( required = false )
-        ProgramStatus programStatus,
-        @RequestParam( required = false )
-        Boolean followUp,
-        @RequestParam( required = false )
-        String trackedEntityInstance,
-        @RequestParam( required = false )
-        String orgUnit,
-        @RequestParam( required = false )
-        OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false )
-        AssignedUserSelectionMode assignedUserMode,
-        @RequestParam( required = false )
-        String assignedUser,
-        @RequestParam( required = false )
-        Date startDate,
-        @RequestParam( required = false )
-        Date endDate,
-        @RequestParam( required = false )
-        Date dueDateStart,
-        @RequestParam( required = false )
-        Date dueDateEnd,
-        @RequestParam( required = false )
-        Date lastUpdated,
-        @RequestParam( required = false )
-        Date lastUpdatedStartDate,
-        @RequestParam( required = false )
-        Date lastUpdatedEndDate,
-        @RequestParam( required = false )
-        EventStatus status,
-        @RequestParam( required = false )
-        String attributeCc,
-        @RequestParam( required = false )
-        String attributeCos,
-        @RequestParam( required = false )
-        boolean skipMeta,
-        @RequestParam( required = false )
-        Integer page,
-        @RequestParam( required = false )
-        Integer pageSize,
-        @RequestParam( required = false )
-        boolean totalPages,
-        @RequestParam( required = false )
-        Boolean skipPaging,
-        @RequestParam( required = false )
-        Boolean paging,
-        @RequestParam( required = false )
-        List<OrderCriteria> order,
-        @RequestParam( required = false )
-        String attachment,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeDeleted,
-        @RequestParam( required = false )
-        String event,
-        @RequestParam( required = false )
-        Set<String> filter,
-        @RequestParam( required = false )
-        Set<String> dataElement,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeAllDataElements,
-        @RequestParam
-        Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
+        @RequestParam( required = false ) String program,
+        @RequestParam( required = false ) String programStage,
+        @RequestParam( required = false ) ProgramStatus programStatus,
+        @RequestParam( required = false ) Boolean followUp,
+        @RequestParam( required = false ) String trackedEntityInstance,
+        @RequestParam( required = false ) String orgUnit,
+        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) AssignedUserSelectionMode assignedUserMode,
+        @RequestParam( required = false ) String assignedUser,
+        @RequestParam( required = false ) Date startDate,
+        @RequestParam( required = false ) Date endDate,
+        @RequestParam( required = false ) Date dueDateStart,
+        @RequestParam( required = false ) Date dueDateEnd,
+        @RequestParam( required = false ) Date lastUpdated,
+        @RequestParam( required = false ) Date lastUpdatedStartDate,
+        @RequestParam( required = false ) Date lastUpdatedEndDate,
+        @RequestParam( required = false ) EventStatus status,
+        @RequestParam( required = false ) String attributeCc,
+        @RequestParam( required = false ) String attributeCos,
+        @RequestParam( required = false ) boolean skipMeta,
+        @RequestParam( required = false ) Integer page,
+        @RequestParam( required = false ) Integer pageSize,
+        @RequestParam( required = false ) boolean totalPages,
+        @RequestParam( required = false ) Boolean skipPaging,
+        @RequestParam( required = false ) Boolean paging,
+        @RequestParam( required = false ) List<OrderCriteria> order,
+        @RequestParam( required = false ) String attachment,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
+        @RequestParam( required = false ) String event,
+        @RequestParam( required = false ) Set<String> filter,
+        @RequestParam( required = false ) Set<String> dataElement,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeAllDataElements,
+        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model, HttpServletResponse response,
         HttpServletRequest request )
         throws Exception
     {
@@ -660,8 +528,7 @@ public class EventController
 
     @RequestMapping( method = RequestMethod.GET )
     public @ResponseBody RootNode getEvents(
-        EventCriteria eventCriteria, @RequestParam
-        Map<String, String> parameters, Model model,
+        EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
         HttpServletResponse response,
         HttpServletRequest request )
     {
@@ -713,8 +580,7 @@ public class EventController
 
     @RequestMapping( method = RequestMethod.GET, produces = { "application/xml", "application/xml+gzip", "text/xml" } )
     public @ResponseBody RootNode getXmlEvents(
-        EventCriteria eventCriteria, @RequestParam
-        Map<String, String> parameters, Model model,
+        EventCriteria eventCriteria, @RequestParam Map<String, String> parameters, Model model,
         HttpServletResponse response,
         HttpServletRequest request )
         throws WebMessageException
@@ -766,8 +632,7 @@ public class EventController
     @RequestMapping( method = RequestMethod.GET, produces = { "application/csv", "application/csv+gzip", "text/csv" } )
     public void getCsvEvents(
         EventCriteria eventCriteria,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean skipHeader,
+        @RequestParam( required = false, defaultValue = "false" ) boolean skipHeader,
         HttpServletResponse response, HttpServletRequest request )
         throws IOException,
         WebMessageException
@@ -800,42 +665,24 @@ public class EventController
 
     @RequestMapping( value = "/eventRows", method = RequestMethod.GET )
     public @ResponseBody EventRows getEventRows(
-        @RequestParam( required = false )
-        String program,
-        @RequestParam( required = false )
-        String orgUnit,
-        @RequestParam( required = false )
-        OrganisationUnitSelectionMode ouMode,
-        @RequestParam( required = false )
-        ProgramStatus programStatus,
-        @RequestParam( required = false )
-        EventStatus eventStatus,
-        @RequestParam( required = false )
-        Date startDate,
-        @RequestParam( required = false )
-        Date endDate,
-        @RequestParam( required = false )
-        String attributeCc,
-        @RequestParam( required = false )
-        String attributeCos,
-        @RequestParam( required = false )
-        Integer page,
-        @RequestParam( required = false )
-        Integer pageSize,
-        @RequestParam( required = false )
-        boolean totalPages,
-        @RequestParam( required = false )
-        Boolean skipPaging,
-        @RequestParam( required = false )
-        Boolean paging,
-        @RequestParam( required = false )
-        List<OrderCriteria> order,
-        @RequestParam( required = false )
-        Boolean skipEventId,
-        @RequestParam( required = false, defaultValue = "false" )
-        boolean includeDeleted,
-        @RequestParam
-        Map<String, String> parameters, IdSchemes idSchemes, Model model )
+        @RequestParam( required = false ) String program,
+        @RequestParam( required = false ) String orgUnit,
+        @RequestParam( required = false ) OrganisationUnitSelectionMode ouMode,
+        @RequestParam( required = false ) ProgramStatus programStatus,
+        @RequestParam( required = false ) EventStatus eventStatus,
+        @RequestParam( required = false ) Date startDate,
+        @RequestParam( required = false ) Date endDate,
+        @RequestParam( required = false ) String attributeCc,
+        @RequestParam( required = false ) String attributeCos,
+        @RequestParam( required = false ) Integer page,
+        @RequestParam( required = false ) Integer pageSize,
+        @RequestParam( required = false ) boolean totalPages,
+        @RequestParam( required = false ) Boolean skipPaging,
+        @RequestParam( required = false ) Boolean paging,
+        @RequestParam( required = false ) List<OrderCriteria> order,
+        @RequestParam( required = false ) Boolean skipEventId,
+        @RequestParam( required = false, defaultValue = "false" ) boolean includeDeleted,
+        @RequestParam Map<String, String> parameters, IdSchemes idSchemes, Model model )
         throws WebMessageException
     {
         CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo( attributeCc, attributeCos,
@@ -854,10 +701,8 @@ public class EventController
     }
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.GET )
-    public @ResponseBody Event getEvent( @PathVariable( "uid" )
-    String uid,
-        @RequestParam
-        Map<String, String> parameters,
+    public @ResponseBody Event getEvent( @PathVariable( "uid" ) String uid,
+        @RequestParam Map<String, String> parameters,
         Model model, HttpServletRequest request )
         throws Exception
     {
@@ -875,11 +720,8 @@ public class EventController
     }
 
     @RequestMapping( value = "/files", method = RequestMethod.GET )
-    public void getEventDataValueFile( @RequestParam
-    String eventUid, @RequestParam
-    String dataElementUid,
-        @RequestParam( required = false )
-        ImageFileDimension dimension,
+    public void getEventDataValueFile( @RequestParam String eventUid, @RequestParam String dataElementUid,
+        @RequestParam( required = false ) ImageFileDimension dimension,
         HttpServletResponse response, HttpServletRequest request )
         throws Exception
     {
@@ -971,8 +813,7 @@ public class EventController
     // -------------------------------------------------------------------------
 
     @RequestMapping( method = RequestMethod.POST, consumes = "application/xml" )
-    public void postXmlEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
-    ImportStrategy strategy,
+    public void postXmlEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
     {
         postEvent( strategy, response, request, importOptions, this::safeAddEventsXml, this::safeGetEventsXml );
@@ -991,8 +832,7 @@ public class EventController
     }
 
     @RequestMapping( method = RequestMethod.POST, consumes = "application/json" )
-    public void postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" )
-    ImportStrategy strategy,
+    public void postJsonEvent( @RequestParam( defaultValue = "CREATE_AND_UPDATE" ) ImportStrategy strategy,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
     {
         postEvent( strategy, response, request, importOptions, this::safeAddEventsJson, this::safeGetEventsJson );
@@ -1061,8 +901,7 @@ public class EventController
     }
 
     @RequestMapping( value = "/{uid}/note", method = RequestMethod.POST, consumes = "application/json" )
-    public void postJsonEventForNote( @PathVariable( "uid" )
-    String uid,
+    public void postJsonEventForNote( @PathVariable( "uid" ) String uid,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
         throws IOException,
         WebMessageException
@@ -1081,8 +920,7 @@ public class EventController
     }
 
     @RequestMapping( method = RequestMethod.POST, consumes = { "application/csv", "text/csv" } )
-    public void postCsvEvents( @RequestParam( required = false, defaultValue = "false" )
-    boolean skipFirst,
+    public void postCsvEvents( @RequestParam( required = false, defaultValue = "false" ) boolean skipFirst,
         HttpServletResponse response, HttpServletRequest request, ImportOptions importOptions )
         throws IOException,
         ParseException
@@ -1109,8 +947,7 @@ public class EventController
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = { "application/xml", "text/xml" } )
     public void putXmlEvent( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" )
-        String uid, ImportOptions importOptions )
+        @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException
     {
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -1122,8 +959,7 @@ public class EventController
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.PUT, consumes = "application/json" )
     public void putJsonEvent( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" )
-        String uid, ImportOptions importOptions )
+        @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException
     {
         InputStream inputStream = StreamUtils.wrapAndCheckCompressionFormat( request.getInputStream() );
@@ -1143,9 +979,7 @@ public class EventController
 
     @RequestMapping( value = "/{uid}/{dataElementUid}", method = RequestMethod.PUT, consumes = "application/json" )
     public void putJsonEventSingleValue( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" )
-        String uid, @PathVariable( "dataElementUid" )
-        String dataElementUid )
+        @PathVariable( "uid" ) String uid, @PathVariable( "dataElementUid" ) String dataElementUid )
         throws IOException,
         WebMessageException
     {
@@ -1166,8 +1000,7 @@ public class EventController
 
     @RequestMapping( value = "/{uid}/eventDate", method = RequestMethod.PUT, consumes = "application/json" )
     public void putJsonEventForEventDate( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" )
-        String uid, ImportOptions importOptions )
+        @PathVariable( "uid" ) String uid, ImportOptions importOptions )
         throws IOException,
         WebMessageException
     {
@@ -1190,8 +1023,7 @@ public class EventController
 
     @RequestMapping( value = "/{uid}", method = RequestMethod.DELETE )
     public void deleteEvent( HttpServletResponse response, HttpServletRequest request,
-        @PathVariable( "uid" )
-        String uid )
+        @PathVariable( "uid" ) String uid )
     {
         ImportSummary importSummary = eventService.deleteEvent( uid );
         webMessageService.send( WebMessageUtils.importSummary( importSummary ), response, request );


### PR DESCRIPTION
[Backport from 2.38]

This fixes the pager object for the cases when `totalPages=false` is set as a parameter in the GET request.

Example for events.:
```
http://localhost:8080/dhis/api/events.json?fields=enrollment&ou=ImspTQPwCqd
&page=201&pageSize=100&program=ur1Edk5Oe2n&programEndDate=2021-05-24
&programStartDate=2021-05-02&totalPages=false
```
Before this fix the page object returned was always:
```
"pager": {
"page": 1,
"total": 0,
"pageSize": 50,
"pageCount": 1
}
```

Now it will look like this:
```
"pager": {
"page": 4,
"pageSize": 50,
"isLastPage": true
}

``` 

Another example, for enrollments, could be:
```
http://localhost:8080/dhis/api/enrollments.json?fields=enrollment&ou=ImspTQPwCqd
&ouMode=DESCENDANTS&page=3&pageSize=20&program=ur1Edk5Oe2n
&programEndDate=2021-05-24&programStartDate=2021-05-02&totalPages=false
```
