### PR TITLE
fix: DEs of type Percentage returns 0.0 for null values [DHIS2-13633]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -34,6 +34,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.commons.lang3.StringUtils.SPACE;
 import static org.hisp.dhis.analytics.DataQueryParams.NUMERATOR_DENOMINATOR_PROPERTIES_COUNT;
 import static org.hisp.dhis.analytics.DataType.NUMERIC;
@@ -919,15 +920,16 @@ public abstract class AbstractJdbcEventAnalyticsManager
     {
         if ( Double.class.getName().equals( header.getType() ) && !header.hasLegendSet() )
         {
-            double val = sqlRowSet.getDouble( index );
+            Object value = sqlRowSet.getObject( index );
+            boolean isDouble = value instanceof Double;
 
-            if ( Double.isNaN( val ) )
+            if ( value == null || (isDouble && Double.isNaN( (Double) value )) )
             {
-                grid.addValue( "" );
+                grid.addValue( EMPTY );
             }
             else
             {
-                grid.addValue( params.isSkipRounding() ? val : MathUtils.getRounded( val ) );
+                grid.addValue( params.isSkipRounding() ? value : MathUtils.getRoundedObject( value ) );
             }
         }
         else if ( header.getValueType() == ValueType.REFERENCE )


### PR DESCRIPTION
_[Backport from master/2.39]_

When Data Elements of type Percentage contain null values in the database, they should return empty values in the response object of analytics event/enrollment requests.

Instead of getting the result as a primitive double, we get it as an object. From there, we apply the logic to apply or not `empty` values.