### PR TITLE
feat: prevent category combo category changes if data exists [DHIS2-1786]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.datavalue;
 import java.util.Date;
 import java.util.List;
 
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dataelement.DataElement;
@@ -205,4 +206,6 @@ public interface DataValueService
      * @return the number of DataValues.
      */
     int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted );
+
+    boolean existsAnyValue( CategoryCombo combo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
@@ -207,5 +207,11 @@ public interface DataValueService
      */
     int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted );
 
+    /**
+     * Checks if any data values exist for the provided {@link CategoryCombo}
+     *
+     * @param combo the combo to check
+     * @return true, if any value exist, otherwise false
+     */
     boolean existsAnyValue( CategoryCombo combo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueService.java
@@ -208,10 +208,10 @@ public interface DataValueService
     int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted );
 
     /**
-     * Checks if any data values exist for the provided {@link CategoryCombo}
+     * Checks if any data values exist for the provided {@link CategoryCombo}.
      *
      * @param combo the combo to check
      * @return true, if any value exist, otherwise false
      */
-    boolean existsAnyValue( CategoryCombo combo );
+    boolean dataValueExists( CategoryCombo combo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueStore.java
@@ -31,6 +31,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -157,4 +158,6 @@ public interface DataValueStore
      * @return the number of DataValues.
      */
     int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted );
+
+    boolean existsAnyValue( CategoryCombo combo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueStore.java
@@ -160,10 +160,10 @@ public interface DataValueStore
     int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted );
 
     /**
-     * Checks if any data values exist for the provided {@link CategoryCombo}
+     * Checks if any data values exist for the provided {@link CategoryCombo}.
      *
      * @param combo the combo to check
      * @return true, if any value exist, otherwise false
      */
-    boolean existsAnyValue( CategoryCombo combo );
+    boolean dataValueExists( CategoryCombo combo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/datavalue/DataValueStore.java
@@ -159,5 +159,11 @@ public interface DataValueStore
      */
     int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted );
 
+    /**
+     * Checks if any data values exist for the provided {@link CategoryCombo}
+     *
+     * @param combo the combo to check
+     * @return true, if any value exist, otherwise false
+     */
     boolean existsAnyValue( CategoryCombo combo );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -59,7 +59,7 @@ public enum ErrorCode
         "with the separator character in one of its codes: `{2}`" ),
     E1118( "Option set `{0}` of value type multi-text cannot have option codes with the separator character: `{1}`" ),
     E1119( "{0} already exists: `{1}`" ),
-    E1120( "Change cannot be applied as it would make existing data values inaccessible." ),
+    E1120( "Update cannot be applied as it would make existing data values inaccessible" ),
 
     /* Org unit merge */
     E1500( "At least two source orgs unit must be specified" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -59,6 +59,7 @@ public enum ErrorCode
         "with the separator character in one of its codes: `{2}`" ),
     E1118( "Option set `{0}` of value type multi-text cannot have option codes with the separator character: `{1}`" ),
     E1119( "{0} already exists: `{1}`" ),
+    E1120( "Change cannot be applied as it would make existing data values inaccessible." ),
 
     /* Org unit merge */
     E1500( "At least two source orgs unit must be specified" ),

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -360,8 +360,8 @@ public class DefaultDataValueService
 
     @Override
     @Transactional( readOnly = true )
