### PR TITLE
test: base classes JUnit extensions

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-test/pom.xml
@@ -53,10 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-jdbc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -137,16 +137,6 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
         setUpTest();
     }
 
-    /**
-     * Retrieves a bean from the application context.
-     *
-     * @param beanId the identifier of the bean.
-     */
-    protected final Object getBean( String beanId )
-    {
-        return applicationContext.getBean( beanId );
-    }
-
     protected void bindSession()
     {
         SessionFactory sessionFactory = (SessionFactory) applicationContext.getBean( "sessionFactory" );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -39,18 +39,21 @@ import org.hisp.dhis.external.conf.ConfigurationKey;
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.utils.TestUtils;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.orm.hibernate5.SessionFactoryUtils;
 import org.springframework.orm.hibernate5.SessionHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
+@ExtendWith( SpringExtension.class )
 @Slf4j
 public abstract class BaseSpringTest extends DhisConvenienceTest implements ApplicationContextAware
 {

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -65,8 +65,6 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
     @Autowired
     protected TransactionTemplate transactionTemplate;
 
-    protected abstract boolean emptyDatabaseAfterTest();
-
     @Override
     public void setApplicationContext( ApplicationContext applicationContext )
         throws BeansException
@@ -115,16 +113,13 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
             log.info( "Failed to clear hibernate session, reason:" + e.getMessage() );
         }
         unbindSession();
-        if ( emptyDatabaseAfterTest() )
-        {
-            // We normally don't want all the delete/empty db statements in the
-            // query logger
-            Configurator.setLevel( ORG_HISP_DHIS_DATASOURCE_QUERY, Level.WARN );
-            transactionTemplate.execute( status -> {
-                dbmsManager.emptyDatabase();
-                return null;
-            } );
-        }
+        // We normally don't want all the delete/empty db statements in the
+        // query logger
+        Configurator.setLevel( ORG_HISP_DHIS_DATASOURCE_QUERY, Level.WARN );
+        transactionTemplate.execute( status -> {
+            dbmsManager.emptyDatabase();
+            return null;
+        } );
     }
 
     protected void integrationTestBefore()

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/BaseSpringTest.java
@@ -43,7 +43,6 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.hibernate5.SessionFactoryUtils;
 import org.springframework.orm.hibernate5.SessionHolder;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -66,18 +65,7 @@ public abstract class BaseSpringTest extends DhisConvenienceTest implements Appl
     @Autowired
     protected TransactionTemplate transactionTemplate;
 
-    protected static JdbcTemplate jdbcTemplate;
-
     protected abstract boolean emptyDatabaseAfterTest();
