### PR TITLE
fix: Use inheritance instead of partitions in analytics export [DHIS2-13429] [2.38]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.table;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.TEXT;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.createIndexStatement;
@@ -107,6 +108,8 @@ public abstract class AbstractJdbcTableManager
 
     protected static final Set<ValueType> NO_INDEX_VAL_TYPES = ImmutableSet.of( ValueType.TEXT, ValueType.LONG_TEXT );
 
+    private static final String WITH_AUTOVACUUM_ENABLED_FALSE = "with(autovacuum_enabled = false)";
+
     protected static final String PREFIX_ORGUNITLEVEL = "uidlevel";
 
     protected final IdentifiableObjectManager idObjectManager;
@@ -181,24 +184,31 @@ public abstract class AbstractJdbcTableManager
     {
     }
 
+    /**
+     * Removes data which was updated or deleted between the last successful
+     * analytics table update and the start of this analytics table update
+     * process, excluding data which was created during that time span.
+     *
+     * Override in order to remove updated and deleted data for "latest"
+     * partition update.
+     */
     @Override
-    public void createTable( AnalyticsTable table )
+    public void removeUpdatedData( List<AnalyticsTable> tables )
     {
-        if ( tableTypeIsPartitioned() )
-        {
-            createPartitionTableWithPartitions( table );
-        }
-        else
-        {
-            createNonPartitionedAnalyticsTable( table );
-        }
     }
 
     @Override
