### PR TITLE
test: no need to empty DB in transactional test

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/reservedvalue/ReservedValueServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/reservedvalue/ReservedValueServiceIntegrationTest.java
@@ -42,18 +42,15 @@ import java.util.Map;
 import org.apache.commons.collections4.ListUtils;
 import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.Objects;
-import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
+import org.hisp.dhis.test.integration.IntegrationTestBase;
 import org.hisp.dhis.textpattern.TextPattern;
 import org.hisp.dhis.textpattern.TextPatternGenerationException;
 import org.hisp.dhis.textpattern.TextPatternParser;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.Commit;
 
-@Commit
-class ReservedValueServiceIntegrationTest extends TransactionalIntegrationTest
+class ReservedValueServiceIntegrationTest extends IntegrationTestBase
 {
 
     @Autowired
@@ -75,8 +72,8 @@ class ReservedValueServiceIntegrationTest extends TransactionalIntegrationTest
 
     private static TrackedEntityAttribute simpleStringPattern;
 
-    @BeforeAll
-    static void setUpClass()
+    @Override
+    protected void setUpTest()
     {
         // Set up future Date
         Calendar calendar = Calendar.getInstance();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/test/integration/TransactionalIntegrationTest.java
@@ -70,14 +70,5 @@ public abstract class TransactionalIntegrationTest extends BaseSpringTest
         {
             log.info( "Failed to clear hibernate session, reason:" + e.getMessage() );
         }
-
-        try
-        {
-            dbmsManager.emptyDatabase();
-        }
-        catch ( Exception e )
-        {
-            log.info( "Failed to empty db, reason:" + e.getMessage() );
-        }
     }
 }


### PR DESCRIPTION
Test annotated with `@Transactional` does not need to empty the DB as this is already done by Spring.

ReservedValueServiceIntegrationTest is testing code that uses
ReservedValueBatchHandler which relies on the
org.hisp.quick.batchhandler. BatchHandler get their own JDBC connection
and thus transactions. Tests that test code like this can thus not
(easily) rely on Springs test transaction management as changes in the
BatchHandler are running in different transactions then the Spring test.

Use non transactional base class IntegrationTestBase which cleans up the
DB "manually".