### PR TITLE
feat: user lookup restricted to capture units [DHIS2-12586]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UserOrgUnitType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/UserOrgUnitType.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static java.util.Arrays.stream;
+
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
 /**
@@ -37,5 +39,10 @@ public enum UserOrgUnitType
 {
     DATA_CAPTURE,
     DATA_OUTPUT,
-    TEI_SEARCH
+    TEI_SEARCH;
+
+    public static UserOrgUnitType fromValue( String name )
+    {
+        return stream( values() ).filter( t -> t.name().equalsIgnoreCase( name ) ).findFirst().orElse( null );
+    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
@@ -163,21 +163,6 @@ public class UserQueryParams
         return this;
     }
 
-    public boolean hasOrganisationUnits()
-    {
-        return !organisationUnits.isEmpty() && orgUnitBoundary == UserOrgUnitType.DATA_CAPTURE;
-    }
-
-    public boolean hasDataViewOrganisationUnits()
-    {
-        return !organisationUnits.isEmpty() && orgUnitBoundary == UserOrgUnitType.DATA_OUTPUT;
-    }
-
-    public boolean hasTeiSearchOrganisationUnits()
-    {
-        return !organisationUnits.isEmpty() && orgUnitBoundary == UserOrgUnitType.TEI_SEARCH;
-    }
-
     public UserQueryParams setOrganisationUnits( Set<OrganisationUnit> units )
     {
         this.organisationUnits = units;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
@@ -33,21 +33,29 @@ import java.util.Set;
 
 import lombok.Getter;
 
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-
-import com.google.common.base.MoreObjects;
 
 /**
  * @author Lars Helge Overland
  */
 @Getter
+@Setter
+@Accessors(chain = true)
+@ToString(onlyExplicitlyIncluded = true)
+@NoArgsConstructor
 public class UserQueryParams
 {
     /**
      * The user query string.
      */
+    @ToString.Include
     private String query;
 
+    @ToString.Include
     private String phoneNumber;
 
     /**
@@ -55,24 +63,34 @@ public class UserQueryParams
      */
     private User user;
 
+    @ToString.Include
     private boolean canManage;
 
+    @ToString.Include
     private boolean authSubset;
 
+    @ToString.Include
     private boolean disjointRoles;
 
+    @ToString.Include
     private Date lastLogin;
 
+    @ToString.Include
     private Date inactiveSince;
 
+    @ToString.Include
     private Date passwordLastUpdated;
 
+    @ToString.Include
     private Integer inactiveMonths;
 
+    @ToString.Include
     private boolean selfRegistered;
 
+    @ToString.Include
     private boolean isNot2FA;
 
+    @ToString.Include
     private UserInvitationStatus invitationStatus;
 
     private Set<OrganisationUnit> organisationUnits = new HashSet<>();
@@ -83,16 +101,22 @@ public class UserQueryParams
 
     private Set<UserGroup> userGroups = new HashSet<>();
 
+    @ToString.Include
     private Integer first;
 
+    @ToString.Include
     private Integer max;
 
+    @ToString.Include
     private boolean userOrgUnits;
 
+    @ToString.Include
     private boolean includeOrgUnitChildren;
 
+    @ToString.Include
     private boolean prefetchUserGroups;
 
+    @ToString.Include
     private Boolean disabled;
 
     /**
@@ -101,47 +125,16 @@ public class UserQueryParams
      * {@link SettingKey.CAN_GRANT_OWN_USER_AUTHORITY_GROUPS} system setting.
      * Should not be exposed in the API.
      */
+    @ToString.Include
     private boolean canSeeOwnRoles = false;
 
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
 
-    public UserQueryParams()
-    {
-    }
-
     public UserQueryParams( User user )
     {
         this.user = user;
-    }
-
-    // -------------------------------------------------------------------------
-    // toString
-    // -------------------------------------------------------------------------
-
-    @Override
-    public String toString()
-    {
-        return MoreObjects.toStringHelper( this )
-            .add( "query", query )
-            .add( "phone number", phoneNumber )
-            .add( "user", user != null ? user.getUsername() : null )
-            .add( "can manage", canManage )
-            .add( "auth subset", authSubset )
-            .add( "disjoint roles", disjointRoles )
-            .add( "last login", lastLogin )
-            .add( "inactive since", inactiveSince )
-            .add( "passwordLastUpdated", passwordLastUpdated )
-            .add( "inactive months", inactiveMonths )
-            .add( "self registered", selfRegistered )
-            .add( "isNot2FA", isNot2FA )
-            .add( "invitation status", invitationStatus )
-            .add( "first", first )
-            .add( "max", max )
-            .add( "includeOrgUnitChildren", includeOrgUnitChildren )
-            .add( "prefetchUserGroups", prefetchUserGroups )
-            .add( "disabled", disabled ).toString();
     }
 
     // -------------------------------------------------------------------------
@@ -191,151 +184,4 @@ public class UserQueryParams
         return user != null;
     }
 
