### PR TITLE
fix: Update regex not to be greedy

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/textpattern/TextPatternMethod.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/textpattern/TextPatternMethod.java
@@ -43,7 +43,7 @@ public enum TextPatternMethod
      * <p>
      * This is the only method that has no keyword associated with it.
      */
-    TEXT( new TextMethodType( Pattern.compile( "\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"" ) ) ),
+    TEXT( new TextMethodType( Pattern.compile( "\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*+)\"" ) ) ),
 
     /**
      * Generator methods has a required param, that needs to be between 1 and 12

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/textpattern/TestTextPatternMethod.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/textpattern/TestTextPatternMethod.java
@@ -38,8 +38,9 @@ class TestTextPatternMethod
     @Test
     void testValidateText()
     {
-        String[] valid = { "\"Hello world!\"", "\"Hello \\\"world\\\"\"" };
-        String[] invalid = { "Hello world", "Hello \" world", "\"Hello world", "Hello world\"" };
+        String[] valid = { "\"Hello world!\"", "\"Hello \\\"world\\\"\"",
+            "\"This is a text with more than two words\"" };
+        String[] invalid = { "Hello world", "Hello \" world", "\"Hello world", "Hello world\"", "\"Hello \"world\"\"" };
         testSyntax( TextPatternMethod.TEXT, valid, true );
         testSyntax( TextPatternMethod.TEXT, invalid, false );
     }

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/SupplementaryDataProvider.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/SupplementaryDataProvider.java
@@ -54,7 +54,7 @@ public class SupplementaryDataProvider
     private static final String USER = "USER";
 
     private static final String REGEX = "d2:inOrgUnitGroup\\( *(([\\d/\\*\\+\\-%\\. ]+)|" +
-        "( *'[^']*'))*( *, *(([\\d/\\*\\+\\-%\\. ]+)|'[^']*'))* *\\)";
+        "( *'[^']*'))*+( *, *(([\\d/\\*\\+\\-%\\. ]+)|'[^']*'))*+ *\\)";
 
     private static final Pattern PATTERN = Pattern.compile( REGEX );
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/helper/JdbcSqlFileExecutor.java
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/java/org/hisp/dhis/db/migration/helper/JdbcSqlFileExecutor.java
@@ -54,7 +54,7 @@ public class JdbcSqlFileExecutor
      * regex to detect delimiter. ignores spaces, allows delimiter in comment,
      * allows an equals-sign
      */
-    public static final Pattern delimP = Pattern.compile( "^\\s*(--)?\\s*delimiter\\s*=?\\s*([^\\s]+)+\\s*.*$",
+    public static final Pattern delimP = Pattern.compile( "^\\s*+(--)?\\s*+delimiter\\s*+=?\\s*+([^\\s]+)+\\s*+.*+$",
         Pattern.CASE_INSENSITIVE );
 
     private final Connection connection;


### PR DESCRIPTION
Reported by Sonarcloud as a potential problem:
When matching large strings, greedy regex can be overloaded and cause issues. By adding "+" after "*", we make the matching possesive rather than greedy.

Tested using existing unit tests (program rules, textpattern) and running a fresh db (flyway).
