### PR TITLE
feat: filter /tracker/events by enrollmentEnrolledAfter DHIS2-13648

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -141,6 +141,8 @@ public class EventSearchParams
 
     private Date dueDateEnd;
 
+    private Date enrollmentEnrolledAfter;
+
     private CategoryOptionCombo categoryOptionCombo;
 
     private IdSchemes idSchemes = new IdSchemes();
@@ -510,6 +512,17 @@ public class EventSearchParams
     public EventSearchParams setDueDateEnd( Date dueDateEnd )
     {
         this.dueDateEnd = dueDateEnd;
+        return this;
+    }
+
+    public Date getEnrollmentEnrolledAfter()
+    {
+        return enrollmentEnrolledAfter;
+    }
+
+    public EventSearchParams setEnrollmentEnrolledAfter( Date enrollmentEnrolledAfter )
+    {
+        this.enrollmentEnrolledAfter = enrollmentEnrolledAfter;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -202,6 +202,7 @@ public class JdbcEventStore implements EventStore
         .put( EVENT_PROGRAM_STAGE_ID, "ps_uid" )
         .put( EVENT_ENROLLMENT_ID, "pi_uid" )
         .put( "enrollmentStatus", "pi_status" )
+        .put( "enrolledAt", "pi_enrollmentdate" )
         .put( EVENT_ORG_UNIT_ID, "ou_uid" )
         .put( EVENT_ORG_UNIT_NAME, "ou_name" )
         .put( "trackedEntityInstance", "tei_uid" )
@@ -1015,7 +1016,8 @@ public class JdbcEventStore implements EventStore
             selectBuilder.append( "decoa.can_access AS decoa_can_access, cocount.option_size AS option_size, " );
         }
 
-        selectBuilder.append( "pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, " )
+        selectBuilder.append(
+            "pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, pi.enrollmentdate as pi_enrollmentdate, " )
             .append( "p.type as p_type, ps.uid as ps_uid, ou.name as ou_name, " )
             .append(
                 "tei.trackedentityinstanceid as tei_id, tei.uid as tei_uid, teiou.uid as tei_ou, teiou.name as tei_ou_name, tei.created as tei_created, tei.inactive as tei_inactive " );
@@ -1105,6 +1107,15 @@ public class JdbcEventStore implements EventStore
             fromBuilder.append( hlp.whereAnd() )
                 .append( " pi.status = " )
                 .append( ":program_status " );
+        }
+
+        if ( params.getEnrollmentEnrolledAfter() != null )
+        {
+            mapSqlParameterSource.addValue( "enrollmentEnrolledAfter", params.getEnrollmentEnrolledAfter(),
+                Types.TIMESTAMP );
+            fromBuilder
+                .append( hlp.whereAnd() )
+                .append( " (pi.enrollmentdate >= :enrollmentEnrolledAfter ) " );
         }
 
         if ( params.getFollowUp() != null )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -141,7 +141,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -157,7 +157,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
     }
 
     @Test
@@ -256,7 +256,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -280,7 +280,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -304,7 +304,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -327,7 +327,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -350,7 +350,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
     }
 
     @Test
@@ -375,7 +375,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @Test
@@ -426,7 +426,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -449,7 +449,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
     }
 
     @ParameterizedTest
@@ -472,7 +472,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( events ),
             () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJO" ), events ) );
+            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -243,7 +243,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramStage( programStage );
 
         DataElement dataElement = dataElement( "DATAEL00001" );
@@ -266,7 +266,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramStatus( ProgramStatus.ACTIVE );
         params.setProgramStage( programStage );
 
@@ -290,7 +290,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramType( ProgramType.WITH_REGISTRATION );
         params.setProgramStage( programStage );
 
@@ -313,7 +313,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramStage( programStage );
 
         DataElement dataElement = dataElement( "DATAEL00001" );
@@ -336,7 +336,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u", "TvctPPhpD8z" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ", "TvctPPhpD8z" ) );
         params.setProgramStage( programStage );
 
         DataElement datael00001 = dataElement( "DATAEL00001" );
