### PR TITLE
fix: import user with legacy UserCredentials

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/User.java
@@ -1473,7 +1473,7 @@ public class User
     public UserCredentialsDto getUserCredentials()
     {
         UserCredentialsDto userCredentialsDto = new UserCredentialsDto();
-        copyProperties( this, userCredentialsDto, "userCredentials", "password", "userRoles", "secret",
+        copyProperties( this, userCredentialsDto, "uid", "userCredentials", "password", "userRoles", "secret",
             "previousPasswords" );
         Set<UserRole> roles = this.getUserRoles();
         if ( roles != null && !roles.isEmpty() )
@@ -1500,7 +1500,7 @@ public class User
         UserCredentialsDto userCredentialsRaw = user.getUserCredentialsRaw();
         if ( userCredentialsRaw != null )
         {
-            copyProperties( userCredentialsRaw, user, "password", "userRoles", "secret", "previousPasswords" );
+            copyProperties( userCredentialsRaw, user, "uid", "password", "userRoles", "secret", "previousPasswords" );
             if ( userCredentialsRaw.getPassword() != null )
             {
                 user.setPassword( userCredentialsRaw.getPassword() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/UserObjectBundleHook.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.dxf2.metadata.objectbundle.hooks;
 
+import static org.hisp.dhis.user.User.populateUserCredentialsDtoFields;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -81,6 +83,8 @@ public class UserObjectBundleHook extends AbstractObjectBundleHook<User>
     public void validate( User user, ObjectBundle bundle,
         Consumer<ErrorReport> addReports )
     {
+        populateUserCredentialsDtoFields( user );
+
         if ( bundle.getImportMode().isCreate() && !ValidationUtils.usernameIsValid( user.getUsername(),
             user.isInvitation() ) )
         {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -823,6 +823,19 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest
     }
 
     @Test
+    void testImportUserLegacyFormat()
+        throws IOException
+    {
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/create_user_with_legacy_format.json" ).getInputStream(),
+            RenderFormat.JSON );
+        MetadataImportParams params = createParams( ImportStrategy.CREATE_AND_UPDATE, metadata );
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.OK, report.getStatus() );
+        assertNotNull( manager.get( User.class, "sPWjoHSY03y" ) );
+    }
+
+    @Test
     void testImportMapCreateAndUpdate()
         throws IOException
     {

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/create_user_with_legacy_format.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/create_user_with_legacy_format.json
@@ -1,0 +1,205 @@
+{
+  "userRoles": [
+    {
+      "dataSets": [ ],
+      "publicAccess": "--------",
+      "name": "Superuser",
+      "programs": [ ],
+      "lastUpdated": "2016-03-12T06:18:41.386+0000",
+      "created": "2016-03-12T06:18:41.386+0000",
+      "userGroupAccesses": [ ],
+      "authorities": [
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "ALL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_DELETE",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_MAP_PUBLIC_ADD",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH",
+        "F_PROGRAM_ENROLLMENT",
+        "F_SQLVIEW_EXTERNAL",
+        "F_GIS_ADMIN",
+        "F_REPLICATE_USER",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_METADATA_IMPORT",
+        "F_VISUALIZATION_PUBLIC_ADD",
+        "F_EVENT_VISUALIZATION_PUBLIC_ADD",
+        "F_EVENT_VISUALIZATION_EXTERNAL",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_VISUALIZATION_EXTERNAL",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_METADATA_EXPORT",
+        "F_PROGRAM_UNENROLLMENT",
+        "F_APPROVE_DATA",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_INSTANCE_ADD",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_TRACKED_ENTITY_DATAVALUE_ADD",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_MAP_EXTERNAL",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "F_TRACKED_ENTITY_DATAVALUE_DELETE"
+      ],
+      "id": "tHEWGwIMsJk"
+    }
+  ],
+  "date": "2016-03-12T06:21:34.667+0000",
+  "organisationUnits": [
+    {
+      "path": "/inVD5SdytkT",
+      "openingDate": "2016-03-11T17:00:00.000+0000",
+      "lastUpdated": "2016-03-12T06:19:49.665+0000",
+      "created": "2016-03-12T06:19:49.649+0000",
+      "shortName": "Country",
+      "user": {
+        "id": "enHApD3I6Ho"
+      },
+      "attributeValues": [ ],
+      "id": "inVD5SdytkT",
+      "name": "Country",
+      "description": "",
+      "featureType": "NONE",
+      "uuid": "0f2d7a85-3b6e-4cae-9d5a-e2903331629b"
+    }
+  ],
+  "trackedEntityTypes": [
+    {
+      "id": "xjZaLLspj2r",
+      "attributeValues": [ ],
+      "description": "Person",
+      "name": "Person",
+      "created": "2016-03-09T09:56:10.596+0000",
+      "lastUpdated": "2016-03-09T09:56:10.597+0000"
+    }
+  ],
+  "users": [
+    {
+      "email": "user@b.org",
+      "surname": "BB",
+      "firstName": "User",
+      "created": "2016-03-12T06:21:02.324+0000",
+      "lastUpdated": "2016-03-12T06:21:02.325+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "yqJHNnkF3SJ",
+        "cogsDimensionConstraints": [ ],
+        "selfRegistered": false,
+        "catDimensionConstraints": [ ],
+        "lastLogin": "2016-03-12T06:21:02.226+0000",
+        "created": "2016-03-12T06:21:02.329+0000",
+        "passwordLastUpdated": "2016-03-12T06:21:02.226+0000",
+        "userInfo": {
+          "id": "MwhEJUnTHkn"
+        },
+        "userRoles": [
+          {
+            "id": "tHEWGwIMsJk"
+          }
+        ],
+        "username": "UserB",
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false
+      },
+      "teiSearchOrganisationUnits": [ ],
+      "id": "MwhEJUnTHkn",
+      "attributeValues": [ ]
+    },
+    {
+      "firstName": "User",
+      "email": "user@a.org",
+      "surname": "AA",
+      "attributeValues": [ ],
+      "id": "sPWjoHSY03y",
+      "created": "2016-03-12T06:20:43.502+0000",
+      "lastUpdated": "2016-03-12T06:20:43.502+0000",
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "m3ww4DWJtMf",
+        "username": "UserA",
+        "userRoles": [
+          {
+            "id": "tHEWGwIMsJk"
+          }
+        ],
+        "invitation": false,
+        "disabled": false,
+        "externalAuth": false,
+        "cogsDimensionConstraints": [ ],
+        "selfRegistered": false,
+        "catDimensionConstraints": [ ],
+        "lastLogin": "2016-03-12T06:20:43.407+0000",
+        "created": "2016-03-12T06:20:43.508+0000",
+        "userInfo": {
+          "id": "sPWjoHSY03y"
+        },
+        "passwordLastUpdated": "2016-03-12T06:20:43.407+0000"
+      },
+      "teiSearchOrganisationUnits": [ ]
+    },
+    {
+      "surname": "admin",
+      "firstName": "admin",
+      "organisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "inVD5SdytkT"
+        }
+      ],
+      "userCredentials": {
+        "id": "EgBSdwGi7rr",
+        "externalAuth": false,
+        "disabled": false,
+        "invitation": false,
+        "userRoles": [
+          {
+            "id": "tHEWGwIMsJk"
+          }
+        ],
+        "username": "admin",
+        "passwordLastUpdated": "2016-03-12T06:18:41.403+0000",
+        "userInfo": {
+          "id": "enHApD3I6Ho"
+        },
+        "created": "2016-03-12T06:18:41.505+0000",
+        "lastLogin": "2016-03-12T06:18:41.401+0000",
+        "catDimensionConstraints": [ ],
+        "selfRegistered": false,
+        "user": {
+          "id": "enHApD3I6Ho"
+        },
+        "cogsDimensionConstraints": [ ]
+      },
+      "lastUpdated": "2016-03-12T06:20:18.336+0000",
+      "created": "2016-03-12T06:18:41.374+0000",
+      "teiSearchOrganisationUnits": [ ],
+      "id": "enHApD3I6Ho",
+      "attributeValues": [ ]
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13675

There are two fixes in this PR
1) ` User.populateUserCredentialsDtoFields` is not added to `UserObjectBundleHook`. It's only added to `MeController` and `UserController`. This is a part of the code for supporting legacy `UserCredentials`.
2) When import `User` with legacy format, the `uid` provided in the payload is changed to a new `uid`. This is caused by some utils method in `User` class which try to copy `UserCredentials` to new format but `uid` is not copied.

Added a new test for legacy format.