-
-    /*
-     * "Special" setter to allow setting JdbcTemplate as static field
-     */
-    @Autowired
-    public static void setJdbcTemplate( JdbcTemplate jdbcTemplate )
-    {
-        BaseSpringTest.jdbcTemplate = jdbcTemplate;
-    }
 
     @Override
     public void setApplicationContext( ApplicationContext applicationContext )

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/SessionExtension.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/SessionExtension.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis;
+
+import org.hibernate.FlushMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.orm.hibernate5.SessionFactoryUtils;
+import org.springframework.orm.hibernate5.SessionHolder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class SessionExtension implements BeforeAllCallback, AfterAllCallback
+{
+    @Override
+    public void beforeAll( ExtensionContext context )
+    {
+        ApplicationContext applicationContext = SpringExtension.getApplicationContext( context );
+        SessionFactory sessionFactory = (SessionFactory) applicationContext.getBean( "sessionFactory" );
+        Session session = sessionFactory.openSession();
+        session.setHibernateFlushMode( FlushMode.AUTO );
+        TransactionSynchronizationManager.bindResource( sessionFactory, new SessionHolder( session ) );
+    }
+
+    @Override
+    public void afterAll( ExtensionContext context )
+    {
+        ApplicationContext applicationContext = SpringExtension.getApplicationContext( context );
+        SessionFactory sessionFactory = (SessionFactory) applicationContext.getBean( "sessionFactory" );
+        SessionHolder sessionHolder = (SessionHolder) TransactionSynchronizationManager
+            .unbindResource( sessionFactory );
+        SessionFactoryUtils.closeSession( sessionHolder.getSession() );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/StartupRoutinesExtension.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/StartupRoutinesExtension.java
@@ -25,34 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.test.integration;
+package org.hisp.dhis;
 
-import org.hisp.dhis.BaseSpringTest;
-import org.hisp.dhis.config.IntegrationTestConfig;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
+import org.hisp.dhis.utils.TestUtils;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-/**
- * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
- */
-@ContextConfiguration( classes = { IntegrationTestConfig.class } )
-@IntegrationTest
-@ActiveProfiles( profiles = { "test-postgres" } )
-public abstract class IntegrationTestBase extends BaseSpringTest
+public class StartupRoutinesExtension implements BeforeAllCallback
 {
-    @BeforeEach
-    public final void before()
-        throws Exception
-    {
-        integrationTestBefore();
-    }
 
-    @AfterEach
-    public final void after()
+    @Override
+    public void beforeAll( ExtensionContext context )
         throws Exception
     {
-        nonTransactionalAfter();
+
+        ApplicationContext applicationContext = SpringExtension.getApplicationContext( context );
+        TestUtils.executeStartupRoutines( applicationContext );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/StartupRoutinesExtension.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/StartupRoutinesExtension.java
@@ -28,16 +28,16 @@
 package org.hisp.dhis;
 
 import org.hisp.dhis.utils.TestUtils;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-public class StartupRoutinesExtension implements BeforeAllCallback
+public class StartupRoutinesExtension implements BeforeEachCallback
 {
 
     @Override
-    public void beforeAll( ExtensionContext context )
+    public void beforeEach( ExtensionContext context )
         throws Exception
     {
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -76,6 +76,9 @@ import com.google.common.collect.Sets;
 class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
 {
 
+    @Autowired
+    private UserService _userService;
+
     private LegendSet lsA;
 
     private Legend leA;
@@ -120,7 +123,7 @@ class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
     @Override
     public void setUpTest()
     {
-        userService = (UserService) getBean( UserService.ID );
+        userService = _userService;
         leA = createLegend( 'A', 0d, 10d );
         leB = createLegend( 'B', 11d, 20d );
         leC = createLegend( 'C', 21d, 30d );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
@@ -31,15 +31,12 @@ import org.hisp.dhis.BaseSpringTest;
 import org.hisp.dhis.config.IntegrationTestConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-@ExtendWith( SpringExtension.class )
 @ContextConfiguration( classes = { IntegrationTestConfig.class } )
 @IntegrationTest
 @ActiveProfiles( profiles = { "test-postgres" } )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/IntegrationTestBase.java
@@ -60,10 +60,4 @@ public abstract class IntegrationTestBase extends BaseSpringTest
     {
         nonTransactionalAfter();
     }
-
-    @Override
-    protected final boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
@@ -68,10 +68,4 @@ public abstract class SingleSetupIntegrationTestBase
     {
         nonTransactionalAfter();
     }
-
-    @Override
-    protected final boolean emptyDatabaseAfterTest()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
@@ -32,10 +32,8 @@ import org.hisp.dhis.config.IntegrationTestConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -44,7 +42,6 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @author Jim Grace
  */
-@ExtendWith( SpringExtension.class )
 @ContextConfiguration( classes = { IntegrationTestConfig.class } )
 @IntegrationTest
 @ActiveProfiles( profiles = { "test-postgres" } )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/SingleSetupIntegrationTestBase.java
@@ -54,8 +54,6 @@ public abstract class SingleSetupIntegrationTestBase
     public final void before()
         throws Exception
     {
-        bindSession();
-
         integrationTestBefore();
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
@@ -33,16 +33,13 @@ import org.hisp.dhis.BaseSpringTest;
 import org.hisp.dhis.config.IntegrationTestConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 /*
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
  */
-@ExtendWith( SpringExtension.class )
 @ContextConfiguration( classes = { IntegrationTestConfig.class } )
 @IntegrationTest
 @ActiveProfiles( profiles = { "test-postgres" } )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
@@ -74,22 +74,13 @@ public abstract class TransactionalIntegrationTest extends BaseSpringTest
             log.info( "Failed to clear hibernate session, reason:" + e.getMessage() );
         }
 
-        if ( emptyDatabaseAfterTest() )
+        try
         {
-            try
-            {
-                dbmsManager.emptyDatabase();
-            }
-            catch ( Exception e )
-            {
-                log.info( "Failed to empty db, reason:" + e.getMessage() );
-            }
+            dbmsManager.emptyDatabase();
         }
-    }
-
-    @Override
-    protected final boolean emptyDatabaseAfterTest()
-    {
-        return true;
+        catch ( Exception e )
+        {
+            log.info( "Failed to empty db, reason:" + e.getMessage() );
+        }
     }
 }


### PR DESCRIPTION
We have several base classes used in integration tests
* TransactionalIntegrationTest (transactional)
* SingleSetupIntegrationTestBase (transactional)
* IntegrationTestBase (non-transactional)
* BaseSpringTest

Use JUnit 5 extensions so we can easily reuse them in other base classes. It also allows us to understand the essence of what we need from our base classes.

Transactional/Non-Transactional/...

Tests should be able to simply use JUnit 5 `@BeforeAll/@BeforeEach` to setup their data.