### PR TITLE
fix: only create data value audit if value changes [DHIS2-13705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -935,7 +935,8 @@ public class DefaultDataValueSetService
         }
         if ( !internalValue.isDeleted()
             && Objects.equals( existingValue.getValue(), internalValue.getValue() )
-            && Objects.equals( existingValue.getComment(), internalValue.getComment() ) )
+            && Objects.equals( existingValue.getComment(), internalValue.getComment() )
+            && existingValue.isFollowup() == internalValue.isFollowup() )
         {
             return; // avoid performing unnecessary updates
         }
@@ -943,7 +944,7 @@ public class DefaultDataValueSetService
         {
             context.getDataValueBatchHandler().updateObject( internalValue );
 
-            if ( !context.isSkipAudit() )
+            if ( !context.isSkipAudit() && !Objects.equals( existingValue.getValue(), internalValue.getValue() ) )
             {
                 DataValueAudit auditValue = new DataValueAudit( internalValue, existingValue.getValue(),
                     context.getStoredBy( dataValue ), auditType );

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetAUpdate.xml
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/datavalueset/dataValueSetAUpdate.xml
@@ -1,7 +1,7 @@
 <dataValueSet xmlns="http://dhis2.org/schema/dxf/2.0" dataSet="pBOMPrpg1QX">
-    <dataValue dataElement="f7n9E0hX8qk" period="201201" orgUnit="DiszpKrYNg8" value="10001" storedBy="john" timestamp="2012-01-01" comment="updated comment" followup="false"/>
-    <dataValue dataElement="f7n9E0hX8qk" period="201201" orgUnit="BdfsJfj87js" value="10002" storedBy="john"
+    <dataValue dataElement="f7n9E0hX8qk" period="201201" orgUnit="DiszpKrYNg8" value="10011" storedBy="john" timestamp="2012-01-01" comment="updated comment" followup="false"/>
+    <dataValue dataElement="f7n9E0hX8qk" period="201201" orgUnit="BdfsJfj87js" value="10022" storedBy="john"
                timestamp="2012-01-02" comment="updated comment" followup="false"/>
-    <dataValue dataElement="f7n9E0hX8qk" period="201202" orgUnit="DiszpKrYNg8" value="10003" storedBy="john"
+    <dataValue dataElement="f7n9E0hX8qk" period="201202" orgUnit="DiszpKrYNg8" value="10033" storedBy="john"
                timestamp="2012-01-03" comment="updated comment" followup="false"/>
 </dataValueSet>


### PR DESCRIPTION
Only create a data value update audit when the value has changed.

From the report of the ticket I also deduced that there are pure followup updates which should mean we only want to skip the update if the followup has not changed.