### PR TITLE
feat: Add ordering on tei attributes for events [DHIS2-13648]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -167,6 +167,8 @@ public class EventSearchParams
 
     private List<OrderParam> gridOrders;
 
+    private List<OrderParam> attributeOrders;
+
     private boolean includeAttributes;
 
     private boolean includeAllDataElements;
@@ -663,6 +665,17 @@ public class EventSearchParams
     public EventSearchParams setGridOrders( List<OrderParam> gridOrders )
     {
         this.gridOrders = gridOrders;
+        return this;
+    }
+
+    public List<OrderParam> getAttributeOrders()
+    {
+        return this.attributeOrders;
+    }
+
+    public EventSearchParams setAttributeOrders( List<OrderParam> attributeOrders )
+    {
+        this.attributeOrders = attributeOrders;
         return this;
     }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -69,6 +69,7 @@ import static org.hisp.dhis.dxf2.events.trackedentity.store.query.EventQuery.COL
 import static org.hisp.dhis.dxf2.events.trackedentity.store.query.EventQuery.COLUMNS.UPDATEDCLIENT;
 import static org.hisp.dhis.system.util.SqlUtils.castToNumber;
 import static org.hisp.dhis.system.util.SqlUtils.lower;
+import static org.hisp.dhis.system.util.SqlUtils.quote;
 import static org.hisp.dhis.util.DateUtils.addDays;
 
 import java.io.IOException;
@@ -987,7 +988,7 @@ public class JdbcEventStore implements EventStore
             sqlBuilder.append( RELATIONSHIP_IDS_QUERY );
         }
 
-        sqlBuilder.append( getOrderQuery( params ) );
+        sqlBuilder.append( getExternalOrderQuery( params ) );
 
         return sqlBuilder.toString();
     }
@@ -1002,6 +1003,8 @@ public class JdbcEventStore implements EventStore
      */
     private void joinAttributeValueWithoutQueryParameter( StringBuilder attributes, List<QueryItem> filterItems )
     {
+        // Option 2: Add ordering here and if the attribute has no filter create
+        // also the join
         for ( QueryItem queryItem : filterItems )
         {
             String teaValueCol = statementBuilder.columnQuote( queryItem.getItemId() );
@@ -1823,6 +1826,18 @@ public class JdbcEventStore implements EventStore
         return "order by lastUpdated desc ";
     }
 
+    private String getExternalOrderQuery( EventSearchParams params )
+    {
+        if ( isNotEmpty( params.getAttributeOrders() ) )
+        {
+            return "";
+        }
+        else
+        {
+            return getOrderQuery( params );
+        }
+    }
+
     private String getOrderQuery( EventSearchParams params )
     {
         ArrayList<String> orderFields = new ArrayList<>();
@@ -1842,6 +1857,16 @@ public class JdbcEventStore implements EventStore
                         break;
                     }
                 }
