### PR TITLE
fix: NPE in OptionObjectBundleHook.preUpdate

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.IdScheme;
@@ -120,6 +121,16 @@ public class OptionSet
     public void removeAllOptions()
     {
         options.clear();
+    }
+
+    public void removeOption( Option option )
+    {
+        if ( options == null || CollectionUtils.isEmpty( options ) )
+        {
+            return;
+        }
+
+        options.remove( option );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/option/OptionSet.java
@@ -125,12 +125,10 @@ public class OptionSet
 
     public void removeOption( Option option )
     {
-        if ( options == null || CollectionUtils.isEmpty( options ) )
+        if ( !CollectionUtils.isEmpty( options ) )
         {
-            return;
+            options.remove( option );
         }
-
-        options.remove( option );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/OptionObjectBundleHook.java
@@ -92,7 +92,7 @@ public class OptionObjectBundleHook extends AbstractObjectBundleHook<Option>
             // Remove the existed option from OptionSet, will add the updating
             // one
             // in postUpdate()
-            optionSet.getOptions().remove( persistedObject );
+            optionSet.removeOption( persistedObject );
         }
     }
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13640
- According to the bug reported, user got NPE when trying to add `Option` to an `OptionSet`.
- I couldn't reproduce it but the issue can be fixed in backend with a `null` check.