### PR TITLE
fix: aggregate DataValueAudit fixes

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -166,11 +166,11 @@ public class DefaultDataValueService
         {
             dataValue.setLastUpdated( new Date() );
 
-            DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
-                dataValue.getStoredBy(), AuditType.UPDATE );
-
             if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
             {
+                DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
+                    dataValue.getStoredBy(), AuditType.UPDATE );
+
                 dataValueAuditService.addDataValueAudit( dataValueAudit );
             }
 
@@ -195,11 +195,11 @@ public class DefaultDataValueService
     @Transactional
     public void deleteDataValue( DataValue dataValue )
     {
-        DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
-            currentUserService.getCurrentUsername(), AuditType.DELETE );
-
         if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
         {
+            DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
+                currentUserService.getCurrentUsername(), AuditType.DELETE );
+
             dataValueAuditService.addDataValueAudit( dataValueAudit );
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -153,7 +153,7 @@ public class DefaultDataValueService
         if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
         {
             DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
-                    dataValue.getStoredBy(), AuditType.CREATE );
+                dataValue.getStoredBy(), AuditType.CREATE );
 
             dataValueAuditService.addDataValueAudit( dataValueAudit );
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -138,14 +138,6 @@ public class DefaultDataValueService
 
         DataValue softDelete = dataValueStore.getSoftDeletedDataValue( dataValue );
 
-        if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
-        {
-            DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
-                dataValue.getStoredBy(), AuditType.CREATE );
-
-            dataValueAuditService.addDataValueAudit( dataValueAudit );
-        }
-
         if ( softDelete != null )
         {
             softDelete.mergeWith( dataValue );
@@ -156,6 +148,14 @@ public class DefaultDataValueService
         else
         {
             dataValueStore.addDataValue( dataValue );
+        }
+
+        if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
+        {
+            DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
+                    dataValue.getStoredBy(), AuditType.CREATE );
+
+            dataValueAuditService.addDataValueAudit( dataValueAudit );
         }
 
         return true;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -138,6 +138,14 @@ public class DefaultDataValueService
 
         DataValue softDelete = dataValueStore.getSoftDeletedDataValue( dataValue );
 
+        if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
+        {
+            DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
+                dataValue.getStoredBy(), AuditType.CREATE );
+
+            dataValueAuditService.addDataValueAudit( dataValueAudit );
+        }
+
         if ( softDelete != null )
         {
             softDelete.mergeWith( dataValue );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jdbc/batchhandler/DataValueAuditBatchHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/jdbc/batchhandler/DataValueAuditBatchHandlerTest.java
@@ -160,10 +160,10 @@ class DataValueAuditBatchHandlerTest extends SingleSetupIntegrationTestBase
         batchHandler.flush();
         List<DataValueAudit> auditsA = auditService.getDataValueAudits( dataValueA );
         assertNotNull( auditsA );
-        assertEquals( 2, auditsA.size() );
+        assertEquals( 3, auditsA.size() );
         List<DataValueAudit> auditsB = auditService.getDataValueAudits( dataValueB );
         assertNotNull( auditsB );
-        assertEquals( 2, auditsB.size() );
+        assertEquals( 3, auditsB.size() );
     }
 
     /**
@@ -187,7 +187,7 @@ class DataValueAuditBatchHandlerTest extends SingleSetupIntegrationTestBase
         auditA.setModifiedBy( "bill" );
         batchHandler.updateObject( auditA );
         List<DataValueAudit> audits = auditService.getDataValueAudits( dataValueA );
-        assertEquals( 1, audits.size() );
+        assertEquals( 2, audits.size() );
         assertEquals( "bill", audits.get( 0 ).getModifiedBy() );
     }
 }


### PR DESCRIPTION
## Summary

* [x] Add `DataValueAudit` of type `CREATE` for created (and where they are undeleted) aggregate data values

[TECH-1260](https://dhis2.atlassian.net/browse/TECH-1260)
[TECH-1261](https://dhis2.atlassian.net/browse/TECH-1261)
