### PR TITLE
feat: filter /tracker/events by filterAttributes DHIS2-13648

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/OrderParam.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/OrderParam.java
@@ -30,15 +30,15 @@ package org.hisp.dhis.webapi.controller.event.mapper;
 import java.util.Arrays;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.Getter;
+import lombok.Value;
 
 /**
  * Order parameter container to use within services.
  *
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
-@Data
+@Value
 public class OrderParam
 {
     private final String field;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/OrderCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/OrderCriteria.java
@@ -34,9 +34,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.With;
+import lombok.Value;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
@@ -48,15 +46,13 @@ import org.hisp.dhis.webapi.controller.event.mapper.OrderParam.SortDirection;
  *
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
-@Data
+@Value
 @AllArgsConstructor( staticName = "of" )
-@NoArgsConstructor
-@With
 public class OrderCriteria
 {
-    private String field;
+    private final String field;
 
-    private SortDirection direction;
+    private final SortDirection direction;
 
     public OrderParam toOrderParam()
     {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -180,6 +180,8 @@ public class EventSearchParams
      */
     private List<QueryItem> filters = new ArrayList<>();
 
+    private List<QueryItem> filterAttributes = new ArrayList<>();
+
     /**
      * DataElements to be included in the response. Can be used to filter
      * response.
@@ -705,6 +707,17 @@ public class EventSearchParams
     public EventSearchParams setFilters( List<QueryItem> filters )
     {
         this.filters = filters;
+        return this;
+    }
+
+    public List<QueryItem> getFilterAttributes()
+    {
+        return filterAttributes;
+    }
+
+    public EventSearchParams setFilterAttributes( List<QueryItem> filters )
+    {
+        this.filterAttributes = filters;
         return this;
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -46,10 +46,13 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObjectManager;
+import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.Event;
@@ -60,6 +63,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
@@ -118,7 +122,7 @@ class EventExporterTest extends TrackerTest
         orgUnit = manager.get( OrganisationUnit.class, "h4w96yEMlzO" );
         programStage = manager.get( ProgramStage.class, "NpsdDv6kKSO" );
         program = programStage.getProgram();
-        trackedEntityInstance = manager.get( TrackedEntityInstance.class, "IOR1AXXl24G" );
+        trackedEntityInstance = manager.get( TrackedEntityInstance.class, "dUE514NMOlo" );
         manager.flush();
     }
 
@@ -624,6 +628,85 @@ class EventExporterTest extends TrackerTest
 
         assertAll( () -> assertNotNull( enrollments ),
             () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+    }
+
+    @Test
+    void testEnrollmentFilterAttributes()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        TrackedEntityAttribute at = new TrackedEntityAttribute();
+        at.setUid( "toUpdate000" );
+        at.setValueType( ValueType.TEXT );
+        at.setAggregationType( AggregationType.NONE );
+        QueryItem item = new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(),
+            at.isUnique() );
+        item.addFilter( new QueryFilter( QueryOperator.EQ, "summer day" ) );
+        params.setFilterAttributes( List.of( item ) );
+
+        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
+            .map( Event::getTrackedEntityInstance )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( trackedEntities ),
+            () -> assertContainsOnly( trackedEntities, "QS6w44flWAf" ) );
+    }
+
+    @Test
+    void testEnrollmentFilterAttributesWithMultipleFiltersOnDifferentAttributes()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+
+        TrackedEntityAttribute at1 = new TrackedEntityAttribute();
+        at1.setUid( "toUpdate000" );
+        at1.setValueType( ValueType.TEXT );
+        at1.setAggregationType( AggregationType.NONE );
+        QueryItem item1 = new QueryItem( at1, null, at1.getValueType(), at1.getAggregationType(), at1.getOptionSet(),
+            at1.isUnique() );
+        item1.addFilter( new QueryFilter( QueryOperator.EQ, "rainy day" ) );
+
+        TrackedEntityAttribute at2 = new TrackedEntityAttribute();
+        at2.setUid( "notUpdated0" );
+        at2.setValueType( ValueType.TEXT );
+        at2.setAggregationType( AggregationType.NONE );
+        QueryItem item2 = new QueryItem( at2, null, at2.getValueType(), at2.getAggregationType(), at2.getOptionSet(),
+            at2.isUnique() );
+        item2.addFilter( new QueryFilter( QueryOperator.EQ, "winter day" ) );
+
+        params.setFilterAttributes( List.of( item1, item2 ) );
+
+        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
+            .map( Event::getTrackedEntityInstance )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( trackedEntities ),
+            () -> assertContainsOnly( trackedEntities, "dUE514NMOlo" ) );
+    }
+
+    @Test
+    void testEnrollmentFilterAttributesWithMultipleFiltersOnTheSameAttribute()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+
+        TrackedEntityAttribute at1 = new TrackedEntityAttribute();
+        at1.setUid( "toUpdate000" );
+        at1.setValueType( ValueType.TEXT );
+        at1.setAggregationType( AggregationType.NONE );
+        QueryItem item1 = new QueryItem( at1, null, at1.getValueType(), at1.getAggregationType(), at1.getOptionSet(),
+            at1.isUnique() );
+        item1.addFilter( new QueryFilter( QueryOperator.LIKE, "day" ) );
+        item1.addFilter( new QueryFilter( QueryOperator.LIKE, "in" ) );
+
+        params.setFilterAttributes( List.of( item1 ) );
+
+        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
+            .map( Event::getTrackedEntityInstance )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( trackedEntities ),
+            () -> assertContainsOnly( trackedEntities, "dUE514NMOlo" ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
+++ b/dhis-2/dhis-test-integration/src/test/resources/log4j2-test.xml
@@ -35,7 +35,7 @@
         <!-- </Logger>-->
         <!-- Uncomment if you want to debug testcontainers -->
         <!-- <Logger name="org.testcontainers" level="debug" additivity="false">-->
-        <!--     <appenderref ref="console"/>-->
+        <!--     <AppenderRef ref="console"/>-->
         <!-- </Logger>-->
         <!-- <Logger name="com.github.dockerjava" level="all" additivity="false">-->
         <!--     <AppenderRef ref="console"/>-->
@@ -43,6 +43,10 @@
         <!-- Uncomment if you want to debug spring test context (cache) -->
         <!-- <Logger name="org.springframework.test.context.cache" level="debug">-->
         <!--     <AppenderRef ref="console"/>-->
+        <!-- </Logger>-->
+        <!-- Uncomment if you want to debug JDBC template queries (SQL) -->
+        <!-- <Logger name="org.springframework.jdbc.core" level="TRACE">-->
+        <!--    <AppenderRef ref="console"/>-->
         <!-- </Logger>-->
     </Loggers>
 </Configuration>

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -32,7 +32,7 @@
   "skipRuleEngine": false,
   "trackedEntities": [
     {
-      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntity": "QS6w44flWAf",
       "trackedEntityType": {
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
@@ -47,11 +47,20 @@
       "deleted": false,
       "potentialDuplicate": false,
       "relationships": [],
-      "attributes": [],
+      "attributes": [
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toUpdate000"
+          },
+          "value": "summer day"
+        }
+      ],
       "enrollments": []
     },
     {
-      "trackedEntity": "IOR1AXXl24G",
+      "trackedEntity": "dUE514NMOlo",
       "trackedEntityType": {
         "idScheme": "UID",
         "identifier": "ja8NY4PW7Xm"
@@ -66,7 +75,24 @@
       "deleted": false,
       "potentialDuplicate": false,
       "relationships": [],
-      "attributes": [],
+      "attributes": [
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "toUpdate000"
+          },
+          "value": "rainy day"
+        },
+        {
+          "valueType": "TEXT",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "notUpdated0"
+          },
+          "value": "winter day"
+        }
+      ],
       "enrollments": []
     }
   ],
@@ -74,7 +100,7 @@
     {
       "enrollment": "nxP7UnKhomJ",
       "createdAtClient": "2017-01-26T13:48:13.363",
-      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntity": "QS6w44flWAf",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"
@@ -97,7 +123,7 @@
     {
       "enrollment": "TvctPPhpD8z",
       "createdAtClient": "2017-01-26T13:48:13.363",
-      "trackedEntity": "IOR1AXXl24G",
+      "trackedEntity": "dUE514NMOlo",
       "program": {
         "idScheme": "UID",
         "identifier": "BFcipDERJnf"

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
@@ -66,6 +66,8 @@ import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.user.CurrentUserService;
@@ -101,6 +103,8 @@ class EventRequestToSearchParamsMapper
     private final AclService aclService;
 
     private final TrackedEntityInstanceService entityInstanceService;
+
+    private final TrackedEntityAttributeService attributeService;
 
     private final DataElementService dataElementService;
 
@@ -196,6 +200,18 @@ class EventRequestToSearchParamsMapper
             {
                 QueryItem item = getQueryItem( filter );
                 params.getFilters().add( item );
+            }
+        }
+
+        Map<String, TrackedEntityAttribute> attributes = attributeService.getAllTrackedEntityAttributes()
+            .stream().collect( Collectors.toMap( TrackedEntityAttribute::getUid, att -> att ) );
+        if ( eventCriteria.getFilterAttributes() != null )
+        {
+            for ( String filter : eventCriteria.getFilterAttributes() )
+            {
+                QueryItem it = getQueryItem( filter, attributes );
+
+                params.getFilterAttributes().add( it );
             }
         }
 
@@ -311,6 +327,51 @@ class EventRequestToSearchParamsMapper
         }
 
         return new QueryItem( de, null, de.getValueType(), de.getAggregationType(), de.getOptionSet() );
+    }
+
+    /**
+     * Creates a QueryItem from the given item string. Item is on format
+     * {attribute-id}:{operator}:{filter-value}[:{operator}:{filter-value}].
+     * Only the attribute-id is mandatory.
+     */
+    private QueryItem getQueryItem( String item, Map<String, TrackedEntityAttribute> attributes )
+    {
+        String[] split = item.split( DimensionalObject.DIMENSION_NAME_SEP );
+
+        if ( split.length % 2 != 1 )
+        {
+            throw new IllegalQueryException( "Query item or filter is invalid: " + item );
+        }
+
+        QueryItem queryItem = getItem( split[0], attributes );
+
+        if ( split.length > 1 ) // Filters specified
+        {
+            for ( int i = 1; i < split.length; i += 2 )
+            {
+                QueryOperator operator = QueryOperator.fromString( split[i] );
+                queryItem.getFilters().add( new QueryFilter( operator, split[i + 1] ) );
+            }
+        }
+
+        return queryItem;
+    }
+
+    private QueryItem getItem( String item, Map<String, TrackedEntityAttribute> attributes )
+    {
+        if ( attributes.isEmpty() )
+        {
+            throw new IllegalQueryException( "Attribute does not exist: " + item );
+        }
+
+        TrackedEntityAttribute at = attributes.get( item );
+
+        if ( at == null )
+        {
+            throw new IllegalQueryException( "Attribute does not exist: " + item );
+        }
+
+        return new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(), at.isUnique() );
     }
 
     private List<OrderParam> getOrderParams( List<OrderCriteria> order )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -117,6 +117,8 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
 
     private Set<String> filter;
 
