### PR TITLE
ci(deps): automatically add 1 of 2 approvals to dependabot minor and patch updates

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -16,13 +16,13 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@v1.3.3
       - name: Approve dependabot PR using GitHub actions bot
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for dependabot PR
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
as patch update approvals have been working well for months now https://github.com/dhis2/dhis2-core/pull/10614

One additional approval by a dev will still be needed on patch and minor updates