### PR TITLE
chore: split old/new tracker GET events param processing

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -114,7 +114,6 @@ import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
-import org.hisp.dhis.webapi.controller.event.mapper.RequestToSearchParamsMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.EventCriteria;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -182,7 +181,7 @@ public class EventController
 
     private final SchemaService schemaService;
 
-    private final RequestToSearchParamsMapper requestToSearchParamsMapper;
+    private final EventRequestToSearchParamsMapper requestToSearchParamsMapper;
 
     private final ContextUtils contextUtils;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.event;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
+import lombok.RequiredArgsConstructor;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.AssignedUserSelectionMode;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdSchemes;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.OrganisationUnitSelectionMode;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.commons.collection.CollectionUtils;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dxf2.events.event.Event;
+import org.hisp.dhis.dxf2.events.event.EventSearchParams;
+import org.hisp.dhis.dxf2.util.InputUtils;
+import org.hisp.dhis.event.EventStatus;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageService;
+import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.query.QueryUtils;
+import org.hisp.dhis.schema.Schema;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam.SortDirection;
+import org.hisp.dhis.webapi.controller.event.webrequest.EventCriteria;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Luciano Fiandesio
+ */
+@Component( "org.hisp.dhis.webapi.controller.event.EventRequestToSearchParamsMapper" )
+@RequiredArgsConstructor
+class EventRequestToSearchParamsMapper
+{
+    private final CurrentUserService currentUserService;
+
+    private final ProgramService programService;
+
+    private final OrganisationUnitService organisationUnitService;
+
+    private final ProgramStageService programStageService;
+
+    private final AclService aclService;
+
+    private final TrackedEntityInstanceService entityInstanceService;
+
+    private final DataElementService dataElementService;
+
+    private final InputUtils inputUtils;
+
+    private final SchemaService schemaService;
+
+    private Schema schema;
+
+    @PostConstruct
+    void setSchema()
+    {
+        if ( schema == null )
+        {
+            schema = schemaService.getDynamicSchema( Event.class );
+        }
+    }
+
+    public EventSearchParams map( String program, String programStage, ProgramStatus programStatus, Boolean followUp,
+        String orgUnit, OrganisationUnitSelectionMode orgUnitSelectionMode, String trackedEntityInstance,
+        Date startDate, Date endDate, Date dueDateStart, Date dueDateEnd, Date lastUpdatedStartDate,
+        Date lastUpdatedEndDate, String lastUpdatedDuration, EventStatus status,
+        CategoryOptionCombo attributeOptionCombo, IdSchemes idSchemes, Integer page, Integer pageSize,
+        boolean totalPages, boolean skipPaging, List<OrderParam> orders, List<OrderParam> gridOrders,
+        boolean includeAttributes,
+        Set<String> events, Boolean skipEventId, AssignedUserSelectionMode assignedUserSelectionMode,
+        Set<String> assignedUsers, Set<String> filters, Set<String> dataElements, boolean includeAllDataElements,
+        boolean includeDeleted )
+    {
+        return map( program, programStage, programStatus, followUp, orgUnit, orgUnitSelectionMode,
+            trackedEntityInstance, startDate, endDate, dueDateStart, dueDateEnd, lastUpdatedStartDate,
+            lastUpdatedEndDate, lastUpdatedDuration, status, attributeOptionCombo, idSchemes, page, pageSize,
+            totalPages, skipPaging, orders, gridOrders, includeAttributes, events, null, skipEventId,
+            assignedUserSelectionMode, assignedUsers, filters, dataElements, includeAllDataElements, includeDeleted );
+    }
+
+    public EventSearchParams map( String program, String programStage, ProgramStatus programStatus, Boolean followUp,
+        String orgUnit, OrganisationUnitSelectionMode orgUnitSelectionMode, String trackedEntityInstance,
+        Date startDate, Date endDate, Date dueDateStart, Date dueDateEnd, Date lastUpdatedStartDate,
+        Date lastUpdatedEndDate, String lastUpdatedDuration, EventStatus status,
+        CategoryOptionCombo attributeOptionCombo, IdSchemes idSchemes, Integer page, Integer pageSize,
+        boolean totalPages, boolean skipPaging, List<OrderParam> orders, List<OrderParam> gridOrders,
+        boolean includeAttributes,
+        Set<String> events, Set<String> programInstances, Boolean skipEventId,
+        AssignedUserSelectionMode assignedUserSelectionMode,
+        Set<String> assignedUsers, Set<String> filters, Set<String> dataElements, boolean includeAllDataElements,
+        boolean includeDeleted )
+    {
+        User user = currentUserService.getCurrentUser();
+
+        EventSearchParams params = new EventSearchParams();
+
+        Program pr = programService.getProgram( program );
+
+        if ( !StringUtils.isEmpty( program ) && pr == null )
+        {
+            throw new IllegalQueryException( "Program is specified but does not exist: " + program );
+        }
+
+        ProgramStage ps = programStageService.getProgramStage( programStage );
+
+        if ( !StringUtils.isEmpty( programStage ) && ps == null )
+        {
+            throw new IllegalQueryException( "Program stage is specified but does not exist: " + programStage );
+        }
+
+        OrganisationUnit ou = organisationUnitService.getOrganisationUnit( orgUnit );
+
+        if ( !StringUtils.isEmpty( orgUnit ) && ou == null )
+        {
+            throw new IllegalQueryException( "Org unit is specified but does not exist: " + orgUnit );
+        }
+
+        if ( pr != null && !user.isSuper() && !aclService.canDataRead( user, pr ) )
+        {
+            throw new IllegalQueryException( "User has no access to program: " + pr.getUid() );
+        }
+
+        if ( ps != null && !user.isSuper() && !aclService.canDataRead( user, ps ) )
+        {
+            throw new IllegalQueryException( "User has no access to program stage: " + ps.getUid() );
+        }
+
+        TrackedEntityInstance tei = entityInstanceService.getTrackedEntityInstance( trackedEntityInstance );
+
+        if ( !StringUtils.isEmpty( trackedEntityInstance ) && tei == null )
+        {
+            throw new IllegalQueryException(
+                "Tracked entity instance is specified but does not exist: " + trackedEntityInstance );
+        }
+
+        if ( attributeOptionCombo != null && !user.isSuper()
+            && !aclService.canDataRead( user, attributeOptionCombo ) )
+        {
+            throw new IllegalQueryException(
+                "User has no access to attribute category option combo: " + attributeOptionCombo.getUid() );
+        }
+
+        if ( !CollectionUtils.isEmpty( events ) && !CollectionUtils.isEmpty( filters ) )
+        {
+            throw new IllegalQueryException( "Event UIDs and filters can not be specified at the same time" );
+        }
+
+        if ( events == null )
+        {
+            events = new HashSet<>();
+        }
+
+        if ( filters != null )
+        {
+            if ( !StringUtils.isEmpty( programStage ) && ps == null )
+            {
+                throw new IllegalQueryException( "ProgramStage needs to be specified for event filtering to work" );
+            }
+
+            for ( String filter : filters )
+            {
+                QueryItem item = getQueryItem( filter );
+                params.getFilters().add( item );
+            }
+        }
+
+        if ( dataElements != null )
+        {
+            for ( String de : dataElements )
+            {
+                QueryItem dataElement = getQueryItem( de );
+
+                params.getDataElements().add( dataElement );
+            }
+        }
+
+        if ( assignedUserSelectionMode != null && assignedUsers != null && !assignedUsers.isEmpty()
+            && !assignedUserSelectionMode.equals( AssignedUserSelectionMode.PROVIDED ) )
+        {
+            throw new IllegalQueryException(
+                "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
+        }
+
+        if ( assignedUsers != null )
+        {
+            assignedUsers = assignedUsers.stream()
+                .filter( CodeGenerator::isValidUid )
+                .collect( Collectors.toSet() );
+        }
+
+        if ( programInstances != null )
+        {
+            programInstances = programInstances.stream()
+                .filter( CodeGenerator::isValidUid )
+                .collect( Collectors.toSet() );
+        }
+
+        return params.setProgram( pr ).setProgramStage( ps ).setOrgUnit( ou ).setTrackedEntityInstance( tei )
+            .setProgramStatus( programStatus ).setFollowUp( followUp ).setOrgUnitSelectionMode( orgUnitSelectionMode )
+            .setAssignedUserSelectionMode( assignedUserSelectionMode ).setAssignedUsers( assignedUsers )
+            .setStartDate( startDate ).setEndDate( endDate ).setDueDateStart( dueDateStart ).setDueDateEnd( dueDateEnd )
+            .setLastUpdatedStartDate( lastUpdatedStartDate ).setLastUpdatedEndDate( lastUpdatedEndDate )
+            .setLastUpdatedDuration( lastUpdatedDuration ).setEventStatus( status )
+            .setCategoryOptionCombo( attributeOptionCombo ).setIdSchemes( idSchemes ).setPage( page )
+            .setPageSize( pageSize ).setTotalPages( totalPages ).setSkipPaging( skipPaging )
+            .setSkipEventId( skipEventId ).setIncludeAttributes( includeAttributes )
+            .setIncludeAllDataElements( includeAllDataElements ).setOrders( orders ).setGridOrders( gridOrders )
+            .setEvents( events ).setProgramInstances( programInstances ).setIncludeDeleted( includeDeleted );
+    }
+
+    private QueryItem getQueryItem( String item )
+    {
+        String[] split = item.split( DimensionalObject.DIMENSION_NAME_SEP );
+
+        if ( split == null || split.length % 2 != 1 )
+        {
+            throw new IllegalQueryException( "Query item or filter is invalid: " + item );
+        }
+
+        QueryItem queryItem = getItem( split[0] );
+
+        if ( split.length > 1 )
+        {
+            for ( int i = 1; i < split.length; i += 2 )
+            {
+                QueryOperator operator = QueryOperator.fromString( split[i] );
+                queryItem.getFilters().add( new QueryFilter( operator, split[i + 1] ) );
+            }
+        }
+
+        return queryItem;
+    }
+
+    private QueryItem getItem( String item )
+    {
+        DataElement de = dataElementService.getDataElement( item );
+
+        if ( de == null )
+        {
+            throw new IllegalQueryException( "Dataelement does not exist: " + item );
+        }
+
+        return new QueryItem( de, null, de.getValueType(), de.getAggregationType(), de.getOptionSet() );
+    }
+
+    public EventSearchParams map( EventCriteria eventCriteria )
+    {
+
+        CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo(
+            eventCriteria.getAttributeCc(),
+            eventCriteria.getAttributeCos(),
+            true );
+
+        Set<String> eventIds = eventCriteria.getEvents();
+        Set<String> assignedUserIds = eventCriteria.getAssignedUsers();
+        Map<String, SortDirection> dataElementOrders = getDataElementsFromOrder( eventCriteria.getOrder() );
+
+        return map( eventCriteria.getProgram(),
+            eventCriteria.getProgramStage(),
+            eventCriteria.getProgramStatus(),
+            eventCriteria.getFollowUp(),
+            eventCriteria.getOrgUnit(),
+            eventCriteria.getOuMode(),
+            eventCriteria.getTrackedEntityInstance(),
+            eventCriteria.getStartDate(),
+            eventCriteria.getEndDate(),
+            eventCriteria.getDueDateStart(),
+            eventCriteria.getDueDateEnd(),
+            eventCriteria.getLastUpdatedStartDate() != null ? eventCriteria.getLastUpdatedStartDate()
+                : eventCriteria.getLastUpdated(),
+            eventCriteria.getLastUpdatedEndDate(),
+            eventCriteria.getLastUpdatedDuration(),
+            eventCriteria.getStatus(),
+            attributeOptionCombo,
+            eventCriteria.getIdSchemes(),
+            eventCriteria.getPage(),
+            eventCriteria.getPageSize(),
+            eventCriteria.isTotalPages(),
+            eventCriteria.isSkipPaging(),
+            getOrderParams( eventCriteria.getOrder() ),
+            getGridOrderParams( eventCriteria.getOrder(), dataElementOrders ),
+            false,
+            eventIds,
+            eventCriteria.getProgramInstances(),
+            eventCriteria.getSkipEventId(),
+            eventCriteria.getAssignedUserMode(),
+            assignedUserIds,
+            eventCriteria.getFilter(),
+            dataElementOrders.keySet(),
+            false,
+            eventCriteria.isIncludeDeleted() );
+    }
+
+    private List<OrderParam> getOrderParams( List<OrderCriteria> order )
+    {
+        if ( order != null && !order.isEmpty() )
+        {
+            return QueryUtils.filteredBySchema( order, schema );
+        }
+        return Collections.emptyList();
+    }
+
+    private List<OrderParam> getGridOrderParams( List<OrderCriteria> order,
+        Map<String, SortDirection> dataElementOrders )
+    {
+        return Optional.ofNullable( order )
+            .orElse( Collections.emptyList() )
+            .stream()
+            .filter( Objects::nonNull )
+            .filter( orderCriteria -> dataElementOrders.containsKey( orderCriteria.getField() ) )
+            .map( orderCriteria -> OrderParam.builder()
+                .field( orderCriteria.getField() )
+                .direction( dataElementOrders.get( orderCriteria.getField() ) )
+                .build() )
+            .collect( Collectors.toList() );
+    }
+
+    private Map<String, SortDirection> getDataElementsFromOrder( List<OrderCriteria> allOrders )
+    {
+        Map<String, SortDirection> dataElements = new HashMap<>();
+
+        if ( allOrders != null )
+        {
+            for ( OrderCriteria orderCriteria : allOrders )
+            {
+                DataElement de = dataElementService.getDataElement( orderCriteria.getField() );
+                if ( de != null )
+                {
+                    dataElements.put( orderCriteria.getField(), orderCriteria.getDirection() );
+                }
+            }
+        }
+        return dataElements;
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -56,7 +56,6 @@ import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.node.Preset;
 import org.hisp.dhis.program.ProgramStageInstanceService;
-import org.hisp.dhis.webapi.controller.event.mapper.RequestToSearchParamsMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerEventCriteria;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
@@ -95,7 +94,7 @@ public class TrackerEventsExportController
     private final ContextService contextService;
 
     @NonNull
-    private final RequestToSearchParamsMapper requestToSearchParamsMapper;
+    private final EventRequestToSearchParamsMapper requestToSearchParams;
 
     @NonNull
     private final ProgramStageInstanceService programStageInstanceService;
@@ -113,7 +112,7 @@ public class TrackerEventsExportController
         throws WebMessageException
     {
 
-        EventSearchParams eventSearchParams = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams eventSearchParams = requestToSearchParams.map( eventCriteria );
 
         if ( areAllEnrollmentsInvalid( eventCriteria, eventSearchParams ) )
         {
@@ -156,7 +155,7 @@ public class TrackerEventsExportController
             fields.addAll( Preset.ALL.getFields() );
         }
 
-        EventSearchParams eventSearchParams = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams eventSearchParams = requestToSearchParams.map( eventCriteria );
 
         if ( areAllEnrollmentsInvalid( eventCriteria, eventSearchParams ) )
         {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapperTest.java
@@ -53,7 +53,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.webapi.controller.event.mapper.RequestToSearchParamsMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +67,7 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-class EventRequestToParamsMapperTest
+class EventRequestToSearchParamsMapperTest
 {
 
     @Mock
@@ -98,12 +97,12 @@ class EventRequestToParamsMapperTest
     @Mock
     private SchemaService schemaService;
 
-    private RequestToSearchParamsMapper requestToSearchParamsMapper;
+    private EventRequestToSearchParamsMapper requestToSearchParamsMapper;
 
     @BeforeEach
     public void setUp()
     {
-        requestToSearchParamsMapper = new RequestToSearchParamsMapper( currentUserService, programService,
+        requestToSearchParamsMapper = new EventRequestToSearchParamsMapper( currentUserService, programService,
             organisationUnitService, programStageService, aclService, entityInstanceService, dataElementService,
             inputUtils, schemaService );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataelement.DataElementService;
+import org.hisp.dhis.dxf2.events.event.EventSearchParams;
+import org.hisp.dhis.dxf2.util.InputUtils;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageService;
+import org.hisp.dhis.schema.SchemaService;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerEventCriteria;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings( strictness = Strictness.LENIENT )
+@ExtendWith( MockitoExtension.class )
+class EventRequestToSearchParamsMapperTest
+{
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private ProgramService programService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @Mock
+    private ProgramStageService programStageService;
+
+    @Mock
+    private AclService aclService;
+
+    @Mock
+    private TrackedEntityInstanceService entityInstanceService;
+
+    @Mock
+    private DataElementService dataElementService;
+
+    @Mock
+    private InputUtils inputUtils;
+
+    @Mock
+    private SchemaService schemaService;
+
+    private EventRequestToSearchParamsMapper requestToSearchParamsMapper;
+
+    private Program program;
+
+    private ProgramStage programStage;
+
+    @BeforeEach
+    public void setUp()
+    {
+        requestToSearchParamsMapper = new EventRequestToSearchParamsMapper( currentUserService, programService,
+            organisationUnitService, programStageService, aclService, entityInstanceService, dataElementService,
+            inputUtils, schemaService );
+
+        User user = new User();
+        when( currentUserService.getCurrentUser() ).thenReturn( user );
+
+        program = new Program();
+        program.setUid( "programuid" );
+        when( programService.getProgram( "programuid" ) ).thenReturn( program );
+        when( aclService.canDataRead( user, program ) ).thenReturn( true );
+
+        programStage = new ProgramStage();
+        programStage.setUid( "programstageuid" );
+        when( programStageService.getProgramStage( "programstageuid" ) ).thenReturn( programStage );
+        when( aclService.canDataRead( user, programStage ) ).thenReturn( true );
+
+        OrganisationUnit ou = new OrganisationUnit();
+        TrackedEntityInstance tei = new TrackedEntityInstance();
+        DataElement de = new DataElement();
+
+        when( organisationUnitService.getOrganisationUnit( any() ) ).thenReturn( ou );
+
+        when( organisationUnitService.isInUserHierarchy( ou ) ).thenReturn( true );
+        when( entityInstanceService.getTrackedEntityInstance( any() ) ).thenReturn( tei );
+        when( dataElementService.getDataElement( any() ) ).thenReturn( de );
+    }
+
+    @Test
+    void testEventRequestToSearchParamsMapperSuccess()
+    {
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setProgram( "programuid" );
+        eventCriteria.setProgramStage( "programstageuid" );
+
+        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+
+        assertEquals( program, params.getProgram() );
+        assertEquals( programStage, params.getProgramStage() );
+    }
+
+    @Test
+    void testMutualExclusionOfEventsAndFilter()
+    {
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setFilter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) );
+        eventCriteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+        assertEquals( "Event UIDs and filters can not be specified at the same time", exception.getMessage() );
+    }
+}


### PR DESCRIPTION
so we can evolve /tracker/events without affecting the old tracker event
endpoint

* duplicated RequestToSearchParamsMapper and its test into EventRequestToSearchParamMapper (for old and new tracker)
* removed unused code in each now that they are only responsible for old/new tracker