### PR TITLE
fix: support displayName in sharing requests

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -183,8 +183,7 @@ public class FieldFilterService
         for ( Object object : params.getObjects() )
         {
             applyAccess( params, fieldPaths, object );
-            applyUserAccessesDisplayName( params, fieldPaths, object );
-            applyUserGroupAccessesDisplayName( params, fieldPaths, object );
+            applySharingDisplayNames( params, fieldPaths, object );
             applyAttributeValuesAttribute( params, fieldPaths, object );
 
             ObjectNode objectNode = objectMapper.valueToTree( object );
@@ -250,8 +249,7 @@ public class FieldFilterService
         for ( Object object : params.getObjects() )
         {
             applyAccess( params, fieldPaths, object );
-            applyUserAccessesDisplayName( params, fieldPaths, object );
-            applyUserGroupAccessesDisplayName( params, fieldPaths, object );
+            applySharingDisplayNames( params, fieldPaths, object );
             applyAttributeValuesAttribute( params, fieldPaths, object );
 
             ObjectNode objectNode = objectMapper.valueToTree( object );
@@ -448,27 +446,19 @@ public class FieldFilterService
             } );
     }
 
-    private void applyUserGroupAccessesDisplayName( FieldFilterParams<?> params, List<FieldPath> fieldPaths,
-        Object object )
+    private void applySharingDisplayNames( FieldFilterParams<?> params, List<FieldPath> fieldPaths,
+        Object root )
     {
-        applyFieldPathVisitor( object, fieldPaths, params,
-            s -> s.equals( "userGroupAccesses.displayName" ) || s.endsWith( ".userGroupAccesses.displayName" ),
+        applyFieldPathVisitor( root, fieldPaths, params,
+            s -> s.contains( "sharing" )
+                || s.equals( "userGroupAccesses.displayName" ) || s.endsWith( ".userGroupAccesses.displayName" )
+                || s.equals( "userAccesses.displayName" ) || s.endsWith( ".userAccesses.displayName" ),
             o -> {
-                if ( o instanceof BaseIdentifiableObject )
+                if ( root instanceof BaseIdentifiableObject )
                 {
-                    ((BaseIdentifiableObject) o).getSharing().getUserGroups().values()
+                    ((BaseIdentifiableObject) root).getSharing().getUserGroups().values()
                         .forEach( uga -> uga.setDisplayName( userGroupService.getDisplayName( uga.getId() ) ) );
-                }
-            } );
-    }
-
-    private void applyUserAccessesDisplayName( FieldFilterParams<?> params, List<FieldPath> fieldPaths, Object object )
-    {
-        applyFieldPathVisitor( object, fieldPaths, params,
-            s -> s.equals( "userAccesses.displayName" ) || s.endsWith( ".userAccesses.displayName" ), o -> {
-                if ( o instanceof BaseIdentifiableObject )
-                {
-                    ((BaseIdentifiableObject) o).getSharing().getUsers().values()
+                    ((BaseIdentifiableObject) root).getSharing().getUsers().values()
                         .forEach( ua -> ua.setDisplayName( userService.getDisplayName( ua.getId() ) ) );
                 }
             } );

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -451,7 +451,9 @@ public class FieldFilterService
     {
         applyFieldPathVisitor( root, fieldPaths, params,
             s -> s.contains( "sharing" )
+                || s.equals( "userGroupAccesses" ) || s.endsWith( ".userGroupAccesses" )
                 || s.equals( "userGroupAccesses.displayName" ) || s.endsWith( ".userGroupAccesses.displayName" )
+                || s.equals( "userAccesses" ) || s.endsWith( ".userAccesses" )
                 || s.equals( "userAccesses.displayName" ) || s.endsWith( ".userAccesses.displayName" ),
             o -> {
                 if ( root instanceof BaseIdentifiableObject )
@@ -459,6 +461,13 @@ public class FieldFilterService
                     ((BaseIdentifiableObject) root).getSharing().getUserGroups().values()
                         .forEach( uga -> uga.setDisplayName( userGroupService.getDisplayName( uga.getId() ) ) );
                     ((BaseIdentifiableObject) root).getSharing().getUsers().values()
+                        .forEach( ua -> ua.setDisplayName( userService.getDisplayName( ua.getId() ) ) );
+                }
+                else if ( o instanceof BaseIdentifiableObject )
+                {
+                    ((BaseIdentifiableObject) o).getSharing().getUserGroups().values()
+                        .forEach( uga -> uga.setDisplayName( userGroupService.getDisplayName( uga.getId() ) ) );
+                    ((BaseIdentifiableObject) o).getSharing().getUsers().values()
                         .forEach( ua -> ua.setDisplayName( userService.getDisplayName( ua.getId() ) ) );
                 }
             } );

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -325,7 +325,9 @@ public class FieldPathHelper
             || Sharing.class.isAssignableFrom( property.getKlass() )
             || Access.class.isAssignableFrom( property.getKlass() )
             || UserAccess.class.isAssignableFrom( property.getKlass() )
-            || UserGroupAccess.class.isAssignableFrom( property.getKlass() );
+            || org.hisp.dhis.user.UserAccess.class.isAssignableFrom( property.getKlass() )
+            || UserGroupAccess.class.isAssignableFrom( property.getKlass() )
+            || org.hisp.dhis.user.UserGroupAccess.class.isAssignableFrom( property.getKlass() );
     }
 
     /**


### PR DESCRIPTION
## Summary

Simply applies `displayName` to requests that is still using legacy sharing requests.