### PR TITLE
test: ensure correct surefire version [2.33]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -328,6 +328,24 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <skipTests>${skipTests}</skipTests>
+            <trimStackTrace>false</trimStackTrace>
+            <argLine>${surefireArgLine}</argLine>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>${ow2.asm.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.10.4</version>
           <configuration>


### PR DESCRIPTION
there are scenarios where we might run maven without any profile or a profile
that does not declare the surefire version in its build config. In that case maven
will resort to a default version which is rather old. This version does not
support JUnit 5 tests. So in case a JUnit 5 test would be added, it might not run.

## Related PRs for other versions

[master/2.39](https://github.com/dhis2/dhis2-core/pull/11524)
[2.38](https://github.com/dhis2/dhis2-core/pull/11538)
[2.37 remove pom-full.xml](https://github.com/dhis2/dhis2-core/pull/11547) [2.37 surefire version](https://github.com/dhis2/dhis2-core/pull/11583)
[2.36 remove pom-full.xml](https://github.com/dhis2/dhis2-core/pull/11568) [2.36 surefire version](https://github.com/dhis2/dhis2-core/pull/11586)
[2.35 remove pom-full.xml](https://github.com/dhis2/dhis2-core/pull/11569) [2.35 surefire version](https://github.com/dhis2/dhis2-core/pull/11587)
[2.34 remove pom-full.xml](https://github.com/dhis2/dhis2-core/pull/11570) [2.34 surefire version](https://github.com/dhis2/dhis2-core/pull/11588)
[2.33 remove pom-full.xml](https://github.com/dhis2/dhis2-core/pull/11571) [2.33 surefire version](https://github.com/dhis2/dhis2-core/pull/11589)