### PR TITLE
feat: Add skip flag for TEI tables in analytics export [DHIS2-13526]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
@@ -27,8 +27,26 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.analytics.AnalyticsTableType.COMPLETENESS;
+import static org.hisp.dhis.analytics.AnalyticsTableType.COMPLETENESS_TARGET;
+import static org.hisp.dhis.analytics.AnalyticsTableType.DATA_VALUE;
+import static org.hisp.dhis.analytics.AnalyticsTableType.ENROLLMENT;
+import static org.hisp.dhis.analytics.AnalyticsTableType.EVENT;
+import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE;
+import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE_ENROLLMENTS;
+import static org.hisp.dhis.analytics.AnalyticsTableType.TRACKED_ENTITY_INSTANCE_EVENTS;
+import static org.hisp.dhis.common.DhisApiVersion.ALL;
+import static org.hisp.dhis.common.DhisApiVersion.DEFAULT;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.createWebMessage;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.jobConfigurationReport;
+import static org.hisp.dhis.feedback.Status.ERROR;
+import static org.hisp.dhis.scheduling.JobStatus.FAILED;
+import static org.hisp.dhis.scheduling.JobType.ANALYTICS_TABLE;
+import static org.hisp.dhis.scheduling.JobType.MONITORING;
+import static org.hisp.dhis.scheduling.JobType.RESOURCE_TABLE;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -36,23 +54,17 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.analytics.AnalyticsTableType;
-import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.scheduling.JobConfigurationWebMessageResponse;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
-import org.hisp.dhis.feedback.Status;
 import org.hisp.dhis.scheduling.JobConfiguration;
-import org.hisp.dhis.scheduling.JobStatus;
-import org.hisp.dhis.scheduling.JobType;
 import org.hisp.dhis.scheduling.SchedulingManager;
 import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -61,17 +73,18 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping( value = ResourceTableController.RESOURCE_PATH )
-@ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
+@ApiVersion( { DEFAULT, ALL } )
 @AllArgsConstructor
 public class ResourceTableController
 {
+
     public static final String RESOURCE_PATH = "/resourceTables";
 
     private final SchedulingManager schedulingManager;
 
     private final CurrentUserService currentUserService;
 
-    @RequestMapping( value = "/analytics", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @RequestMapping( value = "/analytics", method = { PUT, POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseBody
     public WebMessage analytics(
@@ -79,6 +92,7 @@ public class ResourceTableController
         @RequestParam( required = false ) boolean skipAggregate,
         @RequestParam( required = false ) boolean skipEvents,
         @RequestParam( required = false ) boolean skipEnrollment,
+        @RequestParam( required = false ) boolean skipTei,
         @RequestParam( required = false ) Integer lastYears )
     {
         Set<AnalyticsTableType> skipTableTypes = new HashSet<>();
@@ -86,49 +100,55 @@ public class ResourceTableController
 
         if ( skipAggregate )
         {
-            skipTableTypes.add( AnalyticsTableType.DATA_VALUE );
-            skipTableTypes.add( AnalyticsTableType.COMPLETENESS );
-            skipTableTypes.add( AnalyticsTableType.COMPLETENESS_TARGET );
+            skipTableTypes.add( DATA_VALUE );
+            skipTableTypes.add( COMPLETENESS );
+            skipTableTypes.add( COMPLETENESS_TARGET );
         }
 
         if ( skipEvents )
         {
-            skipTableTypes.add( AnalyticsTableType.EVENT );
+            skipTableTypes.add( EVENT );
         }
 
         if ( skipEnrollment )
         {
-            skipTableTypes.add( AnalyticsTableType.ENROLLMENT );
+            skipTableTypes.add( ENROLLMENT );
+        }
+
+        if ( skipTei )
+        {
+            skipTableTypes.add( TRACKED_ENTITY_INSTANCE );
+            skipTableTypes.add( TRACKED_ENTITY_INSTANCE_EVENTS );
+            skipTableTypes.add( TRACKED_ENTITY_INSTANCE_ENROLLMENTS );
         }
 
         AnalyticsJobParameters analyticsJobParameters = new AnalyticsJobParameters( lastYears, skipTableTypes,
-            skipPrograms,
-            skipResourceTables );
+            skipPrograms, skipResourceTables );
 
-        JobConfiguration analyticsTableJob = new JobConfiguration( "inMemoryAnalyticsJob", JobType.ANALYTICS_TABLE, "",
+        JobConfiguration analyticsTableJob = new JobConfiguration( "inMemoryAnalyticsJob", ANALYTICS_TABLE, "",
             analyticsJobParameters, true, true );
         analyticsTableJob.setUserUid( currentUserService.getCurrentUser().getUid() );
 
         return execute( analyticsTableJob );
     }
 
-    @RequestMapping( method = { RequestMethod.PUT, RequestMethod.POST } )
+    @RequestMapping( method = { PUT, POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseBody
     public WebMessage resourceTables()
     {
         JobConfiguration resourceTableJob = new JobConfiguration( "inMemoryResourceTableJob",
-            JobType.RESOURCE_TABLE, currentUserService.getCurrentUser().getUid(), true );
+            RESOURCE_TABLE, currentUserService.getCurrentUser().getUid(), true );
 
         return execute( resourceTableJob );
     }
 
-    @RequestMapping( value = "/monitoring", method = { RequestMethod.PUT, RequestMethod.POST } )
+    @RequestMapping( value = "/monitoring", method = { PUT, POST } )
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @ResponseBody
     public WebMessage monitoring()
     {
-        JobConfiguration monitoringJob = new JobConfiguration( "inMemoryMonitoringJob", JobType.MONITORING, "",
+        JobConfiguration monitoringJob = new JobConfiguration( "inMemoryMonitoringJob", MONITORING, "",
             new MonitoringJobParameters(), true, true );
 
         return execute( monitoringJob );
@@ -139,9 +159,9 @@ public class ResourceTableController
         boolean success = schedulingManager.executeNow( configuration );
         if ( !success )
         {
-            configuration.setJobStatus( JobStatus.FAILED );
-            return createWebMessage( "Job of type " + configuration.getJobType() + " is already running", Status.ERROR,
-                HttpStatus.CONFLICT ).setResponse( new JobConfigurationWebMessageResponse( configuration ) );
+            configuration.setJobStatus( FAILED );
+            return createWebMessage( "Job of type " + configuration.getJobType() + " is already running", ERROR,
+                CONFLICT ).setResponse( new JobConfigurationWebMessageResponse( configuration ) );
         }
         return jobConfigurationReport( configuration );
     }


### PR DESCRIPTION
Add support for skip flag in analytics table export.

When the flag "skipTei" is set to "true", all TEI analytics tables should be skipped during the export process.

Example of the POST endpoint with the "skipTei" flag set to "true".

```
http://localhost:8080/dhis/api/resourceTables/analytics?skipTei=true
```