@@ -358,7 +358,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramStage( programStage );
         params.setProgram( program );
 
@@ -413,7 +413,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramStage( programStage );
 
         DataElement dataElement = dataElement( "DATAEL00005" );
@@ -436,7 +436,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u", "TvctPPhpD8z" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ", "TvctPPhpD8z" ) );
         params.setProgramStage( programStage );
 
         DataElement dataElement = dataElement( "DATAEL00005" );
@@ -459,7 +459,7 @@ class EventExporterTest extends TrackerTest
     {
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
-        params.setProgramInstances( Set.of( "TvctPPhpD8u" ) );
+        params.setProgramInstances( Set.of( "nxP7UnKhomJ" ) );
         params.setProgramStage( programStage );
 
         DataElement dataElement = dataElement( "DATAEL00005" );
@@ -528,7 +528,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( enrollments ),
             () -> assertEquals( 2, enrollments.size() ),
-            () -> assertEquals( List.of( "TvctPPhpD8z", "TvctPPhpD8u" ), enrollments ) );
+            () -> assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments ) );
     }
 
     @Test
@@ -543,7 +543,7 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( enrollments ),
             () -> assertEquals( 2, enrollments.size() ),
-            () -> assertEquals( List.of( "TvctPPhpD8u", "TvctPPhpD8z" ), enrollments ) );
+            () -> assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments ) );
     }
 
     private DataElement dataElement( String uid )

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -85,7 +85,7 @@
         "identifier": "h4w96yEMlzO"
       },
       "orgUnitName": "Mbokie CHP",
