### PR TITLE
ci: Increase maven retry count and connections ttl for dependency fetching on Jenkins [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -16,7 +16,7 @@ pipeline {
     }
 
     environment {
-        MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_OPTS = '-Xms1024m -Xmx4096m -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125'
         AWX_TEMPLATE = 37
         HOST = 'play.dhis2.org'
         INSTANCE_NAME = "${env.GIT_BRANCH == 'master' ? 'dev' : env.GIT_BRANCH + 'dev'}"


### PR DESCRIPTION
Builds on Jenkins sometimes fail due to maven dependency fetching timeouts. This PR adds a couple of maven options that we already have [in the GitHub run-tests workflow](https://github.com/dhis2/dhis2-core/blob/master/.github/workflows/run-tests.yml#L4), in attempt to alleviate that issue and make test failure notifications for the backend team more reliable.

However, from what I was able to find on the topic - `-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false` seem to be contradicting the rest of the options, as they disable http connection pooling altogether (based on the scarce [maven http wagon docs](https://maven.apache.org/wagon/wagon-providers/wagon-http/) and [this semi-relevant GitHub issue](https://github.com/Kotlin/dokka/issues/1626).

_Note that this is a trial change that might be incomplete, as reproducing the dependency fetching timeouts isn't feasible and we just have to try if it works._