### PR TITLE
fix: cron expression validation [DHIS2-9768]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/JobConfigurationObjectBundleHook.java
@@ -49,7 +49,7 @@ import org.hisp.dhis.scheduling.JobConfigurationService;
 import org.hisp.dhis.scheduling.JobParameters;
 import org.hisp.dhis.scheduling.JobService;
 import org.hisp.dhis.scheduling.SchedulingManager;
-import org.springframework.scheduling.support.CronSequenceGenerator;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Component;
 
 /**
@@ -232,7 +232,7 @@ public class JobConfigurationObjectBundleHook
                 addReports
                     .accept( new ErrorReport( JobConfiguration.class, ErrorCode.E7004, jobConfiguration.getUid() ) );
             }
-            else if ( !CronSequenceGenerator.isValidExpression( jobConfiguration.getCronExpression() ) )
+            else if ( !CronExpression.isValidExpression( jobConfiguration.getCronExpression() ) )
             {
                 addReports.accept( new ErrorReport( JobConfiguration.class, ErrorCode.E7005 ) );
             }


### PR DESCRIPTION
### Summary
`CronSequenceGenerator` did not accept the valid expression `0 0 1 ? * TUE-SUN`.
As it was deprecated I tried `CronExpression.isValidExpression` instead as our scheduling is also based on `CronExpression` class. That one does accept the expression.

### Manual Testing
* create a job in the scheduler app using a cron expression like `0 0 1 ? * TUE-SUN` that has a day-of-the-week range. 
* try to safe the job successfully