### PR TITLE
fix: log leader election job on debug [DHIS2-13562]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -149,6 +149,15 @@ public enum JobType
         this.relativeApiElements = relativeApiElements;
     }
 
+    /**
+     * @return when true, general information on job progress should be logged
+     *         on debug level, otherwise when false it is logged on info level
+     */
+    public boolean isDefaultLogLevelDebug()
+    {
+        return this == LEADER_ELECTION;
+    }
+
     public boolean isUsingNotifications()
     {
         return this == RESOURCE_TABLE

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/ControlledJobProgress.java
@@ -79,6 +79,8 @@ public class ControlledJobProgress implements JobProgress
 
     private final boolean usingErrorNotification;
 
+    private final boolean logInfoAsDebug;
+
     public ControlledJobProgress( JobConfiguration configuration )
     {
         this( null, configuration, NoopJobProgress.INSTANCE, true );
@@ -92,6 +94,7 @@ public class ControlledJobProgress implements JobProgress
         this.tracker = tracker;
         this.abortOnFailure = abortOnFailure;
         this.usingErrorNotification = messageService != null && configuration.getJobType().isUsingErrorNotification();
+        this.logInfoAsDebug = configuration.getJobType().isDefaultLogLevelDebug();
     }
 
     public void requestCancellation()
@@ -430,7 +433,14 @@ public class ControlledJobProgress implements JobProgress
 
     private void logInfo( Node source, String action, String message )
     {
-        if ( log.isInfoEnabled() )
+        if ( logInfoAsDebug )
+        {
+            if ( log.isDebugEnabled() )
+            {
+                log.debug( formatLogMessage( source, action, message ) );
+            }
+        }
+        else if ( log.isInfoEnabled() )
         {
             log.info( formatLogMessage( source, action, message ) );
         }


### PR DESCRIPTION
End goal is to have the leader election job logging its "information" log entries on debug level. This is solved by introducing a general flag per job type to switch the log level of general messages from INFO to DEBUG.