### PR TITLE
chore(deps): micrometer libraries should be kept in sync

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -182,8 +182,7 @@
 
     <!-- Monitoring -->
     <micrometer-spring-legacy.version>1.3.20</micrometer-spring-legacy.version>
-    <micrometer-registry-prometheus.version>1.9.3</micrometer-registry-prometheus.version>
-    <micrometer-core.version>1.9.2</micrometer-core.version>
+    <micrometer.version>1.9.3</micrometer.version>
 
     <!-- Logging -->
     <log4j.version>2.18.0</log4j.version>
@@ -2377,12 +2376,12 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
-        <version>${micrometer-registry-prometheus.version}</version>
+        <version>${micrometer.version}</version>
       </dependency>
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>
-        <version>${micrometer-core.version}</version>
+        <version>${micrometer.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
as they are released together
micrometer-spring-legacy is EOL and not released anymore https://github.com/micrometer-metrics/micrometer/issues/1662
We should investigate whether the mix of current and EOL spring-legacy actually works