### PR TITLE
test: trim base classes TECH-1194

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -53,10 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -68,8 +68,6 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
     @Autowired
     protected TransactionTemplate transactionTemplate;
 
-    protected abstract boolean emptyDatabaseAfterTest();
-
     @Override
     public void setApplicationContext( ApplicationContext applicationContext )
         throws BeansException
@@ -118,16 +116,13 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
             log.info( "Failed to clear hibernate session, reason:" + e.getMessage() );
         }
         unbindSession();
-        if ( emptyDatabaseAfterTest() )
-        {
-            // We normally don't want all the delete/empty db statements in the
-            // query logger
-            Configurator.setLevel( ORG_HISP_DHIS_DATASOURCE_QUERY, Level.WARN );
-            transactionTemplate.execute( status -> {
-                dbmsManager.emptyDatabase();
-                return null;
-            } );
-        }
+        // We normally don't want all the delete/empty db statements in the
+        // query logger
+        Configurator.setLevel( ORG_HISP_DHIS_DATASOURCE_QUERY, Level.WARN );
+        transactionTemplate.execute( status -> {
+            dbmsManager.emptyDatabase();
+            return null;
+        } );
     }
 
     protected void integrationTestBefore()

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -140,16 +140,6 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
         setUpTest();
     }
 
-    /**
-     * Retrieves a bean from the application context.
-     *
-     * @param beanId the identifier of the bean.
-     */
-    protected final Object getBean( String beanId )
-    {
-        return applicationContext.getBean( beanId );
-    }
-
     protected void bindSession()
     {
         SessionFactory sessionFactory = (SessionFactory) applicationContext.getBean( "sessionFactory" );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -44,7 +44,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.hibernate5.SessionFactoryUtils;
 import org.springframework.orm.hibernate5.SessionHolder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -69,18 +68,7 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
     @Autowired
     protected TransactionTemplate transactionTemplate;
 
-    protected static JdbcTemplate jdbcTemplate;
-
     protected abstract boolean emptyDatabaseAfterTest();
-
-    /*
-     * "Special" setter to allow setting JdbcTemplate as static field
-     */
-    @Autowired
-    public static void setJdbcTemplate( JdbcTemplate jdbcTemplate )
-    {
-        BaseSpringTest.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     public void setApplicationContext( ApplicationContext applicationContext )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -76,6 +76,9 @@ import com.google.common.collect.Sets;
 class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
 {
 
+    @Autowired
+    private UserService _userService;
+
     private LegendSet lsA;
 
     private Legend leA;
@@ -120,7 +123,7 @@ class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
     @Override
     public void setUpTest()
     {
-        userService = (UserService) getBean( UserService.ID );
+        userService = _userService;
         leA = createLegend( 'A', 0d, 10d );
         leB = createLegend( 'B', 11d, 20d );
         leC = createLegend( 'C', 21d, 30d );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
@@ -57,10 +57,4 @@ public abstract class IntegrationTestBase extends BaseSpringTest
     {
         nonTransactionalAfter();
     }
-
-    @Override
-    protected final boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
@@ -65,10 +65,4 @@ public abstract class SingleSetupIntegrationTestBase
     {
         nonTransactionalAfter();
     }
-
-    @Override
-    protected final boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
@@ -71,22 +71,13 @@ public abstract class TransactionalIntegrationTest extends BaseSpringTest
             log.info( "Failed to clear hibernate session, reason:" + e.getMessage() );
         }
 
-        if ( emptyDatabaseAfterTest() )
+        try
         {
-            try
-            {
-                dbmsManager.emptyDatabase();
-            }
-            catch ( Exception e )
-            {
-                log.info( "Failed to empty db, reason:" + e.getMessage() );
-            }
+            dbmsManager.emptyDatabase();
         }
-    }
-
-    @Override
-    protected final boolean emptyDatabaseAfterTest()
-    {
-        return true;
+        catch ( Exception e )
+        {
+            log.info( "Failed to empty db, reason:" + e.getMessage() );
+        }
     }
 }


### PR DESCRIPTION
Removed unused code.

DB is always emptied so no need to expose `emptyDatabaseAfterTest`. Setting it to `false` could also affect test isolation which is causing us pain already.