### PR TITLE
test: add junit properties to debug integration test execution order

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties
+++ b/dhis-2/dhis-test-integration/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+# Uncomment and use @Order if you suspect test failures are due to test isolation/order issues
+#junit.jupiter.testclass.order.default=org.junit.jupiter.api.ClassOrderer$OrderAnnotation
+# see https://junit.org/junit5/docs/5.5.0-RC1/user-guide/index.html#writing-tests-test-execution-order


### PR DESCRIPTION
Failing tests due to tests not being well isolated from each other are not uncommon. Using [setDependency](https://github.com/dhis2/dhis2-core/blob/5f143981ed88826306a39737bc8aa7b328445f08/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java#L428) without cleaning up changes to the shared application context is a common root cause of tests depending on execution order. Tests then fail on GitHub but not locally as the order differs. Setup an empty config (disabled) where devs can easily influence test execution order https://junit.org/junit5/docs/5.5.0-RC1/user-guide/index.html#writing-tests-test-execution-order.