+            }
+        }
+
+        // Option 1: Add ordering here and if the attribute has no filter create
+        // also the join
+        if ( params.getAttributeOrders() != null )
+        {
+            for ( OrderParam order : params.getAttributeOrders() )
+            {
+                orderFields.add( quote( order.getField() ) + ".value " + order.getDirection() );
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1003,8 +1003,6 @@ public class JdbcEventStore implements EventStore
      */
     private void joinAttributeValueWithoutQueryParameter( StringBuilder attributes, List<QueryItem> filterItems )
     {
-        // Option 2: Add ordering here and if the attribute has no filter create
-        // also the join
         for ( QueryItem queryItem : filterItems )
         {
             String teaValueCol = statementBuilder.columnQuote( queryItem.getItemId() );
@@ -1860,8 +1858,6 @@ public class JdbcEventStore implements EventStore
             }
         }
 
-        // Option 1: Add ordering here and if the attribute has no filter create
-        // also the join
         if ( params.getAttributeOrders() != null )
         {
             for ( OrderParam order : params.getAttributeOrders() )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -710,6 +710,56 @@ class EventExporterTest extends TrackerTest
     }
 
     @Test
+    void testOrderEventsOnAttributeAsc()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+
+        TrackedEntityAttribute at1 = new TrackedEntityAttribute();
+        at1.setUid( "toUpdate000" );
+        at1.setValueType( ValueType.TEXT );
+        at1.setAggregationType( AggregationType.NONE );
+        QueryItem item1 = new QueryItem( at1, null, at1.getValueType(), at1.getAggregationType(), at1.getOptionSet(),
+            at1.isUnique() );
+        item1.addFilter( new QueryFilter( QueryOperator.LIKE, "day" ) );
+        params.setFilterAttributes( List.of( item1 ) );
+        params.setAttributeOrders( List.of( new OrderParam( "toUpdate000", OrderParam.SortDirection.ASC ) ) );
+
+        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
+            .map( Event::getTrackedEntityInstance )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( trackedEntities ),
+            () -> assertEquals( 2, trackedEntities.size() ),
+            () -> assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities ) );
+    }
+
+    @Test
+    void testOrderEventsOnAttributeDesc()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+
+        TrackedEntityAttribute at1 = new TrackedEntityAttribute();
+        at1.setUid( "toUpdate000" );
+        at1.setValueType( ValueType.TEXT );
+        at1.setAggregationType( AggregationType.NONE );
+        QueryItem item1 = new QueryItem( at1, null, at1.getValueType(), at1.getAggregationType(), at1.getOptionSet(),
+            at1.isUnique() );
+        item1.addFilter( new QueryFilter( QueryOperator.LIKE, "day" ) );
+        params.setFilterAttributes( List.of( item1 ) );
+        params.setAttributeOrders( List.of( new OrderParam( "toUpdate000", OrderParam.SortDirection.DESC ) ) );
+
+        List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
+            .map( Event::getTrackedEntityInstance )
+            .collect( Collectors.toList() );
+
+        assertAll( () -> assertNotNull( trackedEntities ),
+            () -> assertEquals( 2, trackedEntities.size() ),
+            () -> assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities ) );
+    }
+
+    @Test
     void testEnrollmentOccurredAfterSetToAfterLastOccurredAtDate()
     {
         EventSearchParams params = new EventSearchParams();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -721,7 +721,6 @@ class EventExporterTest extends TrackerTest
         at1.setAggregationType( AggregationType.NONE );
         QueryItem item1 = new QueryItem( at1, null, at1.getValueType(), at1.getAggregationType(), at1.getOptionSet(),
             at1.isUnique() );
-        item1.addFilter( new QueryFilter( QueryOperator.LIKE, "day" ) );
         params.setFilterAttributes( List.of( item1 ) );
         params.setAttributeOrders( List.of( new OrderParam( "toUpdate000", OrderParam.SortDirection.ASC ) ) );
 
@@ -746,7 +745,6 @@ class EventExporterTest extends TrackerTest
         at1.setAggregationType( AggregationType.NONE );
         QueryItem item1 = new QueryItem( at1, null, at1.getValueType(), at1.getAggregationType(), at1.getOptionSet(),
             at1.isUnique() );
-        item1.addFilter( new QueryFilter( QueryOperator.LIKE, "day" ) );
         params.setFilterAttributes( List.of( item1 ) );
         params.setAttributeOrders( List.of( new OrderParam( "toUpdate000", OrderParam.SortDirection.DESC ) ) );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -320,8 +320,8 @@ class EventRequestToSearchParamsMapperTest
         assertAll(
             () -> assertNotNull( params.getAttributeOrders() ),
             () -> assertContainsOnly( params.getAttributeOrders(),
-                new OrderParam( TEA_1_UID, OrderParam.SortDirection.ASC ) ),
-            () -> assertContainsOnly( params.getFilterAttributes(), new QueryItem( tea1 ) ) );
+                List.of( new OrderParam( TEA_1_UID, OrderParam.SortDirection.ASC ) ) ),
+            () -> assertContainsOnly( params.getFilterAttributes(), List.of( new QueryItem( tea1 ) ) ) );
     }
 
     @Test


### PR DESCRIPTION
- Added ordering by attribute for events. A new `attributeOrders` field was created in `EventSearchParams`.
- `QueryItem` with no filter is created if there is an order on an attribute that has no filter. This is needed because we need to add a join with the attribute table to be able to order
- If there is an order on an attribute, ignore the most external ordering in the query as this would override the attribute order