### PR TITLE
fix: Stable order of data set elements in metadata endpoint [TECH-1310]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -246,7 +246,7 @@ public class DefaultDataSetMetadataExportService
         List<DataSetElement> elements = toDataSetElementList( dataSetElements );
         ArrayNode arrayNode = fieldFilterService.createArrayNode();
         List<ObjectNode> objectNodes = toObjectNodes( elements, FIELDS_DATA_SET_ELEMENTS, DataSetElement.class );
-        objectNodes.forEach( node -> arrayNode.add( node ) );
+        objectNodes.forEach( arrayNode::add );
         return arrayNode;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -277,7 +277,7 @@ public class DefaultDataSetMetadataExportService
     {
         ArrayNode arrayNode = fieldFilterService.createArrayNode();
         Set<String> orgUnits = dataSetOrgUnits.get( dataSet.getUid() );
-        orgUnits.forEach( ou -> arrayNode.add( ou ) );
+        orgUnits.forEach( arrayNode::add );
         return arrayNode;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -301,5 +301,4 @@ public class DefaultDataSetMetadataExportService
 
         return fieldFilterService.toObjectNodes( fieldFilterParams );
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultDataSetMetadataExportService.java
@@ -86,7 +86,6 @@ public class DefaultDataSetMetadataExportService
 
     private static final String FIELDS_DATA_SETS = ":simple,categoryCombo[id],formType,dataEntryForm[id]," +
         "dataInputPeriods[period,openingDate,closingDate]," +
-        // "dataSetElements[dataElement[id],categoryCombo[id]],
         "indicators~pluck[id]," +
         "compulsoryDataElementOperands[dataElement[id],categoryOptionCombo[id]]," +
         "sections[:simple,dataElements~pluck[id],indicators~pluck[id]," +


### PR DESCRIPTION
Provides stable order of data set elements in data set metadata endpoint.

The `dataSet.dataSetElements` association does not provide a stable order when retrieved through the API as it is a Set association. This should likely be improved in the data model, but it is not ideal to introduce a data model change so close to release, hence it is corrected in the data set metadata export service.