### PR TITLE
fix: Not EQ in analytics event query is filtering out null values [DHIS2-13563]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -34,6 +34,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
@@ -91,6 +92,7 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.InQueryFilter;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.common.QueryRuntimeException;
 import org.hisp.dhis.common.Reference;
 import org.hisp.dhis.common.RepeatableStageParams;
@@ -1119,7 +1121,17 @@ public abstract class AbstractJdbcEventAnalyticsManager
         }
         else
         {
-            return field + " " + filter.getSqlOperator() + " " + getSqlFilter( filter, item ) + " ";
+            final QueryOperator operator = filter.getOperator();
+            switch ( operator )
+            {
+            case NEQ:
+            case NE:
+            case NIEQ:
+                return "(" + field + " is null or " + field + SPACE + filter.getSqlOperator() + SPACE
+                    + getSqlFilter( filter, item ) + ") ";
+            default:
+                return field + SPACE + filter.getSqlOperator() + SPACE + getSqlFilter( filter, item ) + SPACE;
+            }
         }
     }
 


### PR DESCRIPTION
When using a filter like `!EQ`, the endpoint should all results that are not equals and also bring all null values.

Currently, the null values are excluded from the results. This change will fix this problem.

Using the Debug DB, we can use this URL for testing:
```
http://localhost:8080/dhis/api/39/analytics/events/query/vBOHFvxlYPJ
?dimension=ou:USER_ORGUNIT,Xd6cKnFMO4L.sC3rTY6UiY6:!EQ:2022-01-02
&headers=ouname,Xd6cKnFMO4L.sC3rTY6UiY6,eventdate
&totalPages=false
&eventDate=THIS_YEAR
&stage=Xd6cKnFMO4L
&displayProperty=SHORTNAME
&outputType=EVENT
&pageSize=100
&page=1
&includeMetadataDetails=true 
```