### PR TITLE
feat: set dataset ID for CSV data value set import via options [DHIS2-8083]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -114,6 +114,12 @@ public class ImportOptions
      */
     private boolean skipCache = false;
 
+    /**
+     * Optional field to set the data set ID of the imported values using
+     * request parameters
+     */
+    private String dataSet;
+
     // --------------------------------------------------------------------------
     // Constructors
     // --------------------------------------------------------------------------
@@ -157,6 +163,7 @@ public class ImportOptions
         options.skipLastUpdated = this.skipLastUpdated;
         options.skipCache = this.skipCache;
         options.mergeDataValues = this.mergeDataValues;
+        options.dataSet = this.dataSet;
 
         return options;
     }
@@ -415,6 +422,13 @@ public class ImportOptions
         return mergeDataValues;
     }
 
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getDataSet()
+    {
+        return dataSet;
+    }
+
     // --------------------------------------------------------------------------
     // Set methods
     // --------------------------------------------------------------------------
@@ -648,6 +662,12 @@ public class ImportOptions
     public void setMergeDataValues( boolean mergeDataValues )
     {
         this.mergeDataValues = mergeDataValues;
+    }
+
+    public ImportOptions setDataSet( String dataSet )
+    {
+        this.dataSet = dataSet;
+        return this;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/CsvDataValueSetReader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/CsvDataValueSetReader.java
@@ -57,11 +57,10 @@ final class CsvDataValueSetReader implements DataValueSetReader, DataValueEntry
         if ( importOptions == null || importOptions.isFirstRowIsHeader() )
         {
             readNext(); // Ignore the first row: assume header row
-            String dataSetId = getString( 11 );
-            if ( isNotEmpty( dataSetId ) )
-            {
-                set.setDataSet( dataSetId );
-            }
+        }
+        if ( importOptions != null && isNotEmpty( importOptions.getDataSet() ) )
+        {
+            set.setDataSet( importOptions.getDataSet() );
         }
         return set;
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
@@ -753,12 +753,13 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase
     }
 
     @Test
-    void testImportDataValuesCsvWithDataSetIdHeader()
+    void testImportDataValuesCsvWithDataSetIdParameter()
     {
         assertDataValuesCount( 0 );
 
         ImportSummary summary = dataValueSetService
-            .importDataValueSetCsv( readFile( "dxf2/datavalueset/dataValueSetWithDataSetHeader.csv" ), null, null );
+            .importDataValueSetCsv( readFile( "dxf2/datavalueset/dataValueSetWithDataSetHeader.csv" ),
+                new ImportOptions().setDataSet( "pBOMPrpg1QX" ), null );
 
         assertSuccessWithImportedUpdatedDeleted( 3, 0, 0, summary );
         assertDataValuesCount( 3 );

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetWithDataSetHeader.csv
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetWithDataSetHeader.csv
@@ -1,4 +1,4 @@
-"dataelelement","period","orgunit","categoryoptioncombo","attributeoptioncombo","value","storedby","timestamp","comment","followup","deleted","pBOMPrpg1QX"
+"dataelelement","period","orgunit","categoryoptioncombo","attributeoptioncombo","value","storedby","timestamp","comment","followup","deleted"
 "f7n9E0hX8qk","201201","DiszpKrYNg8","","","10001","john","2012-01-01","comment","false"
 "f7n9E0hX8qk","201201","BdfsJfj87js","","","10002","john","2012-01-02","comment","false"
 "f7n9E0hX8qk","201202","DiszpKrYNg8","","","10003","john","2012-01-03","comment","false"


### PR DESCRIPTION
### Summary
Allows to provide the data set ID for a data value set import from CSV file using a new import options parameter `dataSet`.

Replaces changes in #11439

### Documentation
https://github.com/dhis2/dhis2-docs/pull/1034