### PR TITLE
fix: Conflict when storing a file resource with existing UID [DHIS2-6288]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -58,6 +58,7 @@ public enum ErrorCode
     E1117( "Data element `{0}` of value type multi-text cannot reference an option set `{1}` " +
         "with the separator character in one of its codes: `{2}`" ),
     E1118( "Option set `{0}` of value type multi-text cannot have option codes with the separator character: `{1}`" ),
+    E1119( "{0} with provided id `{1}` already exists" ),
 
     /* Org unit merge */
     E1500( "At least two source orgs unit must be specified" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -58,7 +58,7 @@ public enum ErrorCode
     E1117( "Data element `{0}` of value type multi-text cannot reference an option set `{1}` " +
         "with the separator character in one of its codes: `{2}`" ),
     E1118( "Option set `{0}` of value type multi-text cannot have option codes with the separator character: `{1}`" ),
-    E1119( "{0} with provided id `{1}` already exists" ),
+    E1119( "{0} already exists: `{1}`" ),
 
     /* Org unit merge */
     E1500( "At least two source orgs unit must be specified" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/webmessage/WebMessageUtils.java
@@ -40,6 +40,7 @@ import org.hisp.dhis.dxf2.webmessage.responses.ImportReportWebMessageResponse;
 import org.hisp.dhis.dxf2.webmessage.responses.ObjectReportWebMessageResponse;
 import org.hisp.dhis.dxf2.webmessage.responses.TypeReportWebMessageResponse;
 import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.feedback.ObjectReport;
 import org.hisp.dhis.feedback.Status;
@@ -127,6 +128,11 @@ public final class WebMessageUtils
     public static WebMessage conflict( String message, ErrorCode errorCode )
     {
         return createWebMessage( message, Status.ERROR, HttpStatus.CONFLICT, errorCode );
+    }
+
+    public static WebMessage conflict( ErrorCode errorCode, Object... args )
+    {
+        return conflict( new ErrorMessage( errorCode, args ).getMessage(), errorCode );
     }
 
     public static WebMessage conflict( String message, String devMessage )

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonWebMessage.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonWebMessage.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.json.domain;
 
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonObject;
 
 /**
@@ -59,6 +60,11 @@ public interface JsonWebMessage extends JsonObject
     default String getDescription()
     {
         return getString( "description" ).string();
+    }
+
+    default ErrorCode getErrorCode()
+    {
+        return getString( "errorCode" ).parsed( ErrorCode::valueOf );
     }
 
     default JsonObject getResponse()

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
@@ -60,4 +60,24 @@ class FileResourceControllerTest extends DhisControllerConvenienceTest
         assertEquals( "OU_profile_image.png", savedObject.getString( "name" ).string() );
         assertEquals( "0123456789a", savedObject.getString( "id" ).string() );
     }
+
+    @Test
+    void testSaveOrgUnitImageWithUid_Update()
+    {
+        MockMultipartFile image = new MockMultipartFile( "file", "OU_profile_image.png", "image/png",
+            "<<png data>>".getBytes() );
+        HttpResponse response = POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789a", image );
+        JsonObject savedObject = response.content( HttpStatus.ACCEPTED ).getObject( "response" )
+            .getObject( "fileResource" );
+        assertEquals( "OU_profile_image.png", savedObject.getString( "name" ).string() );
+        assertEquals( "0123456789a", savedObject.getString( "id" ).string() );
+
+        // now update the resource with a different image but the same UID
+        MockMultipartFile image2 = new MockMultipartFile( "file", "OU_profile_image2.png", "image/png",
+            "<<png data>>".getBytes() );
+
+        assertWebMessage( "Conflict", 409, "ERROR",
+            "A resource with Id 0123456789a already exists",
+            POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789a", image2 ).content( HttpStatus.CONFLICT ) );
+    }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
@@ -29,9 +29,11 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonWebMessage;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
@@ -76,8 +78,9 @@ class FileResourceControllerTest extends DhisControllerConvenienceTest
         MockMultipartFile image2 = new MockMultipartFile( "file", "OU_profile_image2.png", "image/png",
             "<<png data>>".getBytes() );
 
-        assertWebMessage( "Conflict", 409, "ERROR",
-            "A resource with Id 0123456789a already exists",
+        JsonWebMessage message = assertWebMessage( "Conflict", 409, "ERROR",
+            "FileResource with provided id `0123456789a` already exists",
             POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789a", image2 ).content( HttpStatus.CONFLICT ) );
+        assertEquals( ErrorCode.E1119, message.getErrorCode() );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FileResourceControllerTest.java
@@ -68,19 +68,19 @@ class FileResourceControllerTest extends DhisControllerConvenienceTest
     {
         MockMultipartFile image = new MockMultipartFile( "file", "OU_profile_image.png", "image/png",
             "<<png data>>".getBytes() );
-        HttpResponse response = POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789a", image );
+        HttpResponse response = POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789x", image );
         JsonObject savedObject = response.content( HttpStatus.ACCEPTED ).getObject( "response" )
             .getObject( "fileResource" );
         assertEquals( "OU_profile_image.png", savedObject.getString( "name" ).string() );
-        assertEquals( "0123456789a", savedObject.getString( "id" ).string() );
+        assertEquals( "0123456789x", savedObject.getString( "id" ).string() );
 
         // now update the resource with a different image but the same UID
         MockMultipartFile image2 = new MockMultipartFile( "file", "OU_profile_image2.png", "image/png",
             "<<png data>>".getBytes() );
 
         JsonWebMessage message = assertWebMessage( "Conflict", 409, "ERROR",
-            "FileResource with provided id `0123456789a` already exists",
-            POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789a", image2 ).content( HttpStatus.CONFLICT ) );
+            "FileResource already exists: `0123456789x`",
+            POST_MULTIPART( "/fileResources?domain=ORG_UNIT&uid=0123456789x", image2 ).content( HttpStatus.CONFLICT ) );
         assertEquals( ErrorCode.E1119, message.getErrorCode() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.utils;
 
-import static java.lang.String.format;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 
@@ -44,6 +43,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
+import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.hisp.dhis.fileresource.FileResourceService;
@@ -195,7 +195,7 @@ public class FileResourceUtils
 
         if ( uid != null && fileResourceService.fileResourceExists( uid ) )
         {
-            throw new WebMessageException( conflict( format( "A resource with Id %s already exists", uid ) ) );
+            throw new WebMessageException( conflict( ErrorCode.E1119, FileResource.class.getSimpleName(), uid ) );
         }
         fileResourceService.saveFileResource( fileResource, tmpFile );
         return fileResource;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/FileResourceUtils.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.utils;
 
+import static java.lang.String.format;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.conflict;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.error;
 
@@ -192,8 +193,11 @@ public class FileResourceUtils
 
         File tmpFile = toTempFile( file );
 
+        if ( uid != null && fileResourceService.fileResourceExists( uid ) )
+        {
+            throw new WebMessageException( conflict( format( "A resource with Id %s already exists", uid ) ) );
+        }
         fileResourceService.saveFileResource( fileResource, tmpFile );
-
         return fileResource;
     }
 


### PR DESCRIPTION
Mainly this should provide a nicer server response then the 500 caused by FK containt violation in case a file resource with a UID already exist when the client sends the UID.