### PR TITLE
test: allow connecting to test DB via psql

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -168,10 +168,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
-    </dependency>
   </dependencies>
   <properties>
     <rootDir>../../</rootDir>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/PostgresDhisConfigurationProvider.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/config/PostgresDhisConfigurationProvider.java
@@ -30,8 +30,7 @@ package org.hisp.dhis.config;
 /**
  * @author Luciano Fiandesio
  */
-public class PostgresDhisConfigurationProvider
-    extends H2DhisConfigurationProvider
+public class PostgresDhisConfigurationProvider extends TestConfigurationProvider
 {
 
     private static final String DEFAULT_CONFIGURATION_FILE_NAME = "postgresTestConfig.conf";
@@ -39,10 +38,5 @@ public class PostgresDhisConfigurationProvider
     public PostgresDhisConfigurationProvider()
     {
         this.properties = getPropertiesFromFile( DEFAULT_CONFIGURATION_FILE_NAME );
-    }
-
-    public PostgresDhisConfigurationProvider( String configurationFileName )
-    {
-        this.properties = getPropertiesFromFile( configurationFileName );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestConfig.conf
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/resources/postgresTestConfig.conf
@@ -3,11 +3,6 @@ filestore.container = files
 connection.schema=none
 encryption.password=54C73D06-1D34-477F-94B0-8F94E59BE41D
 
-connection.dialect=org.hisp.dhis.hibernate.dialect.DhisPostgresDialect
-connection.driver_class=org.postgresql.Driver
-connection.username=dhis
-connection.password=dhis
-
 hibernate.cache.use_query_cache=false
 hibernate.cache.use_second_level_cache=false
 


### PR DESCRIPTION
# Issue

In https://github.com/dhis2/dhis2-core/pull/11339 we tried using the more declarative approach to setting up the integration test DB https://www.testcontainers.org/modules/databases/jdbc

Due to that we cannot connect to the test DB container anymore. This makes debugging the integration test isolation problems we are facing hard.

# Reason

[This jdbc approach](https://www.testcontainers.org/modules/databases/jdbc) does not set the env vars as was done before in
https://github.com/testcontainers/testcontainers-java/blob/01ed651980558534702f6c96daeee85be05117b8/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java#L75-L77
which means the `dhis` role and DB are not created by the postgres/gis container on startup
https://github.com/docker-library/docs/blob/master/postgres/README.md#postgres_user

This approach does not allow us to set the env vars ourselves
https://github.com/testcontainers/testcontainers-java/issues/5028

Which is why we should (at least for now) go back to 
https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/

