### PR TITLE
ci: Apply maven dependency fetching opts to non-dev pipelines [skip ci]

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -15,7 +15,7 @@ pipeline {
     }
 
     environment {
-        MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_OPTS = '-Xms1024m -Xmx4096m -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125'
     }
 
     stages {

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -15,7 +15,7 @@ pipeline {
     }
 
     environment {
-        MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_OPTS = '-Xms1024m -Xmx4096m -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125'
     }
 
     stages {

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -10,7 +10,7 @@ pipeline {
     }
 
     environment {
-        MAVEN_OPTS = '-Xms1024m -Xmx4096m'
+        MAVEN_OPTS = '-Xms1024m -Xmx4096m -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=125'
         GITHUB_TOKEN = credentials('github-token')
     }
 


### PR DESCRIPTION
Related to https://github.com/dhis2/dhis2-core/pull/11606

There have been no dependency fetching related failures since the changes introduced with the PR above, so applying the options to the rest of the pipelines is in order.