### PR TITLE
fix: NoEntityFound exception for userService.getDisplayName()

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -640,7 +640,7 @@ public class HibernateUserStore
         String sql = "select concat(firstname, ' ', surname) from userinfo where uid =:uid";
         Query<String> query = getSession().createNativeQuery( sql );
         query.setParameter( "uid", userUid );
-        return query.getSingleResult();
+        return getSingleResult( query );
     }
 
     @Override

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -609,4 +609,10 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         userService.disableTwoFA( currentUser, userToModify.getUid(), error -> errors.add( error ) );
         assertTrue( errors.isEmpty() );
     }
+
+    @Test
+    void testGetDisplayNameNull()
+    {
+        assertNull( userService.getDisplayName( "notExist" ) );
+    }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-13607

- Fix exception `No entity found for query`  when calling `userService.getDisplayName(userId)` and the userId doesn't exist.