### PR TITLE
fix: Only restrict page size to max limit if greater than zero [DHIS2-13606]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticsPagingCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AnalyticsPagingCriteria.java
@@ -31,10 +31,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 /**
- * This class contains all the paging criteria that can be used to execute a
- * DHIS2 analytics query using the AnalyticsController
+ * This class contains paging criteria that can be used to execute an analytics
+ * query.
  */
-
 @Getter
 @Setter
 public class AnalyticsPagingCriteria extends RequestTypeAware
@@ -51,26 +50,35 @@ public class AnalyticsPagingCriteria extends RequestTypeAware
 
     /**
      * The paging parameter. When set to false we should not paginate. The
-     * default is true (always paginate).
+     * default is true (paginate).
      */
     private boolean paging = true;
 
     /**
      * The paging parameter. When set to false we should not count total pages.
-     * The default is true (always total pages flag activated).
+     * The default is true (count total pages).
      */
     private boolean totalPages = true;
 
-    public void definePageSize( int analyticsMaxLimit )
+    /**
+     * Sets the page size, taking the configurable max records limit into
+     * account. Note that a value of 0 represents unlimited records.
+     *
+     * @param maxLimit the max limit as defined in the system setting
+     *        'ANALYTICS_MAX_LIMIT'.
+     */
+    public void definePageSize( int maxLimit )
     {
         if ( isPaging() )
         {
-            setPageSize(
-                getPageSize() != null && getPageSize() > analyticsMaxLimit ? analyticsMaxLimit : getPageSize() );
+            if ( getPageSize() != null && maxLimit > 0 && getPageSize() > maxLimit )
+            {
+                setPageSize( maxLimit );
+            }
         }
         else
         {
-            setPageSize( analyticsMaxLimit );
+            setPageSize( maxLimit );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/PagingCriteriaProcessor.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/common/PagingCriteriaProcessor.java
@@ -43,7 +43,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PagingCriteriaProcessor implements Processor<AnalyticsPagingCriteria>
 {
-
     private final SystemSettingManager systemSettingManager;
 
     // TODO: DHIS2-13384 we would really like to have all
@@ -51,11 +50,10 @@ public class PagingCriteriaProcessor implements Processor<AnalyticsPagingCriteri
     // immutable, but PagingCriteria is not
     // returning it for now, should be converted to use builders
     @Override
-    public AnalyticsPagingCriteria process( final AnalyticsPagingCriteria pagingCriteria )
+    public AnalyticsPagingCriteria process( AnalyticsPagingCriteria pagingCriteria )
     {
         int analyticsMaxPageSize = systemSettingManager.getIntSetting( SettingKey.ANALYTICS_MAX_LIMIT );
         pagingCriteria.definePageSize( analyticsMaxPageSize );
         return pagingCriteria;
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryValidator.java
@@ -74,8 +74,8 @@ public interface EventQueryValidator
         throws IllegalQueryException;
 
     /**
-     * Returns the max number of records to return. A value of 0 indicates no
-     * limit.
+     * Returns the max number of records to return. A value of 0 indicates
+     * unlimited records.
      *
      * @return the max number of records to return.
      */

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -158,9 +158,9 @@ public abstract class AbstractAnalyticsService
             }
             else
             {
-                final String uid = getItemUid( item );
+                String uid = getItemUid( item );
 
-                final String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
+                String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
 
                 grid.addHeader( new GridHeader( uid, column, item.getValueType(),
                     false, true, item.getOptionSet(), item.getLegendSet() ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -171,6 +171,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
      * Returns a SQL paging clause.
      *
      * @param params the {@link EventQueryParams}.
+     * @param maxLimit the configurable max limit of records.
      */
     private String getPagingClause( EventQueryParams params, int maxLimit )
     {
@@ -907,7 +908,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
      * @param runnable a {@link Runnable} containing the code block to execute
      *        and wrap around the exception handling.
      */
-    void withExceptionHandling( Runnable runnable )
+    protected void withExceptionHandling( Runnable runnable )
     {
         try
         {
@@ -1112,7 +1113,11 @@ public abstract class AbstractJdbcEventAnalyticsManager
     }
 
     /**
-     * Produces SQL for a single filter inside a queryItem
+     * Creates a SQL statement for a single filter inside a query item.
+     *
+     * @param item the {@link QueryItem}.
+     * @param filter the {@link QueryFilter}.
+     * @param params the {@link EventQueryParams}.
      */
     private String toSql( QueryItem item, QueryFilter filter, EventQueryParams params )
     {

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SettingKey.java
@@ -106,6 +106,11 @@ public enum SettingKey
     RECAPTCHA_SITE( "recaptchaSite", "6LcVwT0UAAAAAAkO_EGPiYOiymIszZUeHfqWIYX5", String.class, true, false ),
     CAN_GRANT_OWN_USER_ROLES( "keyCanGrantOwnUserAuthorityGroups", Boolean.FALSE, Boolean.class ),
     IGNORE_ANALYTICS_APPROVAL_YEAR_THRESHOLD( "keyIgnoreAnalyticsApprovalYearThreshold", -1, Integer.class ),
+
+    /**
+     * Max records to return in the analytics API. Default is 100'000. The value
+     * 0 represents unlimited records.
+     */
     ANALYTICS_MAX_LIMIT( "keyAnalyticsMaxLimit", 100000, Integer.class ),
     INCLUDE_ZERO_VALUES_IN_ANALYTICS( "keyIncludeZeroValuesInAnalytics", Boolean.FALSE, Boolean.class ),
     SQL_VIEW_MAX_LIMIT( "keySqlViewMaxLimit", -1, Integer.class ),
@@ -202,13 +207,13 @@ public enum SettingKey
     RULE_ENGINE_ASSIGN_OVERWRITE( "ruleEngineAssignOverwrite", Boolean.FALSE, Boolean.class ),
 
     /**
-     * Progressive caching factor definition for Analytics. In order to enable
-     * it, the {@link #ANALYTICS_CACHE_TTL_MODE} has to be set to PROGRESSIVE.
+     * Progressive caching factor for the analytics API. To enable, the
+     * {@link #ANALYTICS_CACHE_TTL_MODE} must be set to PROGRESSIVE.
      */
     ANALYTICS_CACHE_PROGRESSIVE_TTL_FACTOR( "keyAnalyticsCacheProgressiveTtlFactor", 160, Integer.class ),
 
     /**
-     * The caching strategy enabled.
+     * The cache time to live value for the analytics API.
      */
     ANALYTICS_CACHE_TTL_MODE( "keyAnalyticsCacheTtlMode", AnalyticsCacheTtlMode.FIXED, AnalyticsCacheTtlMode.class );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -443,5 +443,4 @@ public class EventAnalyticsController
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON,
             CacheStrategy.RESPECT_SYSTEM_SETTING );
     }
-
 }


### PR DESCRIPTION
The event analytics query engine restricted the page size in the paging logic to the max limit of records from the `ANALYTICS_MAX_LIMIT` even when that value as 0. The value 0 in this case represents unlimited records, and the restriction should only happen if the max limit of records is greater than 0. Currently if the max limit is set to unlimited, no events are ever returned from the event analytics query endpoint.