### PR TITLE
fix: Remove decimals zeros in rep. rates/val. rules [DHIS2-8184]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -663,7 +663,7 @@ public class DataHandler
 
         grid.addRow()
             .addValues( dataRow.toArray() )
-            .addValue( getRoundedValueObject( params, value ) );
+            .addValue( params.isSkipRounding() ? value : getRoundedValueObject( params, value ) );
 
         if ( params.isIncludeNumDen() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -99,7 +99,6 @@ import static org.hisp.dhis.period.PeriodType.getPeriodTypeFromIsoString;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_MAX_LIMIT;
 import static org.hisp.dhis.setting.SettingKey.DATABASE_SERVER_CPUS;
 import static org.hisp.dhis.system.grid.GridUtils.getGridIndexByDimensionItem;
-import static org.hisp.dhis.system.util.MathUtils.getRounded;
 import static org.hisp.dhis.system.util.MathUtils.getWithin;
 import static org.hisp.dhis.system.util.MathUtils.isZero;
 import static org.hisp.dhis.util.ObjectUtils.firstNonNull;
@@ -558,7 +557,8 @@ public class DataHandler
     {
         for ( Map.Entry<String, Double> entry : aggregatedDataMap.entrySet() )
         {
-            Double value = params.isSkipRounding() ? entry.getValue() : getRounded( entry.getValue() );
+            Number value = params.isSkipRounding() ? entry.getValue()
+                : (Number) getRoundedValueObject( params, entry.getValue() );
 
             grid.addRow()
                 .addValues( entry.getKey().split( DIMENSION_SEP ) )
@@ -663,7 +663,7 @@ public class DataHandler
 
         grid.addRow()
             .addValues( dataRow.toArray() )
-            .addValue( params.isSkipRounding() ? value : getRounded( value ) );
+            .addValue( getRoundedValueObject( params, value ) );
 
         if ( params.isIncludeNumDen() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
@@ -116,12 +116,15 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         Grid grid = target.getAggregatedDataValueGrid( params );
 
-        assertEquals( expectedReports * timeUnit,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.EXPECTED_REPORTS ) ).get(), 0 );
-        assertEquals( 50D,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(), 0 );
-        assertEquals( 500D,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.ACTUAL_REPORTS ) ).get(), 0 );
+        assertEquals( (expectedReports * timeUnit),
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.EXPECTED_REPORTS ) ).get(),
+            0 );
+        assertEquals( 50L,
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(),
+            0 );
+        assertEquals( 500L,
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.ACTUAL_REPORTS ) ).get(),
+            0 );
     }
 
     @Test
@@ -159,8 +162,9 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
 
         Grid grid = target.getAggregatedDataValueGrid( params );
 
-        assertEquals( 0D,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(), 0 );
+        assertEquals( 0,
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(),
+            0L );
     }
 
     @Test
@@ -234,8 +238,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
         targets.put( dataSetA.getUid() + "-" + "201902", 1D );
 
         // Response for COMPLETENESS - set the completeness value to the same
-        // number of
-        // days of the selected month
+        // number of days of the selected month
         Map<String, Object> actuals = new HashMap<>();
         actuals.put( dataSetA.getUid() + "-" + "201902", 28D );
 
@@ -308,7 +311,7 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
         assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "dx" ) ),
             is( dataset.getUid() + ".REPORTING_RATE" ) );
         assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "pe" ) ), is( period ) );
-        assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "value" ) ), is( 100D ) );
+        assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "value" ) ), is( 100L ) );
     }
 
     private int getDimensionIndex( List<GridHeader> headers, String dimension )
@@ -325,13 +328,13 @@ class AnalyticsServiceReportingRateTest extends AnalyticsServiceBaseTest
         return -1;
     }
 
