### PR TITLE
feat: Increase number of years supported by analytics exp [DHIS2-13558]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/resourcetable/ResourceTable.java
@@ -41,7 +41,7 @@ public abstract class ResourceTable<T>
 {
     public static final int FIRST_YEAR_SUPPORTED = 1975;
 
-    public static final int LATEST_YEAR_SUPPORTED = now().plusYears( 2 ).getYear();
+    public static final int LATEST_YEAR_SUPPORTED = now().plusYears( 25 ).getYear();
 
     protected static final String TEMP_TABLE_SUFFIX = "_temp";
 


### PR DESCRIPTION
Historically, the analytics tables could export data until 2024.
Recently we increased it, to limit the year allowance to `current_year + 2`.

Now, we are increasing it to `current_year + 25`. So users will be able to export data 25 years in the future.

This limitation is set so we can avoid taking too much space during the analytics table export.