### PR TITLE
test: remove dependency on asm

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -220,7 +220,6 @@
     <jrebel-x-maven-plugin.version>1.1.10</jrebel-x-maven-plugin.version>
     <dhis-antlr-expression-parser.version>1.0.28</dhis-antlr-expression-parser.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
-    <ow2.asm.version>9.3</ow2.asm.version>
     <gson.version>2.8.9</gson.version>
     <semver4j.version>3.1.0</semver4j.version>
   </properties>
@@ -361,13 +360,6 @@
                 <log4j2.configurationFile>log4j2-test.xml</log4j2.configurationFile>
               </systemPropertyVariables>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${ow2.asm.version}</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -394,13 +386,6 @@
                 <log4j2.configurationFile>log4j2-test.xml</log4j2.configurationFile>
               </systemPropertyVariables>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${ow2.asm.version}</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -427,13 +412,6 @@
                 <log4j2.configurationFile>log4j2-test.xml</log4j2.configurationFile>
               </systemPropertyVariables>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${ow2.asm.version}</version>
-              </dependency>
-            </dependencies>
           </plugin>
         </plugins>
       </build>
@@ -455,13 +433,6 @@
               <argLine>@{argLine} ${surefireArgLine}</argLine>
               <excludedGroups>integration,integrationH2</excludedGroups>
             </configuration>
-            <dependencies>
-              <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${ow2.asm.version}</version>
-              </dependency>
-            </dependencies>
           </plugin>
           <plugin>
             <groupId>org.zeroturnaround</groupId>
@@ -550,13 +521,6 @@
               </path>
             </annotationProcessorPaths>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.ow2.asm</groupId>
-              <artifactId>asm</artifactId>
-              <version>${ow2.asm.version}</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1225,12 +1189,6 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-jose</artifactId>
         <version>${spring-security.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
@@ -2127,10 +2085,6 @@
         <version>${json-path.version}</version>
         <scope>test</scope>
         <exclusions>
-          <exclusion>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
it was needed when making DHIS2 jdk11 compatible
https://github.com/dhis2/dhis2-core/pull/4187
but is not anymore. DHIS2 itself does not depend on it.
Maven surefire for example does https://maven.apache.org/surefire/maven-surefire-plugin/dependencies.html
It will manage the version it needs itself.