### PR TITLE
feat: adds data element filter to data value set API [DHIS2-11966]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/DefaultAdxDataService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/adx/DefaultAdxDataService.java
@@ -147,7 +147,10 @@ public class DefaultAdxDataService
         {
             params.getDataSets().addAll( getByUidOrCode( DataSet.class, urlParams.getDataSet() ) );
         }
-
+        if ( !isEmpty( urlParams.getDataElement() ) )
+        {
+            params.getDataElements().addAll( getByUidOrCode( DataElement.class, urlParams.getDataElement() ) );
+        }
         if ( !isEmpty( urlParams.getPeriod() ) )
         {
             params.getPeriods().addAll( periodService.reloadIsoPeriods( new ArrayList<>( urlParams.getPeriod() ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetQueryParams.java
@@ -53,6 +53,8 @@ import org.hisp.dhis.common.IdentifiableProperty;
 @AllArgsConstructor( access = AccessLevel.PRIVATE )
 public class DataValueSetQueryParams
 {
+    private Set<String> dataElement;
+
     private Set<String> dataSet;
 
     private Set<String> dataElementGroup;
@@ -99,6 +101,8 @@ public class DataValueSetQueryParams
 
     private IdentifiableProperty inputOrgUnitIdScheme;
 
+    private IdentifiableProperty inputDataElementIdScheme;
+
     private IdentifiableProperty inputDataSetIdScheme;
 
     private IdentifiableProperty inputDataElementGroupIdScheme;
@@ -141,6 +145,7 @@ public class DataValueSetQueryParams
         setNonNull( schemes, inputDataElementGroupIdScheme, IdSchemes::setDataElementGroupIdScheme );
         setNonNull( schemes, inputOrgUnitIdScheme, IdSchemes::setOrgUnitIdScheme );
         setNonNull( schemes, inputDataSetIdScheme, IdSchemes::setDataSetIdScheme );
+        setNonNull( schemes, inputDataElementIdScheme, IdSchemes::setDataElementIdScheme );
         return schemes;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -210,6 +210,13 @@ public class DefaultDataValueSetService
                 urlParams.getDataElementGroup() ) );
         }
 
+        if ( !isEmpty( urlParams.getDataElement() ) )
+        {
+            params.getDataElements().addAll( identifiableObjectManager.getObjects(
+                DataElement.class, IdentifiableProperty.in( inputIdSchemes, IdSchemes::getDataElementIdScheme ),
+                urlParams.getDataElement() ) );
+        }
+
         if ( !isEmpty( urlParams.getPeriod() ) )
         {
             params.getPeriods().addAll( periodService.reloadIsoPeriods( new ArrayList<>( urlParams.getPeriod() ) ) );


### PR DESCRIPTION
### Summary
Adds a new parameter `dataElement` to the data value set API that can be used to provide data element IDs directly instead of using a dataset or data element group.
The parameter can be used in combination with data sets and data element groups. 
Using `inputDataElementIdScheme` in addition allows to provide CODEs or NAMEs instead of IDs.

### Automatic Testing
New test scenario was added using both `dataElement` and `inputDataElementIdScheme`.

### Manual Testing
For example (demo database): 
* `/api/dataValueSets.json?dataElement=JFFUt8yR2iW&period=202203&orgUnit=mzsOsz0NwNY`
* `/api/dataValueSets.json?dataElement=DE_384&period=202203&orgUnit=mzsOsz0NwNY&inputDataElementIdScheme=CODE`