### PR TITLE
test: remove setDependency TECH-1194

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceUnitTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceUnitTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.datavalueset;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.calendar.Calendar;
+import org.hisp.dhis.calendar.CalendarService;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.CompleteDataSetRegistrationService;
+import org.hisp.dhis.dataset.DataSet;
+import org.hisp.dhis.dataset.LockExceptionStore;
+import org.hisp.dhis.datavalue.DataValueService;
+import org.hisp.dhis.dxf2.common.ImportOptions;
+import org.hisp.dhis.dxf2.importsummary.ImportConflicts;
+import org.hisp.dhis.dxf2.importsummary.ImportStatus;
+import org.hisp.dhis.dxf2.importsummary.ImportSummary;
+import org.hisp.dhis.dxf2.util.InputUtils;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.hisp.dhis.fileresource.FileResourceService;
+import org.hisp.dhis.i18n.I18nManager;
+import org.hisp.dhis.jdbc.batchhandler.DataValueBatchHandler;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.MonthlyPeriodType;
+import org.hisp.dhis.period.PeriodService;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.notification.Notifier;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.quick.BatchHandlerFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ClassPathResource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ExtendWith( MockitoExtension.class )
+class DataValueSetServiceUnitTest extends DhisConvenienceTest
+{
+
+    @Mock
+    private IdentifiableObjectManager identifiableObjectManager;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @Mock
+    private PeriodService periodService;
+
+    @Mock
+    private BatchHandlerFactory batchHandlerFactory;
+
+    @Mock
+    private CompleteDataSetRegistrationService completeDataSetRegistrationService;
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private DataValueSetStore dataValueSetStore;
+
+    @Mock
+    private SystemSettingManager systemSettingManager;
+
+    @Mock
+    private LockExceptionStore lockExceptionStore;
+
+    @Mock
+    private I18nManager i18nManager;
+
+    @Mock
+    private Notifier notifier;
+
+    @Mock
+    private InputUtils inputUtils;
+
+    @Mock
+    private CalendarService calendarService;
+
+    @Mock
+    private DataValueService dataValueService;
+
+    @Mock
+    private FileResourceService fileResourceService;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private DataValueSetImportValidator dataValueSetImportValidator;
+
+    @Mock
+    private SchemaService schemaService;
+
+    @InjectMocks
+    private DefaultDataValueSetService dataValueSetService;
+
+    @Test
+    void testImportDataValuesUpdatedSkipNoChange()
+    {
+        Calendar calendar = mock( Calendar.class );
+        when( calendarService.getSystemCalendar() ).thenReturn( calendar );
+
+        DataValueBatchHandler batchHandler = mock( DataValueBatchHandler.class );
+        when( batchHandler.init() ).thenReturn( batchHandler );
+        when( batchHandlerFactory.createBatchHandler( DataValueBatchHandler.class ) ).thenReturn( batchHandler );
+
+        when( notifier.clear( any() ) ).thenReturn( notifier );
+        when( notifier.notify( any(), any(), anyString() ) ).thenReturn( notifier );
+        when( notifier.notify( any(), any(), anyString(), anyBoolean() ) ).thenReturn( notifier );
+
+        DataSet dataSet = createDataSet( 'A', new MonthlyPeriodType() );
+        dataSet.setUid( "pBOMPrpg1QX" );
+        when( identifiableObjectManager.getObject( DataSet.class, IdScheme.UID, "pBOMPrpg1QX" ) ).thenReturn( dataSet );
+        DataElement dataElement = createDataElement( 'A' );
+        dataElement.setUid( "f7n9E0hX8qk" );
+        when( identifiableObjectManager.getObject( DataElement.class, IdScheme.UID, "f7n9E0hX8qk" ) )
+            .thenReturn( dataElement );
+
+        // simulate that the imported DataValue already exists and is identical
+        // (no changes)
+        when( batchHandler.findObject( any() ) ).then( AdditionalAnswers.returnsFirstArg() );
+
+        ImportSummary summary = dataValueSetService
+            .importDataValueSetXml( readFile( "datavalueset/dataValueSetA.xml" ), new ImportOptions() );
+
+        assertSuccessWithImportedUpdatedDeleted( 0, 3, 0, summary );
+        verify( batchHandler, never() ).updateObject( any() );
+    }
+
+    private InputStream readFile( String filename )
+    {
+        try
+        {
+            return new ClassPathResource( filename ).getInputStream();
+        }
+        catch ( IOException ex )
+        {
+            throw new UncheckedIOException( ex );
+        }
+    }
+
+    private static void assertSuccessWithImportedUpdatedDeleted( int imported, int updated, int deleted,
+        ImportSummary summary )
+    {
+        assertAll(
+            () -> assertHasNoConflicts( summary ),
+            () -> assertEquals( imported, summary.getImportCount().getImported(), "unexpected import count" ),
+            () -> assertEquals( updated, summary.getImportCount().getUpdated(), "unexpected update count" ),
+            () -> assertEquals( deleted, summary.getImportCount().getDeleted(), "unexpected deleted count" ),
+            () -> assertEquals( ImportStatus.SUCCESS, summary.getStatus(), summary.getDescription() ) );
+    }
+
+    private static void assertHasNoConflicts( ImportConflicts summary )
+    {
+        assertEquals( 0, summary.getConflictCount(), summary.getConflictsDescription() );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -422,34 +422,6 @@ public abstract class DhisConvenienceTest
     }
 
     // -------------------------------------------------------------------------
-    // Dependency injection methods
-    // -------------------------------------------------------------------------
-
-    protected final <T, D> void setDependency( Class<T> role, BiConsumer<T, D> setter, D dependency,
-        Object... targetServices )
-    {
-        for ( Object targetService : targetServices )
-        {
-            setDependency( role, setter, dependency, targetService );
-        }
-    }
-
-    @SuppressWarnings( "unchecked" )
-    private final <T, D> void setDependency( Class<T> role, BiConsumer<T, D> setter, D dependency,
-        Object targetService )
-    {
-        if ( role.isInstance( targetService ) )
-        {
-            setter.accept( (T) targetService, dependency );
-        }
-        else
-        {
-            throw new IllegalArgumentException( "Failed to set dependency " + role + " on service "
-                + targetService.getClass().getSimpleName() );
-        }
-    }
-
-    // -------------------------------------------------------------------------
     // Create object methods
     // -------------------------------------------------------------------------
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalAuditServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalAuditServiceTest.java
@@ -55,8 +55,6 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupAccessService;
@@ -110,9 +108,6 @@ class DataApprovalAuditServiceTest extends TransactionalIntegrationTest
 
     @Autowired
     protected IdentifiableObjectManager identifiableObjectManager;
-
-    @Autowired
-    private CurrentUserService currentUserService;
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
@@ -338,13 +333,6 @@ class DataApprovalAuditServiceTest extends TransactionalIntegrationTest
         userService.updateUser( userC );
         userService.updateUser( userD );
         userService.updateUser( userZ );
-    }
-
-    @Override
-    public void tearDownTest()
-    {
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, dataApprovalLevelService, dataApprovalAuditService, dataApprovalAuditStore );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -66,8 +66,6 @@ import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupAccessService;
@@ -123,9 +121,6 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
 
     @Autowired
     protected UserService _userService;
