### PR TITLE
feat: optional uid parameter for creation of file resources [DHIS2-6288]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
@@ -48,4 +48,16 @@ class FileResourceControllerTest extends DhisControllerConvenienceTest
             .getObject( "fileResource" );
         assertEquals( "OU_profile_image.png", savedObject.getString( "name" ).string() );
     }
+
+    @Test
+    void testSaveOrgUnitImageWithUid()
+    {
+        MockMultipartFile image = new MockMultipartFile( "file", "OU_profile_image.png", "image/png",
+            "<<png data>>".getBytes() );
+        HttpResponse response = POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789a", image );
+        JsonObject savedObject = response.content( HttpStatus.ACCEPTED ).getObject( "response" )
+            .getObject( "fileResource" );
+        assertEquals( "OU_profile_image.png", savedObject.getString( "name" ).string() );
+        assertEquals( "0123456789a", savedObject.getString( "id" ).string() );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -138,11 +138,12 @@ public class FileResourceController
 
     @PostMapping
     public WebMessage saveFileResource( @RequestParam MultipartFile file,
-        @RequestParam( defaultValue = "DATA_VALUE" ) FileResourceDomain domain )
+        @RequestParam( defaultValue = "DATA_VALUE" ) FileResourceDomain domain,
+        @RequestParam( required = false ) String uid )
         throws WebMessageException,
         IOException
     {
-        FileResource fileResource = fileResourceUtils.saveFileResource( file, domain );
+        FileResource fileResource = fileResourceUtils.saveFileResource( uid, file, domain );
 
         WebMessage webMessage = new WebMessage( Status.OK, HttpStatus.ACCEPTED );
         webMessage.setResponse( new FileResourceWebMessageResponse( fileResource ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -159,6 +159,13 @@ public class FileResourceUtils
         throws WebMessageException,
         IOException
     {
+        return saveFileResource( null, file, domain );
+    }
+
+    public FileResource saveFileResource( String uid, MultipartFile file, FileResourceDomain domain )
+        throws WebMessageException,
+        IOException
+    {
         String filename = StringUtils.defaultIfBlank( FilenameUtils.getName( file.getOriginalFilename() ),
             FileResource.DEFAULT_FILENAME );
 
@@ -181,6 +188,7 @@ public class FileResourceUtils
         String contentMd5 = bytes.hash( Hashing.md5() ).toString();
 
         FileResource fileResource = new FileResource( filename, contentType, contentLength, contentMd5, domain );
+        fileResource.setUid( uid );
 
         File tmpFile = toTempFile( file );
 


### PR DESCRIPTION
### Summary
Adds a new optional `uid` parameter to the `POST` method to create a `FileResouce`.
This allows to create file resources with specific externally generated UIDs.

### Automatic Testing 
New test scenario was added so creation with and without `uid` parameter is now covered.

### Manual Testing
* check file resources with `uid` parameter can be created (`/fileResources?domain=ORG_UNIT&uid={uid}`) and that the resulting resource has the provided uid
* check file resources can still be created without a `uid` parameter and get assignd a new generated UID