+    private Set<String> filterAttributes;
+
     private Set<String> enrollments;
 
     private IdSchemes idSchemes = new IdSchemes();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/package-info.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/view/package-info.java
@@ -1,6 +1,7 @@
 /**
  * Contains the view (JSON) models of tracker. Imports and exports share the
- * same model. Import mappers in
+ * same model. This is deliberate as to ensure we keep the promise of an export
+ * being importable. Import mappers in
  * {@link org.hisp.dhis.webapi.controller.tracker.imports} translate JSON
  * payloads (view models) to the {@link org.hisp.dhis.tracker.domain} which is
  * used internally. Export mappers in

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -39,10 +40,16 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.dxf2.events.event.Event;
@@ -58,6 +65,8 @@ import org.hisp.dhis.schema.Property;
 import org.hisp.dhis.schema.Schema;
 import org.hisp.dhis.schema.SchemaService;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.hisp.dhis.trackedentity.TrackedEntityAttributeService;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.user.CurrentUserService;
@@ -67,6 +76,8 @@ import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -96,6 +107,9 @@ class EventRequestToSearchParamsMapperTest
     private TrackedEntityInstanceService entityInstanceService;
 
     @Mock
+    private TrackedEntityAttributeService attributeService;
+
+    @Mock
     private DataElementService dataElementService;
 
     @Mock
@@ -104,6 +118,7 @@ class EventRequestToSearchParamsMapperTest
     @Mock
     private SchemaService schemaService;
 
+    @InjectMocks
     private EventRequestToSearchParamsMapper requestToSearchParamsMapper;
 
     private Program program;
@@ -114,13 +129,13 @@ class EventRequestToSearchParamsMapperTest
 
     private SimpleDateFormat dateFormatter;
 
+    private TrackedEntityAttribute tea1;
+
+    private TrackedEntityAttribute tea2;
+
     @BeforeEach
     public void setUp()
     {
-        requestToSearchParamsMapper = new EventRequestToSearchParamsMapper( currentUserService, programService,
-            organisationUnitService, programStageService, aclService, entityInstanceService, dataElementService,
-            inputUtils, schemaService );
-
         dateFormatter = new SimpleDateFormat( "yyyy-MM-dd", Locale.ENGLISH );
 
         User user = new User();
@@ -144,6 +159,11 @@ class EventRequestToSearchParamsMapperTest
 
         trackedEntityInstance = new TrackedEntityInstance();
         when( entityInstanceService.getTrackedEntityInstance( "teiuid" ) ).thenReturn( trackedEntityInstance );
+        tea1 = new TrackedEntityAttribute();
+        tea1.setUid( "TvjwTPToKHO" );
+        tea2 = new TrackedEntityAttribute();
+        tea2.setUid( "cy2oRh2sNr6" );
+        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( List.of( tea1, tea2 ) );
 
         when( dataElementService.getDataElement( any() ) ).thenReturn( de );
 
@@ -428,6 +448,93 @@ class EventRequestToSearchParamsMapperTest
         String property2 = "unsupportedProperty2";
         assertTrue( exception.getMessage().contains( property2 ), () -> String
             .format( "expected message to contain '%s', got '%s' instead", property2, exception.getMessage() ) );
+    }
+
+    @Test
+    void testFilterAttributes()
+    {
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setFilterAttributes( Set.of( tea1.getUid() + ":eq:2", tea2.getUid() + ":like:foo" ) );
+
+        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+
+        List<QueryItem> items = params.getFilterAttributes();
+        assertNotNull( items );
+        // mapping to UIDs as the error message by just relying on QueryItem
+        // equals() is not helpful
+        assertContainsOnly( items.stream().map( i -> i.getItem().getUid() ).collect( Collectors.toList() ),
+            tea1.getUid(),
+            tea2.getUid() );
+
+        // QueryItem equals() does not take the QueryFilter into account so
+        // assertContainsOnly alone does not ensure operators and filter value
+        // are correct
+        // the following block is needed because of that
+        // assertion is order independent as the order of QueryItems is not
+        // guaranteed
+        Map<String, QueryFilter> expectedFilters = Map.of(
+            tea1.getUid(), new QueryFilter( QueryOperator.EQ, "2" ),
+            tea2.getUid(), new QueryFilter( QueryOperator.LIKE, "foo" ) );
+        assertAll( items.stream().map( i -> (Executable) () -> {
+            String uid = i.getItem().getUid();
+            QueryFilter expected = expectedFilters.get( uid );
+            assertEquals( expected.getOperator().getValue() + " " + expected.getFilter(), i.getFiltersAsString(),
+                () -> String.format( "QueryFilter mismatch for TEA with UID %s", uid ) );
+        } ).collect( Collectors.toList() ) );
+    }
+
+    @Test
+    void testFilterAttributesWhenNumberOfFilterSegmentsIsEven()
+    {
+        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setFilterAttributes( Set.of( "eq:2" ) );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+        assertEquals( "Query item or filter is invalid: eq:2", exception.getMessage() );
+    }
+
+    @Test
+    void testFilterAttributesWhenNoTEAExist()
+    {
+        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setFilterAttributes( Set.of( tea1.getUid() + ":eq:2" ) );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+        assertEquals( "Attribute does not exist: " + tea1.getUid(), exception.getMessage() );
+    }
+
+    @Test
+    void testFilterAttributesWhenTEAInFilterDoesNotExist()
+    {
+        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setFilterAttributes( Set.of( "JM5zWuf1mkb:eq:2" ) );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+        assertEquals( "Attribute does not exist: JM5zWuf1mkb", exception.getMessage() );
+    }
+
+    @Test
+    void testFilterAttributesUsingOnlyUID()
+    {
+
+        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        eventCriteria.setFilterAttributes( Set.of( tea1.getUid() ) );
+
+        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+
+        assertContainsOnly( params.getFilterAttributes(),
+            new QueryItem( tea1, null, tea1.getValueType(), tea1.getAggregationType(), tea1.getOptionSet(),
+                tea1.isUnique() ) );
     }
 
     private Date date( String date )


### PR DESCRIPTION
* OrderParam/OrderCriteria should be immutable as they represent the users request parameter `order`
* code added to EventRequestToSearchParamsMapper is mostly a duplication of the code we use for the `filter` on `/tracker/trackedEntities`. We can try to extract it later on if we feel like that is important. I did not try to due to the time constraint of the soft freeze.
* multiple filters in `filterAttributes` for the same TEA like `filterAttribues=TvjwTPToKHO:lt:20,TvjwTPToKHO:gt:30` are not allowed