### PR TITLE
fix: Remove code typo [DHIS2-13655]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -790,8 +790,7 @@ public class DefaultEventAnalyticsService
 
         if ( params.getPartitions().hasAny() || params.isSkipPartitioning() )
         {
-            if ( params.isPaging() )
-                eventAnalyticsManager.getEvents( params, grid, queryValidator.getMaxLimit() );
+            eventAnalyticsManager.getEvents( params, grid, queryValidator.getMaxLimit() );
 
             if ( params.isPaging() && params.isTotalPages() )
             {


### PR DESCRIPTION
When we specify the parameter "paging=false", the result rows disappear.
_(a small backport typo caused this, I believe)_

This PR removes the unnecessary `if`.