### PR TITLE
fix: Visualization download to remove redundant 0 decimals [DHIS2-13460]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -99,7 +99,6 @@ import static org.hisp.dhis.period.PeriodType.getPeriodTypeFromIsoString;
 import static org.hisp.dhis.setting.SettingKey.ANALYTICS_MAX_LIMIT;
 import static org.hisp.dhis.setting.SettingKey.DATABASE_SERVER_CPUS;
 import static org.hisp.dhis.system.grid.GridUtils.getGridIndexByDimensionItem;
-import static org.hisp.dhis.system.util.MathUtils.getRounded;
 import static org.hisp.dhis.system.util.MathUtils.getWithin;
 import static org.hisp.dhis.system.util.MathUtils.isZero;
 import static org.hisp.dhis.util.ObjectUtils.firstNonNull;
@@ -546,7 +545,8 @@ public class DataHandler
     {
         for ( Map.Entry<String, Double> entry : aggregatedDataMap.entrySet() )
         {
-            Double value = params.isSkipRounding() ? entry.getValue() : getRounded( entry.getValue() );
+            Number value = params.isSkipRounding() ? entry.getValue()
+                : (Number) getRoundedValueObject( params, entry.getValue() );
 
             grid.addRow()
                 .addValues( entry.getKey().split( DIMENSION_SEP ) )
@@ -651,7 +651,7 @@ public class DataHandler
 
         grid.addRow()
             .addValues( dataRow.toArray() )
-            .addValue( params.isSkipRounding() ? value : getRounded( value ) );
+            .addValue( params.isSkipRounding() ? value : getRoundedValueObject( params, value ) );
 
         if ( params.isIncludeNumDen() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -36,6 +36,7 @@ import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.dataelement.DataElementOperand.TotalType;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
+import static org.hisp.dhis.system.util.MathUtils.getRounded;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.ArrayList;
@@ -89,7 +90,6 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
-import org.hisp.dhis.system.util.MathUtils;
 import org.hisp.dhis.util.DateUtils;
 import org.joda.time.DateTime;
 import org.springframework.util.Assert;
@@ -236,16 +236,21 @@ public class AnalyticsUtils
         }
         else
         {
-            return MathUtils.getRounded( value );
+            return getRounded( value );
         }
     }
 
     /**
      * Rounds a value. If the given parameters has skip rounding, the value is
-     * returned unchanged. If the given number is null or not of class Double,
+     * returned unchanged. If the given number is null or not of type Double,
      * the value is returned unchanged. If skip rounding is specified in the
      * given data query parameters, 10 decimals is used. Otherwise, default
      * rounding is used.
+     *
+     * If the given value is of type Double and ends with one or more decimal
+     * "0" (ie.: "125.0", "2355.000", etc.) a long value will be returned,
+     * forcing the removal of all decimal "0". The resulting value for the
+     * previous example would be, respectively, "125" and "2355".
      *
      * @param params the query parameters.
      * @param value the value.
@@ -262,7 +267,34 @@ public class AnalyticsUtils
             return Precision.round( (Double) value, DECIMALS_NO_ROUNDING );
         }
 
-        return MathUtils.getRounded( (Double) value );
+        final Double rounded = getRounded( (Double) value );
+
+        if ( endsWithZeroAsDecimal( rounded ) )
+        {
+            return rounded.longValue();
+        }
+
+        return rounded;
+    }
+
+    /**
+     * This method simply checks if the given double value (positive or
+     * negative) has one or more "0" as decimal digits. ie.:
+     *
+     * 25.0 -> true
+     *
+     * -232.0000 -> true
+     *
+     * 133.25 -> false
+     *
+     * -1045.00000001 -> false
+     *
+     * @param value
+     * @return true if the value has "0" as decimal digits, false otherwise
+     */
+    public static boolean endsWithZeroAsDecimal( final double value )
+    {
+        return ((value * 10) % 10 == 0);
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceReportingRateTest.java
@@ -118,11 +118,14 @@ public class AnalyticsServiceReportingRateTest
         Grid grid = target.getAggregatedDataValueGrid( params );
 
         assertEquals( expectedReports * timeUnit,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.EXPECTED_REPORTS ) ).get(), 0 );
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.EXPECTED_REPORTS ) ).get(),
+            0 );
         assertEquals( 50D,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(), 0 );
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(),
+            0 );
         assertEquals( 500D,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.ACTUAL_REPORTS ) ).get(), 0 );
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.ACTUAL_REPORTS ) ).get(),
+            0 );
     }
 
     @Test
