### PR TITLE
feat: Indicator .yearToDate() DHIS2-13320

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryModifiers.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryModifiers.java
@@ -67,6 +67,12 @@ public class QueryModifiers
     private final int periodOffset;
 
     /**
+     * Year to date: find calendar year to date data values.
+     */
+    @JsonProperty
+    private final boolean yearToDate;
+
+    /**
      * The minimum date (start of any period) for querying this object.
      */
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.expression;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.expression.MissingValueStrategy.NEVER_SKIP;
 
 import java.time.LocalDate;
@@ -146,6 +147,14 @@ public class ExpressionParams
      */
     @Builder.Default
     private Map<String, Program> programMap = new HashMap<>();
+
+    /**
+     * The periods (if any) for which the expression is evaluated.
+     */
+    @ToString.Include
+    @EqualsAndHashCode.Include
+    @Builder.Default
+    private final List<Period> periods = emptyList();
 
     /**
      * The number of calendar days to be used in evaluating the expression.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.analytics.data.handler;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.Math.min;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/handler/DataHandler.java
@@ -111,6 +111,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -1034,13 +1035,14 @@ public class DataHandler
         DimensionalItemObject dimensionalItem, List<DimensionalItemObject> basePeriods,
         MultiValuedMap<String, DimensionItemObjectValue> valueMap )
     {
-        List<Object> adjustedRow = getAdjustedRow( periodIndex, valueIndex, row, dimensionalItem, basePeriods );
+        Optional<List<Object>> adjustedRow = getAdjustedRow( periodIndex, valueIndex, row, dimensionalItem,
+            basePeriods );
 
-        if ( !isEmpty( adjustedRow ) )
+        if ( adjustedRow.isPresent() )
         {
-            String key = join( remove( adjustedRow.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP );
-
-            Double value = ((Number) adjustedRow.get( valueIndex )).doubleValue();
+            List<Object> aRow = adjustedRow.get();
+            String key = join( remove( aRow.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP );
+            Double value = ((Number) aRow.get( valueIndex )).doubleValue();
 
             valueMap.put( key, new DimensionItemObjectValue( dimensionalItem, value ) );
         }
@@ -1086,17 +1088,17 @@ public class DataHandler
         }
     }
 
-    private List<Object> getAdjustedRow( int periodIndex, int valueIndex, List<Object> row,
+    private Optional<List<Object>> getAdjustedRow( int periodIndex, int valueIndex, List<Object> row,
         DimensionalItemObject dimensionalItemObject, List<DimensionalItemObject> basePeriods )
     {
         if ( !hasPeriod( row, periodIndex ) )
         {
-            return row;
+            return Optional.of( row );
         }
 
         if ( row.get( valueIndex ) == null )
         {
-            return emptyList();
+            return Optional.empty();
         }
 
         int periodOffset = (dimensionalItemObject.getQueryMods() == null)
@@ -1113,10 +1115,10 @@ public class DataHandler
 
         if ( !isPeriodInPeriods( (String) adjustedRow.get( periodIndex ), basePeriods ) )
         {
-            return emptyList();
+            return Optional.empty();
         }
 
-        return adjustedRow;
+        return Optional.of( adjustedRow );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -1046,7 +1046,7 @@ public class AnalyticsUtils
     }
 
     /**
-     * Filters a list of {@link DimensionalItemObject} and returns one ore more
+     * Filters a list of {@link DimensionalItemObject} and returns one or more
      * {@link DimensionalItemObject} matching the given identifier.
      *
      * @param dimensionIdentifier the identifier to match.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
@@ -28,17 +28,30 @@
 package org.hisp.dhis.analytics.util;
 
 import static java.lang.Math.abs;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.apache.commons.lang3.ArrayUtils.remove;
+import static org.apache.commons.lang3.StringUtils.join;
+import static org.hisp.dhis.analytics.util.AnalyticsUtils.hasPeriod;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
+import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
+import static org.hisp.dhis.commons.collection.CollectionUtils.addAllUnique;
+import static org.hisp.dhis.commons.collection.CollectionUtils.addUnique;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.calendar.DateTimeUnit;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
 import org.hisp.dhis.common.Grid;
+import org.hisp.dhis.common.QueryModifiers;
+import org.hisp.dhis.period.BiWeeklyAbstractPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.WeeklyAbstractPeriodType;
 
 /**
  * @author Luciano Fiandesio
@@ -46,9 +59,20 @@ import org.hisp.dhis.period.PeriodType;
  */
 public class PeriodOffsetUtils
 {
+    private PeriodOffsetUtils()
+    {
+        throw new UnsupportedOperationException( "util" );
+    }
+
     /**
      * If the query parameters contain any dimensional item objects with a
      * periodOffset, return query parameters with the extra periods added.
+     * <p>
+     * If any dimensional item objects have a yearToDate modifier, add any extra
+     * periods required from the start of the year.
+     * <p>
+     * If any dimensional item objects have both periodOffset and yearToDate,
+     * include all the year-to-date periods for the offset periods as well.
      * <p>
      * Any added periods are added to the end of the list of query periods, for
      * the convenience of debugging, SQL query log reading, etc.
@@ -69,16 +93,18 @@ public class PeriodOffsetUtils
 
         for ( DimensionalItemObject item : dimension.getItems() )
         {
-            if ( item.getQueryMods() != null && item.getQueryMods().getPeriodOffset() != 0 )
-            {
-                for ( DimensionalItemObject period : params.getPeriods() )
-                {
-                    Period shiftedPeriod = shiftPeriod( (Period) period, item.getQueryMods().getPeriodOffset() );
+            QueryModifiers mods = item.getQueryMods();
 
-                    if ( !periods.contains( shiftedPeriod ) )
-                    {
-                        periods.add( shiftedPeriod );
-                    }
+            if ( mods != null )
+            {
+                if ( mods.getPeriodOffset() != 0 )
+                {
+                    addAllUnique( periods, shiftPeriods( periods, mods.getPeriodOffset() ) );
+                }
+
+                if ( mods.isYearToDate() )
+                {
+                    addAllUnique( periods, yearToDatePeriods( periods ) );
                 }
             }
         }
@@ -146,5 +172,160 @@ public class PeriodOffsetUtils
         adjustedRow.set( periodIndex, shifted.getIsoDate() );
 
         return adjustedRow;
+    }
+
+    /**
+     * Does a {@link DimensionalItemObject} have the year to date property?
+     *
+     * @param dimensionalItem the {@link DimensionalItemObject}.
+     * @return true if year to date, otherwise false.
+     */
+    public static boolean isYearToDate( DimensionalItemObject dimensionalItem )
+    {
+        return dimensionalItem.getQueryMods() != null && dimensionalItem.getQueryMods().isYearToDate();
+    }
+
+    /**
+     * Build a list of year-to-date rows. For each value that might add to a
+     * year-to-date result, save that value and add it to other such values.
+     *
+     * @param periodIndex the current grid row period index.
+     * @param valueIndex the current grid row value index.
+     * @param row the current grid row.
+     * @param dimensionalItem the dimensional item we are collecting for.
+     * @param basePeriods the periods wanted by the user.
+     * @param yearToDateRows the year-to-date rows we are building.
+     */
+    public static void buildYearToDateRows( int periodIndex, int valueIndex, List<Object> row,
+        DimensionalItemObject dimensionalItem, List<DimensionalItemObject> basePeriods,
+        Map<String, List<Object>> yearToDateRows )
+    {
+        if ( !hasPeriod( row, periodIndex ) )
+        {
+            return;
+        }
+
+        List<Period> targetPeriods = shiftPeriods( basePeriods, dimensionalItem.getQueryMods().getPeriodOffset() );
+
+        String rowPeriod = (String) row.get( periodIndex );
+
+        for ( Period targetPeriod : targetPeriods )
+        {
+            Set<String> inputPeriods = yearToDatePeriods( targetPeriod ).stream()
+                .map( Period::getIsoDate )
+                .collect( toUnmodifiableSet() );
+
+            if ( inputPeriods.contains( rowPeriod ) )
+            {
+                addYearToDateRow( periodIndex, valueIndex, row, targetPeriod, yearToDateRows );
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Shifts a list of periods according to a period offset. The list order is
+     * preserived.
+     */
+    private static List<Period> shiftPeriods( List<DimensionalItemObject> periods, int periodOffset )
+    {
+        List<Period> offsetPeriods = new ArrayList<>();
+
+        for ( DimensionalItemObject period : periods )
+        {
+            addUnique( offsetPeriods, shiftPeriod( (Period) period, periodOffset ) );
+        }
+
+        return offsetPeriods;
+    }
+
+    /**
+     * Finds all periods needed for a year-to-date periods. Periods are added in
+     * list order.
+     */
+    private static List<Period> yearToDatePeriods( List<DimensionalItemObject> periods )
+    {
+        List<Period> ytdPeriods = new ArrayList<>();
+
+        for ( DimensionalItemObject period : periods )
+        {
+            addAllUnique( ytdPeriods, yearToDatePeriods( (Period) period ) );
+        }
+
+        return ytdPeriods;
+    }
+
+    /**
+     * Generates the periods needed for one year-to-date period.
+     */
+    private static List<Period> yearToDatePeriods( Period period )
+    {
+        int reportingYear = getReportingYear( period );
+
+        List<Period> periods = new ArrayList<>();
+
+        do
+        {
+            periods.add( period );
+            period = period.getPeriodType().getPreviousPeriod( period );
+        }
+        while ( getReportingYear( period ) == reportingYear );
+
+        return periods;
+    }
+
+    /**
+     * Adds or updates a year-to-date row we are building.
+     */
+    private static void addYearToDateRow( int periodIndex, int valueIndex, List<Object> row, Period targetPeriod,
+        Map<String, List<Object>> yearToDateRows )
+    {
+        List<Object> targetRow = new ArrayList<>( row );
+
+        targetRow.set( periodIndex, targetPeriod.getIsoDate() );
+
+        String key = join( remove( targetRow.toArray( new Object[0] ), valueIndex ), DIMENSION_SEP );
+
+        List<Object> existingRow = yearToDateRows.get( key );
+
+        if ( existingRow != null )
+        {
+            Double existingValue = ((Number) existingRow.get( valueIndex )).doubleValue();
+            Double newValue = ((Number) targetRow.get( valueIndex )).doubleValue();
+            existingRow.set( valueIndex, existingValue + newValue );
+        }
+        else
+        {
+            yearToDateRows.put( key, targetRow );
+        }
+    }
+
+    /**
+     * Gets the analytics reporting year for a period.
+     * <p>
+     * A weekly or biweekly period starting on or after December 29 has three or
+     * fewer days in the current year, and so is considered to be the first week
+     * reported in the following year. (This doesn't make sense for biweekly
+     * periods, but it is how DHIS2 currently operates.)
+     * <p>
+     * A biweekly period starting on or after December 22 has
+     * <p>
+     * For all other periods, the period start year is returned.
+     */
+    private static int getReportingYear( Period period )
+    {
+        DateTimeUnit periodStart = DateTimeUnit.fromJdkDate( period.getStartDate() );
+
+        if ( (period.getPeriodType() instanceof WeeklyAbstractPeriodType
+            || period.getPeriodType() instanceof BiWeeklyAbstractPeriodType)
+            && periodStart.getMonth() == 12 && periodStart.getDay() >= 29 )
+        {
+            return periodStart.getYear() + 1;
+        }
+
+        return periodStart.getYear();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/PeriodOffsetUtils.java
@@ -228,7 +228,7 @@ public class PeriodOffsetUtils
 
     /**
      * Shifts a list of periods according to a period offset. The list order is
-     * preserived.
+     * preserved.
      */
     private static List<Period> shiftPeriods( List<DimensionalItemObject> periods, int periodOffset )
     {
@@ -243,7 +243,7 @@ public class PeriodOffsetUtils
     }
 
     /**
-     * Finds all periods needed for a year-to-date periods. Periods are added in
+     * Finds all periods needed for a year-to-date period. Periods are added in
      * list order.
      */
     private static List<Period> yearToDatePeriods( List<DimensionalItemObject> periods )
@@ -293,8 +293,8 @@ public class PeriodOffsetUtils
 
         if ( existingRow != null )
         {
-            Double existingValue = ((Number) existingRow.get( valueIndex )).doubleValue();
-            Double newValue = ((Number) targetRow.get( valueIndex )).doubleValue();
+            double existingValue = ((Number) existingRow.get( valueIndex )).doubleValue();
+            double newValue = ((Number) targetRow.get( valueIndex )).doubleValue();
             existingRow.set( valueIndex, existingValue + newValue );
         }
         else

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -45,7 +45,6 @@ import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIO
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_EXPRESSION_INFO;
 import static org.hisp.dhis.parser.expression.ParserUtils.COMMON_EXPRESSION_ITEMS;
 import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionLexer.SUB_EXPRESSION;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AGGREGATION_TYPE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AVG;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.A_BRACE;
@@ -66,12 +65,16 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ORGUNIT_GRO
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ORGUNIT_PROGRAM;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.OUG_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PERCENTILE_CONT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PERIOD_IN_YEAR;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.PERIOD_OFFSET;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.R_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV_POP;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.STDDEV_SAMP;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.SUB_EXPRESSION;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.SUM;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.YEARLY_PERIOD_COUNT;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.YEAR_TO_DATE;
 import static org.springframework.util.ObjectUtils.isEmpty;
 
 import java.util.Collection;
@@ -115,6 +118,8 @@ import org.hisp.dhis.expression.dataitem.DimItemProgramIndicator;
 import org.hisp.dhis.expression.dataitem.DimItemReportingRate;
 import org.hisp.dhis.expression.dataitem.ItemDays;
 import org.hisp.dhis.expression.dataitem.ItemOrgUnitGroupCount;
+import org.hisp.dhis.expression.dataitem.ItemPeriodInYear;
+import org.hisp.dhis.expression.dataitem.ItemYearlyPeriodCount;
 import org.hisp.dhis.expression.function.FunctionOrgUnitAncestor;
 import org.hisp.dhis.expression.function.FunctionOrgUnitDataSet;
 import org.hisp.dhis.expression.function.FunctionOrgUnitGroup;
@@ -133,6 +138,7 @@ import org.hisp.dhis.parser.expression.ExpressionState;
 import org.hisp.dhis.parser.expression.function.FunctionAggregationType;
 import org.hisp.dhis.parser.expression.function.FunctionMaxDate;
 import org.hisp.dhis.parser.expression.function.FunctionMinDate;
+import org.hisp.dhis.parser.expression.function.FunctionYearToDate;
 import org.hisp.dhis.parser.expression.function.PeriodOffset;
 import org.hisp.dhis.parser.expression.function.VectorAvg;
 import org.hisp.dhis.parser.expression.function.VectorCount;
@@ -231,8 +237,11 @@ public class DefaultExpressionService
         .put( N_BRACE, new DimItemIndicator() )
         .put( MAX_DATE, new FunctionMaxDate() )
         .put( MIN_DATE, new FunctionMinDate() )
+        .put( PERIOD_IN_YEAR, new ItemPeriodInYear() )
         .put( PERIOD_OFFSET, new PeriodOffset() )
         .put( SUB_EXPRESSION, new FunctionSubExpression() )
+        .put( YEARLY_PERIOD_COUNT, new ItemYearlyPeriodCount() )
+        .put( YEAR_TO_DATE, new FunctionYearToDate() )
         .build();
 
     private static final ImmutableMap<ParseType, ImmutableMap<Integer, ExpressionItem>> PARSE_TYPE_EXPRESSION_ITEMS = ImmutableMap
@@ -397,6 +406,7 @@ public class DefaultExpressionService
             .itemMap( itemMap )
             .valueMap( valueMap )
             .orgUnitCountMap( orgUnitCountMap )
+            .periods( periods )
             .days( days )
             .missingValueStrategy( SKIP_IF_ALL_VALUES_MISSING )
             .build();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYear.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYear.java
@@ -96,20 +96,21 @@ public class ItemPeriodInYear
 
     private double dayOfYear( Period period )
     {
-        Calendar cal = Calendar.getInstance();
-
-        cal.setTime( period.getStartDate() );
-
-        return cal.get( DAY_OF_YEAR );
+        return getCal( period ).get( DAY_OF_YEAR );
     }
 
     private double monthOfYear( Period period )
+    {
+        return 1.0 + getCal( period ).get( MONTH );
+    }
+
+    private Calendar getCal( Period period )
     {
         Calendar cal = Calendar.getInstance();
 
         cal.setTime( period.getStartDate() );
 
-        return 1 + cal.get( MONTH );
+        return cal;
     }
 
     private double trailingDigits( Period period )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCount.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.expression.dataitem;
 
+import static java.lang.String.valueOf;
 import static org.hisp.dhis.calendar.DateTimeUnit.fromJdkDate;
 import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
@@ -92,31 +93,26 @@ public class ItemYearlyPeriodCount
 
     private double weeksInYear( Period period )
     {
-        String isoDate = period.getIsoDate();
-        String testIsoString = isoDate.replaceAll( "\\d+$", "52" );
-        Period testPeriod = getPeriodFromIsoString( testIsoString );
-        DateTimeUnit testEndDate = fromJdkDate( testPeriod.getEndDate() );
-
-        if ( testEndDate.getMonth() == 12 && testEndDate.getDay() < 28 )
-        {
-            return 53;
-        }
-
-        return 52;
+        return testLastPeriodInYear( period, 52 );
     }
 
     private double biWeeksInYear( Period period )
     {
+        return testLastPeriodInYear( period, 26 );
+    }
+
+    private double testLastPeriodInYear( Period period, int count )
+    {
         String isoDate = period.getIsoDate();
-        String testIsoString = isoDate.replaceAll( "\\d+$", "26" );
+        String testIsoString = isoDate.replaceAll( "\\d+$", valueOf( count ) );
         Period testPeriod = getPeriodFromIsoString( testIsoString );
         DateTimeUnit testEndDate = fromJdkDate( testPeriod.getEndDate() );
 
         if ( testEndDate.getMonth() == 12 && testEndDate.getDay() < 28 )
         {
-            return 27;
+            return 1.0 + count;
         }
 
-        return 26;
+        return count;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCount.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.dataitem;
+
+import static org.hisp.dhis.calendar.DateTimeUnit.fromJdkDate;
+import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
+
+import java.util.List;
+
+import org.hisp.dhis.calendar.DateTimeUnit;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.period.BiWeeklyAbstractPeriodType;
+import org.hisp.dhis.period.CalendarPeriodType;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+import org.hisp.dhis.period.WeeklyAbstractPeriodType;
+
+/**
+ * Expression item [yearlyPeriodCount]
+ *
+ * @author Jim Grace
+ */
+public class ItemYearlyPeriodCount
+    implements ExpressionItem
+{
+    @Override
+    public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        return DOUBLE_VALUE_IF_NULL;
+    }
+
+    @Override
+    public Double evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        List<Period> periods = visitor.getParams().getPeriods();
+
+        if ( periods.size() != 1 )
+        {
+            return 0.0; // Not applicable
+        }
+
+        Period period = periods.get( 0 );
+        PeriodType periodType = period.getPeriodType();
+
+        if ( periodType instanceof WeeklyAbstractPeriodType )
+        {
+            return weeksInYear( period );
+        }
+        else if ( periodType instanceof BiWeeklyAbstractPeriodType )
+        {
+            return biWeeksInYear( period );
+        }
+        else if ( periodType instanceof CalendarPeriodType && periodType.getFrequencyOrder() < 365 )
+        {
+            return Double.valueOf( ((CalendarPeriodType) periodType).generatePeriods( period ).size() );
+        }
+
+        return 1.0;
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    private double weeksInYear( Period period )
+    {
+        String isoDate = period.getIsoDate();
+        String testIsoString = isoDate.replaceAll( "\\d+$", "52" );
+        Period testPeriod = getPeriodFromIsoString( testIsoString );
+        DateTimeUnit testEndDate = fromJdkDate( testPeriod.getEndDate() );
+
+        if ( testEndDate.getMonth() == 12 && testEndDate.getDay() < 28 )
+        {
+            return 53;
+        }
+
+        return 52;
+    }
+
+    private double biWeeksInYear( Period period )
+    {
+        String isoDate = period.getIsoDate();
+        String testIsoString = isoDate.replaceAll( "\\d+$", "26" );
+        Period testPeriod = getPeriodFromIsoString( testIsoString );
+        DateTimeUnit testEndDate = fromJdkDate( testPeriod.getEndDate() );
+
+        if ( testEndDate.getMonth() == 12 && testEndDate.getDay() < 28 )
+        {
+            return 27;
+        }
+
+        return 26;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYearTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYearTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.dataitem;
+
+import static java.lang.Math.round;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.expression.ExpressionParams;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests {@link ItemPeriodInYear}.
+ *
+ * @author Jim Grace
+ */
+@ExtendWith( MockitoExtension.class )
+class ItemPeriodInYearTest
+    extends DhisConvenienceTest
+{
+    @Mock
+    private ExprContext ctx;
+
+    @Mock
+    private CommonExpressionVisitor visitor;
+
+    @Mock
+    private ExpressionParams params;
+
+    private final ItemPeriodInYear target = new ItemPeriodInYear();
+
+    @Test
+    void testEvaluateDaily()
+    {
+        assertEquals( 1, evalWith( "20200101" ) );
+        assertEquals( 61, evalWith( "20200301" ) );
+        assertEquals( 366, evalWith( "20201231" ) );
+        assertEquals( 1, evalWith( "20210101" ) );
+        assertEquals( 60, evalWith( "20210301" ) );
+        assertEquals( 365, evalWith( "20211231" ) );
+    }
+
+    @Test
+    void testEvaluateWeekly()
+    {
+        assertEquals( 1, evalWith( "2020W1" ) );
+        assertEquals( 53, evalWith( "2020W53" ) );
+        assertEquals( 1, evalWith( "2021W1" ) );
+        assertEquals( 52, evalWith( "2021W52" ) );
+    }
+
+    @Test
+    void testEvaluateWeeklyThursday()
+    {
+        assertEquals( 1, evalWith( "2020ThuW1" ) );
+        assertEquals( 52, evalWith( "2020ThuW52" ) );
+        assertEquals( 1, evalWith( "2021ThuW1" ) );
+        assertEquals( 52, evalWith( "2021ThuW52" ) );
+    }
+
+    @Test
+    void testEvaluateBiWeekly()
+    {
+        assertEquals( 1, evalWith( "2020BiW1" ) );
+        assertEquals( 27, evalWith( "2020BiW27" ) );
+        assertEquals( 1, evalWith( "2021BiW1" ) );
+        assertEquals( 26, evalWith( "2021BiW26" ) );
+    }
+
+    @Test
+    void testEvaluateMonthly()
+    {
+        assertEquals( 9, evalWith( "202209" ) );
+    }
+
+    @Test
+    void testEvaluateQuarterly()
+    {
+        assertEquals( 1, evalWith( "2022Q1" ) );
+    }
+
+    @Test
+    void testEvaluateYearly()
+    {
+        assertEquals( 1, evalWith( "2022" ) );
+    }
+
+    @Test
+    void testEvaluateYearlyFinancial()
+    {
+        assertEquals( 1, evalWith( "2022Oct" ) );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    private long evalWith( String period )
+    {
+        when( visitor.getParams() ).thenReturn( params );
+        when( params.getPeriods() ).thenReturn( List.of( createPeriod( period ) ) );
+
+        return round( target.evaluate( ctx, visitor ) );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYearTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYearTest.java
@@ -107,6 +107,12 @@ class ItemPeriodInYearTest
     }
 
     @Test
+    void testEvaluateBiMonthly()
+    {
+        assertEquals( 5, evalWith( "202205B" ) );
+    }
+
+    @Test
     void testEvaluateQuarterly()
     {
         assertEquals( 1, evalWith( "2022Q1" ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCountTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCountTest.java
@@ -121,6 +121,12 @@ class ItemYearlyPeriodCountTest
     }
 
     @Test
+    void testEvaluateBiMonthly()
+    {
+        assertEquals( 6, evalWith( "202202B" ) );
+    }
+
+    @Test
     void testEvaluateQuarterly()
     {
         assertEquals( 4, evalWith( "2022Q1" ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCountTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCountTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.dataitem;
+
+import static java.lang.Math.round;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.expression.ExpressionParams;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests {@link ItemYearlyPeriodCount}.
+ *
+ * @author Jim Grace
+ */
+@ExtendWith( MockitoExtension.class )
+class ItemYearlyPeriodCountTest
+    extends DhisConvenienceTest
+{
+    @Mock
+    private ExprContext ctx;
+
+    @Mock
+    private CommonExpressionVisitor visitor;
+
+    @Mock
+    private ExpressionParams params;
+
+    private final ItemYearlyPeriodCount target = new ItemYearlyPeriodCount();
+
+    @Test
+    void testEvaluateDaily()
+    {
+        assertEquals( 366, evalWith( "20201101" ) );
+        assertEquals( 365, evalWith( "20210101" ) );
+    }
+
+    @Test
+    void testEvaluateWeekly()
+    {
+        assertEquals( 53, evalWith( "2020W10" ) );
+        assertEquals( 52, evalWith( "2021W11" ) );
+        assertEquals( 52, evalWith( "2022W12" ) );
+        assertEquals( 52, evalWith( "2023W23" ) );
+        assertEquals( 52, evalWith( "2024W34" ) );
+        assertEquals( 52, evalWith( "2025W45" ) );
+        assertEquals( 53, evalWith( "2026W46" ) );
+        assertEquals( 52, evalWith( "2027W47" ) );
+        assertEquals( 52, evalWith( "2028W48" ) );
+        assertEquals( 52, evalWith( "2029W49" ) );
+    }
+
+    @Test
+    void testEvaluateWeeklyWednesday()
+    {
+        assertEquals( 52, evalWith( "2020WedW10" ) );
+        assertEquals( 52, evalWith( "2021WedW11" ) );
+        assertEquals( 53, evalWith( "2022WedW12" ) );
+        assertEquals( 52, evalWith( "2023WedW23" ) );
+        assertEquals( 52, evalWith( "2024WedW34" ) );
+        assertEquals( 52, evalWith( "2025WedW45" ) );
+        assertEquals( 52, evalWith( "2026WedW46" ) );
+        assertEquals( 52, evalWith( "2027WedW47" ) );
+        assertEquals( 53, evalWith( "2028WedW48" ) );
+        assertEquals( 52, evalWith( "2029WedW49" ) );
+    }
+
+    @Test
+    void testEvaluateBiWeekly()
+    {
+        assertEquals( 27, evalWith( "2020BiW10" ) );
+        assertEquals( 26, evalWith( "2021BiW11" ) );
+        assertEquals( 26, evalWith( "2022BiW12" ) );
+        assertEquals( 26, evalWith( "2023BiW13" ) );
+        assertEquals( 26, evalWith( "2024BiW14" ) );
+        assertEquals( 26, evalWith( "2025BiW15" ) );
+        assertEquals( 27, evalWith( "2026BiW16" ) );
+        assertEquals( 26, evalWith( "2027BiW17" ) );
+        assertEquals( 26, evalWith( "2028BiW18" ) );
+        assertEquals( 26, evalWith( "2029BiW19" ) );
+    }
+
+    @Test
+    void testEvaluateMonthly()
+    {
+        assertEquals( 12, evalWith( "202209" ) );
+    }
+
+    @Test
+    void testEvaluateQuarterly()
+    {
+        assertEquals( 4, evalWith( "2022Q1" ) );
+    }
+
+    @Test
+    void testEvaluateYearly()
+    {
+        assertEquals( 1, evalWith( "2022" ) );
+    }
+
+    @Test
+    void testEvaluateYearlyFinancial()
+    {
+        assertEquals( 1, evalWith( "2022Oct" ) );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
+
+    private long evalWith( String period )
+    {
+        when( visitor.getParams() ).thenReturn( params );
+        when( params.getPeriods() ).thenReturn( List.of( createPeriod( period ) ) );
+
+        return round( target.evaluate( ctx, visitor ) );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
@@ -213,16 +213,32 @@ public class CollectionUtils
     }
 
     /**
-     * Adds all items not already present in the target collection
+     * Adds an item not already present in the target collection
+     *
+     * @param collection collection to add item to.
+     * @param item item to add.
+     */
+    public static <E> void addUnique( Collection<E> collection, E item )
+    {
+        if ( !collection.contains( item ) )
+        {
+            collection.add( item );
+        }
+    }
+
+    /**
+     * Adds all items not already present in the target collection, preserving
+     * the order of the items added (if the collection preserves them).
      *
      * @param collection collection to add items to.
      * @param items collection of items to add.
      */
-    public static <E> void addAllUnique( Collection<E> collection, Collection<E> items )
+    public static <E> void addAllUnique( Collection<E> collection, Collection<? extends E> items )
     {
-        items.stream()
-            .filter( item -> !collection.contains( item ) )
-            .forEach( item -> collection.add( item ) );
+        for ( E item : items )
+        {
+            addUnique( collection, item );
+        }
     }
 
     /**

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionYearToDate.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionYearToDate.java
@@ -25,36 +25,27 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.expression.dataitem;
+package org.hisp.dhis.parser.expression.function;
 
-import static org.hisp.dhis.expression.ExpressionService.DAYS_DESCRIPTION;
-import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
+import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.parser.expression.ExpressionItem;
 
 /**
- * Expression item [days]
+ * Function yearToDate
  *
  * @author Jim Grace
  */
-public class ItemDays
+public class FunctionYearToDate
     implements ExpressionItem
 {
     @Override
-    public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        visitor.getItemDescriptions().put( ctx.getText(), DAYS_DESCRIPTION );
-
-        return DOUBLE_VALUE_IF_NULL;
-    }
-
-    @Override
     public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        Integer days = visitor.getParams().getDays();
+        QueryModifiers queryMods = visitor.getState().getQueryModsBuilder().yearToDate( true ).build();
 
-        return days == null ? null : Double.valueOf( days );
+        return visitor.visitWithQueryMods( ctx.expr( 0 ), queryMods );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -121,13 +121,17 @@ class AnalyticsServiceTest
 
     private Period peMar;
 
-    private Period peApril;
+    private Period peApr;
 
     private Period peMay;
 
-    private Period peJune;
+    private Period peJun;
 
-    private Period peJuly;
+    private Period peJul;
+
+    private Period peAug;
+
+    private Period peSep;
 
     private Period quarter;
 
@@ -277,10 +281,12 @@ class AnalyticsServiceTest
         peJan = createPeriod( "2017-01" );
         peFeb = createPeriod( "2017-02" );
         peMar = createPeriod( "2017-03" );
-        peApril = createPeriod( "2017-04" );
+        peApr = createPeriod( "2017-04" );
         peMay = createPeriod( "2017-05" );
-        peJune = createPeriod( "2017-06" );
-        peJuly = createPeriod( "2017-07" );
+        peJun = createPeriod( "2017-06" );
+        peJul = createPeriod( "2017-07" );
+        peAug = createPeriod( "2017-08" );
+        peSep = createPeriod( "2017-09" );
 
         // These periods don't need to be persisted:
         quarter = createPeriod( "2017Q1" );
@@ -289,10 +295,12 @@ class AnalyticsServiceTest
         periodService.addPeriod( peJan );
         periodService.addPeriod( peFeb );
         periodService.addPeriod( peMar );
-        periodService.addPeriod( peApril );
+        periodService.addPeriod( peApr );
         periodService.addPeriod( peMay );
-        periodService.addPeriod( peJune );
-        periodService.addPeriod( peJuly );
+        periodService.addPeriod( peJun );
+        periodService.addPeriod( peJul );
+        periodService.addPeriod( peAug );
+        periodService.addPeriod( peSep );
 
         deA = createDataElement( 'A' );
         deB = createDataElement( 'B' );
@@ -764,7 +772,82 @@ class AnalyticsServiceTest
                 .withOrganisationUnit( ouA )
                 .withIndicators( Lists.newArrayList( indicatorA ) )
                 .withAggregationType( AnalyticsAggregationType.SUM )
-                .withPeriod( peJuly )
+                .withPeriod( peJul )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorWithYearToDate()
+    {
+        withIndicator( "#{" + deE.getUid() + "}.yearToDate()" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201705", 1.0,
+                "indicatorId-ouabcdefghA-201706", 3.0,
+                "indicatorId-ouabcdefghA-201707", 7.0,
+                "indicatorId-ouabcdefghA-201708", 7.0,
+                "indicatorId-ouabcdefghA-201709", 7.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peApr, peMay, peJun, peJul, peAug, peSep ) )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorWithPeriodOffsetAndYearToDate()
+    {
+        withIndicator( "#{" + deE.getUid() + "}.periodOffset(-1).yearToDate()" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201706", 1.0,
+                "indicatorId-ouabcdefghA-201707", 3.0,
+                "indicatorId-ouabcdefghA-201708", 7.0,
+                "indicatorId-ouabcdefghA-201709", 7.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peApr, peMay, peJun, peJul, peAug, peSep ) )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorWithPeriodInYear()
+    {
+        withIndicator( "#{" + deE.getUid() + "}.yearToDate() + [periodInYear]" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201705", 1.0 + 5,
+                "indicatorId-ouabcdefghA-201706", 3.0 + 6,
+                "indicatorId-ouabcdefghA-201707", 7.0 + 7,
+                "indicatorId-ouabcdefghA-201708", 7.0 + 8,
+                "indicatorId-ouabcdefghA-201709", 7.0 + 9 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peApr, peMay, peJun, peJul, peAug, peSep ) )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
+    void testIndicatorWithYearlyPeriodCount()
+    {
+        withIndicator( "#{" + deE.getUid() + "}.yearToDate() + [yearlyPeriodCount]" );
+
+        assertDataValues(
+            Map.of( "indicatorId-ouabcdefghA-201705", 1.0 + 12,
+                "indicatorId-ouabcdefghA-201706", 3.0 + 12,
+                "indicatorId-ouabcdefghA-201707", 7.0 + 12,
+                "indicatorId-ouabcdefghA-201708", 7.0 + 12,
+                "indicatorId-ouabcdefghA-201709", 7.0 + 12 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouA )
+                .withIndicators( Lists.newArrayList( indicatorA ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriods( List.of( peApr, peMay, peJun, peJul, peAug, peSep ) )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 
@@ -850,7 +933,7 @@ class AnalyticsServiceTest
                 .withFilterOrganisationUnits( Lists.newArrayList( ouC, ouE ) )
                 .withDataElements( Lists.newArrayList( deA, deB, deD ) )
                 .withAggregationType( AnalyticsAggregationType.AVERAGE )
-                .withPeriod( peApril )
+                .withPeriod( peApr )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -64,7 +64,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>2.0.41</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.0.42</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.0</dhis-hisp-quick.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -218,7 +218,7 @@
     <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.10</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.28</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.29</dhis-antlr-expression-parser.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.8.9</gson.version>
     <semver4j.version>3.1.0</semver4j.version>


### PR DESCRIPTION
See [DHIS2-13320](https://dhis2.atlassian.net/browse/DHIS2-13320), especially the `Expression syntax` section of the May 24, 2022 comment.

This PR implements the following expression syntax for indicators:

- yearToDate() modifier to add any previous values in the calendar year

- [periodInYear] returns the number of the period in the calendar year

- [yearlyPeriodCount] returns the total number of periods of this type in the calendar year

The two classes that do most of the heavy lifting are:

### DataHandler

The approach is similar to periodOffset. Before the indicator database query, year-to-date processing adds periods if needed to fetch the values from previous periods within the same calendar year(s) as any requested periods. After the database query, previous calendar year data is added to the results to be returned.

> The alternative approach would have been to do the year-to-date summing in the SQL query itself. This might have been efficient in a way, but might have resulted in more queries and would not allow the reuse of data. If an analytics query returns year-to-date values for a sequence of months, the same monthly figures can be added to several consecutive year-to-date values.


`getAggregatedDataValueMap` now gets the Grid of values. The code that assembles the ValueMap from the Grid has been separated into the following method `getAggregatedValueMapFromGrid` to reduce method complexity and size.

The `Grid rows loop` now accounts for year-to-date values. As it makes a single pass through the grid rows, any values that contribute to one or more year-to-date values are added to a growing collection of `yearToDateRows`. Values not contributing to year-to-date values are just added to the ValueMap within the loop. After the Grid rows loop is complete, then the `yearToDateRows` are added to the ValueMap.

Processing of the non-year-to-date values has been simplified in the Grid rows loop by calling the `addRowToValueMap` method which adjusts the period if needed for a periodOffset and then adds the row to the ValueMap. Generating the key and value and adding it to the map is now just done in one place here, instead of in two places as was previously done: (1) within the grid row loop for non-period values, and (2) within `addItemBasedOnPeriodOffset` for period values. The same `addRowToValueMap` is also used to add the accumulated year-to-date values after looping through all the Grid rows.

The `getAdjustedRow` method has much of the same logic that used to be in `addItemBasedOnPeriodOffset`, and also has the `hasPeriod` test that had been in the Grid rows loop. This method just adjusts the row if needed for period offset, but doesn't add the values to the Grid; that's now done only in `addRowToValueMap`.

### PeriodOffsetUtils

Most of the year-to-date specific logic has been added here. `addShiftedPeriods` now adds any periods needed for year-to-date values as well as for periodOffset values. `buildYearToDateRows` and `addYearToDateRow` do the job of accumulating year-to-date values during the Grid rows loop. `yearToDatePeriods` generates a list of periods in the calendar year that will be needed for year-to-date values. (Weekly and BiWeekly periods that span reporting years will be included in one year or the other depending on how many days they have in each year.)

Note that periodOffset and yearToDate can be used in combination. For example if the period is April and periodOffset is -1, it will fetch year-to-date data from January through March and report it in April.