### PR TITLE
feat: Add test failure notification at build stage [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -39,6 +39,16 @@ pipeline {
                 always {
                     implementIoBuildEnded(buildName: "${STAGE_NAME}")
                 }
+
+                failure {
+                    script {
+                        slack.sendMessage(
+                            '#ff0000',
+                            slack.buildUrl() + "\nLatest test run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                            'team-backend'
+                        )
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
[Related PR in dhis2/jenkins-pipeline-library](https://github.com/dhis2/jenkins-pipeline-library/pull/12).

Note that the `Build` stage might fail for other reasons, like maven repository connectivity issues (kinda rare).  
Haven't yet found a reliable way to determine that the failure is caused by tests, but will be improved at some point.