### PR TITLE
fix: DEs of type Percentage returns 0.0 for null values [DHIS2-13633]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static org.apache.commons.lang.time.DateUtils.addYears;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.DataType.BOOLEAN;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LATITUDE;
 import static org.hisp.dhis.analytics.event.EventAnalyticsService.ITEM_LONGITUDE;
@@ -148,23 +149,36 @@ public class JdbcEventAnalyticsManager
 
             for ( GridHeader header : grid.getHeaders() )
             {
-                if ( ITEM_LONGITUDE.equals( header.getName() ) || ITEM_LATITUDE.equals( header.getName() ) )
-                {
-                    double val = rowSet.getDouble( index );
-                    grid.addValue( Precision.round( val, COORD_DEC ) );
-                }
-                else if ( Double.class.getName().equals( header.getType() ) && !header.hasLegendSet() )
-                {
-                    double val = rowSet.getDouble( index );
-                    grid.addValue( params.isSkipRounding() ? val : MathUtils.getRounded( val ) );
-                }
-                else
-                {
-                    grid.addValue( rowSet.getString( index ) );
-                }
-
+                addGridValue( grid, header, index, rowSet, params );
                 index++;
             }
+        }
+    }
+
+    protected void addGridValue( Grid grid, GridHeader header, int index, SqlRowSet rowSet, EventQueryParams params )
+    {
+        if ( ITEM_LONGITUDE.equals( header.getName() ) || ITEM_LATITUDE.equals( header.getName() ) )
+        {
+            double val = rowSet.getDouble( index );
+            grid.addValue( Precision.round( val, COORD_DEC ) );
+        }
+        else if ( Double.class.getName().equals( header.getType() ) && !header.hasLegendSet() )
+        {
+            Object value = rowSet.getObject( index );
+            boolean isDouble = value instanceof Double;
+
+            if ( value == null || (isDouble && Double.isNaN( (Double) value )) )
+            {
+                grid.addValue( EMPTY );
+            }
+            else
+            {
+                grid.addValue( params.isSkipRounding() ? value : MathUtils.getRoundedObject( value ) );
+            }
+        }
+        else
+        {
+            grid.addValue( rowSet.getString( index ) );
         }
     }
 


### PR DESCRIPTION
_[Backport from master/2.39]_

When Data Elements of type Percentage contain null values in the database, they should return empty values in the response object of analytics event/enrollment requests.

Instead of getting the result as a primitive double, we get it as an object. From there, we apply the logic to apply or not `empty` values.