### PR TITLE
fix: adds XML namespace to ImportOptions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -36,6 +36,7 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 
+import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.dxf2.metadata.feedback.ImportReportMode;
@@ -44,6 +45,7 @@ import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.user.User;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * The idScheme is a general setting which will apply to all objects. The
@@ -64,80 +66,105 @@ public class ImportOptions
     private User user;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private IdSchemes idSchemes = new IdSchemes();
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean dryRun;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private Boolean preheatCache;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean async;
 
     private ImportStrategy importStrategy = ImportStrategy.CREATE_AND_UPDATE;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private MergeMode mergeMode = MergeMode.REPLACE;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private ImportReportMode reportMode = ImportReportMode.FULL;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipExistingCheck;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean sharing;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipNotifications;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipAudit;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean datasetAllowsPeriods;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictPeriods;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictDataElements;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictCategoryOptionCombos;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictAttributeOptionCombos;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictOrganisationUnits;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean requireCategoryOptionCombo;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean requireAttributeOptionCombo;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipPatternValidation;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean ignoreEmptyCollection;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean force;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean firstRowIsHeader = true;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private String filename;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private NotificationLevel notificationLevel;
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipLastUpdated;
 
     /**
@@ -146,12 +173,14 @@ public class ImportOptions
      * full replacement)
      */
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean mergeDataValues;
 
     /**
      * if true, caches for import are not used. Should only be used for testing
      */
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipCache = false;
 
     /**
@@ -159,6 +188,7 @@ public class ImportOptions
      * request parameters
      */
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     private String dataSet;
 
     // --------------------------------------------------------------------------
@@ -208,6 +238,7 @@ public class ImportOptions
     // --------------------------------------------------------------------------
 
     @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public ImportStrategy getImportStrategy()
     {
         return importStrategy != null ? importStrategy : ImportStrategy.NEW_AND_UPDATES;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/common/ImportOptions.java
@@ -45,7 +45,6 @@ import org.hisp.dhis.system.notification.NotificationLevel;
 import org.hisp.dhis.user.User;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
 /**
  * The idScheme is a general setting which will apply to all objects. The
@@ -65,106 +64,81 @@ public class ImportOptions
 {
     private User user;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private IdSchemes idSchemes = new IdSchemes();
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean dryRun;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private Boolean preheatCache;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean async;
 
     private ImportStrategy importStrategy = ImportStrategy.CREATE_AND_UPDATE;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private MergeMode mergeMode = MergeMode.REPLACE;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private ImportReportMode reportMode = ImportReportMode.FULL;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipExistingCheck;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean sharing;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipNotifications;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipAudit;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean datasetAllowsPeriods;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictPeriods;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictDataElements;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictCategoryOptionCombos;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictAttributeOptionCombos;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean strictOrganisationUnits;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean requireCategoryOptionCombo;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean requireAttributeOptionCombo;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipPatternValidation;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean ignoreEmptyCollection;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean force;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean firstRowIsHeader = true;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private String filename;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private NotificationLevel notificationLevel;
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipLastUpdated;
 
     /**
@@ -172,23 +146,20 @@ public class ImportOptions
      * that have to be merged with the existing Data Values (as opposed to a
      * full replacement)
      */
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean mergeDataValues;
 
     /**
      * if true, caches for import are not used. Should only be used for testing
      */
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private boolean skipCache = false;
 
     /**
      * Optional field to set the data set ID of the imported values using
      * request parameters
      */
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     private String dataSet;
 
     // --------------------------------------------------------------------------
@@ -237,8 +208,7 @@ public class ImportOptions
     // Get methods
     // --------------------------------------------------------------------------
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    @JsonProperty( namespace = DxfNamespaces.DXF_2_0 )
     public ImportStrategy getImportStrategy()
     {
         return importStrategy != null ? importStrategy : ImportStrategy.NEW_AND_UPDATES;


### PR DESCRIPTION
This PR adds `namespace` property to the `@JsonProperty` annotations on `ImportOptions`. This is necessary so we don't break XML `ImportSummary` returns (as the inner `importOptions` property would not have ns declared).