### PR TITLE
fix: handle special case where controller getEntity returns a list [DHIS2-13709]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractFullReadOnlyController.java
@@ -447,7 +447,7 @@ public abstract class AbstractFullReadOnlyController<T extends IdentifiableObjec
             postProcessResponseEntity( entity, options, rpParameters );
         }
 
-        return ResponseEntity.ok( new StreamingJsonRoot<>( null, null,
+        return ResponseEntity.ok( new StreamingJsonRoot<>( null, entities.size() > 1 ? getSchema().getPlural() : null,
             FieldFilterParams.of( entities, fields ) ) );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/StreamingJsonRootMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/StreamingJsonRootMessageConverter.java
@@ -164,7 +164,10 @@ public class StreamingJsonRootMessageConverter extends AbstractHttpMessageConver
             else
             {
                 generator.writeStartObject();
-                generator.writeObjectField( "pager", jsonRoot.getPager() );
+                if ( jsonRoot.getPager() != null )
+                {
+                    generator.writeObjectField( "pager", jsonRoot.getPager() );
+                }
                 generator.writeArrayFieldStart( jsonRoot.getWrapperName() );
                 fieldFilterService.toObjectNodesStream( jsonRoot.getParams(), generator );
                 generator.writeEndArray();


### PR DESCRIPTION
The issue was caused by special behaviour of `getEntity` for `/organisationUnits/{uid}?level={level}` where this returns a list but the serialisation was assuming it is always just one entity. By providing a wrapper name in case there is more than one entity match the serialisation ends up in the path creating the wrapper object with array field. There the pager was excluded if it is `null` to match the old behaviour. 