### PR TITLE
ci: relax docker compose restart policy on DB

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -8,7 +8,7 @@ services:
        - "6379"
 
   db:
-    restart: always
+    restart: unless-stopped
     image: postgis/postgis:10-2.5-alpine
     command: postgres -c max_locks_per_transaction=100
     environment:


### PR DESCRIPTION
whenever I restart the dhis2-e2e-db-1 keeps on being started by Docker due to
the https://docs.docker.com/config/containers/start-containers-automatically/
This is annoying as it blocks a port and is wasting resources if I do not want to run
e2e tests.

unless-stopped is 'Similar to always, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts.'