### PR TITLE
ci: only manage surefire and asm version in pluginManagement [2.34]

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -360,11 +360,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
-          <configuration>
-            <skipTests>${skipTests}</skipTests>
-            <trimStackTrace>false</trimStackTrace>
-            <argLine>${surefireArgLine}</argLine>
-          </configuration>
           <dependencies>
             <dependency>
               <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
to not set skipTests when we do not want to