### PR TITLE
fix: boolean value from redis not comparable

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/SystemSettingManager.java
@@ -175,7 +175,7 @@ public interface SystemSettingManager
     @Transactional( readOnly = true )
     default boolean getBoolSetting( SettingKey key )
     {
-        return getSystemSetting( key, Boolean.class ) == Boolean.TRUE;
+        return Boolean.TRUE.equals( getSystemSetting( key, Boolean.class ) );
     }
 
     @Transactional( readOnly = true )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/setting/SystemSettingManagerTest.java
@@ -142,4 +142,11 @@ class SystemSettingManagerTest extends SingleSetupIntegrationTestBase
         assertFalse( EMAIL_HOST_NAME.isConfidential() );
         assertFalse( systemSettingManager.isConfidential( EMAIL_HOST_NAME.getName() ) );
     }
+
+    @Test
+    void testGetBoolean()
+    {
+        systemSettingManager.saveSystemSetting( SettingKey.CAN_GRANT_OWN_USER_ROLES, Boolean.valueOf( "true" ) );
+        assertTrue( systemSettingManager.getBoolSetting( SettingKey.CAN_GRANT_OWN_USER_ROLES ) );
+    }
 }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-13592

- Below code return false for TRUE value if server uses Redis. It works fine without redis enabled.

```
getSystemSetting( key, Boolean.class ) == Boolean.TRUE
```

<img width="409" alt="Screen Shot 2022-08-19 at 15 41 39" src="https://user-images.githubusercontent.com/766102/185585436-77130e2d-2f8a-49b2-bb4e-fa8542b3e52d.png">


- Code return TRUE with the fix

<img width="404" alt="Screen Shot 2022-08-19 at 15 41 55" src="https://user-images.githubusercontent.com/766102/185585663-c492317d-41c3-4609-a781-7c40e4f76f13.png">

