### PR TITLE
fix: DEs of type Percentage returns 0.0 for null values [DHIS2-13633]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
@@ -130,18 +131,31 @@ public class JdbcEnrollmentAnalyticsManager
 
             for ( GridHeader header : grid.getHeaders() )
             {
-                if ( Double.class.getName().equals( header.getType() ) && !header.hasLegendSet() )
-                {
-                    double val = rowSet.getDouble( index );
-                    grid.addValue( params.isSkipRounding() ? val : MathUtils.getRounded( val ) );
-                }
-                else
-                {
-                    grid.addValue( rowSet.getString( index ) );
-                }
-
+                addGridValue( grid, header, index, rowSet, params );
                 index++;
             }
+        }
+    }
+
+    protected void addGridValue( Grid grid, GridHeader header, int index, SqlRowSet rowSet, EventQueryParams params )
+    {
+        if ( Double.class.getName().equals( header.getType() ) && !header.hasLegendSet() )
+        {
+            Object value = rowSet.getObject( index );
+            boolean isDouble = value instanceof Double;
+
+            if ( value == null || (isDouble && Double.isNaN( (Double) value )) )
+            {
+                grid.addValue( EMPTY );
+            }
+            else
+            {
+                grid.addValue( params.isSkipRounding() ? value : MathUtils.getRoundedObject( value ) );
+            }
+        }
+        else
+        {
+            grid.addValue( rowSet.getString( index ) );
         }
     }
 


### PR DESCRIPTION
_[Backport from master/2.39]_

When Data Elements of type Percentage contain null values in the database, they should return empty values in the response object of analytics event/enrollment requests.

Instead of getting the result as a primitive double, we get it as an object. From there, we apply the logic to apply or not `empty` values.