### PR TITLE
fix: allow nulls for primitives in Jackson ObjectMapper

### DIFF
--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
@@ -191,7 +191,6 @@ public class JacksonObjectMapperConfig
 
         objectMapper.disable( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES );
         objectMapper.disable( DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY );
-        objectMapper.enable( DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES );
         objectMapper.enable( DeserializationFeature.WRAP_EXCEPTIONS );
 
         objectMapper.disable( MapperFeature.AUTO_DETECT_FIELDS );


### PR DESCRIPTION
Backport of [DHIS2-13178](https://jira.dhis2.org/browse/DHIS2-13178)