### PR TITLE
fix: duplicate attributes from preheat.getAttributesByClass()

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeService;
@@ -385,7 +386,7 @@ public class DefaultPreheatService implements PreheatService
         List<Attribute> attributes = attributeService.getAttributes( klass );
 
         if ( CollectionUtils.isEmpty( attributes )
-            || !CollectionUtils.isEmpty( preheat.getAttributesByClass( klass ) ) )
+            || !MapUtils.isEmpty( preheat.getAttributesByClass( klass ) ) )
         {
             return;
         }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MetadataAttributeCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/MetadataAttributeCheck.java
@@ -33,9 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
@@ -80,11 +78,8 @@ public class MetadataAttributeCheck implements ObjectValidationCheck
             return;
         }
 
-        Set<Attribute> attributes = bundle.getPreheat().getAttributesByClass( klass );
-
-        Map<String, ValueType> valueTypesMap = attributes != null && !attributes.isEmpty()
+        Map<String, Attribute> attributesMap = bundle.getPreheat().getAttributesByClass( klass ) != null
             ? bundle.getPreheat().getAttributesByClass( klass )
-                .stream().collect( Collectors.toMap( Attribute::getUid, Attribute::getValueType ) )
             : Map.of();
 
         for ( T object : objects )
@@ -97,7 +92,7 @@ public class MetadataAttributeCheck implements ObjectValidationCheck
             List<ErrorReport> errorReports = new ArrayList<>();
 
             object.getAttributeValues()
-                .forEach( av -> getValueType( av.getAttribute().getUid(), valueTypesMap, klass.getSimpleName(),
+                .forEach( av -> getValueType( av.getAttribute().getUid(), attributesMap, klass.getSimpleName(),
                     errorReports::add )
                         .ifPresent( type -> attributeValidator.validate( type, av.getValue(),
                             errorReports::add ) ) );
@@ -122,16 +117,16 @@ public class MetadataAttributeCheck implements ObjectValidationCheck
      * @param addError Consumer for {@link ErrorReport} if any.
      * @return {@link ValueType} if exists otherwise {@link Optional#empty()}
      */
-    private Optional<ValueType> getValueType( String attributeId, Map<String, ValueType> valueTypeMap, String klassName,
+    private Optional<ValueType> getValueType( String attributeId, Map<String, Attribute> valueTypeMap, String klassName,
         Consumer<ErrorReport> addError )
     {
-        ValueType type = valueTypeMap.get( attributeId );
-        if ( type == null )
+        Attribute attribute = valueTypeMap.get( attributeId );
+        if ( attribute == null )
         {
             addError.accept( new ErrorReport( Attribute.class, ErrorCode.E6012, attributeId, klassName ) );
             return Optional.empty();
         }
 
-        return Optional.of( type );
+        return Optional.of( attribute.getValueType() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/MetadataAttributeCheckTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/metadata/attribute/MetadataAttributeCheckTest.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.attribute.Attribute;
@@ -110,7 +110,8 @@ class MetadataAttributeCheckTest
         when( validationContext.getSchemaService() ).thenReturn( schemaService );
 
         preheat = Mockito.mock( Preheat.class );
-        when( preheat.getAttributesByClass( OrganisationUnit.class ) ).thenReturn( Set.of( attribute ) );
+        when( preheat.getAttributesByClass( OrganisationUnit.class ) )
+            .thenReturn( Map.of( attribute.getUid(), attribute ) );
 
         objectBundle = Mockito.mock( ObjectBundle.class );
         when( objectBundle.getPreheat() ).thenReturn( preheat );
@@ -141,7 +142,7 @@ class MetadataAttributeCheckTest
         attribute.setOrganisationUnitAttribute( false );
 
         // OrganisationUnit doesn't have any attribute assigned
-        when( preheat.getAttributesByClass( OrganisationUnit.class ) ).thenReturn( Set.of() );
+        when( preheat.getAttributesByClass( OrganisationUnit.class ) ).thenReturn( Map.of() );
 
         // Import OrganisationUnit with an AttributeValue
         organisationUnit.getAttributeValues().add( new AttributeValue( attribute, "10" ) );


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-13569
- When importing metadata, if the payload contains existing attribute then the `preheat.attributesByTargetObjectType` could contains duplicate attributes. 
- In details, there could be two Attributes with same `uid` but different `id`, where the object loaded from database has `id` = 10 and object from payload has `id` = 0.
- This affects the `MetadataAttributeCheck` which has just beed added to 2.39, so this fix doesn't need to be backport.