-    public boolean existsAnyValue( CategoryCombo combo )
+    public boolean dataValueExists( CategoryCombo combo )
     {
-        return dataValueStore.existsAnyValue( combo );
+        return dataValueStore.dataValueExists( combo );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -38,6 +38,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.AuditType;
@@ -355,5 +356,12 @@ public class DefaultDataValueService
     public int getDataValueCountLastUpdatedBetween( Date startDate, Date endDate, boolean includeDeleted )
     {
         return dataValueStore.getDataValueCountLastUpdatedBetween( startDate, endDate, includeDeleted );
+    }
+
+    @Override
+    @Transactional( readOnly = true )
+    public boolean existsAnyValue( CategoryCombo combo )
+    {
+        return dataValueStore.existsAnyValue( combo );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/hibernate/HibernateDataValueStore.java
@@ -559,7 +559,7 @@ public class HibernateDataValueStore extends HibernateGenericStore<DataValue>
     }
 
     @Override
-    public boolean existsAnyValue( CategoryCombo combo )
+    public boolean dataValueExists( CategoryCombo combo )
     {
         String cocIdsSql = "select distinct categoryoptioncomboid from categorycombos_optioncombos where categorycomboid = :cc";
         List<?> cocIds = getSession().createNativeQuery( cocIdsSql )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceIntegrityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceIntegrityTest.java
@@ -135,7 +135,7 @@ class DataValueServiceIntegrityTest extends SingleSetupIntegrationTestBase
     @Test
     void testExistsAnyValue()
     {
-        assertTrue( dataValueService.existsAnyValue( categoryComboAB ) );
-        assertFalse( dataValueService.existsAnyValue( categoryComboAC ) );
+        assertTrue( dataValueService.dataValueExists( categoryComboAB ) );
+        assertFalse( dataValueService.dataValueExists( categoryComboAC ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceIntegrityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueServiceIntegrityTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.datavalue;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.category.CategoryOption;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
+import org.hisp.dhis.common.DataDimensionType;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests the {@link DataValueService} API methods that are related to data
+ * integrity checks.
+ */
+class DataValueServiceIntegrityTest extends SingleSetupIntegrationTestBase
+{
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private DataValueService dataValueService;
+
+    @Autowired
+    private OrganisationUnitService organisationUnitService;
+
+    @Autowired
+    private DataElementService dataElementService;
+
+    private DataElement deA;
+
+    private Period peA;
+
+    private OrganisationUnit ouA;
+
+    private CategoryCombo categoryComboAB;
+
+    private CategoryCombo categoryComboAC;
+
+    private Category categoryA;
+
+    private Category categoryB;
+
+    private CategoryOptionCombo categoryOptionComboAB;
+
+    private CategoryOptionCombo categoryOptionComboAC;
+
+    @Override
+    protected void setUpTest()
+    {
+        deA = createDataElement( 'A' );
+        dataElementService.addDataElement( deA );
+
+        peA = createPeriod( "2022-07" );
+
+        ouA = createOrganisationUnit( 'A' );
+        organisationUnitService.addOrganisationUnit( ouA );
+
+        CategoryOption categoryOptionAB1 = new CategoryOption( "OptionA1" );
+        categoryService.addCategoryOption( categoryOptionAB1 );
+        CategoryOption categoryOptionAB2 = new CategoryOption( "OptionA2" );
+        categoryService.addCategoryOption( categoryOptionAB2 );
+
+        CategoryOption categoryOptionAC1 = new CategoryOption( "OptionB1" );
+        categoryService.addCategoryOption( categoryOptionAC1 );
+        CategoryOption categoryOptionAC2 = new CategoryOption( "OptionB2" );
+        categoryService.addCategoryOption( categoryOptionAC2 );
+
+        categoryA = createCategory( 'A', categoryOptionAB1, categoryOptionAB2 );
+        categoryB = createCategory( 'B', categoryOptionAC1, categoryOptionAC2 );
+        categoryService.addCategory( categoryA );
+        categoryService.addCategory( categoryB );
+
+        categoryComboAB = new CategoryCombo( "CategoryComboAB", DataDimensionType.DISAGGREGATION,
+            List.of( categoryA, categoryB ) );
+        categoryService.addCategoryCombo( categoryComboAB );
+
+        categoryOptionComboAB = createCategoryOptionCombo( 'A' );
+        categoryOptionComboAB.setCategoryCombo( categoryComboAB );
+        categoryOptionComboAB.setCategoryOptions( Set.of( categoryOptionAB1, categoryOptionAB2 ) );
+        categoryService.addCategoryOptionCombo( categoryOptionComboAB );
+
+        categoryComboAC = new CategoryCombo( "CategoryComboAC", DataDimensionType.DISAGGREGATION,
+            List.of( categoryA, categoryB ) );
+        categoryService.addCategoryCombo( categoryComboAC );
+
+        categoryOptionComboAC = createCategoryOptionCombo( 'B' );
+        categoryOptionComboAC.setCategoryCombo( categoryComboAC );
+        categoryOptionComboAC.setCategoryOptions( Set.of( categoryOptionAC1, categoryOptionAC2 ) );
+        categoryService.addCategoryOptionCombo( categoryOptionComboAC );
+
+        DataValue dataValueA = new DataValue( deA, peA, ouA, categoryOptionComboAB, null, "1" );
+        dataValueService.addDataValue( dataValueA );
+    }
+
+    @Test
+    void testExistsAnyValue()
+    {
+        assertTrue( dataValueService.existsAnyValue( categoryComboAB ) );
+        assertFalse( dataValueService.existsAnyValue( categoryComboAC ) );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/category/CategoryComboControllerTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
+import org.hisp.dhis.datavalue.DataValueService;
 import org.hisp.dhis.dxf2.metadata.MetadataExportParams;
 import org.hisp.dhis.dxf2.metadata.MetadataExportService;
 import org.hisp.dhis.webapi.service.ContextService;
@@ -68,6 +69,9 @@ class CategoryComboControllerTest
 
     @Mock
     private CategoryService service;
+
+    @Mock
+    private DataValueService dataValueService;
 
     @Mock
     private CategoryCombo categoryCombo;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -98,7 +98,7 @@ public class CategoryComboController
         throws WebMessageException
     {
         if ( !Objects.equals( entity.getCategories(), newEntity.getCategories() )
-            && dataValueService.existsAnyValue( entity ) )
+            && dataValueService.dataValueExists( entity ) )
         {
             throw new WebMessageException( conflict( ErrorCode.E1120 ) );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/category/CategoryComboController.java
@@ -32,8 +32,6 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 
 import java.util.Objects;
 
-import lombok.AllArgsConstructor;
-
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.datavalue.DataValueService;
@@ -42,6 +40,7 @@ import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.schema.descriptors.CategoryComboSchemaDescriptor;
 import org.hisp.dhis.webapi.controller.AbstractCrudController;
 import org.hisp.dhis.webapi.controller.metadata.MetadataExportControllerUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -56,13 +55,14 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 @Controller
 @RequestMapping( value = CategoryComboSchemaDescriptor.API_ENDPOINT )
-@AllArgsConstructor
 public class CategoryComboController
     extends AbstractCrudController<CategoryCombo>
 {
-    private final CategoryService categoryService;
+    @Autowired
+    private CategoryService categoryService;
 
-    private final DataValueService dataValueService;
+    @Autowired
+    private DataValueService dataValueService;
 
     @GetMapping( "/{uid}/metadata" )
     public ResponseEntity<JsonNode> getDataSetWithDependencies( @PathVariable( "uid" ) String pvUid,


### PR DESCRIPTION
### Summary
Adds a validation to the category combo endpoint to prevent changing the categories of the combo if data exist.

Depends on #11618 to make the added validation be effective for all ways of updating an object. 


### Automatic Testing
Added a new integration test to check basic functionality of the service method that checks for existing data values.

### Manual Testing
* find or create a category combo where data exist
* try to add or remove a category to/from the combo and check that the attempt results in an error
* find or create a category combo where no data exists
* try to add or remove a category to/from the combo and check that it is permitted
* check the above both for data values where the combo is used of category option combo and/or as attribute option combo