### PR TITLE
fix: Stable order of data entry metadata [TECH-1310]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
@@ -450,7 +450,7 @@ public class IdentifiableObjectUtils
 
     /**
      * Converts the given {@link Set} to a mutable {@link List} and sorts the
-     * items by the UID property.
+     * items by the ID property.
      *
      * @param <T>
      * @param set the {@link Set}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectUtils.java
@@ -29,11 +29,14 @@ package org.hisp.dhis.common;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -86,7 +89,10 @@ public class IdentifiableObjectUtils
             return null;
         }
 
-        List<String> names = objects.stream().map( IdentifiableObject::getDisplayName ).collect( Collectors.toList() );
+        List<String> names = objects.stream()
+            .map( IdentifiableObject::getDisplayName )
+            .collect( Collectors.toList() );
+
         return StringUtils.join( names, SEPARATOR_JOIN );
     }
 
@@ -422,8 +428,6 @@ public class IdentifiableObjectUtils
      */
     public static <T extends BaseIdentifiableObject> String getIdentifierBasedOnIdScheme( T object, IdScheme idScheme )
     {
-        // idScheme with IdentifiableProperty.ATTRIBUTE has to be specially
-        // treated in the code dealing with Attribute IDs
         if ( idScheme.isNull() || idScheme.is( IdentifiableProperty.UID ) )
         {
             return object.getUid();
@@ -442,5 +446,20 @@ public class IdentifiableObjectUtils
         }
 
         return null;
+    }
+
+    /**
+     * Converts the given {@link Set} to a mutable {@link List} and sorts the
+     * items by the UID property.
+     *
+     * @param <T>
+     * @param set the {@link Set}.
+     * @return a {@link List}.
+     */
+    public static <T extends IdentifiableObject> List<T> sortById( Set<T> set )
+    {
+        List<T> list = new ArrayList<>( set );
+        Collections.sort( list, Comparator.comparingLong( T::getId ) );
+        return list;
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hisp.dhis.calendar.Calendar;
 import org.hisp.dhis.calendar.impl.Iso8601Calendar;
@@ -51,7 +52,6 @@ import com.google.common.collect.Lists;
  */
 class IdentifiableObjectUtilsTest
 {
-
     @Test
     void testJoin()
     {
@@ -167,5 +167,22 @@ class IdentifiableObjectUtilsTest
         assertEquals( PeriodType.getPeriodFromIsoString( "2017" ), IdentifiableObjectUtils
             .getPeriodByPeriodType( PeriodType.getPeriodFromIsoString( "2017Q1" ), yearly, calendar ) );
         assertNull( PeriodType.getPeriodFromIsoString( "u3847847" ) );
+    }
+
+    @Test
+    void testSortById()
+    {
+        DataElement deA = new DataElement();
+        DataElement deB = new DataElement();
+        DataElement deC = new DataElement();
+        deA.setId( 1 );
+        deB.setId( 2 );
+        deC.setId( 3 );
+
+        Set<DataElement> set = Set.of( deB, deC, deA );
+
+        List<DataElement> list = IdentifiableObjectUtils.sortByUid( set );
+
+        assertEquals( List.of( deA, deB, deC ), list );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
@@ -181,7 +181,7 @@ class IdentifiableObjectUtilsTest
 
         Set<DataElement> set = Set.of( deB, deC, deA );
 
-        List<DataElement> list = IdentifiableObjectUtils.sortByUid( set );
+        List<DataElement> list = IdentifiableObjectUtils.sortById( set );
 
         assertEquals( List.of( deA, deB, deC ), list );
     }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/IdentifiableObjectUtilsTest.java
@@ -175,6 +175,9 @@ class IdentifiableObjectUtilsTest
         DataElement deA = new DataElement();
         DataElement deB = new DataElement();
         DataElement deC = new DataElement();
+        deA.setAutoFields();
+        deB.setAutoFields();
+        deC.setAutoFields();
         deA.setId( 1 );
         deB.setId( 2 );
         deC.setId( 3 );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -80,9 +80,9 @@ public class DefaultDataSetMetadataExportService
     private static final String PROPERTY_ORGANISATION_UNITS = "organisationUnits";
 
     private static final String FIELDS_DATA_SETS = ":simple,categoryCombo[id],formType,dataEntryForm[id]," +
+        "dataInputPeriods[period,openingDate,closingDate]," +
         "dataSetElements[dataElement[id],categoryCombo[id]],indicators~pluck[id]," +
         "compulsoryDataElementOperands[dataElement[id],categoryOptionCombo[id]]," +
-        "dataInputPeriods[period,openingDate,closingDate]," +
         "sections[:simple,dataElements~pluck[id],indicators~pluck[id]," +
         "greyedFields[dataElement[id],categoryOptionCombo[id]]]";
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -124,17 +124,22 @@ public class DefaultDataSetMetadataExportService
         CategoryCombo defaultCategoryCombo = categoryService.getDefaultCategoryCombo();
         SetValuedMap<String, String> dataSetOrgUnits = dataSetService.getDataSetOrganisationUnitsAssociations();
 
-        List<DataSet> dataSets = idObjectManager.getDataWriteAll( DataSet.class );
-        List<DataElement> dataElements = sortById( flatMapToSet( dataSets, DataSet::getDataElements ) );
-        List<Indicator> indicators = sortById( flatMapToSet( dataSets, DataSet::getIndicators ) );
+        List<DataSet> dataSets = idObjectManager
+            .getDataWriteAll( DataSet.class );
+        List<DataElement> dataElements = sortById(
+            flatMapToSet( dataSets, DataSet::getDataElements ) );
+        List<Indicator> indicators = sortById(
+            flatMapToSet( dataSets, DataSet::getIndicators ) );
         List<CategoryCombo> dataElementCategoryCombos = sortById(
             flatMapToSet( dataElements, DataElement::getCategoryCombos ) );
-        List<CategoryCombo> dataSetCategoryCombos = sortById( mapToSet( dataSets, DataSet::getCategoryCombo ) );
+        List<CategoryCombo> dataSetCategoryCombos = sortById(
+            mapToSet( dataSets, DataSet::getCategoryCombo ) );
         List<Category> dataElementCategories = sortById(
             flatMapToSet( dataElementCategoryCombos, CategoryCombo::getCategories ) );
         List<Category> dataSetCategories = sortById(
             flatMapToSet( dataSetCategoryCombos, CategoryCombo::getCategories ) );
-        List<Category> categories = union( dataElementCategories, dataSetCategories );
+        List<Category> categories = union(
+            dataElementCategories, dataSetCategories );
         List<CategoryOption> categoryOptions = sortById(
             getCategoryOptions( dataElementCategories, dataSetCategories, user ) );
         List<OptionSet> optionSets = sortById( getOptionSets( dataElements ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -27,10 +27,11 @@
  */
 package org.hisp.dhis.dxf2.metadata;
 
-import static com.google.common.collect.Sets.union;
+import static org.hisp.dhis.common.IdentifiableObjectUtils.sortById;
 import static org.hisp.dhis.commons.collection.CollectionUtils.addIfNotNull;
 import static org.hisp.dhis.commons.collection.CollectionUtils.flatMapToSet;
 import static org.hisp.dhis.commons.collection.CollectionUtils.mapToSet;
+import static org.hisp.dhis.commons.collection.ListUtils.union;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -115,7 +116,6 @@ public class DefaultDataSetMetadataExportService
     private final CurrentUserService currentUserService;
 
     // TODO add lock exceptions
-    // TODO add validation caching (ETag and If-None-Match).
 
     @Override
     public ObjectNode getDataSetMetadata()
@@ -125,15 +125,19 @@ public class DefaultDataSetMetadataExportService
         SetValuedMap<String, String> dataSetOrgUnits = dataSetService.getDataSetOrganisationUnitsAssociations();
 
         List<DataSet> dataSets = idObjectManager.getDataWriteAll( DataSet.class );
-        Set<DataElement> dataElements = flatMapToSet( dataSets, DataSet::getDataElements );
-        Set<Indicator> indicators = flatMapToSet( dataSets, DataSet::getIndicators );
-        Set<CategoryCombo> dataElementCategoryCombos = flatMapToSet( dataElements, DataElement::getCategoryCombos );
-        Set<CategoryCombo> dataSetCategoryCombos = mapToSet( dataSets, DataSet::getCategoryCombo );
-        Set<Category> dataElementCategories = flatMapToSet( dataElementCategoryCombos, CategoryCombo::getCategories );
-        Set<Category> dataSetCategories = flatMapToSet( dataSetCategoryCombos, CategoryCombo::getCategories );
-        Set<Category> categories = union( dataElementCategories, dataSetCategories );
-        Set<CategoryOption> categoryOptions = getCategoryOptions( dataElementCategories, dataSetCategories, user );
-        Set<OptionSet> optionSets = getOptionSets( dataElements );
+        List<DataElement> dataElements = sortById( flatMapToSet( dataSets, DataSet::getDataElements ) );
+        List<Indicator> indicators = sortById( flatMapToSet( dataSets, DataSet::getIndicators ) );
+        List<CategoryCombo> dataElementCategoryCombos = sortById(
+            flatMapToSet( dataElements, DataElement::getCategoryCombos ) );
+        List<CategoryCombo> dataSetCategoryCombos = sortById( mapToSet( dataSets, DataSet::getCategoryCombo ) );
+        List<Category> dataElementCategories = sortById(
+            flatMapToSet( dataElementCategoryCombos, CategoryCombo::getCategories ) );
+        List<Category> dataSetCategories = sortById(
+            flatMapToSet( dataSetCategoryCombos, CategoryCombo::getCategories ) );
+        List<Category> categories = union( dataElementCategories, dataSetCategories );
+        List<CategoryOption> categoryOptions = sortById(
+            getCategoryOptions( dataElementCategories, dataSetCategories, user ) );
+        List<OptionSet> optionSets = sortById( getOptionSets( dataElements ) );
 
         dataSetCategoryCombos.remove( defaultCategoryCombo );
         expressionService.substituteIndicatorExpressions( indicators );
@@ -170,7 +174,7 @@ public class DefaultDataSetMetadataExportService
      * @return a set of {@link CategoryOption}.
      */
     private Set<CategoryOption> getCategoryOptions(
-        Set<Category> dataElementCategories, Set<Category> dataSetCategories, User user )
+        Collection<Category> dataElementCategories, Collection<Category> dataSetCategories, User user )
     {
         Set<CategoryOption> options = flatMapToSet( dataElementCategories, Category::getCategoryOptions );
         dataSetCategories.forEach( c -> options.addAll( categoryService.getDataWriteCategoryOptions( c, user ) ) );
@@ -180,10 +184,10 @@ public class DefaultDataSetMetadataExportService
     /**
      * Returns option sets for the given data elements.
      *
-     * @param dataElements the set of data elements.
+     * @param dataElements the collection of data elements.
      * @return a set of option sets.
      */
-    private Set<OptionSet> getOptionSets( Set<DataElement> dataElements )
+    private Set<OptionSet> getOptionSets( Collection<DataElement> dataElements )
     {
         Set<OptionSet> optionSets = new HashSet<>();
         dataElements.forEach( de -> {
@@ -197,12 +201,12 @@ public class DefaultDataSetMetadataExportService
      * Returns data sets as a list of {@link ObjectNode}. Includes associations
      * to organisation units.
      *
-     * @param dataSets the list of {@link DataSet}.
+     * @param dataSets the collection of {@link DataSet}.
      * @param dataSetOrgUnits the associations between data sets and
      *        organisation units.
      * @return data sets as a list of {@link ObjectNode}
      */
-    private List<ObjectNode> toDataSetObjectNodes( List<DataSet> dataSets,
+    private List<ObjectNode> toDataSetObjectNodes( Collection<DataSet> dataSets,
         SetValuedMap<String, String> dataSetOrgUnits )
     {
         List<ObjectNode> objectNodes = new ArrayList<>();


### PR DESCRIPTION
Adds stable ordering of first level objects in the response. Additional work is needed for `dataSets.dataSetElements`.