### PR TITLE
test: add own log4j2 test config for integration tests

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2-test.xml
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/log4j2-test.xml
@@ -4,7 +4,7 @@
      dhis-support-test , please do :) -->
 <Configuration status="warn">
     <Properties>
-        <Property name="layout">%-5p %d{ABSOLUTE} %m (%F [%t])%n</Property>
+        <Property name="layout">%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Property>
     </Properties>
 
     <Appenders>
@@ -17,20 +17,35 @@
     </Appenders>
 
     <Loggers>
-        <!-- A few examples of loggers that might be useful to debug issues. Check the log4j2 config for more -->
-        <!-- Uncomment if you want to debug DHIS2 -->
-        <!--        <Logger name="org.hisp.dhis" level="debug"/>-->
-        <!-- Uncomment if you want to debug testcontainers -->
-        <!--        <Logger name="org.testcontainers" level="debug"/>-->
-        <!-- Uncomment if you want to debug spring test context (cache) -->
-        <!--        <Logger name="org.springframework.test.context.cache" level="info"/>-->
-
         <Root level="warn">
-            <!-- Turned off so CI test runs are quiet, and we see failed tests easily.
-            Kept here, so you can quickly get logs in the console during local development -->
-            <AppenderRef ref="console" level="off"/>
-            <!-- Used to upload test logs during CI in case a test step fails -->
+            <!-- Set to error so CI test runs are quiet, we see failed tests easily but still see errors from libraries
+            we use due to for example misconfigurations or so. If you want to increase the verbosity of specific
+            packages use a logger like shown below. -->
+            <AppenderRef ref="console" level="error"/>
+            <!-- Used to upload test logs during CI in case a test step fails. Verbosity is a bit higher so we have more
+             information when debugging failed tests. -->
             <AppenderRef ref="file" level="warn"/>
         </Root>
+
+        <!-- A few examples of loggers that might be useful to debug integration test issues.
+        Adding an AppenderRef is necessary to overrule the log level we have set on the Root AppenderRefs.
+        Once you add an AppenderRef to a Logger you need to set additivity to false otherwise logs might appear twice
+        as they propagate up from the Logger to its parent which is the Root.
+        Check the log4j2 config documentation for more details. -->
+        <!-- Uncomment if you want to debug DHIS2 -->
+        <!-- <Logger name="org.hisp.dhis" level="debug" additivity="false">-->
+        <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- Uncomment if you want to debug testcontainers -->
+        <!-- <Logger name="org.testcontainers" level="debug" additivity="false">-->
+        <!--     <appenderref ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- <Logger name="com.github.dockerjava" level="all" additivity="false">-->
+        <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- Uncomment if you want to debug spring test context (cache) -->
+        <!-- <Logger name="org.springframework.test.context.cache" level="debug">-->
+        <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
     </Loggers>
 </Configuration>

--- a/dhis-2/dhis-test-integration/pom.xml
+++ b/dhis-2/dhis-test-integration/pom.xml
@@ -44,6 +44,8 @@
                     </ignoredNonTestScopedDependencies>
                     <!-- If code from the following modules is accessed in tests they'll have to move up to ignoredNonTestScopedDependency -->
                     <ignoredUnusedDeclaredDependencies>
+                        <!-- log4j-slf4j-impl is needed to log using slf4j see https://www.slf4j.org/codes.html#noProviders -->
+                        <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j-impl</ignoredUnusedDeclaredDependency>
                         <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-audit-consumer</ignoredUnusedDeclaredDependency>
                         <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-metadata-workflow</ignoredUnusedDeclaredDependency>
                         <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-support-artemis</ignoredUnusedDeclaredDependency>
@@ -245,6 +247,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
+++ b/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="warn">
+    <Properties>
+        <Property name="layout">%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${layout}"/>
+        </Console>
+        <File name="file" fileName="target/test.log">
+            <PatternLayout pattern="${layout}"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Root level="warn">
+            <!-- Set to error so CI test runs are quiet, we see failed tests easily but still see errors from libraries
+            we use due to for example misconfigurations or so. If you want to increase the verbosity of specific
+            packages use a logger like shown below. -->
+            <AppenderRef ref="console" level="error"/>
+            <!-- Used to upload test logs during CI in case a test step fails. Verbosity is a bit higher so we have more
+             information when debugging failed tests. -->
+            <AppenderRef ref="file" level="warn"/>
+        </Root>
+
+        <!-- A few examples of loggers that might be useful to debug integration test issues.
+        Adding an AppenderRef is necessary to overrule the log level we have set on the Root AppenderRefs.
+        Once you add an AppenderRef to a Logger you need to set additivity to false otherwise logs might appear twice
+        as they propagate up from the Logger to its parent which is the Root.
+        Check the log4j2 config documentation for more details. -->
+        <!-- Uncomment if you want to debug DHIS2 -->
+        <!-- <Logger name="org.hisp.dhis" level="debug" additivity="false">-->
+        <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- Uncomment if you want to debug testcontainers -->
+        <!-- <Logger name="org.testcontainers" level="debug" additivity="false">-->
+        <!--     <appenderref ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- <Logger name="com.github.dockerjava" level="all" additivity="false">-->
+        <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- Uncomment if you want to debug spring test context (cache) -->
+        <!-- <Logger name="org.springframework.test.context.cache" level="debug">-->
+        <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
* integration tests were not logging due to https://www.slf4j.org/codes.html#noProviders
* added own log4j2-test.xml for integration tests to iterate more
  quickly and customize it for integration tests
* adapt log pattern so its easier to understand where the log is coming
  from

Integration tests often need debugging since they tend to be more flaky
or only fail in CI. Logging is helpful in that case. The log4j2-test.xml
config we have in the dhis-support-test module is useful so not every
module needs to bring its own. Integration tests logs might need to be
configured differently. We use different tools like testcontainers, ...

Previously, dhis-support-test module needed to be re-installed for every
change to log4j2-test.xml. This is still needed for unit tests, but not
anymore for integration tests.

Only logging a classname like `WaitingConsumer` will leave you wondering
what library is logging the message if the message does not reveal it
itself. Added the package to the log entry. Used a standard log pattern
from log4j2 config, that is easy to read.

Sample log line

`10:07:47.593 [main] DEBUG org.testcontainers.containers.output.WaitingConsumer - STDERR: 2022-07-29 08:07:47.593 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432`

note `STDERR: 2022-07-29 08:07:47.593 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432` is the log message itself, so we are not duplicating the timestamp. That is just because testcontainers logs Docker messages which already contain them. Other libraries do not do that.