### PR TITLE
fix:Org unit group sets are considered filters in events/enrollments queries [2.39] [DHIS2-13638]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1144,11 +1144,18 @@ public class DataQueryParams
      * Returns a list of dimensions and filters of the given set of dimension
      * types.
      */
-    public List<DimensionalObject> getDimensionsAndFilters( Set<DimensionType> dimensionTypes )
+    public List<DimensionalObject> getDimensionsAndFilters( Set<DimensionType> dimensionTypes,
+        Set<DimensionType> filterTypes )
     {
-        return getDimensionsAndFilters().stream()
+        List<DimensionalObject> dimensionsAndFilters = getDimensions().stream()
             .filter( d -> dimensionTypes.contains( d.getDimensionType() ) )
             .collect( Collectors.toList() );
+
+        dimensionsAndFilters.addAll( getFilters().stream()
+            .filter( d -> filterTypes.contains( d.getDimensionType() ) )
+            .collect( Collectors.toList() ) );
+
+        return dimensionsAndFilters;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -90,6 +90,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.InQueryFilter;
+import org.hisp.dhis.common.PrimaryKeyObject;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryRuntimeException;
@@ -348,7 +349,17 @@ public abstract class AbstractJdbcEventAnalyticsManager
             {
                 String alias = getAlias( params, dimension.getDimensionType() );
 
-                columns.add( quote( alias, dimension.getDimensionName() ) );
+                String columnName = quote( alias, dimension.getDimensionName() );
+
+                columns.add( dimension.getDimensionType() == DimensionType.ORGANISATION_UNIT_GROUP_SET
+                    ? " case when " + columnName + " in ('" +
+                        dimension.getItems()
+                            .stream()
+                            .map( PrimaryKeyObject::getUid )
+                            .collect( joining( "','" ) )
+                        + "')" +
+                        " then " + columnName + " else null end as " + quote( dimension.getDimensionName() )
+                    : columnName );
             }
             else if ( params.hasSinglePeriod() )
             {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -265,6 +265,7 @@ public class JdbcEnrollmentAnalyticsManager
         // ---------------------------------------------------------------------
 
         List<DimensionalObject> dynamicDimensions = params.getDimensionsAndFilters(
+            Sets.newHashSet( DimensionType.CATEGORY ),
             Sets.newHashSet( DimensionType.ORGANISATION_UNIT_GROUP_SET, DimensionType.CATEGORY ) );
 
         for ( DimensionalObject dim : dynamicDimensions )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -473,6 +473,7 @@ public class JdbcEventAnalyticsManager
         // ---------------------------------------------------------------------
 
         List<DimensionalObject> dynamicDimensions = params.getDimensionsAndFilters(
+            Sets.newHashSet( DimensionType.CATEGORY, DimensionType.CATEGORY_OPTION_GROUP_SET ),
             Sets.newHashSet( DimensionType.ORGANISATION_UNIT_GROUP_SET, DimensionType.CATEGORY,
                 DimensionType.CATEGORY_OPTION_GROUP_SET ) );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/DataQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/DataQueryParamsTest.java
@@ -410,7 +410,8 @@ class DataQueryParamsTest extends DhisConvenienceTest
             .withPeriods( Lists.newArrayList( peA, peB ) ).withOrganisationUnits( Lists.newArrayList( ouA, ouB ) )
             .build();
         List<DimensionalObject> dimensions = params
-            .getDimensionsAndFilters( Sets.newHashSet( DimensionType.PERIOD, DimensionType.ORGANISATION_UNIT ) );
+            .getDimensionsAndFilters( Sets.newHashSet( DimensionType.PERIOD, DimensionType.ORGANISATION_UNIT ),
+                Sets.newHashSet( DimensionType.PERIOD, DimensionType.ORGANISATION_UNIT ) );
         assertEquals( 2, dimensions.size() );
         assertTrue( dimensions.contains( new BaseDimensionalObject( PERIOD_DIM_ID ) ) );
         assertTrue( dimensions.contains( new BaseDimensionalObject( ORGUNIT_DIM_ID ) ) );


### PR DESCRIPTION
please see https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/boards/104?modal=detail&selectedIssue=DHIS2-13638&quickFilter=497