### PR TITLE
fix: Show attributes in csv response [DHIS2-13621] [2.37]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/serializers/CsvNodeSerializer.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/node/serializers/CsvNodeSerializer.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.node.serializers;
 
 import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
@@ -81,18 +82,20 @@ public class CsvNodeSerializer extends AbstractNodeSerializer
         // build schema
         for ( Node child : rootNode.getChildren() )
         {
-            if ( child.isCollection() )
+            if ( child.isCollection() && !child.getChildren().isEmpty() )
             {
-                if ( !child.getChildren().isEmpty() )
-                {
-                    Node node = child.getChildren().get( 0 );
+                Node node = child.getChildren().get( 0 );
 
-                    for ( Node property : node.getChildren() )
+                for ( Node property : node.getChildren() )
+                {
+                    if ( property.isSimple() )
                     {
-                        if ( property.isSimple() )
-                        {
-                            schemaBuilder.addColumn( property.getName() );
-                        }
+                        schemaBuilder.addColumn( property.getName() );
+                    }
+                    if ( property.getName().equals( "attributes" ) )
+                    {
+                        property.getChildren().stream().findFirst()
+                            .ifPresent( fc -> fc.getChildren().forEach( p -> schemaBuilder.addColumn( p.getName() ) ) );
                     }
                 }
             }
@@ -118,19 +121,66 @@ public class CsvNodeSerializer extends AbstractNodeSerializer
             {
                 for ( Node node : child.getChildren() )
                 {
-                    csvGenerator.writeStartObject();
-
-                    for ( Node property : node.getChildren() )
-                    {
-                        if ( property.isSimple() )
-                        {
-                            writeSimpleNode( (SimpleNode) property );
-                        }
-                    }
-
-                    csvGenerator.writeEndObject();
+                    writeNode( node );
                 }
             }
+        }
+    }
+
+    private void writeNode( Node node )
+        throws Exception
+    {
+        List<SimpleNode> simpleNodeList = new ArrayList<>();
+        boolean hasAttributes = false;
+
+        for ( Node property : node.getChildren() )
+        {
+            if ( property.isSimple() )
+            {
+                simpleNodeList.add( (SimpleNode) property );
+            }
+
+            if ( property.getName().equals( "attributes" ) )
+            {
+                hasAttributes = true;
+                writeComplexNode( property.getChildren(), simpleNodeList, csvGenerator );
+            }
+        }
+        writeSimpleNode( hasAttributes, simpleNodeList, csvGenerator );
+    }
+
+    private void writeComplexNode( List<Node> rootNodeList, List<SimpleNode> simpleNodeList, CsvGenerator csvGenerator )
+        throws Exception
+    {
+        for ( Node attributeRootNode : rootNodeList )
+        {
+            csvGenerator.writeStartObject();
+
+            for ( SimpleNode simplePropertyNode : simpleNodeList )
+            {
+                writeSimpleNode( simplePropertyNode );
+            }
+
+            for ( Node attribute : attributeRootNode.getChildren() )
+            {
+                writeSimpleNode( (SimpleNode) attribute );
+            }
+
+            csvGenerator.writeEndObject();
+        }
+    }
+
+    private void writeSimpleNode( boolean hasAttributes, List<SimpleNode> nodeList, CsvGenerator csvGenerator )
+        throws Exception
+    {
+        if ( !hasAttributes )
+        {
+            csvGenerator.writeStartObject();
+            for ( SimpleNode simplePropertyNode : nodeList )
+            {
+                writeSimpleNode( simplePropertyNode );
+            }
+            csvGenerator.writeEndObject();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/serializer/CsvNodeSerializerTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/serializer/CsvNodeSerializerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.node.serializer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.hisp.dhis.node.serializers.CsvNodeSerializer;
+import org.hisp.dhis.node.types.CollectionNode;
+import org.hisp.dhis.node.types.ComplexNode;
+import org.hisp.dhis.node.types.RootNode;
+import org.hisp.dhis.node.types.SimpleNode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+class CsvNodeSerializerTest
+{
+
+    private final CsvNodeSerializer csvNodeSerializer = new CsvNodeSerializer();
+
+    @Test
+    void CsvFileIsWrittenWhenOnlySimpleNodesAreProvided()
+        throws Exception
+    {
+        csvNodeSerializer.serialize( createCollectionWithSimpleNodes(), new FileOutputStream( "output.csv" ) );
+
+        List<List<String>> values = readTestFile();
+
+        assertEquals( 2, values.size() );
+        assertEquals( 3, values.get( 0 ).size() );
+        assertEquals( 3, values.get( 1 ).size() );
+        assertEquals( "\"First simple node\"", values.get( 0 ).get( 0 ) );
+        assertEquals( "\"Second value simple child\"", values.get( 1 ).get( 1 ) );
+        assertEquals( "\"Third simple node\"", values.get( 0 ).get( 2 ) );
+    }
+
+    @Test
+    void CsvFileIsWrittenWhenAttributesAreProvided()
+        throws Exception
+    {
+        csvNodeSerializer.serialize( createComplexCollection( "attributes", true ),
+            new FileOutputStream( "output.csv" ) );
+
+        List<List<String>> values = readTestFile();
+
+        assertEquals( 2, values.size() );
+        assertEquals( 6, values.get( 0 ).size() );
+        assertEquals( 6, values.get( 1 ).size() );
+        assertEquals( "\"First simple node\"", values.get( 0 ).get( 0 ) );
+        assertEquals( "\"Second attr\"", values.get( 0 ).get( 3 ) );
+        assertEquals( "\"Fourth attr\"", values.get( 0 ).get( 5 ) );
+        assertEquals( "\"First attr value\"", values.get( 1 ).get( 2 ) );
+        assertEquals( "\"Third attr value\"", values.get( 1 ).get( 4 ) );
+    }
+
+    @Test
+    void CsvFileIsWrittenWhenSimpleNodesAreProvidedButAttributeComplexNodeIsNot()
+        throws Exception
+    {
+        csvNodeSerializer.serialize( createComplexCollection( "enrollments", true ),
+            new FileOutputStream( "output.csv" ) );
+
+        List<List<String>> values = readTestFile();
+
+        assertEquals( 2, values.size() );
+        assertEquals( 2, values.get( 0 ).size() );
+        assertEquals( 2, values.get( 1 ).size() );
+        assertEquals( "\"First simple node\"", values.get( 0 ).get( 0 ) );
+        assertEquals( "\"Second value simple child\"", values.get( 1 ).get( 1 ) );
+    }
+
+    @Test
+    void CsvFileIsNotWrittenWhenNoSimpleNodesNorAttributeComplexNodeAreProvided()
+        throws Exception
+    {
+        Exception exception = assertThrows( Exception.class, () -> csvNodeSerializer
+            .serialize( createComplexCollection( "enrollments", false ), new FileOutputStream( "output.csv" ) ) );
+
+        String expectedMessage = "Schema specified that header line is to be written; but contains no column names";
+        String actualMessage = exception.getMessage();
+
+        assertTrue( actualMessage.contains( expectedMessage ) );
+    }
+
+    @AfterEach
+    public void cleanUp()
+    {
+        File f = new File( "output.csv" );
+        if ( !f.delete() )
+        {
+            log.warn( "Not possible to delete file {}", f.getName() );
+        }
+    }
+
+    private RootNode createCollectionWithSimpleNodes()
+    {
+        CollectionNode collectionRootNode = new CollectionNode( "Complex node" );
+        CollectionNode firstCollectionNode = new CollectionNode( "First collection child" );
+        CollectionNode secondCollectionNode = new CollectionNode( "Second collection child" );
+
+        SimpleNode firstSimpleNode = new SimpleNode( "First simple node", "First value simple child" );
+        SimpleNode secondSimpleNode = new SimpleNode( "Second simple node", "Second value simple child" );
+        SimpleNode thirdSimpleNode = new SimpleNode( "Third simple node", "Third value simple child" );
+
+        secondCollectionNode.addChild( firstSimpleNode );
+        secondCollectionNode.addChild( secondSimpleNode );
+        secondCollectionNode.addChild( thirdSimpleNode );
+        firstCollectionNode.addChild( secondCollectionNode );
+        collectionRootNode.addChild( firstCollectionNode );
+
+        return new RootNode( collectionRootNode );
+    }
+
+    private RootNode createComplexCollection( String complexNodeName, boolean includeSimpleNodes )
+    {
+        CollectionNode collectionRootNode = new CollectionNode( "Complex node" );
+        CollectionNode firstCollectionNode = new CollectionNode( "First collection child" );
+        CollectionNode secondCollectionNode = new CollectionNode( "Second collection child" );
+
+        ComplexNode attributesComplexNode = new ComplexNode( complexNodeName );
+        ComplexNode attributeNodeChild = new ComplexNode( "attribute child" );
+        attributeNodeChild.addChild( new SimpleNode( "First attr", "First attr value" ) );
+        attributeNodeChild.addChild( new SimpleNode( "Second attr", "Second attr value" ) );
+        attributeNodeChild.addChild( new SimpleNode( "Third attr", "Third attr value" ) );
+        attributeNodeChild.addChild( new SimpleNode( "Fourth attr", "Fourth attr value" ) );
+
+        attributesComplexNode.addChild( attributeNodeChild );
+
+        if ( includeSimpleNodes )
+        {
+            SimpleNode firstSimpleNode = new SimpleNode( "First simple node", "First value simple child" );
+            SimpleNode secondSimpleNode = new SimpleNode( "Second simple node", "Second value simple child" );
+            secondCollectionNode.addChild( firstSimpleNode );
+            secondCollectionNode.addChild( secondSimpleNode );
+        }
+
+        secondCollectionNode.addChild( attributesComplexNode );
+        firstCollectionNode.addChild( secondCollectionNode );
+        collectionRootNode.addChild( firstCollectionNode );
+
+        return new RootNode( collectionRootNode );
+    }
+
+    private List<List<String>> readTestFile()
+        throws IOException
+    {
+        List<List<String>> values = new ArrayList<>();
+        try ( BufferedReader br = new BufferedReader( new FileReader( "output.csv" ) ) )
+        {
+            String line;
+            while ( (line = br.readLine()) != null )
+            {
+                values.add( Arrays.asList( line.split( "," ) ) );
+            }
+        }
+
+        return values;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/serializer/CsvNodeSerializerTest.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/test/java/org/hisp/dhis/node/serializer/CsvNodeSerializerTest.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.node.serializer;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -44,6 +46,8 @@ import org.hisp.dhis.node.types.SimpleNode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.dataformat.csv.CsvMappingException;
+
 @Slf4j
 class CsvNodeSerializerTest
 {
@@ -54,7 +58,8 @@ class CsvNodeSerializerTest
     void CsvFileIsWrittenWhenOnlySimpleNodesAreProvided()
         throws Exception
     {
-        csvNodeSerializer.serialize( createCollectionWithSimpleNodes(), new FileOutputStream( "output.csv" ) );
+        csvNodeSerializer.serialize( createCollectionWithSimpleNodes(),
+            Files.newOutputStream( Paths.get( "output.csv" ) ) );
 
         List<List<String>> values = readTestFile();
 
@@ -71,7 +76,7 @@ class CsvNodeSerializerTest
         throws Exception
     {
         csvNodeSerializer.serialize( createComplexCollection( "attributes", true ),
-            new FileOutputStream( "output.csv" ) );
+            Files.newOutputStream( Paths.get( "output.csv" ) ) );
 
         List<List<String>> values = readTestFile();
 
@@ -90,7 +95,7 @@ class CsvNodeSerializerTest
         throws Exception
     {
         csvNodeSerializer.serialize( createComplexCollection( "enrollments", true ),
-            new FileOutputStream( "output.csv" ) );
+            Files.newOutputStream( Paths.get( "output.csv" ) ) );
 
         List<List<String>> values = readTestFile();
 
@@ -105,8 +110,9 @@ class CsvNodeSerializerTest
     void CsvFileIsNotWrittenWhenNoSimpleNodesNorAttributeComplexNodeAreProvided()
         throws Exception
     {
-        Exception exception = assertThrows( Exception.class, () -> csvNodeSerializer
-            .serialize( createComplexCollection( "enrollments", false ), new FileOutputStream( "output.csv" ) ) );
+        Exception exception = assertThrows( CsvMappingException.class, () -> csvNodeSerializer
+            .serialize( createComplexCollection( "enrollments", false ),
+                Files.newOutputStream( Paths.get( "output.csv" ) ) ) );
 
         String expectedMessage = "Schema specified that header line is to be written; but contains no column names";
         String actualMessage = exception.getMessage();


### PR DESCRIPTION
This PR aims to fix the issue of writing tracked entity attributes into a csv file.
The attributes were not written into the file because they are not simple properties, they are complex so they were not included.
The PR pushes the fix to include them from now on, plus some unit tests.