-    public void createIndex( final AnalyticsIndex index )
+    public void createTable( AnalyticsTable table )
     {
-        final String indexName = getIndexName( index, getAnalyticsTableType() );
-        final String sql = createIndexStatement( index, getAnalyticsTableType() );
+        createTempTable( table );
+        createTempTablePartitions( table );
+    }
+
+    @Override
+    public void createIndex( AnalyticsIndex index )
+    {
+        String indexName = getIndexName( index, getAnalyticsTableType() );
+        String sql = createIndexStatement( index, getAnalyticsTableType() );
 
         log.debug( "Create index: '{}' with SQL: '{}'", indexName, sql );
 
@@ -210,13 +220,24 @@ public abstract class AbstractJdbcTableManager
     @Override
     public void swapTable( AnalyticsTableUpdateParams params, AnalyticsTable table )
     {
-        log.info( "Swapping master table {}, and its partitions", table.getTableName() );
+        boolean tableExists = partitionManager.tableExists( table.getTableName() );
+        boolean skipMasterTable = params.isPartialUpdate() && tableExists
+            && table.getTableType().hasLatestPartition();
 
-        swapTable( table );
+        log.info( "Swapping table, master table exists: '{}', skip master table: '{}'", tableExists,
+            skipMasterTable );
 
-        if ( getPartitionColumn() != null )
+        table.getTablePartitions().stream().forEach( p -> swapTable( p.getTempTableName(), p.getTableName() ) );
+
+        if ( !skipMasterTable )
         {
-            table.getTablePartitions().forEach( p -> swapTable( table, p ) );
+            swapTable( table.getTempTableName(), table.getTableName() );
+        }
+        else
+        {
+            table.getTablePartitions().stream()
+                .forEach( p -> swapInheritance( p.getTableName(), table.getTempTableName(), table.getTableName() ) );
+            dropTempTable( table );
         }
     }
 
@@ -281,12 +302,6 @@ public abstract class AbstractJdbcTableManager
     protected abstract List<String> getPartitionChecks( AnalyticsTablePartition partition );
 
     /**
-     * Returns the partition column name for the analytics table type, or null
-     * if the table type is not partitioned.
-     */
-    protected abstract String getPartitionColumn();
-
-    /**
      * Populates the given analytics table.
      *
      * @param params the {@link AnalyticsTableUpdateParams}.
@@ -323,7 +338,7 @@ public abstract class AbstractJdbcTableManager
      */
     protected boolean hasRows( String tableName )
     {
-        final String sql = "select * from " + tableName + " limit 1";
+        String sql = "select * from " + tableName + " limit 1";
 
         try
         {
@@ -358,41 +373,71 @@ public abstract class AbstractJdbcTableManager
      *
      * @param table the {@link AnalyticsTable}.
      */
-    private void createPartitionTableWithPartitions( AnalyticsTable table )
+    protected void createTempTable( AnalyticsTable table )
     {
-        createAnalyticsTable( table );
-        table.getTablePartitions().forEach( p -> createAnalyticsTable( table, p ) );
+        validateDimensionColumns( table.getDimensionColumns() );
+
+        String tableName = table.getTempTableName();
+
+        StringBuilder sqlCreate = new StringBuilder( "create table " + tableName + " (" );
+
+        for ( AnalyticsTableColumn col : ListUtils.union( table.getDimensionColumns(), table.getValueColumns() ) )
+        {
+            String notNull = col.getNotNull().isNotNull() ? " not null" : "";
+
+            sqlCreate.append( col.getName() )
+                .append( SPACE )
+                .append( col.getDataType().getValue() )
+                .append( notNull )
+                .append( "," );
+        }
+
+        TextUtils.removeLastComma( sqlCreate ).append( ") " ).append( getTableOptions() );
+
+        log.info( "Creating table: '{}', columns: '{}'", tableName, table.getDimensionColumns().size() );
+
+        log.debug( "Create SQL: {}", sqlCreate );
+
+        jdbcTemplate.execute( sqlCreate.toString() );
     }
 
-    private void createNonPartitionedAnalyticsTable( AnalyticsTable table )
+    /**
+     * Drops and creates the table partitions for the given analytics table.
+     *
+     * @param table the {@link AnalyticsTable}.
+     */
+    protected void createTempTablePartitions( AnalyticsTable table )
     {
-        final String tableName = table.getTableName();
-        final String tempTableName = table.getTempTableName();
-        final String createTableSql = "create table if not exists ";
+        for ( AnalyticsTablePartition partition : table.getTablePartitions() )
+        {
+            String tableName = partition.getTempTableName();
+            List<String> checks = getPartitionChecks( partition );
 
-        String sqlCreate = createTableSql + tableName + " (";
-        String sqlCreateTemp = createTableSql + tempTableName + " (";
+            String sqlCreate = "create table " + tableName + " (";
 
-        String columns = ListUtils.union( table.getDimensionColumns(), table.getValueColumns() )
-            .stream()
-            .map( col -> {
-                String notNull = col.getNotNull().isNotNull() ? " not null" : "";
-                return col.getName() + " " + col.getDataType().getValue() + notNull;
-            } )
-            .collect( Collectors.joining( "," ) ) + ")";
+            if ( !checks.isEmpty() )
+            {
+                StringBuilder sqlCheck = new StringBuilder();
+                checks.stream().forEach( check -> sqlCheck.append( "check (" + check + "), " ) );
+                sqlCreate += TextUtils.removeLastComma( sqlCheck.toString() );
+            }
 
-        sqlCreate = sqlCreate + columns;
-        sqlCreateTemp = sqlCreateTemp + columns;
+            sqlCreate += ") inherits (" + table.getTempTableName() + ") " + getTableOptions();
 
-        log.debug( "Creating non partitioned analytic table: '{}'", tableName );
+            log.info( "Creating partition table: '{}'", tableName );
 
-        log.debug( "Create SQL: '{}'", sqlCreate );
+            log.debug( "Create SQL: {}", sqlCreate );
 
-        jdbcTemplate.execute( sqlCreate );
+            jdbcTemplate.execute( sqlCreate );
+        }
+    }
 
-        log.debug( "CreateTemp SQL: '{}'", sqlCreateTemp );
-
-        jdbcTemplate.execute( sqlCreateTemp );
+    /**
+     * Returns a table options SQL statement.
+     */
+    private String getTableOptions()
+    {
+        return WITH_AUTOVACUUM_ENABLED_FALSE;
     }
 
     /**
@@ -491,8 +536,8 @@ public abstract class AbstractJdbcTableManager
 
     /**
      * Filters out analytics table columns which were created after the time of
-     * the last successful resource table update. This so that the the create
-     * table query does not refer to columns not present in resource tables.
+     * the last successful resource table update. This so that the create table
+     * query does not refer to columns not present in resource tables.
      *
      * @param columns the analytics table columns.
      * @return a list of {@link AnalyticsTableColumn}.
@@ -587,21 +632,14 @@ public abstract class AbstractJdbcTableManager
      * Swaps a database table, meaning drops the real table and renames the
      * temporary table to become the real table.
      *
-     * @param mainTable the partition table.
-     * @param tablePartition the partition.
+     * @param tempTableName the temporary table name.
+     * @param realTableName the real table name.
      */
-    private void swapTable( AnalyticsTable mainTable, AnalyticsTablePartition tablePartition )
+    private void swapTable( String tempTableName, String realTableName )
     {
-        String mainTableName = mainTable.getTableName();
-        String realTableName = tablePartition.getTableName();
-        String tempTableName = tablePartition.getTempTableName();
-
-        final String[] sqlSteps = {
-            " alter table if exists " + mainTableName + " detach partition " + realTableName,
-            " drop table if exists " + realTableName + " cascade",
-            " alter table if exists " + tempTableName + " rename to " + realTableName,
-            " alter table if exists " + mainTableName + " attach partition " + realTableName
-                + " for values in (" + tablePartition.getYear() + ")"
+        String[] sqlSteps = {
+            "drop table if exists " + realTableName + " cascade",
+            "alter table " + tempTableName + " rename to " + realTableName
         };
 
         for ( int i = 0; i < sqlSteps.length; i++ )
@@ -609,96 +647,44 @@ public abstract class AbstractJdbcTableManager
             log.debug( sqlSteps[i] );
             executeSilently( sqlSteps[i] );
         }
+
+        executeSilently( sqlSteps, true );
     }
 
-    private void swapTable( AnalyticsTable mainTable )
+    /**
+     * Updates table inheritance of a table partition from the temp master table
+     * to the real master table.
+     *
+     * @param partitionTableName the partition table name.
+     * @param tempMasterTableName the temporary master table name.
+     * @param realMasterTableName the real master table name.
+     */
+    private void swapInheritance( String partitionTableName, String tempMasterTableName, String realMasterTableName )
     {
-        String mainTableName = mainTable.getTableName();
-        String tempTableName = mainTable.getTempTableName();
-
-        final String[] sqlSteps = {
-            " drop table if exists " + mainTableName + " cascade",
-            " alter table if exists " + tempTableName + " rename to " + mainTableName
+        String[] sqlSteps = {
+            "alter table " + partitionTableName + " inherit " + realMasterTableName,
+            "alter table " + partitionTableName + " no inherit " + tempMasterTableName
         };
 
-        final String sql = String.join( ";", sqlSteps ) + ";";
-
-        log.debug( sql );
-
-        executeSilently( sql );
+        executeSilently( sqlSteps, true );
     }
 
-    /**
-     * Create a analytics table (non partition)
-     *
-     * @param table the partition table.
-     */
-    private void createAnalyticsTable( AnalyticsTable table )
+    private void executeSilently( String[] sqlSteps, boolean atomically )
     {
-        createAnalyticsTable( table, null );
-    }
-
-    /**
-     * Create a analytics partition table, when partition is not null and there
-     * is a valid column for partition index otherwise create a analytics table
-     * (non partition)
-     *
-     * @param table the partition table.
-     * @param partition the table partition.
-     */
-    private void createAnalyticsTable( AnalyticsTable table, AnalyticsTablePartition partition )
-    {
-        createTableAsPartitionOf( table, partition );
-
-        String tableName = partition == null ? table.getTempTableName() : partition.getTempTableName();
-        String sqlCreate = "create table if not exists " + tableName + " (";
-        for ( AnalyticsTableColumn col : ListUtils.union( table.getDimensionColumns(), table.getValueColumns() ) )
+        if ( atomically )
         {
-            String notNull = col.getNotNull().isNotNull() ? " not null" : "";
+            String sql = String.join( ";", sqlSteps ) + ";";
+            log.debug( sql );
 
-            sqlCreate = sqlCreate + (col.getName() + " " + col.getDataType().getValue() + notNull + ",");
+            executeSilently( sql );
         }
-
-        sqlCreate = TextUtils.removeLastComma( sqlCreate ) + ")";
-
-        if ( partition == null && getPartitionColumn() != null )
+        else
         {
-            String partitionColumn = getPartitionColumn();
-            sqlCreate += " partition by list(\"" + partitionColumn + "\")";
+            for ( int i = 0; i < sqlSteps.length; i++ )
+            {
+                log.debug( sqlSteps[i] );
+                executeSilently( sqlSteps[i] );
+            }
         }
-
-        log.debug( "Creating table: '{}', columns: {}", tableName, table.getDimensionColumns().size() );
-        log.debug( "Created SQL: '{}'", sqlCreate );
-
-        jdbcTemplate.execute( sqlCreate );
-    }
-
-    /**
-     * Create a table partition when partition is not null and there is a valid
-     * column for partition index.
-     *
-     * @param table the partition table.
-     * @param partition the table partition.
-     */
-    private void createTableAsPartitionOf( AnalyticsTable table, AnalyticsTablePartition partition )
-    {
-        if ( partition != null && getPartitionColumn() != null )
-        {
-            String createTableAsPartitionOfSql = "create table if not exists " + partition.getTableName()
-                + " partition of " + table.getTempTableName() + " for values in " + "(" + partition.getYear() + ")";
-
-            log.debug( "Creating table: '{}', columns: {}", partition.getTableName(),
-                table.getDimensionColumns().size() );
-
-            jdbcTemplate.execute( createTableAsPartitionOfSql );
-        }
-    }
-
-    /**
-     * Indicates whether this analytics table type is partitioned.
-     */
-    private boolean tableTypeIsPartitioned()
-    {
-        return getPartitionColumn() != null;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static org.hisp.dhis.commons.collection.CollectionUtils.emptyIfNull;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.util.Date;
@@ -44,7 +45,6 @@ import org.hisp.dhis.analytics.AnalyticsTableService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.analytics.cache.AnalyticsCache;
-import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.DebugUtils;
 import org.hisp.dhis.message.MessageService;
 import org.hisp.dhis.resourcetable.ResourceTableService;
@@ -78,11 +78,11 @@ public class DefaultAnalyticsTableGenerator
     @Override
     public void generateTables( AnalyticsTableUpdateParams params, JobProgress progress )
     {
-        final Clock clock = new Clock( log ).startClock();
-        final Date lastSuccessfulUpdate = systemSettingManager
+        Clock clock = new Clock( log ).startClock();
+        Date lastSuccessfulUpdate = systemSettingManager
             .getDateSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE );
-        final Set<AnalyticsTableType> skipTypes = CollectionUtils.emptyIfNull( params.getSkipTableTypes() );
-        final Set<AnalyticsTableType> availableTypes = analyticsTableServices.stream()
+        Set<AnalyticsTableType> skipTypes = emptyIfNull( params.getSkipTableTypes() );
+        Set<AnalyticsTableType> availableTypes = analyticsTableServices.stream()
             .map( AnalyticsTableService::getAnalyticsTableType )
             .collect( Collectors.toSet() );
 
@@ -149,7 +149,7 @@ public class DefaultAnalyticsTableGenerator
     @Override
     public void generateResourceTables( JobProgress progress )
     {
-        final Clock clock = new Clock().startClock();
+        Clock clock = new Clock().startClock();
 
         progress.startingProcess( "Generating resource tables" );
         try

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -82,7 +82,7 @@ public class DefaultAnalyticsTableService
     @Override
     public void update( AnalyticsTableUpdateParams params, JobProgress progress )
     {
-        final int processNo = getProcessNo();
+        int processNo = getProcessNo();
 
         int tableUpdates = 0;
 
@@ -103,7 +103,7 @@ public class DefaultAnalyticsTableService
             return;
         }
 
-        final List<AnalyticsTable> tables = tableManager.getAnalyticsTables( params );
+        List<AnalyticsTable> tables = tableManager.getAnalyticsTables( params );
 
         if ( tables.isEmpty() )
         {
@@ -115,7 +115,7 @@ public class DefaultAnalyticsTableService
         }
 
         clock.logTime( String.format( "Table update start: %s, earliest: %s, parameters: %s",
-            tableType.getTableName(), getLongDateString( params.getFromDate() ), params.toString() ) );
+            tableType.getTableName(), getLongDateString( params.getFromDate() ), params ) );
         progress.startingStage( "Performing pre-create table work" );
         progress.runStage( () -> tableManager.preCreateTables( params ) );
         clock.logTime( "Performed pre-create table work " + tableType );
@@ -201,7 +201,6 @@ public class DefaultAnalyticsTableService
      */
     private void dropAllTempTables( final JobProgress progress, final List<AnalyticsTable> tables )
     {
-        dropTempTablesPartitions( tables, progress );
         dropTempTables( tables, progress );
     }
 
@@ -211,18 +210,6 @@ public class DefaultAnalyticsTableService
     private void dropTempTables( final List<AnalyticsTable> tables, final JobProgress progress )
     {
         progress.runStage( tables, AnalyticsTable::getTableName, tableManager::dropTempTable );
-    }
-
-    /**
-     * Drops the given temporary analytics tables.
-     */
-    private void dropTempTablesPartitions( final List<AnalyticsTable> tables, final JobProgress progress )
-    {
-        for ( final AnalyticsTable table : tables )
-        {
-            progress.runStage( table.getTablePartitions(), AnalyticsTablePartition::getTableName,
-                tableManager::dropTempTablePartition );
-        }
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -222,32 +222,25 @@ public class JdbcAnalyticsTableManager
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
         return partition.isLatestPartition() ? newArrayList()
-            : newArrayList(
-                "year = " + partition.getYear() + "",
+            : newArrayList( "year = " + partition.getYear() + "",
                 "pestartdate < '" + DateUtils.getMediumDateString( partition.getEndDate() ) + "'" );
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return "year";
     }
 
     @Override
     protected void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition )
     {
-        final String dbl = statementBuilder.getDoubleColumnType();
-        final boolean skipDataTypeValidation = systemSettingManager
+        String dbl = statementBuilder.getDoubleColumnType();
+        boolean skipDataTypeValidation = systemSettingManager
             .getBoolSetting( SettingKey.SKIP_DATA_TYPE_VALIDATION_IN_ANALYTICS_TABLE_EXPORT );
-        final boolean includeZeroValues = systemSettingManager
+        boolean includeZeroValues = systemSettingManager
             .getBoolSetting( SettingKey.INCLUDE_ZERO_VALUES_IN_ANALYTICS );
 
-        final String numericClause = skipDataTypeValidation ? ""
+        String numericClause = skipDataTypeValidation ? ""
             : ("and dv.value " + statementBuilder.getRegexpMatch() + " '" + MathUtils.NUMERIC_LENIENT_REGEXP + "' ");
-        final String zeroValueCondition = includeZeroValues ? " or de.zeroissignificant = true" : "";
-        final String zeroValueClause = "(dv.value != '0' or de.aggregationtype in ('" + AggregationType.AVERAGE + "','"
+        String zeroValueCondition = includeZeroValues ? " or de.zeroissignificant = true" : "";
+        String zeroValueClause = "(dv.value != '0' or de.aggregationtype in ('" + AggregationType.AVERAGE + "','"
             + AggregationType.AVERAGE_SUM_ORG_UNIT + "')" + zeroValueCondition + ") ";
-        final String intClause = zeroValueClause + numericClause;
+        String intClause = zeroValueClause + numericClause;
 
         populateTable( params, partition, "cast(dv.value as " + dbl + ")", "null", ValueType.NUMERIC_TYPES, intClause );
         populateTable( params, partition, "1", "null", Sets.newHashSet( ValueType.BOOLEAN, ValueType.TRUE_ONLY ),
@@ -268,12 +261,12 @@ public class JdbcAnalyticsTableManager
     private void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition,
         String valueExpression, String textValueExpression, Set<ValueType> valueTypes, String whereClause )
     {
-        final String tableName = partition.getTempTableName();
-        final String valTypes = TextUtils.getQuotedCommaDelimitedString( ObjectUtils.asStringList( valueTypes ) );
-        final boolean respectStartEndDates = systemSettingManager
+        String tableName = partition.getTempTableName();
+        String valTypes = TextUtils.getQuotedCommaDelimitedString( ObjectUtils.asStringList( valueTypes ) );
+        boolean respectStartEndDates = systemSettingManager
             .getBoolSetting( SettingKey.RESPECT_META_DATA_START_END_DATES_IN_ANALYTICS_TABLE_EXPORT );
-        final String approvalClause = getApprovalJoinClause( partition.getYear() );
-        final String partitionClause = partition.isLatestPartition()
+        String approvalClause = getApprovalJoinClause( partition.getYear() );
+        String partitionClause = partition.isLatestPartition()
             ? "and dv.lastupdated >= '" + getLongDateString( partition.getStartDate() ) + "' "
             : "and ps.year = " + partition.getYear() + " ";
 
@@ -521,7 +514,7 @@ public class JdbcAnalyticsTableManager
     @Override
     public void vacuumTables( AnalyticsTablePartition partition )
     {
-        final String sql = statementBuilder.getVacuum( partition.getTempTableName() );
+        String sql = statementBuilder.getVacuum( partition.getTempTableName() );
 
         log.debug( "Vacuum SQL: " + sql );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.analytics.ColumnDataType.BOOLEAN;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.DATE;
@@ -166,21 +166,14 @@ public class JdbcCompletenessTableManager
     @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
-        return partition.isLatestPartition() ? newArrayList()
-            : Lists.newArrayList( "year = " + partition.getYear() + "" );
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return "year";
+        return partition.isLatestPartition() ? emptyList() : List.of( "year = " + partition.getYear() + "" );
     }
 
     @Override
     protected void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition )
     {
-        final String tableName = partition.getTempTableName();
-        final String partitionClause = partition.isLatestPartition()
+        String tableName = partition.getTempTableName();
+        String partitionClause = partition.isLatestPartition()
             ? "and cdr.lastupdated >= '" + getLongDateString( partition.getStartDate() ) + "' "
             : "and ps.year = " + partition.getYear() + " ";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.DATE;
 import static org.hisp.dhis.analytics.ColumnDataType.DOUBLE;
@@ -130,13 +131,7 @@ public class JdbcCompletenessTargetTableManager
     @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
-        return Lists.newArrayList();
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return null;
+        return emptyList();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.DOUBLE;
 import static org.hisp.dhis.analytics.ColumnDataType.GEOMETRY;
@@ -162,19 +163,13 @@ public class JdbcEnrollmentAnalyticsTableManager
     @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
-        return Lists.newArrayList();
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return null;
+        return emptyList();
     }
 
     @Override
     protected void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition )
     {
-        final Program program = partition.getMasterTable().getProgram();
+        Program program = partition.getMasterTable().getProgram();
 
         String fromClause = "from programinstance pi " +
             "inner join program pr on pi.programid=pr.programid " +

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.DOUBLE;
 import static org.hisp.dhis.analytics.ColumnDataType.GEOMETRY;
@@ -324,26 +325,16 @@ public class JdbcEventAnalyticsTableManager
     @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
-        return partition.isLatestPartition() ? Lists.newArrayList()
-            : Lists.newArrayList(
-                "yearly = '" + partition.getYear() + "'",
-                "executiondate >= '" + DateUtils.getMediumDateString( partition.getStartDate() ) + "'",
-                "executiondate < '" + DateUtils.getMediumDateString( partition.getEndDate() ) + "'" );
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return "yearly";
+        return partition.isLatestPartition() ? emptyList() : List.of( "yearly = '" + partition.getYear() + "'" );
     }
 
     @Override
     protected void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition )
     {
-        final Program program = partition.getMasterTable().getProgram();
-        final String start = DateUtils.getLongDateString( partition.getStartDate() );
-        final String end = DateUtils.getLongDateString( partition.getEndDate() );
-        final String partitionClause = partition.isLatestPartition() ? "and psi.lastupdated >= '" + start + "' "
+        Program program = partition.getMasterTable().getProgram();
+        String start = DateUtils.getLongDateString( partition.getStartDate() );
+        String end = DateUtils.getLongDateString( partition.getEndDate() );
+        String partitionClause = partition.isLatestPartition() ? "and psi.lastupdated >= '" + start + "' "
             : "and psi.executiondate >= '" + start + "' and psi.executiondate < '" + end + "' ";
 
         String fromClause = "from programstageinstance psi " +
@@ -500,7 +491,7 @@ public class JdbcEventAnalyticsTableManager
 
         if ( databaseInfo.isSpatialSupport() )
         {
-            final String geoSql = selectForInsert( attribute,
+            String geoSql = selectForInsert( attribute,
                 "ou.geometry from organisationunit ou where ou.uid = (select value", dataClause );
             columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_GEOMETRY_COL_SUFFIX ),
                 ColumnDataType.GEOMETRY, geoSql )
@@ -508,8 +499,8 @@ public class JdbcEventAnalyticsTableManager
         }
 
         // Add org unit name column
-        final String fromTypeSql = "ou.name from organisationunit ou where ou.uid = (select value";
-        final String ouNameSql = selectForInsert( attribute, fromTypeSql, dataClause );
+        String fromTypeSql = "ou.name from organisationunit ou where ou.uid = (select value";
+        String ouNameSql = selectForInsert( attribute, fromTypeSql, dataClause );
 
         columns.add( new AnalyticsTableColumn( quote( attribute.getUid() + OU_NAME_COL_SUFFIX ), TEXT, ouNameSql )
             .withSkipIndex( true ) );
@@ -534,8 +525,8 @@ public class JdbcEventAnalyticsTableManager
         }
 
         // Add org unit name column
-        final String fromTypeSql = "ou.name from organisationunit ou where ou.uid = (select " + columnName;
-        final String ouNameSql = selectForInsert( dataElement, fromTypeSql, dataClause );
+        String fromTypeSql = "ou.name from organisationunit ou where ou.uid = (select " + columnName;
+        String ouNameSql = selectForInsert( dataElement, fromTypeSql, dataClause );
 
         columns.add( new AnalyticsTableColumn( quote( dataElement.getUid() + OU_NAME_COL_SUFFIX ), TEXT, ouNameSql )
             .withSkipIndex( true ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.table;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.analytics.ColumnDataType.CHARACTER_11;
 import static org.hisp.dhis.analytics.ColumnDataType.DOUBLE;
 import static org.hisp.dhis.analytics.ColumnNotNullConstraint.NOT_NULL;
@@ -120,19 +121,13 @@ public class JdbcOrgUnitTargetTableManager
     @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
-        return Lists.newArrayList();
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return null;
+        return emptyList();
     }
 
     @Override
     protected void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition )
     {
-        final String tableName = partition.getTempTableName();
+        String tableName = partition.getTempTableName();
 
         String sql = "insert into " + partition.getTempTableName() + " (";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
@@ -139,20 +139,13 @@ public class JdbcValidationResultTableManager
     @Override
     protected List<String> getPartitionChecks( AnalyticsTablePartition partition )
     {
-        return Lists.newArrayList(
-            "year = " + partition.getYear() + "" );
-    }
-
-    @Override
-    protected String getPartitionColumn()
-    {
-        return "year";
+        return Lists.newArrayList( "year = " + partition.getYear() + "" );
     }
 
     @Override
     protected void populateTable( AnalyticsTableUpdateParams params, AnalyticsTablePartition partition )
     {
-        final String tableName = partition.getTempTableName();
+        String tableName = partition.getTempTableName();
 
         String insert = "insert into " + partition.getTempTableName() + " (";
 
@@ -191,7 +184,7 @@ public class JdbcValidationResultTableManager
             "and vrs.created < '" + getLongDateString( params.getStartTime() ) + "' " +
             "and vrs.created is not null";
 
-        final String sql = insert + select;
+        String sql = insert + select;
 
         invokeTimeAndLog( sql, String.format( "Populate %s", tableName ) );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/PartitionUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/PartitionUtils.java
@@ -98,7 +98,7 @@ public class PartitionUtils
     /**
      * Returns partitions for the given list of periods.
      *
-     * @param period the period.
+     * @param periods the period.
      * @return partitions for the given list of periods.
      */
     public static Partitions getPartitions( List<DimensionalItemObject> periods )
@@ -252,7 +252,7 @@ public class PartitionUtils
      * Returns partition name. Aggregate only for now!
      *
      * @param tableName the table name.
-     * @param partitiont the partition.
+     * @param partition the partition.
      * @return the partition name.
      */
     public static String getPartitionName( String tableName, Integer partition )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsIndexHelper.java
@@ -56,7 +56,6 @@ import com.google.common.collect.Lists;
  */
 public class AnalyticsIndexHelper
 {
-
     private static final String PREFIX_INDEX = "in_";
 
     private AnalyticsIndexHelper()
@@ -69,19 +68,19 @@ public class AnalyticsIndexHelper
      * @param partitions the list of {@link AnalyticsTablePartition}.
      * @return a {@link java.util.concurrent.ConcurrentLinkedQueue} of indexes.
      */
-    public static List<AnalyticsIndex> getIndexes( final List<AnalyticsTablePartition> partitions )
+    public static List<AnalyticsIndex> getIndexes( List<AnalyticsTablePartition> partitions )
     {
-        final List<AnalyticsIndex> indexes = new ArrayList<>();
+        List<AnalyticsIndex> indexes = new ArrayList<>();
 
-        for ( final AnalyticsTablePartition partition : partitions )
+        for ( AnalyticsTablePartition partition : partitions )
         {
-            final List<AnalyticsTableColumn> columns = partition.getMasterTable().getDimensionColumns();
+            List<AnalyticsTableColumn> columns = partition.getMasterTable().getDimensionColumns();
 
-            for ( final AnalyticsTableColumn col : columns )
+            for ( AnalyticsTableColumn col : columns )
             {
                 if ( !col.isSkipIndex() )
                 {
-                    final List<String> indexColumns = col.hasIndexColumns() ? col.getIndexColumns()
+                    List<String> indexColumns = col.hasIndexColumns() ? col.getIndexColumns()
                         : Lists.newArrayList( col.getName() );
 
                     indexes.add( new AnalyticsIndex( partition.getTempTableName(), indexColumns, col.getIndexType() ) );
@@ -102,7 +101,7 @@ public class AnalyticsIndexHelper
      * @param tableType the {@link AnalyticsTableType}
      * @return the SQL index statement
      */
-    public static String createIndexStatement( final AnalyticsIndex index, final AnalyticsTableType tableType )
+    public static String createIndexStatement( AnalyticsIndex index, AnalyticsTableType tableType )
     {
         final String indexName = getIndexName( index, tableType );
         final String indexColumns = maybeApplyFunctionToIndex( index, join( index.getColumns(), "," ) );
@@ -119,9 +118,9 @@ public class AnalyticsIndexHelper
      * @param index the {@link AnalyticsIndex}
      * @param tableType the {@link AnalyticsTableType}
      */
-    public static String getIndexName( final AnalyticsIndex index, final AnalyticsTableType tableType )
+    public static String getIndexName( AnalyticsIndex index, AnalyticsTableType tableType )
     {
-        final String columnName = join( index.getColumns(), "_" );
+        String columnName = join( index.getColumns(), "_" );
 
         return quote( maybeSuffixIndexName( index,
             PREFIX_INDEX + removeQuote( columnName ) + "_" + shortenTableName( index.getTable(), tableType )
@@ -136,7 +135,7 @@ public class AnalyticsIndexHelper
      * @param indexColumns the columns to be used in the function
      * @return the columns inside the respective function
      */
-    private static String maybeApplyFunctionToIndex( final AnalyticsIndex index, final String indexColumns )
+    private static String maybeApplyFunctionToIndex( AnalyticsIndex index, String indexColumns )
     {
         if ( index.hasFunction() )
         {
@@ -147,9 +146,9 @@ public class AnalyticsIndexHelper
     }
 
     /**
-     * If the conditions are met, this method adds an additional index, that
-     * uses the "lower" function, into the given list of "indexes". A new index
-     * will be added in the following rules are matched:
+     * If the conditions are met, this method adds an index, that uses the
+     * "lower" function, into the given list of "indexes". A new index will be
+     * added in the following rules are matched:
      *
      * Column data type is TEXT AND "indexColumns" has ONLY one element AND the
      * column name is a valid UID.
@@ -159,14 +158,13 @@ public class AnalyticsIndexHelper
      * @param column the {@link AnalyticsTableColumn}
      * @param indexColumns the columns to be used in the function
      */
-    private static void maybeAddTextLowerIndex( final List<AnalyticsIndex> indexes, final String tableName,
-        final AnalyticsTableColumn column, final List<String> indexColumns )
+    private static void maybeAddTextLowerIndex( List<AnalyticsIndex> indexes, String tableName,
+        AnalyticsTableColumn column, List<String> indexColumns )
     {
-        final String columnName = RegExUtils.removeAll( column.getName(), "\"" );
+        String columnName = RegExUtils.removeAll( column.getName(), "\"" );
+        boolean isSingleColumn = indexColumns.size() == 1;
 
-        // The "lower" function can only be applied into a single column, hence
-        // the size == 1 comparison.
-        if ( column.getDataType() == TEXT && isValidUid( columnName ) && indexColumns.size() == 1 )
+        if ( column.getDataType() == TEXT && isValidUid( columnName ) && isSingleColumn )
         {
             indexes.add( new AnalyticsIndex( tableName, indexColumns, column.getIndexType(),
                 LOWER ) );
@@ -179,7 +177,7 @@ public class AnalyticsIndexHelper
      * @param table the table name
      * @param tableType
      */
-    private static String shortenTableName( String table, final AnalyticsTableType tableType )
+    private static String shortenTableName( String table, AnalyticsTableType tableType )
     {
         table = table.replaceAll( tableType.getTableName(), "ax" );
         table = table.replaceAll( TABLE_TEMP_SUFFIX, EMPTY );
@@ -195,7 +193,7 @@ public class AnalyticsIndexHelper
      * @param indexName
      * @return the index name plus the function suffix if any
      */
-    private static String maybeSuffixIndexName( final AnalyticsIndex index, final String indexName )
+    private static String maybeSuffixIndexName( AnalyticsIndex index, String indexName )
     {
         if ( index.hasFunction() )
         {

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/util/TextUtils.java
@@ -238,6 +238,24 @@ public class TextUtils
     }
 
     /**
+     * Removes the last occurrence of comma (",") from the given StringBuilder,
+     * including any character after the comma. It changes the object by
+     * reference, and returns the same object for convenience.
+     *
+     * @param stringBuilder the StringBuilder.
+     * @return the chopped StringBuilder.
+     */
+    public static StringBuilder removeLastComma( StringBuilder stringBuilder )
+    {
+        if ( stringBuilder != null && stringBuilder.length() > 0 )
+        {
+            stringBuilder.delete( stringBuilder.lastIndexOf( "," ), stringBuilder.length() );
+        }
+
+        return stringBuilder;
+    }
+
+    /**
      * Removes the last occurrence of the the given string, including potential
      * trailing spaces.
      *

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/TextUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/TextUtilsTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.commons.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hisp.dhis.commons.util.TextUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -62,41 +61,42 @@ class TextUtilsTest
     public void testRemoveNonEssentialChars()
     {
         String same = "abcdefghijkl-";
-        assertEquals( same, removeNonEssentialChars( same ) );
+        assertEquals( same, TextUtils.removeNonEssentialChars( same ) );
 
-        assertEquals( "abcdefghijkl-", removeNonEssentialChars( "abcdefghijkl-øæå" ) );
-        assertEquals( "abcdefghijkl-", removeNonEssentialChars( "abcdefghijkl-øæå§!" ) );
-        assertEquals( " abcdefghijkl-", removeNonEssentialChars( " abcdefghijkl-øæå§!" ) );
-        assertEquals( " abcde fghijkl-", removeNonEssentialChars( "/(/%å^{} abcde fghijkl-øæå§!&" ) );
+        assertEquals( "abcdefghijkl-", TextUtils.removeNonEssentialChars( "abcdefghijkl-øæå" ) );
+        assertEquals( "abcdefghijkl-", TextUtils.removeNonEssentialChars( "abcdefghijkl-øæå§!" ) );
+        assertEquals( " abcdefghijkl-", TextUtils.removeNonEssentialChars( " abcdefghijkl-øæå§!" ) );
+        assertEquals( " abcde fghijkl-", TextUtils.removeNonEssentialChars( "/(/%å^{} abcde fghijkl-øæå§!&" ) );
     }
 
     @Test
     void testHtmlLinks()
     {
-        assertEquals( "<a href=\"http://dhis2.org\">http://dhis2.org</a>", htmlLinks( "http://dhis2.org" ) );
-        assertEquals( "<a href=\"https://dhis2.org\">https://dhis2.org</a>", htmlLinks( "https://dhis2.org" ) );
-        assertEquals( "<a href=\"http://www.dhis2.org\">www.dhis2.org</a>", htmlLinks( "www.dhis2.org" ) );
+        assertEquals( "<a href=\"http://dhis2.org\">http://dhis2.org</a>", TextUtils.htmlLinks( "http://dhis2.org" ) );
+        assertEquals( "<a href=\"https://dhis2.org\">https://dhis2.org</a>",
+            TextUtils.htmlLinks( "https://dhis2.org" ) );
+        assertEquals( "<a href=\"http://www.dhis2.org\">www.dhis2.org</a>", TextUtils.htmlLinks( "www.dhis2.org" ) );
         assertEquals(
             "Navigate to <a href=\"http://dhis2.org\">http://dhis2.org</a> or <a href=\"http://www.dhis2.com\">www.dhis2.com</a> to read more.",
-            htmlLinks( "Navigate to http://dhis2.org or www.dhis2.com to read more." ) );
+            TextUtils.htmlLinks( "Navigate to http://dhis2.org or www.dhis2.com to read more." ) );
     }
 
     @Test
     void testSubString()
     {
-        assertEquals( "abcdefghij", subString( STRING, 0, 10 ) );
-        assertEquals( "cdef", subString( STRING, 2, 4 ) );
-        assertEquals( "ghij", subString( STRING, 6, 4 ) );
-        assertEquals( "ghij", subString( STRING, 6, 6 ) );
-        assertEquals( "", subString( STRING, 11, 3 ) );
-        assertEquals( "j", subString( STRING, 9, 1 ) );
-        assertEquals( "", subString( STRING, 4, 0 ) );
+        assertEquals( "abcdefghij", TextUtils.subString( STRING, 0, 10 ) );
+        assertEquals( "cdef", TextUtils.subString( STRING, 2, 4 ) );
+        assertEquals( "ghij", TextUtils.subString( STRING, 6, 4 ) );
+        assertEquals( "ghij", TextUtils.subString( STRING, 6, 6 ) );
+        assertEquals( "", TextUtils.subString( STRING, 11, 3 ) );
+        assertEquals( "j", TextUtils.subString( STRING, 9, 1 ) );
+        assertEquals( "", TextUtils.subString( STRING, 4, 0 ) );
     }
 
     @Test
     void testTrim()
     {
-        assertEquals( "abcdefgh", trimEnd( "abcdefghijkl", 4 ) );
+        assertEquals( "abcdefgh", TextUtils.trimEnd( "abcdefghijkl", 4 ) );
     }
 
     @Test
@@ -134,11 +134,25 @@ class TextUtilsTest
     @Test
     void testRemoveLastComma()
     {
-        assertEquals( null, TextUtils.removeLastComma( null ) );
+        String nullValue = null;
+
+        assertEquals( null, TextUtils.removeLastComma( nullValue ) );
         assertEquals( "", TextUtils.removeLastComma( "" ) );
         assertEquals( "tom,john", TextUtils.removeLastComma( "tom,john," ) );
         assertEquals( "tom, john", TextUtils.removeLastComma( "tom, john, " ) );
         assertEquals( "tom, john", TextUtils.removeLastComma( "tom, john,  " ) );
+    }
+
+    @Test
+    void testRemoveLastCommaStringBuilder()
+    {
+        final StringBuilder nullValue = null;
+
+        assertEquals( null, TextUtils.removeLastComma( nullValue ) );
+        assertEquals( "", TextUtils.removeLastComma( new StringBuilder() ).toString() );
+        assertEquals( "tom,john", TextUtils.removeLastComma( new StringBuilder( "tom,john," ) ).toString() );
+        assertEquals( "tom, john", TextUtils.removeLastComma( new StringBuilder( "tom, john, " ) ).toString() );
+        assertEquals( "tom, john", TextUtils.removeLastComma( new StringBuilder( "tom, john,  " ) ).toString() );
     }
 
     @Test


### PR DESCRIPTION
_[Backport from master/2.39]_

This PR aims to restore the expected Analytics export and table _partitioning_ using `inheritance` (as release 2.36).

**Overview**
Since release 2.37, some behaviours were not correctly covered when we introduced partition tables.

Pepfar identified and raised those issues in three JIRA tickets: DHIS2-13429, DHIS2-DHIS2-13478 and DHIS2-13479. In summary, those tickets describe the following problems.

**Problems**
1) The table `analytics_0` never gets cleaned after a full export. It causes data duplication when the application hits the query below, in `JdbcAnalyticsManager.getFromSourceClause`.
```
 select ap.*
      from analytics_0 as ap
      union all
      select ap.*
      from analytics_2019 as ap
      union all
      select ap.*
      from analytics_2020 as ap
```

2) After running the Analytics job (export) for the `last_years=x` all partitions are removed and replaced by the partitions related to `last_years` only. It causes old generated data to be lost and obliges the user to run the full export to recover all data, which takes much longer.

3) When the Analytics job is triggered using `last_years=0`, all years/partitions are removed. This obliges the user to run a full export so they can recover all Analytics tables.

**Resolution**
The changes present on this PR should fix those issues and mimic the same behaviour before version 2.37, per the items above.
Also, before this fix, it's important to mention that the table `_0`could never be added as a partition of the main table. This happened because the table `_0` could contain rows for any specific year, making it impossible to map this partition with a single year. Even if we could, year `0` would not make much sense. For this reason, we had to restore the previous behaviour, where we used `table inheritance` instead of `partitioned tables`.

**Scenarios of tests run**
The following testing _scenarios_ **-> results** were run to check if the process is working as expected:

1) _Run the analytics job specifying `lastYears=0`, ie: `localhost:8080/dhis/api/resourceTables/analytics?lastYears=0&skipEvents=false&skipEnrollment=false`:_
**-> It creates and populates the analytics `_0` table and keeps all existing tables in place.**

2) _Run continuous analytics job:_
**-> It creates the analytics `_0` table and keeps all existing tables in place.**

3) _Manually delete the table `_0`:_
**-> The queries to analytics still work fine.**

4) _Full export all tables, all years:_
**-> All tables for all years are generated and populated. The tables `_0` are removed.**

5) _Partial export (2 years):_
**-> Generates tables only for specific the last 2 years. The tables `_0` are not removed.**

6) _Export table setting numbers of years to include  to `1`:_
**-> Generates tables only for the current year. The tables `_0` are not removed.**

7) _Running full export on top of `partition tables`:_
**-> Process removes all existing tables and recreates them using inheritance.**

8) _Partial export on top of `partition tables`:_
**-> Process removes all existing tables and recreates them using inheritance.**
