### PR TITLE
fix: remove deprecation notice from Node classes for now

### DIFF
--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/AbstractNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/AbstractNode.java
@@ -42,12 +42,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 /**
+ * The Node services are being deprecated so please do not use in new code.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
- * @deprecated No new usage of this class and its children should happen, we
- *             should instead directly use Jackson ObjectMappers or Jackson
- *             object factory if we need dynamically created objects.
  */
-@Deprecated
 public abstract class AbstractNode implements Node
 {
     protected String name;

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/Node.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/Node.java
@@ -33,12 +33,10 @@ import org.hisp.dhis.schema.Property;
 import org.springframework.core.Ordered;
 
 /**
+ * The Node services are being deprecated so please do not use in new code.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
- * @deprecated No new usage of this class and its children should happen, we
- *             should instead directly use Jackson ObjectMappers or Jackson
- *             object factory if we need dynamically created objects.
  */
-@Deprecated
 public interface Node extends Ordered
 {
     /**

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/CollectionNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/CollectionNode.java
@@ -35,12 +35,10 @@ import org.hisp.dhis.node.NodeType;
 import com.google.common.collect.Lists;
 
 /**
+ * The Node services are being deprecated so please do not use in new code.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
- * @deprecated No new usage of this class and its children should happen, we
- *             should instead directly use Jackson ObjectMappers or Jackson
- *             object factory if we need dynamically created objects.
  */
-@Deprecated
 public class CollectionNode extends AbstractNode
 {
     /**

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/ComplexNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/ComplexNode.java
@@ -32,12 +32,10 @@ import org.hisp.dhis.node.NodeType;
 import org.hisp.dhis.schema.Property;
 
 /**
+ * The Node services are being deprecated so please do not use in new code.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
- * @deprecated No new usage of this class and its children should happen, we
- *             should instead directly use Jackson ObjectMappers or Jackson
- *             object factory if we need dynamically created objects.
  */
-@Deprecated
 public class ComplexNode extends AbstractNode
 {
     public ComplexNode( String name )

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/RootNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/RootNode.java
@@ -33,12 +33,10 @@ import org.hisp.dhis.node.Node;
 import org.hisp.dhis.node.config.Config;
 
 /**
+ * The Node services are being deprecated so please do not use in new code.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
- * @deprecated No new usage of this class and its children should happen, we
- *             should instead directly use Jackson ObjectMappers or Jackson
- *             object factory if we need dynamically created objects.
  */
-@Deprecated
 public class RootNode extends ComplexNode
 {
     private String defaultNamespace;

--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/SimpleNode.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/types/SimpleNode.java
@@ -36,12 +36,10 @@ import org.hisp.dhis.node.exception.InvalidTypeException;
 import org.hisp.dhis.schema.Property;
 
 /**
+ * The Node services are being deprecated so please do not use in new code.
+ *
  * @author Morten Olav Hansen <mortenoh@gmail.com>
- * @deprecated No new usage of this class and its children should happen, we
- *             should instead directly use Jackson ObjectMappers or Jackson
- *             object factory if we need dynamically created objects.
  */
-@Deprecated
 public class SimpleNode
     extends AbstractNode
 {


### PR DESCRIPTION
Since we are not removing the `Node` classes until 2.40/2.41, this PR removes the deprecation notices for now.