### PR TITLE
feat: dashboard search with q parameter [DHIS2-12284]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DashboardController.java
@@ -77,6 +77,15 @@ public class DashboardController
     // Search
     // -------------------------------------------------------------------------
 
+    @GetMapping( "/search" )
+    public @ResponseBody DashboardSearchResult searchAsParam( @RequestParam String q,
+        @RequestParam( required = false ) Set<DashboardItemType> max,
+        @RequestParam( required = false ) Integer count,
+        @RequestParam( required = false ) Integer maxCount )
+    {
+        return dashboardService.search( q, max, count, maxCount );
+    }
+
     @GetMapping( "/q/{query}" )
     public @ResponseBody DashboardSearchResult search( @PathVariable String query,
         @RequestParam( required = false ) Set<DashboardItemType> max,

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.net.URI;
+
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dashboard.DashboardItemType;
 import org.hisp.dhis.dashboard.DashboardService;
@@ -90,6 +92,15 @@ class DashboardControllerTest
         mockMvc.perform( get( ENDPOINT ) ).andExpect( status().isOk() );
 
         verify( dashboardService ).search( null, null, null );
+    }
+
+    @Test
+    void verifyEndpointWithSearchParameterArgs()
+        throws Exception
+    {
+        mockMvc.perform( get( new URI( "/dashboards/search?q=HIV%2FTB" ) ) ).andExpect( status().isOk() );
+
+        verify( dashboardService ).search( "HIV/TB", null, null, null );
     }
 
     @Test


### PR DESCRIPTION
### Summary
Adds a new endpoint `/dashboards/search` that is used with the `q` query parameter.

### Automatic Testing
A new test scenario was added to existing tests.