### PR TITLE
test: ensure correct surefire version

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -358,6 +358,24 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <skipTests>${skipTests}</skipTests>
+            <trimStackTrace>false</trimStackTrace>
+            <argLine>${surefireArgLine}</argLine>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>${ow2.asm.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.4</version>
           <configuration>


### PR DESCRIPTION
there are scenarios where we might run maven without any profile or a profile
that does not declare the surefire version in its build config. In that case maven
will resort to a default version which is rather old. This version does not
support JUnit 5 tests. So in case a JUnit 5 test would be added, it might not run.