### PR TITLE
feat: expose manifest plugin launch paths in /api/apps API [DHIS2-13710]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/App.java
@@ -65,6 +65,8 @@ public class App
 
     private String launchPath;
 
+    private String pluginLaunchPath;
+
     private String[] installsAllowedFrom;
 
     private String defaultLocale;
@@ -91,6 +93,8 @@ public class App
     private AppActivities activities;
 
     private String launchUrl;
+
+    private String pluginLaunchUrl;
 
     private String baseUrl;
 
@@ -122,7 +126,12 @@ public class App
 
         if ( contextPath != null && name != null && launchPath != null )
         {
-            launchUrl = String.join( "/", baseUrl, launchPath.replaceFirst( "^/+", "" ) );
+            this.launchUrl = String.join( "/", baseUrl, launchPath.replaceFirst( "^/+", "" ) );
+        }
+
+        if ( contextPath != null && name != null && pluginLaunchPath != null )
+        {
+            this.pluginLaunchUrl = String.join( "/", baseUrl, pluginLaunchPath.replaceFirst( "^/+", "" ) );
         }
     }
 
@@ -240,6 +249,18 @@ public class App
         this.launchPath = launchPath;
     }
 
+    @JsonProperty( "plugin_launch_path" )
+    @JacksonXmlProperty( localName = "plugin_launch_path", namespace = DxfNamespaces.DXF_2_0 )
+    public String getPluginLaunchPath()
+    {
+        return pluginLaunchPath;
+    }
+
+    public void setPluginLaunchPath( String pluginLaunchPath )
+    {
+        this.pluginLaunchPath = pluginLaunchPath;
+    }
+
     @JsonProperty( "installs_allowed_from" )
     @JacksonXmlProperty( localName = "installs_allowed_from", namespace = DxfNamespaces.DXF_2_0 )
     public String[] getInstallsAllowedFrom()
@@ -336,15 +357,15 @@ public class App
     }
 
     @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
     public String getLaunchUrl()
     {
         return launchUrl;
     }
 
-    public void setLaunchUrl( String launchUrl )
+    @JsonProperty
+    public String getPluginLaunchUrl()
     {
-        this.launchUrl = launchUrl;
+        return pluginLaunchUrl;
     }
 
     @JsonProperty
@@ -453,6 +474,7 @@ public class App
             "\"appType:\"" + appType + "\", " +
             "\"baseUrl:\"" + baseUrl + "\", " +
             "\"launchPath:\"" + launchPath + "\" " +
+            "\"pluginLaunchPath:\"" + pluginLaunchPath + "\" " +
             "}";
     }
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/appmanager/AppTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/appmanager/AppTest.java
@@ -62,6 +62,7 @@ class AppTest
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure( DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false );
         this.app = mapper.readValue( appJson, App.class );
+        this.app.init( "https://example.com" );
     }
 
     @AfterEach
@@ -76,6 +77,7 @@ class AppTest
         Assertions.assertEquals( "0.1", app.getVersion() );
         Assertions.assertEquals( "Test App", app.getName() );
         Assertions.assertEquals( "/index.html", app.getLaunchPath() );
+        Assertions.assertEquals( "/plugin.html", app.getPluginLaunchPath() );
         Assertions.assertEquals( "*", app.getInstallsAllowedFrom()[0] );
         Assertions.assertEquals( "en", app.getDefaultLocale() );
     }
@@ -123,6 +125,12 @@ class AppTest
     }
 
     @Test
+    void testGetSeeAppAuthority()
+    {
+        assertEquals( "M_Test_App", app.getSeeAppAuthority() );
+    }
+
+    @Test
     void testGetUrlFriendlyName()
     {
         App appA = new App();
@@ -131,5 +139,25 @@ class AppTest
         appB.setName( null );
         assertEquals( "Org-Facility-Registry", appA.getUrlFriendlyName() );
         assertNull( appB.getUrlFriendlyName() );
+    }
+
+    @Test
+    void testGetLaunchUrl()
+    {
+        Assertions.assertEquals( "https://example.com/api/apps/Test-App/index.html", app.getLaunchUrl() );
+    }
+
+    @Test
+    void testGetPluginLaunchUrl()
+    {
+        Assertions.assertEquals( "https://example.com/api/apps/Test-App/plugin.html", app.getPluginLaunchUrl() );
+
+        App appWithoutPlugin = new App();
+        appWithoutPlugin.setName( "Test App" );
+        appWithoutPlugin.setLaunchPath( "/index.html" );
+        appWithoutPlugin.init( "https://example.com" );
+        Assertions.assertEquals( "https://example.com/api/apps/Test-App/index.html", appWithoutPlugin.getLaunchUrl() );
+        Assertions.assertEquals( null, appWithoutPlugin.getPluginLaunchUrl() );
+
     }
 }

--- a/dhis-2/dhis-api/src/test/resources/manifest.webapp
+++ b/dhis-2/dhis-api/src/test/resources/manifest.webapp
@@ -3,6 +3,7 @@
     "name": "Test App",
     "description": "Test Description",
     "launch_path": "/index.html",
+    "plugin_launch_path": "/plugin.html",
     "icons": {
         "16": "/img/icons/mortar-16.png",
         "48": "/img/icons/mortar-48.png",


### PR DESCRIPTION
Fixes [DHIS2-13710](https://dhis2.atlassian.net/DHIS2-13710)

This adds support for parsing a new `plugin_launch_path` property from web application manifests.  It then generates a fully-qualified `pluginLaunchUrl` property and exposes this in the `/api/apps` endpoint.  I added some minimal tests, but this file is largely untested so a separate change to improve test coverage would be good to explore.