### PR TITLE
fix: metadata csv export

### DIFF
--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
@@ -42,6 +42,7 @@ import org.springframework.context.annotation.Primary;
 
 import com.bedatadriven.jackson.datatype.jts.JtsModule;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -115,6 +116,12 @@ public class JacksonObjectMapperConfig
     public ObjectMapper xmlMapper()
     {
         return xmlMapper;
+    }
+
+    @Bean
+    public CsvMapper csvMapper()
+    {
+        return csvMapper;
     }
 
     public static ObjectMapper staticJsonMapper()
@@ -198,6 +205,14 @@ public class JacksonObjectMapperConfig
     private static CsvMapper configureCsvMapper( CsvMapper mapper )
     {
         mapper.disable( CsvParser.Feature.FAIL_ON_MISSING_COLUMNS );
+        mapper.configure( JsonGenerator.Feature.IGNORE_UNKNOWN, true );
+
+        mapper.registerModule( new SimpleModule()
+            .addSerializer( Date.class, new WriteDateStdSerializer() )
+            .addSerializer( Instant.class, new WriteInstantStdSerializer() ) );
+
+        mapper.registerModule( new Jdk8Module() );
+
         return mapper;
     }
 }

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -236,6 +236,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -236,10 +236,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jdk8</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -161,7 +161,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
     // Custom CSV mapper for field filtering
     // --------------------------------------------------------------------------
 
-    protected final static CsvMapper CSV_MAPPER = new CsvMapper();
+    protected static final CsvMapper CSV_MAPPER = new CsvMapper();
 
     static
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -345,13 +345,8 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
 
         try ( StringWriter strW = new StringWriter() )
         {
-            SequenceWriter seqW = csvMapper.writer()
+            SequenceWriter seqW = csvMapper.writer( schema )
                 .writeValues( strW );
-
-            if ( !skipHeader )
-            {
-                seqW.write( obj2valueByProperty.keySet().toArray() );
-            }
 
             Object[] row = new Object[obj2valueByProperty.size()];
 


### PR DESCRIPTION
## Summary

Fixes various minor issues with the new csv field filtering.

- [x] Add date modules to `CsvMapper` so that `Date` is properly serialized.
- [x] Add back support for `separator`.
- [x] Add back support for `arraySeparator`.