-    // -------------------------------------------------------------------------
-    // Set methods
-    // -------------------------------------------------------------------------
-
-    public UserQueryParams setQuery( String query )
-    {
-        this.query = query;
-        return this;
-    }
-
-    public UserQueryParams setPhoneNumber( String phoneNumber )
-    {
-        this.phoneNumber = phoneNumber;
-        return this;
-    }
-
-    public UserQueryParams setUser( User user )
-    {
-        this.user = user;
-        return this;
-    }
-
-    public UserQueryParams setCanManage( boolean canManage )
-    {
-        this.canManage = canManage;
-        return this;
-    }
-
-    public UserQueryParams setAuthSubset( boolean authSubset )
-    {
-        this.authSubset = authSubset;
-        return this;
-    }
-
-    public UserQueryParams setDisjointRoles( boolean disjointRoles )
-    {
-        this.disjointRoles = disjointRoles;
-        return this;
-    }
-
-    public UserQueryParams setLastLogin( Date lastLogin )
-    {
-        this.lastLogin = lastLogin;
-        return this;
-    }
-
-    public UserQueryParams setInactiveSince( Date inactiveSince )
-    {
-        this.inactiveSince = inactiveSince;
-        return this;
-    }
-
-    public UserQueryParams setInactiveMonths( Integer inactiveMonths )
-    {
-        this.inactiveMonths = inactiveMonths;
-        return this;
-    }
-
-    public UserQueryParams setSelfRegistered( boolean selfRegistered )
-    {
-        this.selfRegistered = selfRegistered;
-        return this;
-    }
-
-    public UserQueryParams setNot2FA( boolean isNot2FA )
-    {
-        this.isNot2FA = isNot2FA;
-        return this;
-    }
-
-    public UserQueryParams setInvitationStatus( UserInvitationStatus invitationStatus )
-    {
-        this.invitationStatus = invitationStatus;
-        return this;
-    }
-
-    public UserQueryParams setOrganisationUnits( Set<OrganisationUnit> organisationUnits )
-    {
-        this.organisationUnits = organisationUnits;
-        return this;
-    }
-
-    public UserQueryParams setDataViewOrganisationUnits( Set<OrganisationUnit> dataViewOrganisationUnits )
-    {
-        this.dataViewOrganisationUnits = dataViewOrganisationUnits;
-        return this;
-    }
-
-    public UserQueryParams setTeiSearchOrganisationUnits( Set<OrganisationUnit> teiSearchOrganisationUnits )
-    {
-        this.teiSearchOrganisationUnits = teiSearchOrganisationUnits;
-        return this;
-    }
-
-    public UserQueryParams setUserGroups( Set<UserGroup> userGroups )
-    {
-        this.userGroups = userGroups;
-        return this;
-    }
-
-    public UserQueryParams setFirst( Integer first )
-    {
-        this.first = first;
-        return this;
-    }
-
-    public UserQueryParams setMax( Integer max )
-    {
-        this.max = max;
-        return this;
-    }
-
-    public UserQueryParams setUserOrgUnits( boolean userOrgUnits )
-    {
-        this.userOrgUnits = userOrgUnits;
-        return this;
-    }
-
-    public UserQueryParams setIncludeOrgUnitChildren( boolean includeOrgUnitChildren )
-    {
-        this.includeOrgUnitChildren = includeOrgUnitChildren;
-        return this;
-    }
-
-    public UserQueryParams setPrefetchUserGroups( boolean prefetchUserGroups )
-    {
-        this.prefetchUserGroups = prefetchUserGroups;
-        return this;
-    }
-
-    public UserQueryParams setPasswordLastUpdated( Date passwordLastUpdated )
-    {
-        this.passwordLastUpdated = passwordLastUpdated;
-        return this;
-    }
-
-    public UserQueryParams setDisabled( Boolean disabled )
-    {
-        this.disabled = disabled;
-        return this;
-    }
-
-    public UserQueryParams setCanSeeOwnUserRoles( boolean canSeeOwnUserRoles )
-    {
-        this.canSeeOwnRoles = canSeeOwnUserRoles;
-        return this;
-    }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
@@ -32,11 +32,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 import lombok.Getter;
-
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+
+import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 
 /**
@@ -44,8 +45,8 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
  */
 @Getter
 @Setter
