### PR TITLE
feat: allow data set ID in CSV header row of data value import [DHIS2-8083]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/CsvDataValueSetReader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/CsvDataValueSetReader.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.dxf2.datavalueset;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
@@ -56,7 +58,7 @@ final class CsvDataValueSetReader implements DataValueSetReader, DataValueEntry
         {
             readNext(); // Ignore the first row: assume header row
             String dataSetId = getString( 11 );
-            if ( dataSetId != null && !dataSetId.isEmpty() )
+            if ( isNotEmpty( dataSetId ) )
             {
                 set.setDataSet( dataSetId );
             }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/CsvDataValueSetReader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/CsvDataValueSetReader.java
@@ -51,11 +51,17 @@ final class CsvDataValueSetReader implements DataValueSetReader, DataValueEntry
     @Override
     public DataValueSet readHeader()
     {
+        DataValueSet set = new DataValueSet();
         if ( importOptions == null || importOptions.isFirstRowIsHeader() )
         {
             readNext(); // Ignore the first row: assume header row
+            String dataSetId = getString( 11 );
+            if ( dataSetId != null && !dataSetId.isEmpty() )
+            {
+                set.setDataSet( dataSetId );
+            }
         }
-        return new DataValueSet();
+        return set;
     }
 
     @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
@@ -536,6 +536,18 @@ class DataValueSetServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
+    void testImportDataValuesCsvWithDataSetIdHeader()
+        throws Exception
+    {
+        in = new ClassPathResource( "dxf2/datavalueset/dataValueSetWithDataSetHeader.csv" ).getInputStream();
+        ImportSummary summary = dataValueSetService.importDataValueSetCsv( in, null, null );
+        assertEquals( 3, summary.getImportCount().getImported() );
+        assertEquals( 0, summary.getImportCount().getUpdated() );
+        assertEquals( 0, summary.getImportCount().getDeleted() );
+        assertEquals( ImportStatus.SUCCESS, summary.getStatus() );
+    }
+
+    @Test
     void testImportDataValuesCsvWithoutHeader()
         throws Exception
     {

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetWithDataSetHeader.csv
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetWithDataSetHeader.csv
@@ -1,0 +1,4 @@
+"dataelelement","period","orgunit","categoryoptioncombo","attributeoptioncombo","value","storedby","timestamp","comment","followup","deleted","pBOMPrpg1QX"
+"f7n9E0hX8qk","201201","DiszpKrYNg8","","","10001","john","2012-01-01","comment","false"
+"f7n9E0hX8qk","201201","BdfsJfj87js","","","10002","john","2012-01-02","comment","false"
+"f7n9E0hX8qk","201202","DiszpKrYNg8","","","10003","john","2012-01-03","comment","false"


### PR DESCRIPTION
### Summary
Adds possibility to add the data set ID of a data value set CSV import by adding another header column (last). 
The column header is the data set ID. It is the 12th column after the "deleted" column.
Nothing else about the CSV import changes. This is purely an additional optional feature that allows to specify the data set ID of the imported set.

### Automatic Testing
Added a unit test with a CSV file that tests the scenario for success.