-      "enrolledAt": "2021-03-28T12:05:00.000",
+      "enrolledAt": "2021-02-28T12:05:00.000",
       "occurredAt": "2021-03-28T12:05:00.000",
       "followUp": false,
       "deleted": false,

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -72,7 +72,7 @@
   ],
   "enrollments": [
     {
-      "enrollment": "TvctPPhpD8u",
+      "enrollment": "nxP7UnKhomJ",
       "createdAtClient": "2017-01-26T13:48:13.363",
       "trackedEntity": "IOR1AXXl24H",
       "program": {
@@ -130,7 +130,7 @@
         "idScheme": "UID",
         "identifier": "NpsdDv6kKSO"
       },
-      "enrollment": "TvctPPhpD8u",
+      "enrollment": "nxP7UnKhomJ",
       "orgUnit": {
         "idScheme": "UID",
         "identifier": "h4w96yEMlzO"

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -120,7 +120,7 @@
   ],
   "events": [
     {
-      "event": "D9PbzJY8bJO",
+      "event": "pTzf9KYMk72",
       "status": "COMPLETED",
       "program": {
         "idScheme": "UID",

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
@@ -81,7 +81,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class EventRequestToSearchParamsMapper
 {
-    public static final Stream<String> NON_EVENT_ORDER_PROPERTIES = Stream.of( "enrolledAt" );
 
     private final CurrentUserService currentUserService;
 
@@ -322,7 +321,8 @@ class EventRequestToSearchParamsMapper
             .map( Property::getName );
         // Other properties that we allow to order by that are not in the Event
         // schema have to be specified in JdbcEventStore.QUERY_PARAM_COL_MAP
-        Set<String> allowedProperties = Stream.concat( eventProperties, NON_EVENT_ORDER_PROPERTIES )
+        Stream<String> nonEventProperties = Stream.of( "enrolledAt" );
+        Set<String> allowedProperties = Stream.concat( eventProperties, nonEventProperties )
             .collect( Collectors.toSet() );
 
         requestProperties.removeAll( allowedProperties );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
 
@@ -62,7 +63,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramService;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStageService;
-import org.hisp.dhis.query.QueryUtils;
+import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
@@ -72,6 +73,7 @@ import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam.SortDirection;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.springframework.stereotype.Component;
 
@@ -79,6 +81,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 class EventRequestToSearchParamsMapper
 {
+    public static final Stream<String> NON_EVENT_ORDER_PROPERTIES = Stream.of( "enrolledAt" );
+
     private final CurrentUserService currentUserService;
 
     private final ProgramService programService;
@@ -233,6 +237,7 @@ class EventRequestToSearchParamsMapper
             .setLastUpdatedStartDate( eventCriteria.getUpdatedAfter() )
             .setLastUpdatedEndDate( eventCriteria.getUpdatedBefore() )
             .setLastUpdatedDuration( eventCriteria.getUpdatedWithin() )
+            .setEnrollmentEnrolledAfter( eventCriteria.getEnrollmentEnrolledAfter() )
             .setEventStatus( eventCriteria.getStatus() )
             .setCategoryOptionCombo( attributeOptionCombo ).setIdSchemes( eventCriteria.getIdSchemes() )
             .setPage( eventCriteria.getPage() )
@@ -300,11 +305,33 @@ class EventRequestToSearchParamsMapper
 
     private List<OrderParam> getOrderParams( List<OrderCriteria> order )
     {
-        if ( order != null && !order.isEmpty() )
+        if ( order == null || order.isEmpty() )
         {
-            return QueryUtils.filteredBySchema( order, schema );
+            return Collections.emptyList();
         }
-        return Collections.emptyList();
+        validateOrderParams( order );
+
+        return OrderParamsHelper.toOrderParams( order );
+    }
+
+    private void validateOrderParams( List<OrderCriteria> order )
+    {
+        Set<String> requestProperties = order.stream().map( OrderCriteria::getField ).collect( Collectors.toSet() );
+
+        Stream<String> eventProperties = schema.getProperties().stream().filter( Property::isSimple )
+            .map( Property::getName );
+        // Other properties that we allow to order by that are not in the Event
+        // schema have to be specified in JdbcEventStore.QUERY_PARAM_COL_MAP
+        Set<String> allowedProperties = Stream.concat( eventProperties, NON_EVENT_ORDER_PROPERTIES )
+            .collect( Collectors.toSet() );
+
+        requestProperties.removeAll( allowedProperties );
+        if ( !requestProperties.isEmpty() )
+        {
+            throw new IllegalQueryException(
+                String.format( "Order by property `%s` is not supported. Supported are `%s`",
+                    String.join( ", ", requestProperties ), String.join( ", ", allowedProperties ) ) );
+        }
     }
 
     private List<OrderParam> getGridOrderParams( List<OrderCriteria> order,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -91,6 +91,8 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
 
     private String updatedWithin;
 
+    private Date enrollmentEnrolledAfter;
+
     private EventStatus status;
 
     private String attributeCc;


### PR DESCRIPTION
/tracker/events
* filter by `enrollmentEnrolledAfter`
* order by `order=enrolledAt:desc` or `order=enrolledAt:asc`

Added validation to `order` request parameter. Previously, we were simply removing a property that we cannot order by so `/tracker/events?order=foo:desc` would turn into `/tracker/events` without the user being made aware of this. Now we fail and list the properties that are order able by.

For example requesting `/tracker/events?order=foo:desc` leads to

```
{
  "httpStatus": "Conflict",
  "httpStatusCode": 409,
  "status": "ERROR",
  "message": "Order by property `foo` is not supported. Supported are `storedBy, attributeCategoryOptions, dueDate, assignedUserUsername, createdAtClient, program, lastUpdated, href, event, assignedUser, programStage, programType, created, orgUnit, completedDate, enrollment, trackedEntityInstance, followup, deleted, enrollmentStatus, attributeOptionCombo, assignedUserDisplayName, completedBy, status, orgUnitName, eventDate, lastUpdatedAtClient, enrolledAt`"
}
```

## Other small improvement

Generate new UIDs for enrollments, events in the test fixture JSON. We often just change one character which makes it harder to read error messages as most of the UIDs are the same.