@@ -160,8 +163,9 @@ public class AnalyticsServiceReportingRateTest
 
         Grid grid = target.getAggregatedDataValueGrid( params );
 
-        assertEquals( 0D,
-            getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(), 0 );
+        assertEquals( 0,
+            (Long) getValueFromGrid( grid.getRows(), makeKey( dataSetA, ReportingRateMetric.REPORTING_RATE ) ).get(),
+            0 );
     }
 
     @Test
@@ -309,7 +313,7 @@ public class AnalyticsServiceReportingRateTest
         assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "dx" ) ),
             is( dataset.getUid() + ".REPORTING_RATE" ) );
         assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "pe" ) ), is( period ) );
-        assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "value" ) ), is( 100D ) );
+        assertThat( grid.getRow( 0 ).get( getDimensionIndex( grid.getHeaders(), "value" ) ), is( 100L ) );
     }
 
     private int getDimensionIndex( List<GridHeader> headers, String dimension )
@@ -326,13 +330,13 @@ public class AnalyticsServiceReportingRateTest
         return -1;
     }
 
-    private Optional<Double> getValueFromGrid( List<List<Object>> rows, String key )
+    private Optional<Number> getValueFromGrid( List<List<Object>> rows, String key )
     {
         for ( List<Object> row : rows )
         {
             if ( row.get( 0 ).equals( key ) )
             {
-                return Optional.of( (Double) row.get( 2 ) );
+                return Optional.of( (Number) row.get( 2 ) );
             }
         }
         return Optional.empty();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -117,7 +117,7 @@ public class AnalyticsServiceTest
 
     private Map<String, AnalyticalObject> analyticalObjectHashMap = new HashMap<>();
 
-    private Map<String, Map<String, Double>> results = new HashMap<>();
+    private Map<String, Map<String, Number>> results = new HashMap<>();
 
     @Autowired
     private DataElementService dataElementService;
@@ -668,70 +668,72 @@ public class AnalyticsServiceTest
         // Set results
         // --------------------------------------------------------------------
 
-        Map<String, Double> de_avg_2017_03_keyValue = new HashMap<>();
+        Map<String, Number> de_avg_2017_03_keyValue = new HashMap<>();
         de_avg_2017_03_keyValue.put( "deabcdefghC-201703", 6.75 );
 
-        Map<String, Double> deC_ouB_2017_03_keyValue = new HashMap<>();
-        deC_ouB_2017_03_keyValue.put( "deabcdefghC-ouabcdefghB-201703", 6.0 );
-        deC_ouB_2017_03_keyValue.put( "deabcdefghC-201703-ouabcdefghB", 6.0 );
+        Map<String, Number> deC_ouB_2017_03_keyValue = new HashMap<>();
+        deC_ouB_2017_03_keyValue.put( "deabcdefghC-ouabcdefghB-201703", 6L );
+        deC_ouB_2017_03_keyValue.put( "deabcdefghC-201703-ouabcdefghB", 6L );
 
-        Map<String, Double> deA_ouA_2017_Q01_keyValue = new HashMap<>();
-        deA_ouA_2017_Q01_keyValue.put( "deabcdefghA-ouabcdefghA-2017Q1", 308.0 );
-        deA_ouA_2017_Q01_keyValue.put( "deabcdefghA-2017Q1-ouabcdefghA", 308.0 );
+        Map<String, Number> deA_ouA_2017_Q01_keyValue = new HashMap<>();
+        deA_ouA_2017_Q01_keyValue.put( "deabcdefghA-ouabcdefghA-2017Q1", 308L );
+        deA_ouA_2017_Q01_keyValue.put( "deabcdefghA-2017Q1-ouabcdefghA", 308L );
 
-        Map<String, Double> inA_2017_keyValue = new HashMap<>();
+        // Indicators, default to ".0" decimal when no decimal digit is set.
+        Map<String, Number> inA_2017_keyValue = new HashMap<>();
         inA_2017_keyValue.put( "inabcdefghA-2017", 308.0 );
 
-        Map<String, Double> inB_deB_deC_2017_Q01_keyValue = new HashMap<>();
+        // Indicators, default to ".0" decimal when no decimal digit is set.
+        Map<String, Number> inB_deB_deC_2017_Q01_keyValue = new HashMap<>();
         inB_deB_deC_2017_Q01_keyValue.put( "inabcdefghB-2017Q1", 567.0 );
 
-        Map<String, Double> inC_deB_deC_2017_Q01_keyValue = new HashMap<>();
+        Map<String, Number> inC_deB_deC_2017_Q01_keyValue = new HashMap<>();
         inC_deB_deC_2017_Q01_keyValue.put( "inabcdefghC-2017Q1", 258.50 );
         inC_deB_deC_2017_Q01_keyValue.put( "inabcdefghC-2017Q1-ouabcdefghA", 258.50 );
 
-        Map<String, Double> inD_deA_deB_deC_2017_Q01_keyValue = new HashMap<>();
+        Map<String, Number> inD_deA_deB_deC_2017_Q01_keyValue = new HashMap<>();
         inD_deA_deB_deC_2017_Q01_keyValue.put( "inabcdefghD-2017Q1", 29.8 );
 
-        Map<String, Double> inE_deA_reRateA_2017_Q01_keyValue = new HashMap<>();
+        Map<String, Number> inE_deA_reRateA_2017_Q01_keyValue = new HashMap<>();
         inE_deA_reRateA_2017_Q01_keyValue.put( "inabcdefghE-ouabcdefghD-2017Q1", 99.6 );
 
-        Map<String, Double> inF_deA_reRateB_2017_Q01_keyValue = new HashMap<>();
+        Map<String, Number> inF_deA_reRateB_2017_Q01_keyValue = new HashMap<>();
         inF_deA_reRateB_2017_Q01_keyValue.put( "inabcdefghF-ouabcdefghD-2017Q1", 199.4 );
 
-        Map<String, Double> inG_deE_periodOffsets_2017_07_keyvalue = new HashMap<>();
+        Map<String, Number> inG_deE_periodOffsets_2017_07_keyvalue = new HashMap<>();
         inG_deE_periodOffsets_2017_07_keyvalue.put( "inabcdefghG-ouabcdefghA-201707", 3.0 );
 
-        Map<String, Double> deA_ouB_ouC_2017_02_keyValue = new HashMap<>();
-        deA_ouB_ouC_2017_02_keyValue.put( "deabcdefghA-201702", 233.0 );
+        Map<String, Number> deA_ouB_ouC_2017_02_keyValue = new HashMap<>();
+        deA_ouB_ouC_2017_02_keyValue.put( "deabcdefghA-201702", 233L );
 
-        Map<String, Double> deA_deB_deD_ouC_ouE_2017_04_keyValue = new HashMap<>();
+        Map<String, Number> deA_deB_deD_ouC_ouE_2017_04_keyValue = new HashMap<>();
         deA_deB_deD_ouC_ouE_2017_04_keyValue.put( "deabcdefghD-201704", 10.5 );
 
-        Map<String, Double> deA_deB_2017_Q01_keyValue = new HashMap<>();
+        Map<String, Number> deA_deB_2017_Q01_keyValue = new HashMap<>();
         deA_deB_2017_Q01_keyValue.put( "2017Q1", 53.3 );
 
-        Map<String, Double> ouB_2017_01_01_2017_02_20_keyValue = new HashMap<>();
-        ouB_2017_01_01_2017_02_20_keyValue.put( "deabcdefghA-ouabcdefghB", 68.0 );
+        Map<String, Number> ouB_2017_01_01_2017_02_20_keyValue = new HashMap<>();
+        ouB_2017_01_01_2017_02_20_keyValue.put( "deabcdefghA-ouabcdefghB", 68L );
 
-        Map<String, Double> reRate_2017_Q01_ouC_keyValue = new HashMap<>();
-        reRate_2017_Q01_ouC_keyValue.put( "a23dataSetA.REPORTING_RATE-ouabcdefghC-2017Q1", 100.0 );
+        Map<String, Number> reRate_2017_Q01_ouC_keyValue = new HashMap<>();
+        reRate_2017_Q01_ouC_keyValue.put( "a23dataSetA.REPORTING_RATE-ouabcdefghC-2017Q1", 100L );
 
-        Map<String, Double> reRate_2017_Q01_ouD_keyValue = new HashMap<>();
+        Map<String, Number> reRate_2017_Q01_ouD_keyValue = new HashMap<>();
         reRate_2017_Q01_ouD_keyValue.put( "a23dataSetB.REPORTING_RATE-ouabcdefghD-2017Q1", 33.3 );
 
-        Map<String, Double> ou_2017_validationruleA_keyValue = new HashMap<>();
-        ou_2017_validationruleA_keyValue.put( "a234567vruA-ouabcdefghA-2017", 4.0 );
-        ou_2017_validationruleA_keyValue.put( "a234567vruA-ouabcdefghB-2017", 2.0 );
+        Map<String, Number> ou_2017_validationruleA_keyValue = new HashMap<>();
+        ou_2017_validationruleA_keyValue.put( "a234567vruA-ouabcdefghA-2017", 4L );
+        ou_2017_validationruleA_keyValue.put( "a234567vruA-ouabcdefghB-2017", 2L );
 
-        Map<String, Double> ou_2017_validationruleB_keyValue = new HashMap<>();
-        ou_2017_validationruleB_keyValue.put( "a234567vruB-ouabcdefghA-2017", 3.0 );
-        ou_2017_validationruleB_keyValue.put( "a234567vruB-ouabcdefghB-2017", 2.0 );
+        Map<String, Number> ou_2017_validationruleB_keyValue = new HashMap<>();
+        ou_2017_validationruleB_keyValue.put( "a234567vruB-ouabcdefghA-2017", 3L );
+        ou_2017_validationruleB_keyValue.put( "a234567vruB-ouabcdefghB-2017", 2L );
 
-        Map<String, Double> ou_2017_validationruleAB_keyValue = new HashMap<>();
-        ou_2017_validationruleAB_keyValue.put( "a234567vruA-ouabcdefghA-2017", 4.0 );
-        ou_2017_validationruleAB_keyValue.put( "a234567vruA-ouabcdefghB-2017", 2.0 );
-        ou_2017_validationruleAB_keyValue.put( "a234567vruB-ouabcdefghA-2017", 3.0 );
-        ou_2017_validationruleAB_keyValue.put( "a234567vruB-ouabcdefghB-2017", 2.0 );
+        Map<String, Number> ou_2017_validationruleAB_keyValue = new HashMap<>();
+        ou_2017_validationruleAB_keyValue.put( "a234567vruA-ouabcdefghA-2017", 4L );
+        ou_2017_validationruleAB_keyValue.put( "a234567vruA-ouabcdefghB-2017", 2L );
+        ou_2017_validationruleAB_keyValue.put( "a234567vruB-ouabcdefghA-2017", 3L );
+        ou_2017_validationruleAB_keyValue.put( "a234567vruB-ouabcdefghB-2017", 2L );
 
         results.put( "de_avg_2017_03", de_avg_2017_03_keyValue );
         results.put( "deC_ouB_2017_03", deC_ouB_2017_03_keyValue );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryPlannerTest.java
@@ -1291,12 +1291,12 @@ public class QueryPlannerTest
     private void assertCollectionsMatch( List<DimensionItemObjectValue> collection,
         final List<DimensionItemObjectValue> in )
     {
-        Function<String, Double> findValueByUid = ( String uid ) -> in.stream()
+        Function<String, Number> findValueByUid = ( String uid ) -> in.stream()
             .filter( v -> v.getDimensionalItemObject().getUid().equals( uid ) ).findFirst().get().getValue();
 
         for ( DimensionItemObjectValue dimensionItemObjectValue : collection )
         {
-            final Double val = findValueByUid.apply( dimensionItemObjectValue.getDimensionalItemObject().getUid() );
+            final Number val = findValueByUid.apply( dimensionItemObjectValue.getDimensionalItemObject().getUid() );
             assertEquals( val, dimensionItemObjectValue.getValue() );
         }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceTest.java
@@ -180,7 +180,7 @@ public class EventAnalyticsServiceTest
             .build();
 
         // The results
-        Map<String, Double> events_2017_keyValue = new HashMap<>();
+        Map<String, Number> events_2017_keyValue = new HashMap<>();
         events_2017_keyValue.put( "ouabcdefghA", 6.0 );
 
         // When


### PR DESCRIPTION
**_[Backport from master/23.9]_**

The download of a Visualization is showing "0" digits for numbers like "237.0", "55.0", "13300.0" and so on.

Instead, it should remove `0` decimal digits, as they are redundant. So the numbers above would became: "237", "55", "13300".

This happens when exporting Data Elements of Value Type "Number" because the number of decimal digits is not configurable (in Indicators this option exists).

This PR aims to remove the redundant `zeros` for the Data Element results.

The GET request below can be used to reproduce the issue in master, and also to display the expected results on this branch.
```
http://localhost:8080/dhis/api/analytics.json?dimension=dx:fbfJHSPpUQD;cYeuwXTCPkU;Jtf34kNZhzP;hfdmMSPBgLG&dimension=pe:LAST_12_MONTHS&showHierarchy=false&hierarchyMeta=false&includeMetadataDetails=true&includeNumDen=true&skipRounding=false&completedOnly=false&outputIdScheme=NAME&filter=ou:ImspTQPwCqd
```

**_This backport includes also the PR related to `DHIS2-8184`, where we apply the same behaviour for Reporting Rates for consistency. As the fixes are very close and related, I decided to backport both on the same ticket. See ticket https://jira.dhis2.org/browse/DHIS2-8184_**