### PR TITLE
fix: Add pager to json SQL View data DHIS2-9213

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/SqlViewController.java
@@ -41,6 +41,8 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.node.NodeService;
+import org.hisp.dhis.node.NodeUtils;
+import org.hisp.dhis.node.types.RootNode;
 import org.hisp.dhis.schema.descriptors.SqlViewSchemaDescriptor;
 import org.hisp.dhis.sqlview.SqlView;
 import org.hisp.dhis.sqlview.SqlViewQuery;
@@ -81,7 +83,7 @@ public class SqlViewController
     // -------------------------------------------------------------------------
 
     @GetMapping( value = "/{uid}/data", produces = ContextUtils.CONTENT_TYPE_JSON )
-    public @ResponseBody Grid getViewJson( @PathVariable( "uid" ) String uid,
+    public @ResponseBody RootNode getViewJson( @PathVariable( "uid" ) String uid,
         SqlViewQuery query, HttpServletResponse response )
         throws WebMessageException
     {
@@ -89,7 +91,18 @@ public class SqlViewController
 
         contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_JSON, sqlView.getCacheStrategy() );
 
-        return getViewGrid( sqlView, query );
+        Grid grid = getViewGrid( sqlView, query );
+
+        RootNode rootNode = NodeUtils.createMetadata();
+
+        if ( !query.isSkipPaging() )
+        {
+            rootNode.addChild( NodeUtils.createPager( query.getPager() ) );
+        }
+
+        rootNode.addChild( nodeService.toNode( grid ) );
+
+        return rootNode;
     }
 
     @GetMapping( "/{uid}/data.xml" )


### PR DESCRIPTION
SQL View data is currently returned in versions 2.36 - 2.39 from `/api/sqlViews/{uid}/data` in both json and XML formats but without the pager node. This causes the Maintenance app in all these versions to hang when trying to view any SQL view data, and also breaks some PEPFAR custom apps that rely on SQL Views. PEPFAR is currently on 2.36 and is testing 2.38, hoping to upgrade to it. PEPFAR needs this fixed in 2.38 so they can continue testing with other recent fixes that are being made, and they might also need it fixed in 2.36 in case they need to upgrade to another 2.36 patch version before they can upgrade to 2.38. It also should be fixed in 2.36 - 2.38 for other installations.

This PR adds the pager node back in for json format, which when backported will fix the Maintenance app and PEPFAR custom apps for 2.36 - 2.38. In addition, SQL Views will now be returned also in XML format, though without the pager. In the long term however I suggest that we fix this so the XML format includes the pager as it has always worked for other paged XML data returns.

After this PR, SQL View data will not be returned in 2.39 because of another recent change made in trunk. An additional fix will be needed for this. I intend to write a ticket for this work once the current PR is merged. This problem is discussed next.

### Additional 2.39 fix needed

In 2.39 with this fix, no SQL View data is ever returned by `/api/sqlViews/{uid}/data`. The `"listGrid"` object is returned but the `"rows"` json array is empty because `DefaultNodeService.toNode( Object )` returns no content when called for `"rows"` (which contains a Java `List`). This is because the `"rows"` property of the `"listGrid"` object is not considered `simple` when tested at `DefaultFieldFilterService:499` within `buildNode`.

The Java `List` is not considered `simple` because `JacksonPropertyIntrospector:313` in `initCollectionProperty` has changed the test for what is `simple`. In 2.38 it tests to see if the `klass` ( which is `List`) has properties. If there are none, it marks it as simple. In 2.39 it calls a new method `isSimple` which does other tests. This change was introduced for 2.39 on May 9 as part of [pull/10274](https://github.com/dhis2/dhis2-core/pull/10274) "feat: add back new field filtering".

I have been able to make SQL View data work again by changing JacksonPropertyIntrospector:313 from

            if ( isSimple( klass ) )

to

            if ( isSimple( klass ) || !hasProperties( klass ) )

and restoring the `hasProperties` method along with the `private static final Map<Class<?>, Boolean> HAS_PROPERTIES` cache that it uses. However, I don't fully understand much of the rest of the logic around this, so I would defer to @mortenoh and/or @jbee, who have both worked on this code, for the best approach to fixing the problem.

At any rate, this PR does not implement any fix to this problem; that will need to be done subsequently.

### My suggested next steps:

1. Merge this PR into trunk and backport it to 2.36 - 2.38. This fixes the immediate problems with supported versions.

2. Fix 2.39 so SQL View data is returned (the problem discussed above).

3. Add a test case to `SqlViewControllerTest` to test for returned SQL View data. (This is not tested at present.) Such a test would have been useful in avoiding both the removal of the pager problem and the absence of data problem.

4. Fix the return of SQL View data in XML format so it can include the header. Alternatively, we might drop support for returning SQL View data in XML format (especially if PEFPAR agrees, since they originated [DHIS2-9213](https://jira.dhis2.org/browse/DHIS2-9213).)
