### PR TITLE
feat: filter /tracker/events by enrollmentOccurredBefore/After DHIS2-13648

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -141,9 +141,13 @@ public class EventSearchParams
 
     private Date dueDateEnd;
 
+    private Date enrollmentEnrolledBefore;
+
     private Date enrollmentEnrolledAfter;
 
-    private Date enrollmentEnrolledBefore;
+    private Date enrollmentOccurredBefore;
+
+    private Date enrollmentOccurredAfter;
 
     private CategoryOptionCombo categoryOptionCombo;
 
@@ -517,6 +521,17 @@ public class EventSearchParams
         return this;
     }
 
+    public Date getEnrollmentEnrolledBefore()
+    {
+        return enrollmentEnrolledBefore;
+    }
+
+    public EventSearchParams setEnrollmentEnrolledBefore( Date enrollmentEnrolledBefore )
+    {
+        this.enrollmentEnrolledBefore = enrollmentEnrolledBefore;
+        return this;
+    }
+
     public Date getEnrollmentEnrolledAfter()
     {
         return enrollmentEnrolledAfter;
@@ -528,14 +543,25 @@ public class EventSearchParams
         return this;
     }
 
-    public Date getEnrollmentEnrolledBefore()
+    public Date getEnrollmentOccurredBefore()
     {
-        return enrollmentEnrolledBefore;
+        return enrollmentOccurredBefore;
     }
 
-    public EventSearchParams setEnrollmentEnrolledBefore( Date enrollmentEnrolledBefore )
+    public EventSearchParams setEnrollmentOccurredBefore( Date enrollmentOccurredBefore )
     {
-        this.enrollmentEnrolledBefore = enrollmentEnrolledBefore;
+        this.enrollmentOccurredBefore = enrollmentOccurredBefore;
+        return this;
+    }
+
+    public Date getEnrollmentOccurredAfter()
+    {
+        return enrollmentOccurredAfter;
+    }
+
+    public EventSearchParams setEnrollmentOccurredAfter( Date enrollmentOccurredAfter )
+    {
+        this.enrollmentOccurredAfter = enrollmentOccurredAfter;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -203,6 +203,7 @@ public class JdbcEventStore implements EventStore
         .put( EVENT_ENROLLMENT_ID, "pi_uid" )
         .put( "enrollmentStatus", "pi_status" )
         .put( "enrolledAt", "pi_enrollmentdate" )
+        .put( "occurredAt", "pi_incidentdate" )
         .put( EVENT_ORG_UNIT_ID, "ou_uid" )
         .put( EVENT_ORG_UNIT_NAME, "ou_name" )
         .put( "trackedEntityInstance", "tei_uid" )
@@ -1017,7 +1018,7 @@ public class JdbcEventStore implements EventStore
         }
 
         selectBuilder.append(
-            "pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, pi.enrollmentdate as pi_enrollmentdate, " )
+            "pi.uid as pi_uid, pi.status as pi_status, pi.followup as pi_followup, pi.enrollmentdate as pi_enrollmentdate, pi.incidentdate as pi_incidentdate, " )
             .append( "p.type as p_type, ps.uid as ps_uid, ou.name as ou_name, " )
             .append(
                 "tei.trackedentityinstanceid as tei_id, tei.uid as tei_uid, teiou.uid as tei_ou, teiou.name as tei_ou_name, tei.created as tei_created, tei.inactive as tei_inactive " );
@@ -1125,6 +1126,24 @@ public class JdbcEventStore implements EventStore
             fromBuilder
                 .append( hlp.whereAnd() )
                 .append( " (pi.enrollmentdate >= :enrollmentEnrolledAfter ) " );
+        }
+
+        if ( params.getEnrollmentOccurredBefore() != null )
+        {
+            mapSqlParameterSource.addValue( "enrollmentOccurredBefore", params.getEnrollmentOccurredBefore(),
+                Types.TIMESTAMP );
+            fromBuilder
+                .append( hlp.whereAnd() )
+                .append( " (pi.incidentdate <= :enrollmentOccurredBefore ) " );
+        }
+
+        if ( params.getEnrollmentOccurredAfter() != null )
+        {
+            mapSqlParameterSource.addValue( "enrollmentOccurredAfter", params.getEnrollmentOccurredAfter(),
+                Types.TIMESTAMP );
+            fromBuilder
+                .append( hlp.whereAnd() )
+                .append( " (pi.incidentdate >= :enrollmentOccurredAfter ) " );
         }
 
         if ( params.getFollowUp() != null )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -476,47 +476,6 @@ class EventExporterTest extends TrackerTest
     }
 
     @Test
-    void testEnrollmentEnrolledAfterSetToBeforeLastEnrolledAtDate()
-    {
-        EventSearchParams params = new EventSearchParams();
-        params.setOrgUnit( orgUnit );
-        params.setEnrollmentEnrolledAfter( parseDate( "2021-03-27T12:05:00.000" ) );
-
-        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
-            .collect( Collectors.toList() );
-
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
-    }
-
-    @Test
-    void testEnrollmentEnrolledAfterEqualToLastEnrolledAtDate()
-    {
-        EventSearchParams params = new EventSearchParams();
-        params.setOrgUnit( orgUnit );
-        params.setEnrollmentEnrolledAfter( parseDate( "2021-03-28T12:05:00.000" ) );
-
-        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
-            .collect( Collectors.toList() );
-
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
-    }
-
-    @Test
-    void testEnrollmentEnrolledAfterSetToAfterLastEnrolledAtDate()
-    {
-        EventSearchParams params = new EventSearchParams();
-        params.setOrgUnit( orgUnit );
-        params.setEnrollmentEnrolledAfter( parseDate( "2021-03-28T13:05:00.000" ) );
-
-        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
-            .collect( Collectors.toList() );
-
-        assertIsEmpty( enrollments );
-    }
-
-    @Test
     void testEnrollmentEnrolledBeforeSetToBeforeFirstEnrolledAtDate()
     {
         EventSearchParams params = new EventSearchParams();
@@ -558,6 +517,129 @@ class EventExporterTest extends TrackerTest
     }
 
     @Test
