### PR TITLE
fix: sharing userGroup displayName is empty (2.38)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -80,6 +80,7 @@ import org.hisp.dhis.user.UserAccess;
 import org.hisp.dhis.user.UserGroupAccess;
 import org.hisp.dhis.user.UserGroupService;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.sharing.Sharing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -390,6 +391,14 @@ public class DefaultFieldFilterService implements FieldFilterService
         {
             AttributeValue attributeValue = (AttributeValue) object;
             attributeValue.setAttribute( attributeService.getAttribute( attributeValue.getAttribute().getUid() ) );
+        }
+
+        if ( Sharing.class.isAssignableFrom( object.getClass() ) )
+        {
+            Sharing sharing = (Sharing) object;
+            sharing.getUsers().values().forEach( u -> u.setDisplayName( userService.getDisplayName( u.getId() ) ) );
+            sharing.getUserGroups().values()
+                .forEach( ug -> ug.setDisplayName( userGroupService.getDisplayName( ug.getId() ) ) );
         }
 
         if ( UserGroupAccess.class.isAssignableFrom( object.getClass() ) )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/DhisControllerConvenienceTest.java
@@ -77,7 +77,7 @@ public abstract class DhisControllerConvenienceTest extends DhisMockMvcControlle
     private UserService _userService;
 
     @Autowired
-    private IdentifiableObjectManager manager;
+    protected IdentifiableObjectManager manager;
 
     private MockMvc mvc;
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AbstractCrudControllerTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.http.HttpStatus.Series.SUCCESSFUL;
 
 import java.util.List;
+import java.util.Set;
 
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonArray;
@@ -47,6 +48,7 @@ import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
 import org.hisp.dhis.webapi.json.domain.JsonError;
 import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
@@ -666,6 +668,39 @@ class AbstractCrudControllerTest extends DhisControllerConvenienceTest
         JsonTypeReport response = message.get( "response", JsonTypeReport.class );
         assertEquals( 1, response.getObjectReports().size() );
         assertEquals( ErrorCode.E3015, response.getObjectReports().get( 0 ).getErrorReports().get( 0 ).getErrorCode() );
+    }
+
+    @Test
+    void testSharingDisplayName()
+    {
+        UserGroup userGroup = createUserGroup( 'A', Set.of() );
+        manager.save( userGroup );
+        String userId = getCurrentUser().getUid();
+
+        String sharing = "{'owner':'" + userId + "', 'public':'rwrw----', 'external': true,'userGroups':{\""
+            + userGroup.getUid() + "\":{\"id\":\"" + userGroup.getUid() + "\",\"access\":\"rwrw----\"} } }";
+
+        String programId = assertStatus( HttpStatus.CREATED,
+            POST( "/programs/", "{'name':'test', 'shortName':'test', 'programType':'WITHOUT_REGISTRATION', 'sharing': "
+                + sharing + "}" ) );
+
+        assertStatus( HttpStatus.CREATED,
+            POST( "/programStages/", "{\"id\": \"VlhIwWqEHsI\",\n" + "\"sortOrder\": 1," +
+                "\"name\": \"test\", \"minDaysFromStart\": \"0\", \"displayGenerateEventBox\": true, \"autoGenerateEvent\": true,"
+                +
+                "\"program\":" + "{\"id\": \"" + programId + "\"}, \"sharing\": " + sharing + "}" ) );
+
+        JsonIdentifiableObject program = GET( "/programs/{id}?fields=sharing", programId ).content()
+            .as( JsonIdentifiableObject.class );
+        assertEquals( "UserGroupA",
+            program.getSharing().getUserGroups().get( userGroup.getUid() ).getString( "displayName" ).string() );
+
+        JsonIdentifiableObject programStage = GET( "/programs/{id}?fields=programStages[sharing]", programId ).content()
+            .as( JsonIdentifiableObject.class );
+        assertEquals( "UserGroupA",
+            programStage.getList( "programStages", JsonIdentifiableObject.class ).get( 0 ).getSharing().getUserGroups()
+                .get( userGroup.getUid() ).getString( "displayName" ).string() );
+
     }
 
     @Test


### PR DESCRIPTION
backport https://github.com/dhis2/dhis2-core/pull/11422
- The fix is different from https://github.com/dhis2/dhis2-core/pull/11422 because in 2.38 we still use the old `FieldFilterService`. Only the test `AbstractCrudControllerTest#testSharingDisplayName` is backport.