### PR TITLE
fix: nLike and nILike filters in event analytics [DHIS2-13693]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1158,7 +1158,11 @@ public abstract class AbstractJdbcEventAnalyticsManager
                 case NEQ:
                 case NE:
                 case NIEQ:
-                    return "(" + field + " is null or " + field + SPACE + filter.getSqlOperator() + SPACE
+                case NLIKE:
+                case NILIKE:
+                    // This ensures that null values will always match the
+                    // filters above.
+                    return "(coalesce(" + field + ", '') = '' or " + field + SPACE + filter.getSqlOperator() + SPACE
                         + getSqlFilter( filter, item ) + ") ";
                 }
             }


### PR DESCRIPTION
The `!ILIKE` and `!LIKE` filters are filtering out null/empty values.
This change will fix it.

Examples of GET requests to test the behaviour:

```
http://localhost:8080/dhis/api/29/analytics/events/query/IpHINAT79UW.json
?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd
&dimension=A03MvHHogjR.zDhUuAYrxNC:!ILIKE:A&stage=A03MvHHogjR
&displayProperty=NAME&totalPages=false&outputType=EVENT
&desc=eventdate&pageSize=10000&page=1
```
```
http://localhost:8080/dhis/api/29/analytics/enrollments/query/qDkgAbB5Jlk.json
?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd
&dimension=hYyB7FUS5eR.aW66s2QSosT:!LIKE:a&stage=hYyB7FUS5eR
&displayProperty=NAME&totalPages=false&outputType=ENROLLMENT
&desc=enrollmentdate&pageSize=10000&page=1
```