+    void testEnrollmentEnrolledAfterSetToBeforeLastEnrolledAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentEnrolledAfter( parseDate( "2021-03-27T12:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+    }
+
+    @Test
+    void testEnrollmentEnrolledAfterEqualToLastEnrolledAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentEnrolledAfter( parseDate( "2021-03-28T12:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+    }
+
+    @Test
+    void testEnrollmentEnrolledAfterSetToAfterLastEnrolledAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentEnrolledAfter( parseDate( "2021-03-28T13:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertIsEmpty( enrollments );
+    }
+
+    @Test
+    void testEnrollmentOccurredBeforeSetToBeforeFirstOccurredAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentOccurredBefore( parseDate( "2021-02-27T12:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertIsEmpty( enrollments );
+    }
+
+    @Test
+    void testEnrollmentOccurredBeforeEqualToFirstOccurredAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentOccurredBefore( parseDate( "2021-02-28T12:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertContainsOnly( enrollments, "nxP7UnKhomJ" ) );
+    }
+
+    @Test
+    void testEnrollmentOccurredBeforeSetToAfterFirstOccurredAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentOccurredBefore( parseDate( "2021-02-28T13:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertContainsOnly( enrollments, "nxP7UnKhomJ" ) );
+    }
+
+    @Test
+    void testEnrollmentOccurredAfterSetToBeforeLastOccurredAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentOccurredAfter( parseDate( "2021-03-27T12:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+    }
+
+    @Test
+    void testEnrollmentOccurredAfterEqualToLastOccurredAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentOccurredAfter( parseDate( "2021-03-28T12:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+    }
+
+    @Test
+    void testEnrollmentOccurredAfterSetToAfterLastOccurredAtDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setEnrollmentOccurredAfter( parseDate( "2021-03-28T13:05:00.000" ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertIsEmpty( enrollments );
+    }
+
+    @Test
     void testOrderByEnrolledAtDesc()
     {
         EventSearchParams params = new EventSearchParams();
@@ -578,6 +660,36 @@ class EventExporterTest extends TrackerTest
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
         params.setOrders( List.of( new OrderParam( "enrolledAt", OrderParam.SortDirection.ASC ) ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertEquals( 2, enrollments.size() ),
+            () -> assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments ) );
+    }
+
+    @Test
+    void testOrderByOccurredAtDesc()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setOrders( List.of( new OrderParam( "occurredAt", OrderParam.SortDirection.DESC ) ) );
+
+        List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( enrollments ),
+            () -> assertEquals( 2, enrollments.size() ),
+            () -> assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments ) );
+    }
+
+    @Test
+    void testOrderByOccurredAtAsc()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setOrders( List.of( new OrderParam( "occurredAt", OrderParam.SortDirection.ASC ) ) );
 
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -86,7 +86,7 @@
       },
       "orgUnitName": "Mbokie CHP",
       "enrolledAt": "2021-02-28T12:05:00.000",
-      "occurredAt": "2021-03-28T12:05:00.000",
+      "occurredAt": "2021-02-28T12:05:00.000",
       "followUp": false,
       "deleted": false,
       "events": [],

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -91,9 +91,13 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
 
     private String updatedWithin;
 
+    private Date enrollmentEnrolledBefore;
+
     private Date enrollmentEnrolledAfter;
 
-    private Date enrollmentEnrolledBefore;
+    private Date enrollmentOccurredBefore;
+
+    private Date enrollmentOccurredAfter;
 
     private EventStatus status;
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -249,7 +249,7 @@ class EventRequestToSearchParamsMapperTest
     }
 
     @Test
-    void testMappingEnrollmentDates()
+    void testMappingEnrollmentEnrolledAtDates()
     {
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
 
@@ -260,8 +260,24 @@ class EventRequestToSearchParamsMapperTest
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
-        assertEquals( enrolledAfter, params.getEnrollmentEnrolledAfter() );
         assertEquals( enrolledBefore, params.getEnrollmentEnrolledBefore() );
+        assertEquals( enrolledAfter, params.getEnrollmentEnrolledAfter() );
+    }
+
+    @Test
+    void testMappingEnrollmentOcurredAtDates()
+    {
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+
+        Date enrolledBefore = date( "2022-01-01" );
+        eventCriteria.setEnrollmentOccurredBefore( enrolledBefore );
+        Date enrolledAfter = date( "2022-02-01" );
+        eventCriteria.setEnrollmentOccurredAfter( enrolledAfter );
+
+        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+
+        assertEquals( enrolledBefore, params.getEnrollmentOccurredBefore() );
+        assertEquals( enrolledAfter, params.getEnrollmentOccurredAfter() );
     }
 
     @Test


### PR DESCRIPTION
and order by occurredAt

* switched order of after/before fields to before/after as my brain had a hard time dealing with the former 🧠 😂 