### PR TITLE
fix: null value for CompleteDataSetRegistration.periodName

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/notifications/DefaultDataSetNotificationService.java
@@ -352,6 +352,8 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
     private ProgramMessage createProgramMessage( DataSetNotificationTemplate template,
         CompleteDataSetRegistration registration )
     {
+        registration.setPeriodName( getPeriodString( registration.getPeriod() ) );
+
         NotificationMessage message = renderer.render( registration, template );
 
         ProgramMessageRecipients recipients;
@@ -378,6 +380,8 @@ public class DefaultDataSetNotificationService implements DataSetNotificationSer
     private DhisMessage createDhisMessage( DataSetNotificationTemplate template,
         CompleteDataSetRegistration registration )
     {
+        registration.setPeriodName( getPeriodString( registration.getPeriod() ) );
+
         return new DhisMessage( renderer.render( registration, template ),
             resolveInternalRecipients( template, registration ) );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/dataset/notifications/DataSetNotificationServiceTest.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.CompleteDataSetRegistration;
 import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
 import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.i18n.I18nFormat;
 import org.hisp.dhis.i18n.I18nManager;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.notification.NotificationMessage;
@@ -68,6 +69,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.Sets;
@@ -240,6 +242,9 @@ class DataSetNotificationServiceTest extends DhisConvenienceTest
             .thenReturn( notificationMessage );
         when( externalMessageService.sendMessages( anyList() ) ).thenReturn( successStatus );
         when( dsntService.getCompleteNotifications( any( DataSet.class ) ) ).thenReturn( templates );
+        I18nFormat format = Mockito.mock( I18nFormat.class );
+        when( i18nManager.getI18nFormat() ).thenReturn( format );
+        when( format.formatPeriod( any() ) ).thenReturn( "2000-1-1" );
 
         subject.sendCompleteDataSetNotifications( registrationA );
 


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-12566
- `CompleteDataSetRegistration.periodName` is a transient field and its value need to be set before sending it to the `BaseNotificationMessageRenderer`