### PR TITLE
chore: use prePatchEntity with before and after arguments

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractCrudController.java
@@ -186,7 +186,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
 
         Patch patch = diff( request );
 
-        prePatchEntity( persistedObject );
+        prePatchEntity( persistedObject, persistedObject );
         patchService.apply( patch, persistedObject );
         validateAndThrowErrors( () -> schemaValidator.validate( persistedObject ) );
         manager.update( persistedObject );
@@ -237,7 +237,7 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
             throw new WebMessageException( badRequest( "Unknown payload format." ) );
         }
 
-        prePatchEntity( persistedObject );
+        prePatchEntity( persistedObject, persistedObject );
         Object value = property.getGetterMethod().invoke( object );
         property.getSetterMethod().invoke( persistedObject, value );
 
@@ -296,10 +296,10 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
 
         manager.resetNonOwnerProperties( persistedObject );
 
-        prePatchEntity( persistedObject );
-
         final JsonPatch patch = jsonMapper.readValue( request.getInputStream(), JsonPatch.class );
         final T patchedObject = jsonPatchManager.apply( patch, persistedObject );
+
+        prePatchEntity( patchedObject, patchedObject );
 
         // Do not allow changing IDs
         ((BaseIdentifiableObject) patchedObject).setId( persistedObject.getId() );
@@ -961,11 +961,6 @@ public abstract class AbstractCrudController<T extends IdentifiableObject> exten
     }
 
     protected void prePatchEntity( T entity, T newEntity )
-        throws Exception
-    {
-    }
-
-    protected void prePatchEntity( T newEntity )
         throws Exception
     {
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -122,14 +122,6 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void prePatchEntity( JobConfiguration jobConfiguration )
-        throws WebMessageException
-    {
-        checkConfigurable( jobConfiguration, HttpStatus.UNPROCESSABLE_ENTITY,
-            "Job %s is a system job that cannot be modified." );
-    }
-
-    @Override
     protected void preUpdateEntity( JobConfiguration before, JobConfiguration after )
         throws WebMessageException
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -181,14 +181,6 @@ public class ApiTokenController extends AbstractCrudController<ApiToken>
     }
 
     @Override
-    protected void prePatchEntity( ApiToken newToken )
-    {
-        final ApiToken oldToken = apiTokenService.getWithUid( newToken.getUid() );
-        newToken.setKey( oldToken.getKey() );
-        validateApiKeyAttributes( newToken );
-    }
-
-    @Override
     protected void prePatchEntity( ApiToken oldToken, ApiToken newToken )
     {
         newToken.setKey( oldToken.getKey() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -635,7 +635,7 @@ public class UserController
 
         mergeUserCredentialsMutations( patch );
 
-        prePatchEntity( persistedObject );
+        prePatchEntity( persistedObject, persistedObject );
         patchService.apply( patch, persistedObject );
 
         boolean twoFAfter = persistedObject.getTwoFA();
@@ -791,20 +791,6 @@ public class UserController
     // -------------------------------------------------------------------------
     // PATCH
     // -------------------------------------------------------------------------
-
-    @Override
-    protected void prePatchEntity( User entity )
-        throws Exception
-    {
-        User currentUser = currentUserService.getCurrentUser();
-
-        if ( !userService.canAddOrUpdateUser( getUids( entity.getGroups() ), currentUser )
-            || !currentUser.canModifyUser( entity ) )
-        {
-            throw new WebMessageException( conflict(
-                "You must have permissions to create user, or ability to manage at least one user group for the user." ) );
-        }
-    }
 
     @Override
     protected void postPatchEntity( User user )


### PR DESCRIPTION
Use the `prePatchEntity(old,new)` instead of `prePatchEntity(new)` method.
In 2 places this required to make a copy of the state before the patch. I used the new patch service to copy the object by applying an empty list of operations to it.