-
-    @Autowired
-    protected CurrentUserService currentUserService;
 
     @Autowired
     protected DataSetService dataSetService;
@@ -532,9 +527,6 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
     @Override
     public void tearDownTest()
     {
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, dataApprovalService, dataApprovalStore, dataApprovalLevelService,
-            organisationUnitService, hibernateCategoryOptionGroupStore );
         systemSettingManager.saveSystemSetting( SettingKey.IGNORE_ANALYTICS_APPROVAL_YEAR_THRESHOLD, -1 );
         systemSettingManager.saveSystemSetting( SettingKey.ACCEPTANCE_REQUIRED_FOR_APPROVAL, false );
         DataApprovalPermissionsEvaluator.invalidateCache();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreUserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreUserTest.java
@@ -43,8 +43,6 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
@@ -75,9 +73,6 @@ class DataApprovalStoreUserTest extends IntegrationTestBase
 
     @Autowired
     protected DataSetService dataSetService;
-
-    @Autowired
-    protected CurrentUserService currentUserService;
 
     @Autowired
     private OrganisationUnitService organisationUnitService;
@@ -148,13 +143,6 @@ class DataApprovalStoreUserTest extends IntegrationTestBase
 
         currentUser = createAndAddUser( true, "username", newHashSet( orgUnitA ), newHashSet( orgUnitA ) );
         injectSecurityContext( currentUser );
