### PR TITLE
fix: use HttpHeaders.CONTENT_TYPE instead of string value

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/HttpUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/HttpUtils.java
@@ -53,6 +53,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.springframework.http.HttpHeaders;
 
 /**
  * This class has the utility methods to invoke REST endpoints for various HTTP
@@ -175,7 +176,7 @@ public class HttpUtils
 
             if ( !StringUtils.isNotEmpty( contentType ) )
             {
-                httpPost.setHeader( "Content-Type", contentType );
+                httpPost.setHeader( HttpHeaders.CONTENT_TYPE, contentType );
             }
 
             if ( authorize )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
@@ -56,6 +56,7 @@ import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -135,7 +136,7 @@ public class UserSettingController
             .get( key );
 
         response.setHeader( ContextUtils.HEADER_CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue() );
-        response.setHeader( "Content-Type", ContextUtils.CONTENT_TYPE_TEXT );
+        response.setHeader( HttpHeaders.CONTENT_TYPE, ContextUtils.CONTENT_TYPE_TEXT );
         return String.valueOf( value );
     }
 


### PR DESCRIPTION
## Summary

Updates direct usage of string `Content-Type` to use Springs `HttpHeaders.CONTENT_TYPE`. `dhis2-support-test` has not been updated as I did not want to add dependency on the web layer to it.