### PR TITLE
fix: NPE when changing avatar image without F_USER_VIEW authority [DHIS2-9761]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.user;
 
-import static java.util.Collections.emptySet;
-import static java.util.Collections.unmodifiableSet;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.util.ArrayList;
@@ -289,20 +287,16 @@ public class User
      */
     public Set<String> getAllAuthorities()
     {
-        if ( userRoles.isEmpty() )
-        {
-            return emptySet();
-        }
-        if ( userRoles.size() == 1 )
-        {
-            return unmodifiableSet( userRoles.iterator().next().getAuthorities() );
-        }
         Set<String> authorities = new HashSet<>();
+
         for ( UserRole group : userRoles )
         {
             authorities.addAll( group.getAuthorities() );
         }
-        return Collections.unmodifiableSet( authorities );
+
+        authorities = Collections.unmodifiableSet( authorities );
+
+        return authorities;
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.user;
 
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
 import static org.springframework.beans.BeanUtils.copyProperties;
 
 import java.util.ArrayList;
@@ -287,16 +289,20 @@ public class User
      */
     public Set<String> getAllAuthorities()
     {
+        if ( userRoles.isEmpty() )
+        {
+            return emptySet();
+        }
+        if ( userRoles.size() == 1 )
+        {
+            return unmodifiableSet( userRoles.iterator().next().getAuthorities() );
+        }
         Set<String> authorities = new HashSet<>();
-
         for ( UserRole group : userRoles )
         {
             authorities.addAll( group.getAuthorities() );
         }
-
-        authorities = Collections.unmodifiableSet( authorities );
-
-        return authorities;
+        return Collections.unmodifiableSet( authorities );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/FileResourceController.java
@@ -163,15 +163,15 @@ public class FileResourceController
          * doesn't make sense So we will return false if the fileResource have
          * either of these domains.
          */
-        if ( fileResource.getDomain().equals( FileResourceDomain.DATA_VALUE )
-            || fileResource.getDomain().equals( FileResourceDomain.PUSH_ANALYSIS ) )
+        FileResourceDomain domain = fileResource.getDomain();
+        if ( domain == FileResourceDomain.DATA_VALUE || domain == FileResourceDomain.PUSH_ANALYSIS )
         {
             return false;
         }
 
-        if ( fileResource.getDomain().equals( FileResourceDomain.USER_AVATAR ) )
+        if ( domain == FileResourceDomain.USER_AVATAR )
         {
-            return currentUser.isAuthorized( "F_USER_VIEW" ) || currentUser.getAvatar().equals( fileResource );
+            return currentUser.isAuthorized( "F_USER_VIEW" ) || fileResource.equals( currentUser.getAvatar() );
         }
 
         return true;


### PR DESCRIPTION
NPE occured because of the `currentUser.getAvatar().equals( fileResource )` where `currentUser.getAvatar()` could be null if it was never set. The NPE was indirectly prevented by the `F_USER_VIEW` authority as the condition would already be true so that the second part would never be evaluated.

With this fix in place the file itself can be uploaded but a user lacking authority might still not be able to then set the image file resource as avatar as he cannot modify its own profile (`User` object). This is a more general issue that maybe is best addressed in another PR.