### PR TITLE
ci: fix surefire version to run all tests on Jenkins [2.35]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -350,6 +350,24 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <skipTests>${skipTests}</skipTests>
+            <trimStackTrace>false</trimStackTrace>
+            <argLine>${surefireArgLine}</argLine>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>${ow2.asm.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.4</version>
           <configuration>


### PR DESCRIPTION
https://github.com/dhis2/dhis2-core/pull/11569 fixed potential issues
that could cause the count of tests running on Jenkins/GitHub to divert.
The actual root cause for version 2.35 is that we were using an old
version of surefire

org.apache.maven.plugins:maven-surefire-plugin:2.12.4

which you can see by running the tests without default or integration
profile. So with only jdk8 or jdk11.

When profiles default or integration are used like they are on GitHub
where unit and integration tests run in parallel we actually use

org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5

The newer plugin has support for JUnit 5 as described in https://maven.apache.org/surefire/maven-surefire-plugin/examples/junit-platform.html

which is why you also see the build log

Using the provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider

when running the build with -X in a module that has a JUnit 5
dependency.

Ultimately, the test count differed by the number of JUnit 5 tests which
did not run using maven-surefire-plugin 2.12.4