### PR TITLE
fix: Schedule date column not displaying custom label [DHIS2-13713]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/LabelMapper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/LabelMapper.java
@@ -42,6 +42,7 @@ public class LabelMapper
 {
     private LabelMapper()
     {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -57,6 +58,24 @@ public class LabelMapper
         if ( programStage != null && isNotBlank( programStage.getDisplayExecutionDateLabel() ) )
         {
             return programStage.getDisplayExecutionDateLabel();
+        }
+
+        return defaultLabel;
+    }
+
+    /**
+     * Returns a custom label for the schedule date if it exists, otherwise the
+     * given default label.
+     *
+     * @param programStage the {@link ProgramStage}.
+     * @param defaultLabel the default label.
+     * @return the custom label, otherwise the default label.
+     */
+    public static String getScheduleDateLabel( ProgramStage programStage, String defaultLabel )
+    {
+        if ( programStage != null && isNotBlank( programStage.getDisplayDueDateLabel() ) )
+        {
+            return programStage.getDisplayDueDateLabel();
         }
 
         return defaultLabel;

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -725,7 +725,9 @@ public class DefaultEventAnalyticsService
             .addHeader( new GridHeader(
                 ITEM_LAST_UPDATED_BY_DISPLAY_NAME, NAME_LAST_UPDATED_BY_DISPLAY_NAME, TEXT, false, true ) )
             .addHeader( new GridHeader( ITEM_LAST_UPDATED, NAME_LAST_UPDATED, DATE, false, true ) )
-            .addHeader( new GridHeader( ITEM_SCHEDULED_DATE, NAME_SCHEDULED_DATE, DATE, false, true ) );
+            .addHeader( new GridHeader( ITEM_SCHEDULED_DATE,
+                LabelMapper.getScheduleDateLabel( params.getProgramStage(), NAME_SCHEDULED_DATE ), DATE, false,
+                true ) );
 
         if ( params.getProgram().isRegistration() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/LabelMapperTest.java
@@ -48,6 +48,8 @@ class LabelMapperTest
 
     public static final String ENROLLMENT_DATE = "Enrollment date";
 
+    private static final String NAME_SCHEDULED_DATE = "Scheduled date";
+
     @Test
     void testGetHeaderNameFor_NAME_EVENT_DATE()
     {
@@ -59,6 +61,20 @@ class LabelMapperTest
 
         // Then
         assertThat( actualName, is( aMockedProgramStageWithLabels.getDisplayExecutionDateLabel() ) );
+    }
+
+    @Test
+    void testGetHeaderNameFor_NAME_SCHEDULED_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithLabels = mockProgramStageWithLabels();
+
+        // When
+        final String actualName = LabelMapper.getScheduleDateLabel( aMockedProgramStageWithLabels,
+            NAME_SCHEDULED_DATE );
+
+        // Then
+        assertThat( actualName, is( aMockedProgramStageWithLabels.getDisplayDueDateLabel() ) );
     }
 
     @Test
@@ -98,6 +114,19 @@ class LabelMapperTest
 
         // Then
         assertThat( actualName, is( EVENT_DATE ) );
+    }
+
+    @Test
+    void testGetHeaderNameWhenNoLabelIsSetFor_NAME_SCHEDULED_DATE()
+    {
+        // Given
+        final ProgramStage aMockedProgramStageWithNoLabels = mockProgramStageWithoutLabels();
+
+        // When
+        final String actualName = LabelMapper.getEventDateLabel( aMockedProgramStageWithNoLabels, NAME_SCHEDULED_DATE );
+
+        // Then
+        assertThat( actualName, is( NAME_SCHEDULED_DATE ) );
     }
 
     @Test
@@ -158,6 +187,7 @@ class LabelMapperTest
     {
         final ProgramStage programStage = new ProgramStage();
         programStage.setExecutionDateLabel( "execution date label" );
+        programStage.setDueDateLabel( "scheduled date label" );
         final Program program = new Program();
         program.setEnrollmentDateLabel( "enrollment date label" );
         program.setIncidentDateLabel( "incident date label" );


### PR DESCRIPTION
The “due date” custom label for a Program Stage, in a Tracker Program, is ignored by the events/query API.

GET request example for testing it:
```
http://localhost:8080/dhis/api/29/analytics/events/query/IpHINAT79UW
?dimension=ou:USER_ORGUNIT,p2Zxg0wcPQ3&headers=scheduleddate
&totalPages=false&eventDate=LAST_12_MONTHS&stage=A03MvHHogjR
&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1
&includeMetadataDetails=true&desc=scheduleddate
```