### PR TITLE
fix: NV filter on events not working [DHIS2-13563]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -34,6 +34,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.analytics.QueryKey.NV;
@@ -1091,7 +1092,21 @@ public abstract class AbstractJdbcEventAnalyticsManager
         }
         else
         {
-            return field + " " + filter.getSqlOperator() + " " + getSqlFilter( filter, item ) + " ";
+            // NV filter has its own specific logic, so we should skip values
+            // comparisons when NV is set as filter.
+            if ( !NV.equals( filter.getFilter() ) )
+            {
+                switch ( filter.getOperator() )
+                {
+                case NEQ:
+                case NE:
+                case NIEQ:
+                    return "(" + field + " is null or " + field + SPACE + filter.getSqlOperator() + SPACE
+                        + getSqlFilter( filter, item ) + ") ";
+                }
+            }
+
+            return field + SPACE + filter.getSqlOperator() + SPACE + getSqlFilter( filter, item ) + SPACE;
         }
     }
 


### PR DESCRIPTION
**_[Backport from master/2.39]_**

This issue was introduced by my previous PR https://github.com/dhis2/dhis2-core/pull/11430

I haven't considered the `NV` filter on the previous fix.

Test URLs:

```
http://localhost:8080/dhis/api/29/analytics/events/query/IpHINAT79UW.json?dimension=pe:LAST_12_MONTHS
&dimension=ou:ImspTQPwCqd
&dimension=A03MvHHogjR.H6uSAMO5WLD:NE:NV
&stage=A03MvHHogjR
&displayProperty=NAME
&totalPages=false&
outputType=EVENT
&desc=eventdate
&pageSize=100
&page=1
```
```
http://localhost:8080/dhis/api/29/analytics/events/query/IpHINAT79UW.json?dimension=pe:LAST_12_MONTHS
&dimension=ou:ImspTQPwCqd
&dimension=A03MvHHogjR.H6uSAMO5WLD:!EQ:gates
&stage=A03MvHHogjR
&displayProperty=NAME
&totalPages=false
&outputType=EVENT
&desc=eventdate
&pageSize=100
&page=1
```