### PR TITLE
test: add assertStartsWith to Assertions DHIS2-13648

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -111,4 +111,18 @@ public final class Assertions
         assertNotNull( actual );
         assertTrue( actual.isEmpty(), actual.toString() );
     }
+
+    /**
+     * Asserts that the given string starts with the expected prefix.
+     *
+     * @param expected expected prefix of actual string
+     * @param actual actual string which should contain the expected prefix
+     */
+    public static void assertStartsWith( String expected, String actual )
+    {
+        assertNotNull( actual, () -> String
+            .format( "expected string to start with '%s', got null instead", expected ) );
+        assertTrue( actual.startsWith( expected ), () -> String
+            .format( "expected string to start with '%s', got '%s' instead", expected, actual ) );
+    }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -426,10 +427,7 @@ class EventRequestToSearchParamsMapperTest
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
-        assertNotNull( exception.getMessage() );
-        String prefix = "Order by property `nonSimple` is not supported";
-        assertTrue( exception.getMessage().startsWith( prefix ), () -> String
-            .format( "expected message to start with '%s', got '%s' instead", prefix, exception.getMessage() ) );
+        assertStartsWith( "Order by property `nonSimple` is not supported", exception.getMessage() );
     }
 
     @Test
@@ -441,10 +439,7 @@ class EventRequestToSearchParamsMapperTest
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
-        assertNotNull( exception.getMessage() );
-        String prefix = "Order by property `";
-        assertTrue( exception.getMessage().startsWith( prefix ), () -> String
-            .format( "expected message to start with '%s', got '%s' instead", prefix, exception.getMessage() ) );
+        assertStartsWith( "Order by property `", exception.getMessage() );
         // order of properties in exception message might not always be the same
         String property1 = "unsupportedProperty1";
         assertTrue( exception.getMessage().contains( property1 ), () -> String
@@ -539,10 +534,9 @@ class EventRequestToSearchParamsMapperTest
         assertNotNull( exception.getMessage() );
         // order of TEA UIDs in exception message might not always be the same;
         // therefore using contains to check for UIDs
-        String prefix = "filterAttributes can only have one filter per tracked entity attribute (TEA).";
         assertAll(
-            () -> assertTrue( exception.getMessage().startsWith( prefix ), () -> String
-                .format( "expected message to start with '%s', got '%s' instead", prefix, exception.getMessage() ) ),
+            () -> assertStartsWith( "filterAttributes can only have one filter per tracked entity attribute (TEA).",
+                exception.getMessage() ),
             () -> assertTrue( exception.getMessage().contains( TEA_1_UID ), () -> String
                 .format( "expected message to contain '%s', got '%s' instead", TEA_1_UID, exception.getMessage() ) ),
             () -> assertTrue( exception.getMessage().contains( TEA_2_UID ), () -> String


### PR DESCRIPTION
according to our new guideline on Assertions
https://github.com/dhis2/wow-backend/blob/8e9bd4ccdfd8997b1f2f03d9e21543c902d225a6/guides/testing.md?plain=1#L93

# Example Failures

```java
assertStartsWith("prefix",null);

org.opentest4j.AssertionFailedError: expected string to start with 'prefix', got null instead ==> expected: not <null>
```

```java
assertStartsWith("prefix", "is not contained");

org.opentest4j.AssertionFailedError: expected string to start with 'prefix', got 'is not contained' instead ==> 
Expected :true
Actual   :false
```