-@Accessors(chain = true)
-@ToString(onlyExplicitlyIncluded = true)
+@Accessors( chain = true )
+@ToString( onlyExplicitlyIncluded = true )
 @NoArgsConstructor
 public class UserQueryParams
 {
@@ -109,6 +110,9 @@ public class UserQueryParams
 
     @ToString.Include
     private boolean userOrgUnits;
+
+    @ToString.Include
+    private UserOrgUnitType orgUnitBoundary;
 
     @ToString.Include
     private boolean includeOrgUnitChildren;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserQueryParams.java
@@ -96,10 +96,6 @@ public class UserQueryParams
 
     private Set<OrganisationUnit> organisationUnits = new HashSet<>();
 
-    private Set<OrganisationUnit> dataViewOrganisationUnits = new HashSet<>();
-
-    private Set<OrganisationUnit> teiSearchOrganisationUnits = new HashSet<>();
-
     private Set<UserGroup> userGroups = new HashSet<>();
 
     @ToString.Include
@@ -148,34 +144,62 @@ public class UserQueryParams
     public UserQueryParams addOrganisationUnit( OrganisationUnit unit )
     {
         this.organisationUnits.add( unit );
+        setOrgUnitBoundary( UserOrgUnitType.DATA_CAPTURE );
         return this;
     }
 
     public UserQueryParams addDataViewOrganisationUnit( OrganisationUnit unit )
     {
-        this.dataViewOrganisationUnits.add( unit );
+
+        this.organisationUnits.add( unit );
+        setOrgUnitBoundary( UserOrgUnitType.DATA_OUTPUT );
         return this;
     }
 
     public UserQueryParams addTeiSearchOrganisationUnit( OrganisationUnit unit )
     {
-        this.teiSearchOrganisationUnits.add( unit );
+        this.organisationUnits.add( unit );
+        setOrgUnitBoundary( UserOrgUnitType.TEI_SEARCH );
         return this;
     }
 
     public boolean hasOrganisationUnits()
     {
-        return !organisationUnits.isEmpty();
+        return !organisationUnits.isEmpty() && orgUnitBoundary == UserOrgUnitType.DATA_CAPTURE;
     }
 
     public boolean hasDataViewOrganisationUnits()
     {
-        return !dataViewOrganisationUnits.isEmpty();
+        return !organisationUnits.isEmpty() && orgUnitBoundary == UserOrgUnitType.DATA_OUTPUT;
     }
 
     public boolean hasTeiSearchOrganisationUnits()
     {
-        return !teiSearchOrganisationUnits.isEmpty();
+        return !organisationUnits.isEmpty() && orgUnitBoundary == UserOrgUnitType.TEI_SEARCH;
+    }
+
+    public UserQueryParams setOrganisationUnits( Set<OrganisationUnit> units )
+    {
+        this.organisationUnits = units;
+        if ( orgUnitBoundary == null )
+        {
+            this.orgUnitBoundary = UserOrgUnitType.DATA_CAPTURE;
+        }
+        return this;
+    }
+
+    public UserQueryParams setDataViewOrganisationUnits( Set<OrganisationUnit> units )
+    {
+        this.organisationUnits = units;
+        this.orgUnitBoundary = UserOrgUnitType.DATA_OUTPUT;
+        return this;
+    }
+
+    public UserQueryParams setTeiSearchOrganisationUnits( Set<OrganisationUnit> units )
+    {
+        this.organisationUnits = units;
+        this.orgUnitBoundary = UserOrgUnitType.TEI_SEARCH;
+        return this;
     }
 
     public boolean hasUserGroups()

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/MetadataOrgUnitMergeHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/merge/orgunit/handler/MetadataOrgUnitMergeHandler.java
@@ -126,7 +126,7 @@ public class MetadataOrgUnitMergeHandler
     public void mergeUsers( OrgUnitMergeRequest request )
     {
         List<User> dataCaptureUsers = userService.getUsers( new UserQueryParams()
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setOrganisationUnits( request.getSources() ) );
 
         dataCaptureUsers.forEach( u -> {
@@ -135,7 +135,7 @@ public class MetadataOrgUnitMergeHandler
         } );
 
         List<User> dataViewUsers = userService.getUsers( new UserQueryParams()
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setDataViewOrganisationUnits( request.getSources() ) );
 
         dataViewUsers.forEach( u -> {
@@ -144,7 +144,7 @@ public class MetadataOrgUnitMergeHandler
         } );
 
         List<User> teiSearchOrgUnits = userService.getUsers( new UserQueryParams()
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setTeiSearchOrganisationUnits( request.getSources() ) );
 
         teiSearchOrgUnits.forEach( u -> {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandler.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/split/orgunit/handler/MetadataOrgUnitSplitHandler.java
@@ -97,7 +97,7 @@ public class MetadataOrgUnitSplitHandler
         Set<OrganisationUnit> source = Sets.newHashSet( request.getSource() );
 
         List<User> dataCaptureUsers = userService.getUsers( new UserQueryParams()
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setOrganisationUnits( source ) );
 
         dataCaptureUsers.forEach( u -> {
@@ -106,7 +106,7 @@ public class MetadataOrgUnitSplitHandler
         } );
 
         List<User> dataViewUsers = userService.getUsers( new UserQueryParams()
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setDataViewOrganisationUnits( source ) );
 
         dataViewUsers.forEach( u -> {
@@ -115,7 +115,7 @@ public class MetadataOrgUnitSplitHandler
         } );
 
         List<User> teiSearchOrgUnits = userService.getUsers( new UserQueryParams()
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setTeiSearchOrganisationUnits( source ) );
 
         teiSearchOrgUnits.forEach( u -> {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -337,14 +337,15 @@ public class DefaultUserService
             if ( params.isUserOrgUnits() || orgUnitBoundary == UserOrgUnitType.DATA_CAPTURE )
             {
                 params.setOrganisationUnits( params.getUser().getOrganisationUnits() );
+                params.setOrgUnitBoundary( UserOrgUnitType.DATA_CAPTURE );
             }
             else if ( orgUnitBoundary == UserOrgUnitType.DATA_OUTPUT )
             {
-                params.setDataViewOrganisationUnits( params.getUser().getDataViewOrganisationUnits() );
+                params.setOrganisationUnits( params.getUser().getDataViewOrganisationUnits() );
             }
             else if ( orgUnitBoundary == UserOrgUnitType.TEI_SEARCH )
             {
-                params.setTeiSearchOrganisationUnits( params.getUser().getTeiSearchOrganisationUnits() );
+                params.setOrganisationUnits( params.getUser().getTeiSearchOrganisationUnits() );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.common.AuditLogUtil;
 import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.commons.filter.FilterUtils;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -330,9 +331,21 @@ public class DefaultUserService
             params.setInactiveSince( cal.getTime() );
         }
 
-        if ( params.isUserOrgUnits() && params.hasUser() )
+        if ( params.hasUser() )
         {
-            params.setOrganisationUnits( params.getUser().getOrganisationUnits() );
+            UserOrgUnitType orgUnitBoundary = params.getOrgUnitBoundary();
+            if ( params.isUserOrgUnits() || orgUnitBoundary == UserOrgUnitType.DATA_CAPTURE )
+            {
+                params.setOrganisationUnits( params.getUser().getOrganisationUnits() );
+            }
+            else if ( orgUnitBoundary == UserOrgUnitType.DATA_OUTPUT )
+            {
+                params.setDataViewOrganisationUnits( params.getUser().getDataViewOrganisationUnits() );
+            }
+            else if ( orgUnitBoundary == UserOrgUnitType.TEI_SEARCH )
+            {
+                params.setTeiSearchOrganisationUnits( params.getUser().getTeiSearchOrganisationUnits() );
+            }
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -65,6 +65,7 @@ import org.hibernate.annotations.QueryHints;
 import org.hibernate.query.Query;
 import org.hisp.dhis.cache.QueryCacheManager;
 import org.hisp.dhis.common.IdentifiableObjectUtils;
+import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.SqlHelper;
@@ -216,9 +217,14 @@ public class HibernateUserStore
             hql += "left join u.groups g ";
         }
 
-        if ( params.hasOrganisationUnits() )
+        if ( !params.getOrganisationUnits().isEmpty() )
         {
-            hql += "left join u.organisationUnits ou ";
+            String opProperty = Map.of(
+                UserOrgUnitType.DATA_CAPTURE, "organisationUnits",
+                UserOrgUnitType.DATA_OUTPUT, "dataViewOrganisationUnits",
+                UserOrgUnitType.TEI_SEARCH, "teiSearchOrganisationUnits" )
+                .getOrDefault( params.getOrgUnitBoundary(), "organisationUnits" );
+            hql += "left join u." + opProperty + " ou ";
 
             if ( params.isIncludeOrgUnitChildren() )
             {
@@ -234,48 +240,6 @@ public class HibernateUserStore
             else
             {
                 hql += hlp.whereAnd() + " ou.id in (:ouIds) ";
-            }
-        }
-
-        if ( params.hasDataViewOrganisationUnits() )
-        {
-            hql += "left join u.dataViewOrganisationUnits dwou ";
-
-            if ( params.isIncludeOrgUnitChildren() )
-            {
-                hql += hlp.whereAnd() + " (";
-
-                for ( OrganisationUnit ou : params.getOrganisationUnits() )
-                {
-                    hql += format( "dwou.path like :dwOu%s or ", ou.getUid() );
-                }
-
-                hql = TextUtils.removeLastOr( hql ) + ")";
-            }
-            else
-            {
-                hql += hlp.whereAnd() + " dwou.id in (:dwOuIds) ";
-            }
-        }
-
-        if ( params.hasTeiSearchOrganisationUnits() )
-        {
-            hql += "left join u.teiSearchOrganisationUnits tsou ";
-
-            if ( params.isIncludeOrgUnitChildren() )
-            {
-                hql += hlp.whereAnd() + " (";
-
-                for ( OrganisationUnit ou : params.getOrganisationUnits() )
-                {
-                    hql += format( "tsou.path like :tsOu%s or ", ou.getUid() );
-                }
-
-                hql = TextUtils.removeLastOr( hql ) + ")";
-            }
-            else
-            {
-                hql += hlp.whereAnd() + " tsou.id in (:tsOuIds) ";
             }
         }
 
@@ -433,7 +397,7 @@ public class HibernateUserStore
             query.setParameter( "inactiveSince", params.getInactiveSince() );
         }
 
-        if ( params.hasOrganisationUnits() )
+        if ( !params.getOrganisationUnits().isEmpty() )
         {
             if ( params.isIncludeOrgUnitChildren() )
             {
@@ -447,42 +411,6 @@ public class HibernateUserStore
                 Collection<Long> ouIds = IdentifiableObjectUtils.getIdentifiers( params.getOrganisationUnits() );
 
                 query.setParameterList( "ouIds", ouIds );
-            }
-        }
-
-        if ( params.hasDataViewOrganisationUnits() )
-        {
-            if ( params.isIncludeOrgUnitChildren() )
-            {
-                for ( OrganisationUnit ou : params.getOrganisationUnits() )
-                {
-                    query.setParameter( format( "dwOu%s", ou.getUid() ), "%/" + ou.getUid() + "%" );
-                }
-            }
-            else
-            {
-                Collection<Long> ouIds = IdentifiableObjectUtils
-                    .getIdentifiers( params.getOrganisationUnits() );
-
-                query.setParameterList( "dwOuIds", ouIds );
-            }
-        }
-
-        if ( params.hasTeiSearchOrganisationUnits() )
-        {
-            if ( params.isIncludeOrgUnitChildren() )
-            {
-                for ( OrganisationUnit ou : params.getOrganisationUnits() )
-                {
-                    query.setParameter( format( "tsOu%s", ou.getUid() ), "%/" + ou.getUid() + "%" );
-                }
-            }
-            else
-            {
-                Collection<Long> ouIds = IdentifiableObjectUtils
-                    .getIdentifiers( params.getOrganisationUnits() );
-
-                query.setParameterList( "tsOuIds", ouIds );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -245,7 +245,7 @@ public class HibernateUserStore
             {
                 hql += hlp.whereAnd() + " (";
 
-                for ( OrganisationUnit ou : params.getDataViewOrganisationUnits() )
+                for ( OrganisationUnit ou : params.getOrganisationUnits() )
                 {
                     hql += format( "dwou.path like :dwOu%s or ", ou.getUid() );
                 }
@@ -266,7 +266,7 @@ public class HibernateUserStore
             {
                 hql += hlp.whereAnd() + " (";
 
-                for ( OrganisationUnit ou : params.getTeiSearchOrganisationUnits() )
+                for ( OrganisationUnit ou : params.getOrganisationUnits() )
                 {
                     hql += format( "tsou.path like :tsOu%s or ", ou.getUid() );
                 }
@@ -454,7 +454,7 @@ public class HibernateUserStore
         {
             if ( params.isIncludeOrgUnitChildren() )
             {
-                for ( OrganisationUnit ou : params.getDataViewOrganisationUnits() )
+                for ( OrganisationUnit ou : params.getOrganisationUnits() )
                 {
                     query.setParameter( format( "dwOu%s", ou.getUid() ), "%/" + ou.getUid() + "%" );
                 }
@@ -462,7 +462,7 @@ public class HibernateUserStore
             else
             {
                 Collection<Long> ouIds = IdentifiableObjectUtils
-                    .getIdentifiers( params.getDataViewOrganisationUnits() );
+                    .getIdentifiers( params.getOrganisationUnits() );
 
                 query.setParameterList( "dwOuIds", ouIds );
             }
@@ -472,7 +472,7 @@ public class HibernateUserStore
         {
             if ( params.isIncludeOrgUnitChildren() )
             {
-                for ( OrganisationUnit ou : params.getTeiSearchOrganisationUnits() )
+                for ( OrganisationUnit ou : params.getOrganisationUnits() )
                 {
                     query.setParameter( format( "tsOu%s", ou.getUid() ), "%/" + ou.getUid() + "%" );
                 }
@@ -480,7 +480,7 @@ public class HibernateUserStore
             else
             {
                 Collection<Long> ouIds = IdentifiableObjectUtils
-                    .getIdentifiers( params.getTeiSearchOrganisationUnits() );
+                    .getIdentifiers( params.getOrganisationUnits() );
 
                 query.setParameterList( "tsOuIds", ouIds );
             }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUser.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonUser.java
@@ -39,6 +39,11 @@ import org.hisp.dhis.jsontree.JsonList;
  */
 public interface JsonUser extends JsonIdentifiableObject
 {
+    default String getUsername()
+    {
+        return getString( "username" ).string();
+    }
+
     default String getSurname()
     {
         return getString( "surname" ).string();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -129,7 +129,7 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
 
     private UserQueryParams getDefaultParams()
     {
-        return new UserQueryParams().setCanSeeOwnUserRoles( true );
+        return new UserQueryParams().setCanSeeOwnRoles( true );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserLookupControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserLookupControllerTest.java
@@ -121,7 +121,7 @@ class UserLookupControllerTest extends DhisControllerConvenienceTest
 
         // test
         switchContextToUser( john );
-        JsonList<JsonUser> matches = GET( "/userLookup?query=FirstName&captureUnitsOnly=true" ).content()
+        JsonList<JsonUser> matches = GET( "/userLookup?query=FirstName&orgUnitBoundary=DATA_CAPTURE" ).content()
             .getArray( "users" ).asList( JsonUser.class );
         // all 4 users have "FirstName" in their first name but john can see
         // paul and himself
@@ -130,7 +130,7 @@ class UserLookupControllerTest extends DhisControllerConvenienceTest
 
         // similar
         switchContextToUser( george );
-        matches = GET( "/userLookup?query=FirstName&captureUnitsOnly=true" ).content()
+        matches = GET( "/userLookup?query=FirstName&orgUnitBoundary=DATA_CAPTURE" ).content()
             .getArray( "users" ).asList( JsonUser.class );
         // all 4 users have "FirstName" in their first name but george can see
         // ringo and himself

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserLookupControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserLookupControllerTest.java
@@ -27,13 +27,20 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
 import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.json.domain.JsonIdentifiableObject;
 import org.hisp.dhis.webapi.json.domain.JsonUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,13 +56,21 @@ class UserLookupControllerTest extends DhisControllerConvenienceTest
 
     private String roleId;
 
+    private User john;
+
+    private User paul;
+
+    private User george;
+
+    private User ringo;
+
     @BeforeEach
     void setUp()
     {
-        User john = switchToNewUser( "John" );
-        User paul = switchToNewUser( "Paul" );
-        User george = switchToNewUser( "George" );
-        User ringo = switchToNewUser( "Ringo" );
+        john = switchToNewUser( "John" );
+        paul = switchToNewUser( "Paul" );
+        george = switchToNewUser( "George" );
+        ringo = switchToNewUser( "Ringo" );
         switchToSuperuser();
         roleId = assertStatus( HttpStatus.CREATED, POST( "/userRoles", "{'name':'common'}" ) );
         assertStatus( HttpStatus.NO_CONTENT, POST( "/userRoles/" + roleId + "/users/" + john.getUid() ) );
@@ -79,5 +94,47 @@ class UserLookupControllerTest extends DhisControllerConvenienceTest
         assertEquals( 1, matches.size() );
         JsonUser user = matches.get( 0, JsonUser.class );
         assertEquals( "FirstNameJohn", user.getFirstName() );
+    }
+
+    @Test
+    void testLookUpUsers_captureUnitsOnly()
+    {
+        // setup
+        String ouA = assertStatus( HttpStatus.CREATED,
+            POST( "/organisationUnits/", "{'name':'testA', 'shortName':'TA', 'openingDate':'2021-01-01'}" ) );
+        String ouB = assertStatus( HttpStatus.CREATED,
+            POST( "/organisationUnits/", "{'name':'testB', 'shortName':'TB', 'openingDate':'2021-01-01'}" ) );
+
+        BiConsumer<String, String> addUserToOrgUnit = ( user, orgUnit ) -> assertEquals( HttpStatus.OK,
+            PATCH( "/users/" + user + "?importReportMode=ERRORS", "["
+                + "{'op': 'add', 'path': '/organisationUnits', 'value': [{'id':'" + orgUnit + "'}]}"
+                + "]" ).status() );
+
+        addUserToOrgUnit.accept( john.getUid(), ouA );
+        addUserToOrgUnit.accept( paul.getUid(), ouA );
+        addUserToOrgUnit.accept( george.getUid(), ouB );
+        addUserToOrgUnit.accept( ringo.getUid(), ouB );
+
+        // verify setup
+        assertEquals( List.of( ouA ), GET( "/users/" + paul.getUid() ).content()
+            .as( JsonUser.class ).getOrganisationUnits().toList( JsonIdentifiableObject::getId ) );
+
+        // test
+        switchContextToUser( john );
+        JsonList<JsonUser> matches = GET( "/userLookup?query=FirstName&captureUnitsOnly=true" ).content()
+            .getArray( "users" ).asList( JsonUser.class );
+        // all 4 users have "FirstName" in their first name but john can see
+        // paul and himself
+        assertEquals( 2, matches.size() );
+        assertEquals( Set.of( "John", "Paul" ), matches.stream().map( JsonUser::getUsername ).collect( toSet() ) );
+
+        // similar
+        switchContextToUser( george );
+        matches = GET( "/userLookup?query=FirstName&captureUnitsOnly=true" ).content()
+            .getArray( "users" ).asList( JsonUser.class );
+        // all 4 users have "FirstName" in their first name but george can see
+        // ringo and himself
+        assertEquals( 2, matches.size() );
+        assertEquals( Set.of( "George", "Ringo" ), matches.stream().map( JsonUser::getUsername ).collect( toSet() ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -62,6 +62,7 @@ import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.common.Pager;
+import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.common.TranslateParams;
@@ -250,6 +251,7 @@ public class UserController
         params.setInvitationStatus( UserInvitationStatus.fromValue( options.get( "invitationStatus" ) ) );
         params.setUserOrgUnits( options.isTrue( "userOrgUnits" ) );
         params.setIncludeOrgUnitChildren( options.isTrue( "includeChildren" ) );
+        params.setOrgUnitBoundary( UserOrgUnitType.fromValue( options.get( "orgUnitBoundary" ) ) );
 
         return params;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
@@ -35,6 +35,7 @@ import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
+import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserQueryParams;
@@ -81,12 +82,19 @@ public class UserLookupController
     }
 
     @GetMapping
-    public UserLookups lookUpUsers( @RequestParam String query )
+    public UserLookups lookUpUsers( @RequestParam String query,
+        @RequestParam( defaultValue = "false" ) boolean captureUnitsOnly,
+        @CurrentUser User currentUser )
     {
         UserQueryParams params = new UserQueryParams()
             .setQuery( query )
             .setCanSeeOwnUserRoles( true )
             .setMax( 25 );
+
+        if ( captureUnitsOnly )
+        {
+            params.setOrganisationUnits( currentUser.getOrganisationUnits() );
+        }
 
         List<UserLookup> users = userService.getUsers( params ).stream()
             .map( UserLookup::fromUser )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
@@ -83,12 +83,12 @@ public class UserLookupController
 
     @GetMapping
     public UserLookups lookUpUsers( @RequestParam String query,
-        @RequestParam( required = false ) UserOrgUnitType orgUnitBoundary )
+        @RequestParam( required = false ) String orgUnitBoundary )
     {
         UserQueryParams params = new UserQueryParams()
             .setQuery( query )
             .setCanSeeOwnRoles( true )
-            .setOrgUnitBoundary( orgUnitBoundary )
+            .setOrgUnitBoundary( UserOrgUnitType.fromValue( orgUnitBoundary ) )
             .setMax( 25 );
 
         List<UserLookup> users = userService.getUsers( params ).stream()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
@@ -83,18 +83,14 @@ public class UserLookupController
 
     @GetMapping
     public UserLookups lookUpUsers( @RequestParam String query,
-        @RequestParam( defaultValue = "false" ) boolean captureUnitsOnly,
-        @CurrentUser User currentUser )
+        @RequestParam( defaultValue = "false" ) boolean captureUnitsOnly)
     {
         UserQueryParams params = new UserQueryParams()
             .setQuery( query )
             .setCanSeeOwnUserRoles( true )
             .setMax( 25 );
 
-        if ( captureUnitsOnly )
-        {
-            params.setOrganisationUnits( currentUser.getOrganisationUnits() );
-        }
+        params.setUserOrgUnits( captureUnitsOnly );
 
         List<UserLookup> users = userService.getUsers( params ).stream()
             .map( UserLookup::fromUser )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserLookupController.java
@@ -32,10 +32,10 @@ import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.configuration.ConfigurationService;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
-import org.hisp.dhis.user.CurrentUser;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserQueryParams;
@@ -83,14 +83,13 @@ public class UserLookupController
 
     @GetMapping
     public UserLookups lookUpUsers( @RequestParam String query,
-        @RequestParam( defaultValue = "false" ) boolean captureUnitsOnly)
+        @RequestParam( required = false ) UserOrgUnitType orgUnitBoundary )
     {
         UserQueryParams params = new UserQueryParams()
             .setQuery( query )
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
+            .setOrgUnitBoundary( orgUnitBoundary )
             .setMax( 25 );
-
-        params.setUserOrgUnits( captureUnitsOnly );
 
         List<UserLookup> users = userService.getUsers( params ).stream()
             .map( UserLookup::fromUser )
@@ -112,7 +111,7 @@ public class UserLookupController
         UserQueryParams params = new UserQueryParams()
             .setQuery( query )
             .setUserGroups( Sets.newHashSet( feedbackRecipients ) )
-            .setCanSeeOwnUserRoles( true )
+            .setCanSeeOwnRoles( true )
             .setMax( 25 );
 
         List<UserLookup> users = userService.getUsers( params ).stream()


### PR DESCRIPTION
### Summary
Adds `orgUnitBoundary` parameter to both `/users` and `/userLoopup` endpoints.
The parameter accepts any of the `UserOrgUnitType` enum values and restricts the search to the users that share an organisation unit with the current user for the selected boundary.

The existing parameter `&userOrgUnits=true` would be identical to `&orgUnitBoundary=DATA_CAPTURE` and is kept for backwards compatibility. If `userOrgUnits` is true it takes precedence over any `orgUnitBoundary` provided additionally.

### Automatic Testing
A new controller test scenario was added.

### Manual Testing
* create a user and set its capture organisation unit to a specific unit
* create another user and set its capture organisation unit to the same unit
* login as one of those users
* use `/userLookup` search to find the users sharing a capture organisation unit using `query` and `orgUnitBoundary=DATA_CAPTURE` parameters
* check other users that otherwise would match the `query` are not found as they do not share the capture organisation unit
* repeat the test for `/users` and other boundary types

### Documentation
https://github.com/dhis2/dhis2-docs/pull/1036