-    }
-
-    @Override
-    public void tearDownTest()
-    {
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, dataApprovalStore, dataApprovalLevelService );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/DataSetServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/DataSetServiceTest.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.user.UserService;
@@ -167,13 +166,6 @@ class DataSetServiceTest extends TransactionalIntegrationTest
             UserRole.AUTHORITY_ALL );
         injectSecurityContext( superUser );
 
-    }
-
-    @Override
-    public void tearDownTest()
-    {
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, approvalService, approvalStore, levelService );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
@@ -85,7 +85,6 @@ import org.hisp.dhis.security.acl.AccessStringHelper;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.hisp.quick.BatchHandlerFactory;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -136,9 +135,6 @@ class DataValueSetServiceTest extends IntegrationTestBase
 
     @Autowired
     private UserService _userService;
-
-    @Autowired
-    private BatchHandlerFactory batchHandlerFactory;
 
     private Attribute attribute;
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceTest.java
@@ -1143,6 +1143,7 @@ class DataValueSetServiceTest extends IntegrationTestBase
             () -> assertEquals( imported, summary.getImportCount().getImported(), "unexpected import count" ),
             () -> assertEquals( updated, summary.getImportCount().getUpdated(), "unexpected update count" ),
             () -> assertEquals( deleted, summary.getImportCount().getDeleted(), "unexpected deleted count" ),
