### PR TITLE
fix: make FieldFilterService xml fix only applicable for sharing (2.37)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
@@ -46,6 +46,9 @@ public class SharingUtils
     private static final ImmutableList<String> LEGACY_SHARING_PROPERTIES = ImmutableList.<String> builder().add(
         "userAccesses", "userGroupAccess", "publicAccess", "externalAccess" ).build();
 
+    private static final ImmutableList<String> SHARING_PROPERTIES = ImmutableList.<String> builder().add(
+        "userGroups", "users" ).build();
+
     private static final ObjectMapper FROM_AND_TO_JSON = createMapper();
 
     private SharingUtils()
@@ -136,6 +139,18 @@ public class SharingUtils
     public static boolean isLegacySharingProperty( Property property )
     {
         return LEGACY_SHARING_PROPERTIES.contains( property.getFieldName() );
+    }
+
+    /**
+     * Check if given property is {@link Sharing#userGroups} or
+     * {@link Sharing#users} property.
+     *
+     * @param property {@link Property} for checking.
+     * @return TRUE if given property is {@link Sharing}'s property.
+     */
+    public static boolean isSharingProperty( Property property )
+    {
+        return SHARING_PROPERTIES.contains( property.getFieldName() );
     }
 
     private static ObjectMapper createMapper()

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -83,6 +83,8 @@ import org.hisp.dhis.user.UserCredentials;
 import org.hisp.dhis.user.UserGroupAccess;
 import org.hisp.dhis.user.UserGroupService;
 import org.hisp.dhis.user.UserService;
+import org.hisp.dhis.user.sharing.Sharing;
+import org.hisp.dhis.util.SharingUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -531,7 +533,8 @@ public class DefaultFieldFilterService implements FieldFilterService
                 }
                 else
                 {
-                    if ( property.getKlass().isAssignableFrom( Map.class ) )
+                    if ( property.getKlass().isAssignableFrom( Map.class )
+                        && SharingUtils.isSharingProperty( property ) )
                     {
                         child = handleMapProperty( returnValue, property );
                     }
@@ -610,9 +613,10 @@ public class DefaultFieldFilterService implements FieldFilterService
 
     /**
      * Generate ComplexNode from Map structure based on given inputMapObject.
+     * Only accept {@link Sharing#userGroups} or {@link Sharing#users}. Example
+     * in xml:
      *
      * <pre>
-     * Example in xml:
      * {@code
      * <userGroups>
      *  <B6JNeAQ6akX>
@@ -629,11 +633,13 @@ public class DefaultFieldFilterService implements FieldFilterService
      *
      * @param inputMapObject Map to be used for generating ComplexNode
      * @param property {@link Property} type of the given map object.
-     * @return {@link ComplexNode}
+     * @return Return {@code null} if given property is not {@link Sharing}'s
+     *         property. Otherwise, return the {@link ComplexNode} of given
+     *         inputMapObject.
      */
     private ComplexNode handleMapProperty( Object inputMapObject, Property property )
     {
-        if ( inputMapObject == null )
+        if ( inputMapObject == null || !SharingUtils.isSharingProperty( property ) )
         {
             return null;
         }


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-13490
PR https://github.com/dhis2/dhis2-core/pull/11243 introduced a fix to make the metadata api return `Sharing` properties in correct xml format. However, that fix broke analytic objects.
This PR make that fix only applicable for `Sharing` properties and ignore other objects.