### PR TITLE
fix: add index.action suffix for data entry redirect [DHIS2-6705]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
@@ -77,10 +77,6 @@ public class RedirectAction
                     if ( app.getShortName().equals( startModule.substring( "app:".length() ) ) )
                     {
                         redirectUrl = app.getLaunchUrl();
-                        if ( redirectUrl.endsWith( "dhis-web-dataentry/" ) )
-                        {
-                            redirectUrl += "index.action";
-                        }
                         return SUCCESS;
                     }
                 }

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/about/action/RedirectAction.java
@@ -77,6 +77,10 @@ public class RedirectAction
                     if ( app.getShortName().equals( startModule.substring( "app:".length() ) ) )
                     {
                         redirectUrl = app.getLaunchUrl();
+                        if ( redirectUrl.endsWith( "dhis-web-dataentry/" ) )
+                        {
+                            redirectUrl += "index.action";
+                        }
                         return SUCCESS;
                     }
                 }
@@ -84,6 +88,10 @@ public class RedirectAction
             else
             {
                 redirectUrl = "../" + startModule + "/";
+                if ( redirectUrl.endsWith( "dhis-web-dataentry/" ) )
+                {
+                    redirectUrl += "index.action";
+                }
                 return SUCCESS;
             }
         }


### PR DESCRIPTION
### Summary
This is a workaround so that the `/dhis-web-dataentry/` URL becomes `/dhis-web-dataentry/index.action` when doing the redirct 
after login. This is important so have the data entry work as start app.

### Manual Testing
* goto System settings => Appearance and select _Data Entry_ as _Start Page_
* logout
* login again, check the data entry app is displayed correctly as the first page the user sees