### PR TITLE
test: fix DataValueSetServiceIntegrationTest assertions depending on order

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceIntegrationTest.java
@@ -44,6 +44,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.time.DateUtils;
@@ -587,8 +588,9 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase
         assertNotNull( dataValues );
         assertEquals( 3, dataValues.size() );
         assertTrue( dataValues.contains( new DataValue( deA, peA, ouA, ocDef, ocDef ) ) );
-        assertEquals( "10002", dataValues.get( 1 ).getValue() );
-        assertEquals( "10003", dataValues.get( 2 ).getValue() );
+        assertEquals( Set.of( "10001", "10002", "10003" ),
+            dataValues.stream().map( d -> d.getValue() ).collect( Collectors.toSet() ),
+            "mismatch in dataValues values" );
 
         List<Executable> audits = dataValues.stream()
             .map( dv -> ((Executable) () -> assertEquals( List.of(), dataValueAuditService.getDataValueAudits( dv ) )) )
@@ -620,8 +622,9 @@ class DataValueSetServiceIntegrationTest extends IntegrationTestBase
         assertNotNull( dataValues );
         assertEquals( 3, dataValues.size() );
         assertTrue( dataValues.contains( new DataValue( deA, peA, ouA, ocDef, ocDef ) ) );
-        assertEquals( "10002", dataValues.get( 1 ).getValue() );
-        assertEquals( "10003", dataValues.get( 2 ).getValue() );
+        assertEquals( Set.of( "10001", "10002", "10003" ),
+            dataValues.stream().map( d -> d.getValue() ).collect( Collectors.toSet() ),
+            "mismatch in dataValues values" );
 
         List<Executable> audits = dataValues.stream()
             .map( dv -> ((Executable) () -> assertEquals( List.of(), dataValueAuditService.getDataValueAudits( dv ) )) )


### PR DESCRIPTION
DataValueSetServiceIntegrationTest failed on Jenkins in a commit with completely unrelated changes while passing on GitHub. This suggests that the order of DataValues might have been different. [DataValueService.getAllDataValues()](https://github.com/dhis2/dhis2-core/blob/4380176ede3e773fa5a4b1dd2bc733e5f782a993/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java#L163-L168) does not state that it guarantees the order of DataValues.
Our assertion should therefore not expect a certain order.