-    private Optional<Double> getValueFromGrid( List<List<Object>> rows, String key )
+    private Optional<Number> getValueFromGrid( List<List<Object>> rows, String key )
     {
         for ( List<Object> row : rows )
         {
             if ( row.get( 0 ).equals( key ) )
             {
-                return Optional.of( (Double) row.get( 2 ) );
+                return Optional.of( (Number) row.get( 2 ) );
             }
         }
         return Optional.empty();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -872,7 +872,7 @@ class AnalyticsServiceTest
     void test_reRate_2017_Q01_ouC()
     {
         assertDataValues(
-            Map.of( "a23dataSetA.REPORTING_RATE-ouabcdefghC-2017Q1", 100.0 ),
+            Map.of( "a23dataSetA.REPORTING_RATE-ouabcdefghC-2017Q1", 100L ),
             DataQueryParams.newBuilder()
                 .withOrganisationUnit( ouC )
                 .withReportingRates( List.of( reportingRateA ) )
@@ -898,8 +898,8 @@ class AnalyticsServiceTest
     void test_ou_2017_validationruleA()
     {
         assertDataValues(
-            Map.of( "a234567vruA-ouabcdefghA-2017", 4.0,
-                "a234567vruA-ouabcdefghB-2017", 2.0 ),
+            Map.of( "a234567vruA-ouabcdefghA-2017", 4L,
+                "a234567vruA-ouabcdefghB-2017", 2L ),
             DataQueryParams.newBuilder()
                 .withValidationRules( List.of( validationRuleA ) )
                 .withOrganisationUnits( organisationUnitService.getAllOrganisationUnits() )
@@ -912,8 +912,8 @@ class AnalyticsServiceTest
     void test_ou_2017_validationruleB()
     {
         assertDataValues(
-            Map.of( "a234567vruB-ouabcdefghA-2017", 3.0,
-                "a234567vruB-ouabcdefghB-2017", 2.0 ),
+            Map.of( "a234567vruB-ouabcdefghA-2017", 3L,
+                "a234567vruB-ouabcdefghB-2017", 2L ),
             DataQueryParams.newBuilder()
                 .withValidationRules( List.of( validationRuleB ) )
                 .withOrganisationUnits( organisationUnitService.getAllOrganisationUnits() )
@@ -926,10 +926,10 @@ class AnalyticsServiceTest
     void test_ou_2017_validationruleAB()
     {
         assertDataValues(
-            Map.of( "a234567vruA-ouabcdefghA-2017", 4.0,
-                "a234567vruA-ouabcdefghB-2017", 2.0,
-                "a234567vruB-ouabcdefghA-2017", 3.0,
-                "a234567vruB-ouabcdefghB-2017", 2.0 ),
+            Map.of( "a234567vruA-ouabcdefghA-2017", 4L,
+                "a234567vruA-ouabcdefghB-2017", 2L,
+                "a234567vruB-ouabcdefghA-2017", 3L,
+                "a234567vruB-ouabcdefghB-2017", 2L ),
             DataQueryParams.newBuilder()
                 .withValidationRules( List.of( validationRuleA, validationRuleB ) )
                 .withOrganisationUnits( organisationUnitService.getAllOrganisationUnits() )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
@@ -1082,11 +1082,11 @@ class QueryPlannerTest extends TransactionalIntegrationTest
     private void assertCollectionsMatch( List<DimensionItemObjectValue> collection,
         final List<DimensionItemObjectValue> in )
     {
-        Function<String, Double> findValueByUid = ( String uid ) -> in.stream()
+        Function<String, Number> findValueByUid = ( String uid ) -> in.stream()
             .filter( v -> v.getDimensionalItemObject().getUid().equals( uid ) ).findFirst().get().getValue();
         for ( DimensionItemObjectValue dimensionItemObjectValue : collection )
         {
-            final Double val = findValueByUid.apply( dimensionItemObjectValue.getDimensionalItemObject().getUid() );
+            final Number val = findValueByUid.apply( dimensionItemObjectValue.getDimensionalItemObject().getUid() );
             assertEquals( val, dimensionItemObjectValue.getValue() );
         }
     }


### PR DESCRIPTION
This change is a complement of https://github.com/dhis2/dhis2-core/pull/11199

It will also remove decimal "zeros" from report rates and validation rules for consistency.

So, numbers like `123.0` will simply become `123`.