### PR TITLE
chore: Notifier API cleanup

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/InMemoryNotifier.java
@@ -48,18 +48,6 @@ public class InMemoryNotifier implements Notifier
     private final NotificationMap notificationMap = new NotificationMap( MAX_POOL_TYPE_SIZE );
 
     @Override
-    public Notifier notify( JobConfiguration id, String message )
-    {
-        return notify( id, NotificationLevel.INFO, message, false );
-    }
-
-    @Override
-    public Notifier notify( JobConfiguration id, NotificationLevel level, String message )
-    {
-        return notify( id, level, message, false );
-    }
-
-    @Override
     public Notifier notify( JobConfiguration id, NotificationLevel level, String message, boolean completed )
     {
         if ( id != null && !(level != null && level.isOff()) )
@@ -74,35 +62,6 @@ public class InMemoryNotifier implements Notifier
             notificationMap.add( id, notification );
 
             NotificationLoggerUtil.log( log, level, message );
-        }
-
-        return this;
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, String message )
-    {
-        return update( id, NotificationLevel.INFO, message, false );
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, String message, boolean completed )
-    {
-        return update( id, NotificationLevel.INFO, message, completed );
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, NotificationLevel level, String message )
-    {
-        return update( id, level, message, false );
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, NotificationLevel level, String message, boolean completed )
-    {
-        if ( id != null && !(level != null && level.isOff()) )
-        {
-            notify( id, level, message, completed );
         }
 
         return this;
@@ -138,14 +97,8 @@ public class InMemoryNotifier implements Notifier
     }
 
     @Override
-    public Notifier addJobSummary( JobConfiguration id, Object jobSummary, Class<?> jobSummaryType )
-    {
-        return addJobSummary( id, NotificationLevel.INFO, jobSummary, jobSummaryType );
-    }
-
-    @Override
-    public Notifier addJobSummary( JobConfiguration id, NotificationLevel level, Object jobSummary,
-        Class<?> jobSummaryType )
+    public <T> Notifier addJobSummary( JobConfiguration id, NotificationLevel level, T jobSummary,
+        Class<T> jobSummaryType )
     {
         if ( id != null && !(level != null && level.isOff()) )
         {

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notifier.java
@@ -35,22 +35,45 @@ import org.hisp.dhis.scheduling.JobType;
 
 /**
  * @author Lars Helge Overland
+ * @author Jan Bernitt (pulled up default methods)
  */
 public interface Notifier
 {
-    Notifier notify( JobConfiguration id, String message );
+    default Notifier notify( JobConfiguration id, String message )
+    {
+        return notify( id, NotificationLevel.INFO, message, false );
+    }
 
-    Notifier notify( JobConfiguration id, NotificationLevel level, String message );
+    default Notifier notify( JobConfiguration id, NotificationLevel level, String message )
+    {
+        return notify( id, level, message, false );
+    }
 
     Notifier notify( JobConfiguration id, NotificationLevel level, String message, boolean completed );
 
-    Notifier update( JobConfiguration id, String message );
+    default Notifier update( JobConfiguration id, String message )
+    {
+        return update( id, NotificationLevel.INFO, message, false );
+    }
 
-    Notifier update( JobConfiguration id, String message, boolean completed );
+    default Notifier update( JobConfiguration id, String message, boolean completed )
+    {
+        return update( id, NotificationLevel.INFO, message, completed );
+    }
 
-    Notifier update( JobConfiguration id, NotificationLevel level, String message );
+    default Notifier update( JobConfiguration id, NotificationLevel level, String message )
+    {
+        return update( id, level, message, false );
+    }
 
-    Notifier update( JobConfiguration id, NotificationLevel level, String message, boolean completed );
+    default Notifier update( JobConfiguration id, NotificationLevel level, String message, boolean completed )
+    {
+        if ( id != null && !(level != null && level.isOff()) )
+        {
+            notify( id, level, message, completed );
+        }
+        return this;
+    }
 
     Map<JobType, Map<String, Deque<Notification>>> getNotifications();
 
@@ -60,9 +83,12 @@ public interface Notifier
 
     Notifier clear( JobConfiguration id );
 
-    Notifier addJobSummary( JobConfiguration id, Object taskSummary, Class<?> jobSummaryType );
+    default <T> Notifier addJobSummary( JobConfiguration id, T jobSummary, Class<T> jobSummaryType )
+    {
+        return addJobSummary( id, NotificationLevel.INFO, jobSummary, jobSummaryType );
+    }
 
-    Notifier addJobSummary( JobConfiguration id, NotificationLevel level, Object jobSummary, Class<?> jobSummaryType );
+    <T> Notifier addJobSummary( JobConfiguration id, NotificationLevel level, T jobSummary, Class<T> jobSummaryType );
 
     Map<String, Object> getJobSummariesForJobType( JobType jobType );
 

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
@@ -91,24 +91,6 @@ public class RedisNotifier implements Notifier
     // -------------------------------------------------------------------------
 
     @Override
-    public Notifier notify( JobConfiguration id, String message )
-    {
-        return notify( id, NotificationLevel.INFO, message, false );
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, String message, boolean completed )
-    {
-        return notify( id, NotificationLevel.INFO, message, completed );
-    }
-
-    @Override
-    public Notifier notify( JobConfiguration id, NotificationLevel level, String message )
-    {
-        return notify( id, level, message, false );
-    }
-
-    @Override
     public Notifier notify( JobConfiguration id, NotificationLevel level, String message, boolean completed )
     {
         if ( id != null && !(level != null && level.isOff()) )
@@ -145,29 +127,6 @@ public class RedisNotifier implements Notifier
 
             NotificationLoggerUtil.log( log, level, message );
         }
-        return this;
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, String message )
-    {
-        return update( id, NotificationLevel.INFO, message, false );
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, NotificationLevel level, String message )
-    {
-        return update( id, level, message, false );
-    }
-
-    @Override
-    public Notifier update( JobConfiguration id, NotificationLevel level, String message, boolean completed )
-    {
-        if ( id != null && !(level != null && level.isOff()) )
-        {
-            notify( id, level, message, completed );
-        }
-
         return this;
     }
 
@@ -226,14 +185,8 @@ public class RedisNotifier implements Notifier
     }
 
     @Override
-    public Notifier addJobSummary( JobConfiguration id, Object jobSummary, Class<?> jobSummaryType )
-    {
-        return addJobSummary( id, NotificationLevel.INFO, jobSummary, jobSummaryType );
-    }
-
-    @Override
-    public Notifier addJobSummary( JobConfiguration id, NotificationLevel level, Object jobSummary,
-        Class<?> jobSummaryType )
+    public <T> Notifier addJobSummary( JobConfiguration id, NotificationLevel level, T jobSummary,
+        Class<T> jobSummaryType )
     {
         if ( id != null && !(level != null && level.isOff()) && jobSummary.getClass().equals( jobSummaryType ) )
         {


### PR DESCRIPTION
* moves "default parameter" delegating methods from implementation to `default` methods in interface
* introduces a method generic for the summary object to enforce that the `Class` and `Object` argument passed match