+            () -> assertEquals( ignored, summary.getImportCount().getIgnored(), "unexpected ignored count" ),
             () -> assertEquals( ImportStatus.SUCCESS, summary.getStatus(), summary.getDescription() ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -79,8 +79,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValue;
 import org.hisp.dhis.trackedentityattributevalue.TrackedEntityAttributeValueService;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
@@ -140,9 +138,6 @@ class EventPredictionServiceTest extends IntegrationTestBase
 
     @Autowired
     private AnalyticsService analyticsService;
-
-    @Autowired
-    private CurrentUserService currentUserService;
 
     @Autowired
     private CategoryManager categoryManager;
@@ -337,8 +332,6 @@ class EventPredictionServiceTest extends IntegrationTestBase
     {
         setDependency( AnalyticsServiceTarget.class, AnalyticsServiceTarget::setAnalyticsService, analyticsService,
             predictionService );
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, predictionService );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/EventPredictionServiceTest.java
@@ -39,7 +39,6 @@ import java.util.Set;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsService;
-import org.hisp.dhis.analytics.AnalyticsServiceTarget;
 import org.hisp.dhis.analytics.MockAnalyticsService;
 import org.hisp.dhis.category.CategoryManager;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -83,6 +82,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.google.common.collect.Sets;
 
@@ -313,8 +313,7 @@ class EventPredictionServiceTest extends IntegrationTestBase
         itemGridMap.put( PROGRAM_INDICATOR_B_UID, newGrid( PROGRAM_INDICATOR_B_UID, 10.0, 11.0 ) );
         MockAnalyticsService mockAnalyticsSerivce = new MockAnalyticsService();
         mockAnalyticsSerivce.setItemGridMap( itemGridMap );
-        setDependency( AnalyticsServiceTarget.class, AnalyticsServiceTarget::setAnalyticsService, mockAnalyticsSerivce,
-            predictionService );
+        ReflectionTestUtils.setField( predictionService, "analyticsService", mockAnalyticsSerivce );
 
         User user = createAndAddUser( true, "mockUser", orgUnitASet, orgUnitASet );
         injectSecurityContext( user );
@@ -330,8 +329,7 @@ class EventPredictionServiceTest extends IntegrationTestBase
     @Override
     public void tearDownTest()
     {
-        setDependency( AnalyticsServiceTarget.class, AnalyticsServiceTarget::setAnalyticsService, analyticsService,
-            predictionService );
+        ReflectionTestUtils.setField( predictionService, "analyticsService", analyticsService );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -69,8 +69,6 @@ import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.scheduling.JobProgress;
 import org.hisp.dhis.scheduling.NoopJobProgress;
 import org.hisp.dhis.test.integration.IntegrationTestBase;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
 import org.hisp.quick.BatchHandler;
@@ -120,9 +118,6 @@ class PredictionServiceTest extends IntegrationTestBase
 
     @Autowired
     private ProgramService programService;
-
-    @Autowired
-    private CurrentUserService currentUserService;
 
     @Autowired
     private BatchHandlerFactory batchHandlerFactory;
@@ -318,13 +313,6 @@ class PredictionServiceTest extends IntegrationTestBase
 
         User user = createAndAddUser( true, "mockUser", units, units );
         injectSecurityContext( user );
-    }
-
-    @Override
-    public void tearDownTest()
-    {
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, predictionService );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationResultStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationResultStoreTest.java
@@ -59,8 +59,6 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
-import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.user.CurrentUserServiceTarget;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserGroupAccessService;
@@ -110,9 +108,6 @@ class ValidationResultStoreTest extends TransactionalIntegrationTest
 
     @Autowired
     private UserService _userService;
-
-    @Autowired
-    private CurrentUserService currentUserService;
 
     // -------------------------------------------------------------------------
     // Supporting data
@@ -279,13 +274,6 @@ class ValidationResultStoreTest extends TransactionalIntegrationTest
         validationResultBC = new ValidationResult( validationRuleB, periodB, sourceB, optionComboC, 1.0, 2.0, 3 );
         validationResultCA = new ValidationResult( validationRuleB, periodB, sourceC, optionComboA, 1.0, 2.0, 3 );
         validationResultAB.setNotificationSent( true );
-    }
-
-    @Override
-    public void tearDownTest()
-    {
-        setDependency( CurrentUserServiceTarget.class, CurrentUserServiceTarget::setCurrentUserService,
-            currentUserService, validationResultStore );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetAUpdate.xml
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetAUpdate.xml
@@ -1,0 +1,7 @@
+<dataValueSet xmlns="http://dhis2.org/schema/dxf/2.0" dataSet="pBOMPrpg1QX">
+    <dataValue dataElement="f7n9E0hX8qk" period="201201" orgUnit="DiszpKrYNg8" value="10001" storedBy="john" timestamp="2012-01-01" comment="updated comment" followup="false"/>
+    <dataValue dataElement="f7n9E0hX8qk" period="201201" orgUnit="BdfsJfj87js" value="10002" storedBy="john"
+               timestamp="2012-01-02" comment="updated comment" followup="false"/>
+    <dataValue dataElement="f7n9E0hX8qk" period="201202" orgUnit="DiszpKrYNg8" value="10003" storedBy="john"
+               timestamp="2012-01-03" comment="updated comment" followup="false"/>
+</dataValueSet>


### PR DESCRIPTION
* remove `setDependency` which repeatedly caused tests to only fail on GitHub due to an unclean `ApplicationContext` https://github.com/dhis2/dhis2-core/pull/11462
* replace EventPredictionServiceTest use of `setDependency` with reflection to set an AnalyticsService mock. The analytics team should revisit the test and either turn it into a unit test using mocks or an integration test without mocks. Using reflection to mutate the `ApplicationContext` can again cause the same issues as `setDependency`.
* migrate integration test for https://github.com/dhis2/dhis2-core/pull/7950 to unit test DataValueSetServiceUnitTest. We can easily check that we do not hit the DB if DataValues are updated with the same value/comment in a unit test. Asserting that in an integration test is hard.

Some cleanup PR(s) will follow: remove interfaces like `CurrentUserServiceTarget` which allow mutating services/component dependencies after instantiation, merge 2 integration tests DataValueSetServiceTest, DataValueSetServiceIntegrationTest into one ...
