### PR TITLE
test: add context to assertContainsOnly DHIS2-13648

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -369,10 +369,10 @@ class DataIntegrityServiceTest
         assertEquals( 2, result.size() );
         DataIntegrityIssue issue0 = result.get( 0 );
         assertEquals( seed + 1, issue0.getId() );
-        assertContainsOnly( issue0.getRefs(), issueName( dataSet1 ), issueName( dataSet2 ) );
+        assertContainsOnly( List.of( issueName( dataSet1 ), issueName( dataSet2 ) ), issue0.getRefs() );
         DataIntegrityIssue issue1 = result.get( 1 );
         assertEquals( seed + 4, issue1.getId() );
-        assertContainsOnly( issue1.getRefs(), issueName( dataSet1 ), issueName( dataSet2 ) );
+        assertContainsOnly( List.of( issueName( dataSet1 ), issueName( dataSet2 ) ), issue1.getRefs() );
     }
 
     @Test
@@ -416,8 +416,7 @@ class DataIntegrityServiceTest
         List<DataIntegrityIssue> issues = subject.getIndicatorsWithIdenticalFormulas();
 
         assertEquals( 1, issues.size() );
-        assertContainsOnly( issues.get( 0 ).getRefs(),
-            issueName( indicatorB ), issueName( indicatorC ) );
+        assertContainsOnly( List.of( issueName( indicatorB ), issueName( indicatorC ) ), issues.get( 0 ).getRefs() );
     }
 
     @Test
@@ -466,7 +465,7 @@ class DataIntegrityServiceTest
         assertEquals( 1, issues.size() );
         DataIntegrityIssue issue = issues.get( 0 );
         assertEquals( issueName( programB ), issue.getName() );
-        assertContainsOnly( issue.getRefs(), issueName( programRuleB ) );
+        assertContainsOnly( List.of( issueName( programRuleB ) ), issue.getRefs() );
     }
 
     @Test
@@ -485,7 +484,7 @@ class DataIntegrityServiceTest
         assertEquals( 1, issues.size() );
         DataIntegrityIssue issue = issues.get( 0 );
         assertEquals( issueName( programA ), issue.getName() );
-        assertContainsOnly( issue.getRefs(), issueName( programRuleVariableA ) );
+        assertContainsOnly( List.of( issueName( programRuleVariableA ) ), issue.getRefs() );
     }
 
     @Test
@@ -504,7 +503,7 @@ class DataIntegrityServiceTest
         assertEquals( 1, issues.size() );
         DataIntegrityIssue issue = issues.get( 0 );
         assertEquals( issueName( programRuleA ), issue.getName() );
-        assertContainsOnly( issue.getRefs(), issueName( programRuleActionA ) );
+        assertContainsOnly( List.of( issueName( programRuleActionA ) ), issue.getRefs() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -522,12 +522,13 @@ class ExpressionService2Test extends DhisConvenienceTest
             .parseType( PREDICTOR_EXPRESSION )
             .build() );
 
-        assertContainsOnly( info.getItemIds(), getId( opA ), getId( reportingRate ) );
-        assertContainsOnly( info.getSampleItemIds(), getId( deB ), getId( pdeA ) );
-        assertContainsOnly( info.getAllItemIds(), getId( opA ), getId( reportingRate ), getId( deB ), getId( pdeA ) );
-        assertContainsOnly( info.getOrgUnitGroupIds(), groupA.getUid(), groupB.getUid() );
-        assertContainsOnly( info.getOrgUnitDataSetIds(), dataSetA.getUid(), dataSetB.getUid() );
-        assertContainsOnly( info.getOrgUnitProgramIds(), programA.getUid(), programB.getUid() );
+        assertContainsOnly( Set.of( getId( opA ), getId( reportingRate ) ), info.getItemIds() );
+        assertContainsOnly( Set.of( getId( deB ), getId( pdeA ) ), info.getSampleItemIds() );
+        assertContainsOnly( Set.of( getId( opA ), getId( reportingRate ), getId( deB ), getId( pdeA ) ),
+            info.getAllItemIds() );
+        assertContainsOnly( Set.of( groupA.getUid(), groupB.getUid() ), info.getOrgUnitGroupIds() );
+        assertContainsOnly( Set.of( dataSetA.getUid(), dataSetB.getUid() ), info.getOrgUnitDataSetIds() );
+        assertContainsOnly( Set.of( programA.getUid(), programB.getUid() ), info.getOrgUnitProgramIds() );
         assertTrue( info.getOrgUnitGroupCountIds().isEmpty() );
     }
 
@@ -542,7 +543,7 @@ class ExpressionService2Test extends DhisConvenienceTest
             .parseType( INDICATOR_EXPRESSION )
             .build() );
 
-        assertContainsOnly( info.getOrgUnitGroupCountIds(), groupA.getUid(), groupB.getUid() );
+        assertContainsOnly( Set.of( groupA.getUid(), groupB.getUid() ), info.getOrgUnitGroupCountIds() );
         assertTrue( info.getItemIds().isEmpty() );
         assertTrue( info.getSampleItemIds().isEmpty() );
         assertTrue( info.getAllItemIds().isEmpty() );
@@ -571,8 +572,8 @@ class ExpressionService2Test extends DhisConvenienceTest
             .parseType( PREDICTOR_EXPRESSION )
             .build() );
 
-        assertContainsOnly( info.getItemIds(), getId( opA ), getId( pdeA ) );
-        assertContainsOnly( info.getSampleItemIds(), getId( deB ), getId( reportingRate ) );
+        assertContainsOnly( Set.of( getId( opA ), getId( pdeA ) ), info.getItemIds() );
+        assertContainsOnly( Set.of( getId( deB ), getId( reportingRate ) ), info.getSampleItemIds() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -271,7 +272,8 @@ class PredictionAnalyticsDataFetcherTest
 
         List<FoundDimensionItemValue> actual = fetcher.getValues( orgUnits );
 
-        assertContainsOnly( actual, expected1, expected2, expected3, expected4, expected5, expected6, expected7 );
+        assertContainsOnly( List.of( expected1, expected2, expected3, expected4, expected5, expected6, expected7 ),
+            actual );
     }
 
     @Test
@@ -281,6 +283,6 @@ class PredictionAnalyticsDataFetcherTest
 
         List<FoundDimensionItemValue> actual = fetcher.getValues( orgUnits );
 
-        assertContainsOnly( actual );
+        assertIsEmpty( actual );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionContextGeneratorTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionContextGeneratorTest.java
@@ -312,7 +312,7 @@ class PredictionContextGeneratorTest
 
         List<String> actualFormatted = formatPredictionContextList( actual );
 
-        assertContainsOnly( actualFormatted, formatted1, formatted2, formatted3, formatted4 );
+        assertContainsOnly( List.of( formatted1, formatted2, formatted3, formatted4 ), actualFormatted );
 
         checkOrder( actual );
     }
@@ -339,7 +339,7 @@ class PredictionContextGeneratorTest
 
         List<String> actualFormatted = formatPredictionContextList( actual );
 
-        assertContainsOnly( actualFormatted, formatted1, formatted2 );
+        assertContainsOnly( List.of( formatted1, formatted2 ), actualFormatted );
 
         checkOrder( actual );
     }
@@ -388,7 +388,7 @@ class PredictionContextGeneratorTest
 
         List<String> actualFormatted = formatPredictionContextList( actual );
 
-        assertContainsOnly( actualFormatted, formatted1, formatted2, formatted3, formatted4 );
+        assertContainsOnly( List.of( formatted1, formatted2, formatted3, formatted4 ), actualFormatted );
 
         checkOrder( actual );
     }
@@ -406,7 +406,7 @@ class PredictionContextGeneratorTest
 
         List<String> actualFormatted = formatPredictionContextList( actual );
 
-        assertContainsOnly( actualFormatted, formatted1, formatted2 );
+        assertContainsOnly( List.of( formatted1, formatted2 ), actualFormatted );
 
         checkOrder( actual );
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionDataValueFetcherTest.java
@@ -353,13 +353,14 @@ class PredictionDataValueFetcherTest
         PredictionData data1 = fetcher.getData();
         assertNotNull( data1 );
         assertEquals( orgUnitB, data1.getOrgUnit() );
-        assertContainsOnly( data1.getValues(), foundValueA, foundValueAB, foundValueC, foundValueD, foundValueE );
-        assertContainsOnly( data1.getOldPredictions(), dataValueY );
+        assertContainsOnly( List.of( foundValueA, foundValueAB, foundValueC, foundValueD, foundValueE ),
+            data1.getValues() );
+        assertContainsOnly( List.of( dataValueY ), data1.getOldPredictions() );
 
         PredictionData data2 = fetcher.getData();
         assertNotNull( data2 );
         assertEquals( orgUnitC, data2.getOrgUnit() );
-        assertContainsOnly( data2.getValues(), foundValueB );
+        assertContainsOnly( List.of( foundValueB ), data2.getValues() );
         assertTrue( data2.getOldPredictions().isEmpty() );
 
         PredictionData data3 = fetcher.getData();
@@ -398,13 +399,14 @@ class PredictionDataValueFetcherTest
         PredictionData data1 = fetcher.getData();
         assertNotNull( data1 );
         assertEquals( orgUnitB, data1.getOrgUnit() );
-        assertContainsOnly( data1.getValues(), foundValueA, foundValueAB, foundValueC, foundValueD, foundValueE );
-        assertContainsOnly( data1.getOldPredictions(), dataValueW, dataValueY );
+        assertContainsOnly( List.of( foundValueA, foundValueAB, foundValueC, foundValueD, foundValueE ),
+            data1.getValues() );
+        assertContainsOnly( List.of( dataValueW, dataValueY ), data1.getOldPredictions() );
 
         PredictionData data2 = fetcher.getData();
         assertNotNull( data2 );
         assertEquals( orgUnitC, data2.getOrgUnit() );
-        assertContainsOnly( data2.getValues(), foundValueB );
+        assertContainsOnly( List.of( foundValueB ), data2.getValues() );
         assertTrue( data2.getOldPredictions().isEmpty() );
 
         PredictionData data3 = fetcher.getData();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/TrackerIdentifierCollectorTest.java
@@ -102,10 +102,10 @@ class TrackerIdentifierCollectorTest
         Map<Class<?>, Set<String>> ids = collector.collect( params );
 
         assertNotNull( ids );
-        assertContainsOnly( ids.get( TrackedEntity.class ), trackedEntity.getTrackedEntity() );
-        assertContainsOnly( ids.get( TrackedEntityType.class ), "sunshine" );
-        assertContainsOnly( ids.get( OrganisationUnit.class ), "ward" );
-        assertContainsOnly( ids.get( TrackedEntityAttribute.class ), "VohJnvWfvyo", "qv9xOw8fBzy" );
+        assertContainsOnly( Set.of( trackedEntity.getTrackedEntity() ), ids.get( TrackedEntity.class ) );
+        assertContainsOnly( Set.of( "sunshine" ), ids.get( TrackedEntityType.class ) );
+        assertContainsOnly( Set.of( "ward" ), ids.get( OrganisationUnit.class ) );
+        assertContainsOnly( Set.of( "VohJnvWfvyo", "qv9xOw8fBzy" ), ids.get( TrackedEntityAttribute.class ) );
     }
 
     @Test
@@ -132,11 +132,11 @@ class TrackerIdentifierCollectorTest
         Map<Class<?>, Set<String>> ids = collector.collect( params );
 
         assertNotNull( ids );
-        assertContainsOnly( ids.get( Enrollment.class ), enrollment.getUid() );
-        assertContainsOnly( ids.get( TrackedEntity.class ), enrollment.getTrackedEntity() );
-        assertContainsOnly( ids.get( Program.class ), "sunshine" );
-        assertContainsOnly( ids.get( OrganisationUnit.class ), "ward" );
-        assertContainsOnly( ids.get( TrackedEntityAttribute.class ), "VohJnvWfvyo", "qv9xOw8fBzy" );
+        assertContainsOnly( Set.of( enrollment.getUid() ), ids.get( Enrollment.class ) );
+        assertContainsOnly( Set.of( enrollment.getTrackedEntity() ), ids.get( TrackedEntity.class ) );
+        assertContainsOnly( Set.of( "sunshine" ), ids.get( Program.class ) );
+        assertContainsOnly( Set.of( "ward" ), ids.get( OrganisationUnit.class ) );
+        assertContainsOnly( Set.of( "VohJnvWfvyo", "qv9xOw8fBzy" ), ids.get( TrackedEntityAttribute.class ) );
     }
 
     @Test
@@ -169,15 +169,15 @@ class TrackerIdentifierCollectorTest
         Map<Class<?>, Set<String>> ids = collector.collect( params );
 
         assertNotNull( ids );
-        assertContainsOnly( ids.get( Event.class ), event.getUid() );
-        assertContainsOnly( ids.get( Enrollment.class ), event.getEnrollment() );
-        assertContainsOnly( ids.get( Program.class ), "sunshine" );
-        assertContainsOnly( ids.get( ProgramStage.class ), "flowers" );
-        assertContainsOnly( ids.get( OrganisationUnit.class ), "ward" );
-        assertContainsOnly( ids.get( DataElement.class ), "VohJnvWfvyo", "qv9xOw8fBzy" );
-        assertContainsOnly( ids.get( CategoryOptionCombo.class ), "rgb" );
-        assertContainsOnly( ids.get( CategoryOption.class ), "red", "green", "blue" );
-        assertContainsOnly( ids.get( TrackedEntityComment.class ), "i1vviSlidJE" );
+        assertContainsOnly( Set.of( event.getUid() ), ids.get( Event.class ) );
+        assertContainsOnly( Set.of( event.getEnrollment() ), ids.get( Enrollment.class ) );
+        assertContainsOnly( Set.of( "sunshine" ), ids.get( Program.class ) );
+        assertContainsOnly( Set.of( "flowers" ), ids.get( ProgramStage.class ) );
+        assertContainsOnly( Set.of( "ward" ), ids.get( OrganisationUnit.class ) );
+        assertContainsOnly( Set.of( "VohJnvWfvyo", "qv9xOw8fBzy" ), ids.get( DataElement.class ) );
+        assertContainsOnly( Set.of( "rgb" ), ids.get( CategoryOptionCombo.class ) );
+        assertContainsOnly( Set.of( "red", "green", "blue" ), ids.get( CategoryOption.class ) );
+        assertContainsOnly( Set.of( "i1vviSlidJE" ), ids.get( TrackedEntityComment.class ) );
     }
 
     @Test
@@ -241,10 +241,10 @@ class TrackerIdentifierCollectorTest
         Map<Class<?>, Set<String>> ids = collector.collect( params );
 
         assertNotNull( ids );
-        assertContainsOnly( ids.get( Relationship.class ), relationship.getRelationship() );
-        assertContainsOnly( ids.get( RelationshipType.class ), "sunshine" );
-        assertContainsOnly( ids.get( Enrollment.class ), relationship.getFrom().getEnrollment() );
-        assertContainsOnly( ids.get( Event.class ), relationship.getTo().getEvent() );
+        assertContainsOnly( Set.of( relationship.getRelationship() ), ids.get( Relationship.class ) );
+        assertContainsOnly( Set.of( "sunshine" ), ids.get( RelationshipType.class ) );
+        assertContainsOnly( Set.of( relationship.getFrom().getEnrollment() ), ids.get( Enrollment.class ) );
+        assertContainsOnly( Set.of( relationship.getTo().getEvent() ), ids.get( Event.class ) );
     }
 
     private String uid()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/converter/EventTrackerConverterServiceTest.java
@@ -233,7 +233,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         EventDataValue expect2 = new EventDataValue();
         expect2.setDataElement( dataElement.getUid() );
         expect2.setValue( newDataValue.getValue() );
-        assertContainsOnly( programStageInstance.getEventDataValues(), expect1, expect2 );
+        assertContainsOnly( Set.of( expect1, expect2 ), programStageInstance.getEventDataValues() );
     }
 
     @Test
@@ -261,7 +261,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         EventDataValue expect1 = new EventDataValue();
         expect1.setDataElement( dataElement.getUid() );
         expect1.setValue( updatedValue.getValue() );
-        assertContainsOnly( programStageInstance.getEventDataValues(), expect1 );
+        assertContainsOnly( Set.of( expect1 ), programStageInstance.getEventDataValues() );
     }
 
     @Test
@@ -294,7 +294,7 @@ class EventTrackerConverterServiceTest extends DhisConvenienceTest
         EventDataValue expect1 = new EventDataValue();
         expect1.setDataElement( dataElement.getUid() );
         expect1.setValue( updatedValue.getValue() );
-        assertContainsOnly( programStageInstance.getEventDataValues(), expect1 );
+        assertContainsOnly( Set.of( expect1 ), programStageInstance.getEventDataValues() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/OrganisationUnitMapperTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdScheme
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +56,6 @@ class OrganisationUnitMapperTest
         assertEquals( "HpSAvRWtdDR", mapped.getUid() );
         assertEquals( "meet", mapped.getName() );
         assertEquals( "green", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ), mapped.getAttributeValues() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramInstanceMapperTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdScheme
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,7 @@ class ProgramInstanceMapperTest
         assertEquals( "WTTYiPQDqh1", mapped.getProgram().getUid() );
         assertEquals( "friendship", mapped.getProgram().getName() );
         assertEquals( "red", mapped.getProgram().getCode() );
-        assertContainsOnly( mapped.getProgram().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "yellow" ) ),
+            mapped.getProgram().getAttributeValues() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramMapperTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.category.CategoryCombo;
@@ -73,7 +74,7 @@ class ProgramMapperTest extends DhisConvenienceTest
         assertEquals( "WTTYiPQDqh1", mapped.getUid() );
         assertEquals( "friendship", mapped.getName() );
         assertEquals( "red", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "yellow" ) ), mapped.getAttributeValues() );
 
         Optional<ProgramTrackedEntityAttribute> actual = mapped.getProgramAttributes().stream().findFirst();
         assertTrue( actual.isPresent() );
@@ -81,7 +82,8 @@ class ProgramMapperTest extends DhisConvenienceTest
         assertEquals( "khBzbxTLo8k", value.getAttribute().getUid() );
         assertEquals( "clouds", value.getAttribute().getName() );
         assertEquals( "orange", value.getAttribute().getCode() );
-        assertContainsOnly( value.getAttribute().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ),
+            value.getAttribute().getAttributeValues() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/ProgramStageMapperTest.java
@@ -80,12 +80,13 @@ class ProgramStageMapperTest
         assertEquals( "HpSAvRWtdDR", mapped.getUid() );
         assertEquals( "meet", mapped.getName() );
         assertEquals( "green", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ), mapped.getAttributeValues() );
 
         assertEquals( "WTTYiPQDqh1", mapped.getProgram().getUid() );
         assertEquals( "friendship", mapped.getProgram().getName() );
         assertEquals( "red", mapped.getProgram().getCode() );
-        assertContainsOnly( mapped.getProgram().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "yellow" ) ),
+            mapped.getProgram().getAttributeValues() );
 
         Optional<ProgramStageDataElement> actual = mapped.getProgramStageDataElements().stream().findFirst();
         assertTrue( actual.isPresent() );
@@ -93,6 +94,7 @@ class ProgramStageMapperTest
         assertEquals( "khBzbxTLo8k", value.getDataElement().getUid() );
         assertEquals( "clouds", value.getDataElement().getName() );
         assertEquals( "orange", value.getDataElement().getCode() );
-        assertContainsOnly( value.getDataElement().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ),
+            value.getDataElement().getAttributeValues() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipMapperTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdScheme
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.relationship.Relationship;
 import org.hisp.dhis.relationship.RelationshipType;
 import org.junit.jupiter.api.Test;
@@ -58,8 +60,8 @@ class RelationshipMapperTest
         assertEquals( "WTTYiPQDqh1", mapped.getRelationshipType().getUid() );
         assertEquals( "friendship", mapped.getRelationshipType().getName() );
         assertEquals( "red", mapped.getRelationshipType().getCode() );
-        assertContainsOnly( mapped.getRelationshipType().getAttributeValues(),
-            attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "yellow" ) ),
+            mapped.getRelationshipType().getAttributeValues() );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipTypeMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/RelationshipTypeMapperTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdScheme
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.relationship.RelationshipType;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +56,7 @@ class RelationshipTypeMapperTest
         assertEquals( "WTTYiPQDqh1", mapped.getUid() );
         assertEquals( "friendship", mapped.getName() );
         assertEquals( "red", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "yellow" ) ), mapped.getAttributeValues() );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityAttributeMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityAttributeMapperTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdScheme
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +57,6 @@ class TrackedEntityAttributeMapperTest
         assertEquals( "HpSAvRWtdDR", mapped.getUid() );
         assertEquals( "meet", mapped.getName() );
         assertEquals( "green", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ), mapped.getAttributeValues() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityInstanceMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityInstanceMapperTest.java
@@ -83,14 +83,14 @@ class TrackedEntityInstanceMapperTest
         assertEquals( "WTTYiPQDqh1", mapped.getTrackedEntityType().getUid() );
         assertEquals( "friendship", mapped.getTrackedEntityType().getName() );
         assertEquals( "red", mapped.getTrackedEntityType().getCode() );
-        assertContainsOnly( mapped.getTrackedEntityType().getAttributeValues(),
-            attributeValue( "m0GpPuMUfFW", "yellow" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "yellow" ) ),
+            mapped.getTrackedEntityType().getAttributeValues() );
 
         assertEquals( "HpSAvRWtdDR", mapped.getOrganisationUnit().getUid() );
         assertEquals( "meet", mapped.getOrganisationUnit().getName() );
         assertEquals( "green", mapped.getOrganisationUnit().getCode() );
-        assertContainsOnly( mapped.getOrganisationUnit().getAttributeValues(),
-            attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ),
+            mapped.getOrganisationUnit().getAttributeValues() );
 
         Optional<TrackedEntityAttributeValue> actual = mapped.getTrackedEntityAttributeValues().stream().findFirst();
         assertTrue( actual.isPresent() );
@@ -98,7 +98,8 @@ class TrackedEntityInstanceMapperTest
         assertEquals( "khBzbxTLo8k", value.getAttribute().getUid() );
         assertEquals( "clouds", value.getAttribute().getName() );
         assertEquals( "orange", value.getAttribute().getCode() );
-        assertContainsOnly( value.getAttribute().getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ),
+            value.getAttribute().getAttributeValues() );
     }
 
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityTypeMapperTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/mappers/TrackedEntityTypeMapperTest.java
@@ -33,6 +33,8 @@ import static org.hisp.dhis.tracker.preheat.mappers.AttributeCreator.setIdScheme
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +57,6 @@ class TrackedEntityTypeMapperTest
         assertEquals( "HpSAvRWtdDR", mapped.getUid() );
         assertEquals( "meet", mapped.getName() );
         assertEquals( "green", mapped.getCode() );
-        assertContainsOnly( mapped.getAttributeValues(), attributeValue( "m0GpPuMUfFW", "purple" ) );
+        assertContainsOnly( Set.of( attributeValue( "m0GpPuMUfFW", "purple" ) ), mapped.getAttributeValues() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplierTest.java
@@ -97,7 +97,7 @@ class FileResourceSupplierTest extends DhisConvenienceTest
 
         supplier.preheatAdd( params, preheat );
 
-        assertContainsOnly( preheat.getAll( FileResource.class ), fileResource );
+        assertContainsOnly( List.of( fileResource ), preheat.getAll( FileResource.class ) );
     }
 
     @Test
@@ -130,7 +130,7 @@ class FileResourceSupplierTest extends DhisConvenienceTest
 
         supplier.preheatAdd( params, preheat );
 
-        assertContainsOnly( preheat.getAll( FileResource.class ), fileResource );
+        assertContainsOnly( List.of( fileResource ), preheat.getAll( FileResource.class ) );
     }
 
     @Test
@@ -149,7 +149,7 @@ class FileResourceSupplierTest extends DhisConvenienceTest
 
         supplier.preheatAdd( params, preheat );
 
-        assertContainsOnly( preheat.getAll( FileResource.class ), fileResource );
+        assertContainsOnly( List.of( fileResource ), preheat.getAll( FileResource.class ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplierTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplierTest.java
@@ -94,7 +94,7 @@ class OrgUnitValueTypeSupplierTest extends DhisConvenienceTest
 
         supplier.preheatAdd( params, preheat );
 
-        assertContainsOnly( preheat.getAll( OrganisationUnit.class ), orgUnit );
+        assertContainsOnly( List.of( orgUnit ), preheat.getAll( OrganisationUnit.class ) );
     }
 
     @Test
@@ -128,7 +128,7 @@ class OrgUnitValueTypeSupplierTest extends DhisConvenienceTest
 
         supplier.preheatAdd( params, preheat );
 
-        assertContainsOnly( preheat.getAll( OrganisationUnit.class ), orgUnit );
+        assertContainsOnly( List.of( orgUnit ), preheat.getAll( OrganisationUnit.class ) );
     }
 
     @Test
@@ -147,7 +147,7 @@ class OrgUnitValueTypeSupplierTest extends DhisConvenienceTest
 
         supplier.preheatAdd( params, preheat );
 
-        assertContainsOnly( preheat.getAll( OrganisationUnit.class ), orgUnit );
+        assertContainsOnly( List.of( orgUnit ), preheat.getAll( OrganisationUnit.class ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
@@ -55,7 +55,7 @@ class TrackerValidationReportTest
 
         assertNotNull( report.getErrors() );
         assertEquals( 1, report.getErrors().size() );
-        assertContainsOnly( report.getErrors(), error );
+        assertContainsOnly( List.of( error ), report.getErrors() );
 
         report.addError( error );
 
@@ -72,11 +72,11 @@ class TrackerValidationReportTest
 
         report.addError( error1 );
 
-        assertContainsOnly( report.getErrors(), error1 );
+        assertContainsOnly( List.of( error1 ), report.getErrors() );
 
         report.addErrors( List.of( error1, error2 ) );
 
-        assertContainsOnly( report.getErrors(), error1, error2 );
+        assertContainsOnly( List.of( error1, error2 ), report.getErrors() );
     }
 
     @Test
@@ -90,7 +90,7 @@ class TrackerValidationReportTest
 
         assertNotNull( report.getWarnings() );
         assertEquals( 1, report.getWarnings().size() );
-        assertContainsOnly( report.getWarnings(), warning );
+        assertContainsOnly( List.of( warning ), report.getWarnings() );
 
         report.addWarning( warning );
 
@@ -107,11 +107,11 @@ class TrackerValidationReportTest
 
         report.addWarning( warning1 );
 
-        assertContainsOnly( report.getWarnings(), warning1 );
+        assertContainsOnly( List.of( warning1 ), report.getWarnings() );
 
         report.addWarnings( List.of( warning1, warning2 ) );
 
-        assertContainsOnly( report.getWarnings(), warning1, warning2 );
+        assertContainsOnly( List.of( warning1, warning2 ), report.getWarnings() );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/CappedLocalCacheTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/cache/CappedLocalCacheTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -115,6 +116,6 @@ class CappedLocalCacheTest
     {
         testRegion.put( "x", "y" );
         testRegion.put( "a", "b" );
-        assertContainsOnly( testRegion.getAll().collect( toList() ), "y", "b" );
+        assertContainsOnly( List.of( "y", "b" ), testRegion.getAll().collect( toList() ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -50,7 +50,8 @@ public final class Assertions
     }
 
     /**
-     * Asserts that the given collection contains exactly the given items.
+     * Asserts that the given collection contains exactly the given items in any
+     * order.
      *
      * @param <E> the type.
      * @param actual the actual collection.
@@ -59,10 +60,11 @@ public final class Assertions
     @SafeVarargs
     public static <E> void assertContainsOnly( Collection<E> actual, E... expected )
     {
+        assertNotNull( actual, String.format( "Expected collection to contain '%s', got null instead", expected ) );
         for ( E e : expected )
         {
             assertTrue( actual.contains( e ),
-                String.format( "Expected value %s not found in %s", e.toString(), actual.toString() ) );
+                String.format( "Expected value %s not found in %s", e.toString(), actual ) );
         }
 
         assertEquals( expected.length, actual.size() );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -27,15 +27,18 @@
  */
 package org.hisp.dhis.utils;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.hisp.dhis.common.ErrorCodeException;
+import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.junit.jupiter.api.function.Executable;
 
@@ -54,20 +57,20 @@ public final class Assertions
      * order.
      *
      * @param <E> the type.
-     * @param actual the actual collection.
      * @param expected the expected items.
+     * @param actual the actual collection.
      */
-    @SafeVarargs
-    public static <E> void assertContainsOnly( Collection<E> actual, E... expected )
+    public static <E> void assertContainsOnly( Collection<E> expected, Collection<E> actual )
     {
-        assertNotNull( actual, String.format( "Expected collection to contain '%s', got null instead", expected ) );
-        for ( E e : expected )
-        {
-            assertTrue( actual.contains( e ),
-                String.format( "Expected value %s not found in %s", e.toString(), actual ) );
-        }
+        assertNotNull( actual, String.format( "Expected collection to contain %s, got null instead", expected ) );
 
-        assertEquals( expected.length, actual.size() );
+        List<E> missing = CollectionUtils.difference( expected, actual );
+        List<E> extra = CollectionUtils.difference( actual, expected );
+        assertAll( "assertContainsOnly found mismatch",
+            () -> assertTrue( missing.isEmpty(), () -> String.format( "Expected %s to be in %s", missing, actual ) ),
+            () -> assertTrue( extra.isEmpty(), () -> String.format( "Expected %s NOT to be in %s", extra, actual ) ),
+            () -> assertEquals( expected.size(), actual.size(),
+                String.format( "Expected %s or actual %s contains unexpected duplicates", expected, actual ) ) );
     }
 
     public static <K, V> void assertMapEquals( Map<K, V> expected, Map<K, V> actual )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataexchange/analytics/AggregateDataExchangeStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataexchange/analytics/AggregateDataExchangeStoreTest.java
@@ -31,6 +31,8 @@ import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.List;
+
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchangeStore;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
@@ -72,8 +74,8 @@ class AggregateDataExchangeStoreTest extends TransactionalIntegrationTest
 
         assertEquals( "DataExchangeUpdated", de.getName() );
         assertEquals( 3, de.getSource().getRequests().get( 0 ).getDx().size() );
-        assertContainsOnly( de.getSource().getRequests().get( 0 ).getDx(),
-            "LrDpG50RAU9", "uR5HCiJhQ1w", "NhSFzklRD55" );
+        assertContainsOnly( List.of( "LrDpG50RAU9", "uR5HCiJhQ1w", "NhSFzklRD55" ),
+            de.getSource().getRequests().get( 0 ).getDx() );
         assertEquals( "https://play.dhis2.org/dev", de.getTarget().getApi().getUrl() );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/DataSetStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/DataSetStoreTest.java
@@ -122,7 +122,7 @@ class DataSetStoreTest extends SingleSetupIntegrationTestBase
     {
         DataSet dataSetA = addDataSet( 'A' );
         DataSet dataSetB = addDataSet( 'B' );
-        assertContainsOnly( dataSetStore.getAll(), dataSetA, dataSetB );
+        assertContainsOnly( List.of( dataSetA, dataSetB ), dataSetStore.getAll() );
     }
 
     @Test
@@ -133,8 +133,8 @@ class DataSetStoreTest extends SingleSetupIntegrationTestBase
         PeriodType periodType2 = types.get( 1 );
         DataSet dataSetA = addDataSet( 'A', periodType1 );
         DataSet dataSetB = addDataSet( 'B', periodType2 );
-        assertContainsOnly( dataSetStore.getDataSetsByPeriodType( periodType1 ), dataSetA );
-        assertContainsOnly( dataSetStore.getDataSetsByPeriodType( periodType2 ), dataSetB );
+        assertContainsOnly( List.of( dataSetA ), dataSetStore.getDataSetsByPeriodType( periodType1 ) );
+        assertContainsOnly( List.of( dataSetB ), dataSetStore.getDataSetsByPeriodType( periodType2 ) );
     }
 
     @Test
@@ -145,13 +145,13 @@ class DataSetStoreTest extends SingleSetupIntegrationTestBase
         DataSet dataSetC = addDataSet( 'C' );
         DataEntryForm dataEntryFormX = addDataEntryForm( 'X', dataSetA );
         DataEntryForm dataEntryFormY = addDataEntryForm( 'Y' );
-        assertContainsOnly( dataSetStore.getDataSetsByDataEntryForm( dataEntryFormX ), dataSetA );
+        assertContainsOnly( List.of( dataSetA ), dataSetStore.getDataSetsByDataEntryForm( dataEntryFormX ) );
         dataSetC.setDataEntryForm( dataEntryFormX );
         dataSetStore.update( dataSetC );
-        assertContainsOnly( dataSetStore.getDataSetsByDataEntryForm( dataEntryFormX ), dataSetA, dataSetC );
+        assertContainsOnly( List.of( dataSetA, dataSetC ), dataSetStore.getDataSetsByDataEntryForm( dataEntryFormX ) );
         dataSetB.setDataEntryForm( dataEntryFormY );
         dataSetStore.update( dataSetB );
-        assertContainsOnly( dataSetStore.getDataSetsByDataEntryForm( dataEntryFormY ), dataSetB );
+        assertContainsOnly( List.of( dataSetB ), dataSetStore.getDataSetsByDataEntryForm( dataEntryFormY ) );
     }
 
     @Test
@@ -161,7 +161,7 @@ class DataSetStoreTest extends SingleSetupIntegrationTestBase
         DataSet dataSetA = addDataSet( 'A' );
         addDataSet( 'B', unitX );
         DataSet dataSetC = addDataSet( 'C' );
-        assertContainsOnly( dataSetStore.getDataSetsNotAssignedToOrganisationUnits(), dataSetA, dataSetC );
+        assertContainsOnly( List.of( dataSetA, dataSetC ), dataSetStore.getDataSetsNotAssignedToOrganisationUnits() );
     }
 
     private OrganisationUnit addOrganisationUnit( char uniqueCharacter )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/LockExceptionStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataset/LockExceptionStoreTest.java
@@ -106,11 +106,11 @@ class LockExceptionStoreTest extends SingleSetupIntegrationTestBase
 
         List<LockException> lockExceptions = store.getLockExceptions( List.of( dsA, dsB ) );
 
-        assertContainsOnly( lockExceptions, leA, leB, leD, leE );
+        assertContainsOnly( List.of( leA, leB, leD, leE ), lockExceptions );
 
         lockExceptions = store.getLockExceptions( List.of( dsA ) );
 
-        assertContainsOnly( lockExceptions, leA, leD );
+        assertContainsOnly( List.of( leA, leD ), lockExceptions );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreEntryStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datastore/DatastoreEntryStoreTest.java
@@ -32,6 +32,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.List;
+
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +60,7 @@ class DatastoreEntryStoreTest extends SingleSetupIntegrationTestBase
     {
         addEntry( "A", "1" );
         addEntry( "B", "1" );
-        assertContainsOnly( store.getNamespaces(), "A", "B" );
+        assertContainsOnly( List.of( "A", "B" ), store.getNamespaces() );
     }
 
     @Test
@@ -67,7 +69,7 @@ class DatastoreEntryStoreTest extends SingleSetupIntegrationTestBase
         addEntry( "A", "1" );
         addEntry( "A", "2" );
         addEntry( "B", "1" );
-        assertContainsOnly( store.getKeysInNamespace( "A" ), "1", "2" );
+        assertContainsOnly( List.of( "1", "2" ), store.getKeysInNamespace( "A" ) );
     }
 
     @Test
@@ -84,7 +86,7 @@ class DatastoreEntryStoreTest extends SingleSetupIntegrationTestBase
         DatastoreEntry entryA2 = addEntry( "A", "2" );
         DatastoreEntry entryA3 = addEntry( "A", "3" );
         DatastoreEntry entryB1 = addEntry( "B", "1" );
-        assertContainsOnly( store.getEntryByNamespace( "A" ), entryA1, entryA2, entryA3 );
+        assertContainsOnly( List.of( entryA1, entryA2, entryA3 ), store.getEntryByNamespace( "A" ) );
         assertFalse( store.getEntryByNamespace( "A" ).contains( entryB1 ) );
     }
 
@@ -108,7 +110,7 @@ class DatastoreEntryStoreTest extends SingleSetupIntegrationTestBase
         addEntry( "B", "1" );
         addEntry( "C", "1" );
         store.deleteNamespace( "A" );
-        assertContainsOnly( store.getNamespaces(), "B", "C" );
+        assertContainsOnly( List.of( "B", "C" ), store.getNamespaces() );
     }
 
     private DatastoreEntry addEntry( String ns, String key )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueAuditServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueAuditServiceTest.java
@@ -153,7 +153,7 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
         dataValueAuditService.addDataValueAudit( dataValueAuditB );
 
         List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( dataValueA );
-        assertContainsOnly( audits, dataValueAuditA );
+        assertContainsOnly( List.of( dataValueAuditA ), audits );
     }
 
     @Test
@@ -174,7 +174,7 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
             .setAttributeOptionCombo( optionCombo );
 
         List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( params );
-        assertContainsOnly( audits, dataValueAuditA );
+        assertContainsOnly( List.of( dataValueAuditA ), audits );
     }
 
     @Test
@@ -200,7 +200,7 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
             .setCategoryOptionCombo( optionCombo )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
 
-        assertContainsOnly( dataValueAuditService.getDataValueAudits( params ), dvaA );
+        assertContainsOnly( List.of( dvaA ), dataValueAuditService.getDataValueAudits( params ) );
 
         params = new DataValueAuditQueryParams()
             .setDataElements( List.of( dataElementA, dataElementB ) )
@@ -209,17 +209,17 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
             .setCategoryOptionCombo( optionCombo )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
 
-        assertContainsOnly( dataValueAuditService.getDataValueAudits( params ), dvaA, dvaB );
+        assertContainsOnly( List.of( dvaA, dvaB ), dataValueAuditService.getDataValueAudits( params ) );
 
         params = new DataValueAuditQueryParams()
             .setAuditTypes( List.of( AuditType.CREATE ) );
 
-        assertContainsOnly( dataValueAuditService.getDataValueAudits( params ), dvaC );
+        assertContainsOnly( List.of( dvaC ), dataValueAuditService.getDataValueAudits( params ) );
 
         params = new DataValueAuditQueryParams()
             .setAuditTypes( List.of( AuditType.CREATE, AuditType.DELETE ) );
 
-        assertContainsOnly( dataValueAuditService.getDataValueAudits( params ), dvaC, dvaD );
+        assertContainsOnly( List.of( dvaC, dvaD ), dataValueAuditService.getDataValueAudits( params ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueAuditServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueAuditServiceTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.datavalue;
 
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
@@ -154,7 +153,6 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
         dataValueAuditService.addDataValueAudit( dataValueAuditB );
 
         List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( dataValueA );
-        assertNotNull( audits );
         assertContainsOnly( audits, dataValueAuditA );
     }
 
@@ -176,7 +174,6 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
             .setAttributeOptionCombo( optionCombo );
 
         List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits( params );
-        assertNotNull( audits );
         assertContainsOnly( audits, dataValueAuditA );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/adx/AdxDataServiceIntegrationTest.java
@@ -468,7 +468,7 @@ class AdxDataServiceIntegrationTest extends IntegrationTestBase
         importOptions.setIdSchemes( idSchemes );
         adxDataService.saveDataValueSet( in, importOptions, null );
         List<DataValue> dataValues = dataValueService.getAllDataValues();
-        assertContainsOnly( dataValues, new DataValue( deA, pe202001, ouA, cocFUnder5, cocDefault, "1" ),
+        assertContainsOnly( List.of( new DataValue( deA, pe202001, ouA, cocFUnder5, cocDefault, "1" ),
             new DataValue( deA, pe202001, ouA, cocMUnder5, cocDefault, "2" ),
             new DataValue( deA, pe202001, ouA, cocFOver5, cocDefault, "3" ),
             new DataValue( deA, pe202001, ouA, cocMOver5, cocDefault, "4" ),
@@ -476,6 +476,6 @@ class AdxDataServiceIntegrationTest extends IntegrationTestBase
             new DataValue( deA, pe202002, ouB, cocFUnder5, cocDefault, "6" ),
             new DataValue( deA, pe2021Q1, ouB, cocFUnder5, cocPepfar, "10" ),
             new DataValue( deA, pe2021Q1, ouB, cocFOver5, cocMcDonalds, "20" ),
-            new DataValue( deA, pe2021Q1, ouB, cocMUnder5, cocMcDonalds, "30" ) );
+            new DataValue( deA, pe2021Q1, ouB, cocMUnder5, cocMcDonalds, "30" ) ), dataValues );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceGetFromUrlTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/datavalueset/DataValueSetServiceGetFromUrlTest.java
@@ -119,7 +119,7 @@ class DataValueSetServiceGetFromUrlTest extends SingleSetupIntegrationTestBase
 
         DataExportParams exportParams = dataValueSetService.getFromUrl( params );
 
-        assertContainsOnly( exportParams.getAttributeOptionCombos(), optionComboA );
+        assertContainsOnly( Set.of( optionComboA ), exportParams.getAttributeOptionCombos() );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/trackedentity/store/DefaultAclStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/trackedentity/store/DefaultAclStoreTest.java
@@ -109,7 +109,7 @@ class DefaultAclStoreTest extends IntegrationTestBase
         programB.setPublicAccess( "--------" );
         manager.save( programB, false );
         List<Long> programIds = aclStore.getAccessiblePrograms( user.getUid(), Collections.emptyList() );
-        assertContainsOnly( programIds, programA.getId() );
+        assertContainsOnly( List.of( programA.getId() ), programIds );
     }
 
     @Test
@@ -130,7 +130,7 @@ class DefaultAclStoreTest extends IntegrationTestBase
         programB.getSharing().addUserAccess( a );
         manager.save( programB, false );
         List<Long> programIds = aclStore.getAccessiblePrograms( user.getUid(), Collections.emptyList() );
-        assertContainsOnly( programIds, programB.getId() );
+        assertContainsOnly( List.of( programB.getId() ), programIds );
     }
 
     @Test
@@ -154,6 +154,6 @@ class DefaultAclStoreTest extends IntegrationTestBase
         manager.save( programB, false );
         List<Long> programIds = aclStore.getAccessiblePrograms( user.getUid(),
             Collections.singletonList( g.getUid() ) );
-        assertContainsOnly( programIds, programB.getId() );
+        assertContainsOnly( List.of( programB.getId() ), programIds );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/UserMetadataOrgUnitMergeHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/merge/orgunit/handler/UserMetadataOrgUnitMergeHandlerTest.java
@@ -31,6 +31,8 @@ import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.merge.orgunit.OrgUnitMergeRequest;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -100,11 +102,11 @@ class UserMetadataOrgUnitMergeHandlerTest extends SingleSetupIntegrationTestBase
         assertFalse( userB.getTeiSearchOrganisationUnits().contains( ouB ) );
         assertTrue( ouC.getUsers().contains( userA ) );
         assertTrue( ouC.getUsers().contains( userB ) );
-        assertContainsOnly( userA.getOrganisationUnits(), ouC );
-        assertContainsOnly( userA.getDataViewOrganisationUnits(), ouC );
-        assertContainsOnly( userA.getTeiSearchOrganisationUnits(), ouC );
-        assertContainsOnly( userB.getOrganisationUnits(), ouC );
-        assertContainsOnly( userB.getDataViewOrganisationUnits(), ouC );
-        assertContainsOnly( userB.getTeiSearchOrganisationUnits(), ouC );
+        assertContainsOnly( Set.of( ouC ), userA.getOrganisationUnits() );
+        assertContainsOnly( Set.of( ouC ), userA.getDataViewOrganisationUnits() );
+        assertContainsOnly( Set.of( ouC ), userA.getTeiSearchOrganisationUnits() );
+        assertContainsOnly( Set.of( ouC ), userB.getOrganisationUnits() );
+        assertContainsOnly( Set.of( ouC ), userB.getDataViewOrganisationUnits() );
+        assertContainsOnly( Set.of( ouC ), userB.getTeiSearchOrganisationUnits() );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/minmax/MinMaxDataElementStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/minmax/MinMaxDataElementStoreTest.java
@@ -142,7 +142,7 @@ class MinMaxDataElementStoreTest extends SingleSetupIntegrationTestBase
 
         List<MinMaxDataElement> values = minMaxDataElementStore.get( ouA, List.of( deA, deB ) );
 
-        assertContainsOnly( values, valueA, valueB );
+        assertContainsOnly( List.of( valueA, valueB ), values );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupStoreTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.organisationunit;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -49,7 +50,7 @@ class OrganisationUnitGroupStoreTest extends OrganisationUnitBaseSpringTest
         OrganisationUnitGroup noSet = addOrganisationUnitGroup( 'X', someUnit );
         OrganisationUnitGroup withSet = addOrganisationUnitGroup( 'W', someUnit );
         addOrganisationUnitGroupSet( 'S', withSet );
-        assertContainsOnly( groupStore.getOrganisationUnitGroupsWithoutGroupSets(), noSet );
+        assertContainsOnly( List.of( noSet ), groupStore.getOrganisationUnitGroupsWithoutGroupSets() );
     }
 
     @Test
@@ -59,7 +60,7 @@ class OrganisationUnitGroupStoreTest extends OrganisationUnitBaseSpringTest
         addOrganisationUnitGroup( 'X', someUnit );
         OrganisationUnitGroup withSet = addOrganisationUnitGroup( 'W', someUnit );
         addOrganisationUnitGroupSet( 'S', withSet );
-        assertContainsOnly( groupStore.getOrganisationUnitGroupsWithGroupSets(), withSet );
+        assertContainsOnly( List.of( withSet ), groupStore.getOrganisationUnitGroupsWithGroupSets() );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreIntegrationTest.java
@@ -28,13 +28,11 @@
 package org.hisp.dhis.organisationunit;
 
 import static org.hisp.dhis.organisationunit.FeatureType.POINT;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.system.util.GeoUtils;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
@@ -79,27 +77,16 @@ class OrganisationUnitStoreIntegrationTest extends TransactionalIntegrationTest
         manager.save( ouC );
         manager.save( ouD );
         List<OrganisationUnit> ous = getOUsFromPointToDistance( point, _150KM );
-        assertContainsOnly( ous, ouA );
+        assertContainsOnly( List.of( ouA ), ous );
         ous = getOUsFromPointToDistance( point, _190KM );
-        assertContainsOnly( ous, ouA, ouC );
+        assertContainsOnly( List.of( ouA, ouC ), ous );
         ous = getOUsFromPointToDistance( point, _250KM );
-        assertContainsOnly( ous, ouA, ouB, ouC, ouD );
+        assertContainsOnly( List.of( ouA, ouB, ouC, ouD ), ous );
     }
 
     private List<OrganisationUnit> getOUsFromPointToDistance( Geometry point, long distance )
     {
         double[] box = GeoUtils.getBoxShape( point.getCoordinate().x, point.getCoordinate().y, distance );
         return organisationUnitStore.getWithinCoordinateArea( box );
-    }
-
-    private void assertContainsOnly( List<OrganisationUnit> ous, OrganisationUnit... ou )
-    {
-        List<String> ouNames = ous.stream().map( BaseIdentifiableObject::getName ).collect( Collectors.toList() );
-        for ( OrganisationUnit organisationUnit : ou )
-        {
-            if ( !ouNames.contains( organisationUnit.getName() ) )
-                fail( "Org Unit with name " + organisationUnit.getName()
-                    + " is not part of list of Org Units returned from query" );
-        }
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitStoreTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.List;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -75,7 +77,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         OrganisationUnit ouE = addOrganisationUnit( 'E', ouB );
         addOrganisationUnitGroup( 'A', ouA );
         addOrganisationUnitGroup( 'B', ouB );
-        assertContainsOnly( unitStore.getOrganisationUnitsWithoutGroups(), ouC, ouD, ouE );
+        assertContainsOnly( List.of( ouC, ouD, ouE ), unitStore.getOrganisationUnitsWithoutGroups() );
     }
 
     @Test
@@ -121,8 +123,8 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         OrganisationUnit ouG = addOrganisationUnit( 'G', ouC );
         Program prA = addProgram( 'A', ouA, ouB, ouC, ouE );
         Program prB = addProgram( 'B', ouA, ouD, ouE );
-        assertContainsOnly( unitStore.getOrganisationUnitsWithProgram( prA ), ouA, ouB, ouC, ouE );
-        assertContainsOnly( unitStore.getOrganisationUnitsWithProgram( prB ), ouA, ouD, ouE );
+        assertContainsOnly( List.of( ouA, ouB, ouC, ouE ), unitStore.getOrganisationUnitsWithProgram( prA ) );
+        assertContainsOnly( List.of( ouA, ouD, ouE ), unitStore.getOrganisationUnitsWithProgram( prB ) );
     }
 
     @Test
@@ -145,60 +147,57 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         OrganisationUnitGroup ougA = addOrganisationUnitGroup( 'A', ouD, ouF );
         OrganisationUnitGroup ougB = addOrganisationUnitGroup( 'B', ouE, ouG );
         // Query
-        assertContainsOnly(
-            unitStore.getOrganisationUnits( createParams( OrganisationUnitQueryParams::setQuery, "UnitC" ) ), ouC );
+        assertContainsOnly( List.of( ouC ),
+            unitStore.getOrganisationUnits( createParams( OrganisationUnitQueryParams::setQuery, "UnitC" ) ) );
         // Query
-        assertContainsOnly( unitStore.getOrganisationUnits(
-            createParams( OrganisationUnitQueryParams::setQuery, "OrganisationUnitCodeA" ) ), ouA );
+        assertContainsOnly( List.of( ouA ), unitStore.getOrganisationUnits(
+            createParams( OrganisationUnitQueryParams::setQuery, "OrganisationUnitCodeA" ) ) );
         // Parents
-        assertContainsOnly( unitStore.getOrganisationUnits(
-            createParams( OrganisationUnitQueryParams::setParents, Sets.newHashSet( ouC, ouF ) ) ), ouC, ouF, ouG );
+        assertContainsOnly( List.of( ouC, ouF, ouG ), unitStore.getOrganisationUnits(
+            createParams( OrganisationUnitQueryParams::setParents, Sets.newHashSet( ouC, ouF ) ) ) );
         // Groups
-        assertContainsOnly( unitStore.getOrganisationUnits(
-            createParams( OrganisationUnitQueryParams::setGroups, Sets.newHashSet( ougA ) ) ), ouD, ouF );
+        assertContainsOnly( List.of( ouD, ouF ), unitStore.getOrganisationUnits(
+            createParams( OrganisationUnitQueryParams::setGroups, Sets.newHashSet( ougA ) ) ) );
         // Groups
-        assertContainsOnly(
-            unitStore.getOrganisationUnits(
-                createParams( OrganisationUnitQueryParams::setGroups, Sets.newHashSet( ougA, ougB ) ) ),
-            ouD, ouF, ouE, ouG );
+        assertContainsOnly( List.of( ouD, ouF, ouE, ouG ), unitStore.getOrganisationUnits(
+            createParams( OrganisationUnitQueryParams::setGroups, Sets.newHashSet( ougA, ougB ) ) ) );
         // Levels
-        assertContainsOnly( unitStore.getOrganisationUnits(
-            createParams( OrganisationUnitQueryParams::setLevels, Sets.newHashSet( 2 ) ) ), ouB, ouC );
+        assertContainsOnly( List.of( ouB, ouC ), unitStore.getOrganisationUnits(
+            createParams( OrganisationUnitQueryParams::setLevels, Sets.newHashSet( 2 ) ) ) );
         // Levels
-        assertContainsOnly(
-            unitStore.getOrganisationUnits(
-                createParams( OrganisationUnitQueryParams::setLevels, Sets.newHashSet( 2, 3 ) ) ),
-            ouB, ouC, ouD, ouE, ouF, ouG );
+        assertContainsOnly( List.of( ouB, ouC, ouD, ouE, ouF, ouG ), unitStore.getOrganisationUnits(
+            createParams( OrganisationUnitQueryParams::setLevels, Sets.newHashSet( 2, 3 ) ) ) );
         // Levels and groups
-        assertContainsOnly( unitStore.getOrganisationUnits( createParams( params -> {
+        assertContainsOnly( List.of( ouD, ouF ), unitStore.getOrganisationUnits( createParams( params -> {
             params.setLevels( Sets.newHashSet( 3 ) );
             params.setGroups( Sets.newHashSet( ougA ) );
-        } ) ), ouD, ouF );
+        } ) ) );
         // Parents and groups
-        assertContainsOnly( unitStore.getOrganisationUnits( createParams( params -> {
+        assertContainsOnly( List.of( ouG ), unitStore.getOrganisationUnits( createParams( params -> {
             params.setParents( Sets.newHashSet( ouC ) );
             params.setGroups( Sets.newHashSet( ougB ) );
-        } ) ), ouG );
+        } ) ) );
         // Parents and max levels
-        assertContainsOnly( unitStore.getOrganisationUnits( createParams( params -> {
+        assertContainsOnly( List.of( ouA, ouB, ouC ), unitStore.getOrganisationUnits( createParams( params -> {
             params.setParents( Sets.newHashSet( ouA ) );
             params.setMaxLevels( 2 );
-        } ) ), ouA, ouB, ouC );
+        } ) ) );
         // Parents and max levels
-        assertContainsOnly( unitStore.getOrganisationUnits( createParams( params -> {
-            params.setParents( Sets.newHashSet( ouA ) );
-            params.setMaxLevels( 3 );
-        } ) ), ouA, ouB, ouC, ouD, ouE, ouF, ouG );
+        assertContainsOnly( List.of( ouA, ouB, ouC, ouD, ouE, ouF, ouG ),
+            unitStore.getOrganisationUnits( createParams( params -> {
+                params.setParents( Sets.newHashSet( ouA ) );
+                params.setMaxLevels( 3 );
+            } ) ) );
         // Parents and max levels
-        assertContainsOnly( unitStore.getOrganisationUnits( createParams( params -> {
+        assertContainsOnly( List.of( ouA ), unitStore.getOrganisationUnits( createParams( params -> {
             params.setParents( Sets.newHashSet( ouA ) );
             params.setMaxLevels( 1 );
-        } ) ), ouA );
+        } ) ) );
         // Parents and max levels
-        assertContainsOnly( unitStore.getOrganisationUnits( createParams( params -> {
+        assertContainsOnly( List.of( ouB, ouD, ouE ), unitStore.getOrganisationUnits( createParams( params -> {
             params.setParents( Sets.newHashSet( ouB ) );
             params.setMaxLevels( 3 );
-        } ) ), ouB, ouD, ouE );
+        } ) ) );
     }
 
     // -------------------------------------------------------------------------
@@ -218,7 +217,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
     {
         OrganisationUnitLevel levelA = addOrganisationUnitLevel( 1, "National" );
         OrganisationUnitLevel levelB = addOrganisationUnitLevel( 2, "District" );
-        assertContainsOnly( levelStore.getAll(), levelA, levelB );
+        assertContainsOnly( List.of( levelA, levelB ), levelStore.getAll() );
     }
 
     @Test
@@ -269,7 +268,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         ouA.setParent( ouB );
         ouB.getChildren().add( ouA );
         unitStore.save( ouB );
-        assertContainsOnly( unitStore.getOrganisationUnitsWithCyclicReferences(), ouA, ouB );
+        assertContainsOnly( Set.of( ouA, ouB ), unitStore.getOrganisationUnitsWithCyclicReferences() );
     }
 
     @Test
@@ -286,7 +285,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         ouA.setParent( ouD );
         ouD.getChildren().add( ouA );
         unitStore.save( ouD );
-        assertContainsOnly( unitStore.getOrganisationUnitsWithCyclicReferences(), ouA, ouB, ouC, ouD );
+        assertContainsOnly( Set.of( ouA, ouB, ouC, ouD ), unitStore.getOrganisationUnitsWithCyclicReferences() );
     }
 
     @Test
@@ -294,7 +293,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
     {
         OrganisationUnit ouA = addOrganisationUnit( 'A' );
         OrganisationUnit ouB = addOrganisationUnit( 'B' );
-        assertContainsOnly( unitStore.getOrphanedOrganisationUnits(), ouA, ouB );
+        assertContainsOnly( List.of( ouA, ouB ), unitStore.getOrphanedOrganisationUnits() );
     }
 
     @Test
@@ -303,7 +302,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         OrganisationUnit ouA = addOrganisationUnit( 'A' );
         OrganisationUnit ouB = addOrganisationUnit( 'B' );
         OrganisationUnit ouC = addOrganisationUnit( 'C', ouA );
-        assertContainsOnly( unitStore.getOrphanedOrganisationUnits(), ouB );
+        assertContainsOnly( List.of( ouB ), unitStore.getOrphanedOrganisationUnits() );
     }
 
     @Test
@@ -321,7 +320,7 @@ class OrganisationUnitStoreTest extends OrganisationUnitBaseSpringTest
         addOrganisationUnitGroupSet( 'K', groupA );
         addOrganisationUnitGroupSet( 'X', groupC, groupD, groupE );
         // unit D is in group D and E which are both in set X
-        assertContainsOnly( unitStore.getOrganisationUnitsViolatingExclusiveGroupSets(), ouD );
+        assertContainsOnly( List.of( ouD ), unitStore.getOrganisationUnitsViolatingExclusiveGroupSets() );
     }
 
     private Program addProgram( char uniqueCharacter, OrganisationUnit... units )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityDataValueAuditStoreTest.java
@@ -203,14 +203,14 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
             .setDataElements( List.of( deA, deB ) )
             .setProgramStageInstances( List.of( psiA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaA, dvaB );
+        assertContainsOnly( List.of( dvaA, dvaB ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 2, auditStore.countTrackedEntityDataValueAudits( params ) );
 
         params = new TrackedEntityDataValueAuditQueryParams()
             .setDataElements( List.of( deA ) )
             .setProgramStageInstances( List.of( psiA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaA );
+        assertContainsOnly( List.of( dvaA ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 1, auditStore.countTrackedEntityDataValueAudits( params ) );
     }
 
@@ -230,13 +230,13 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
         TrackedEntityDataValueAuditQueryParams params = new TrackedEntityDataValueAuditQueryParams()
             .setOrgUnits( List.of( ouA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaA, dvaB );
+        assertContainsOnly( List.of( dvaA, dvaB ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 2, auditStore.countTrackedEntityDataValueAudits( params ) );
 
         params = new TrackedEntityDataValueAuditQueryParams()
             .setOrgUnits( List.of( ouB ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaC );
+        assertContainsOnly( List.of( dvaC ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 1, auditStore.countTrackedEntityDataValueAudits( params ) );
     }
 
@@ -263,14 +263,15 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
             .setOrgUnits( List.of( ouB ) )
             .setOuMode( OrganisationUnitSelectionMode.DESCENDANTS )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaB, dvaD, dvaE );
+        assertContainsOnly( List.of( dvaB, dvaD, dvaE ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 3, auditStore.countTrackedEntityDataValueAudits( params ) );
 
         params = new TrackedEntityDataValueAuditQueryParams()
             .setOrgUnits( List.of( ouA ) )
             .setOuMode( OrganisationUnitSelectionMode.DESCENDANTS )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaA, dvaB, dvaC, dvaD, dvaE );
+        assertContainsOnly( List.of( dvaA, dvaB, dvaC, dvaD, dvaE ),
+            auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 5, auditStore.countTrackedEntityDataValueAudits( params ) );
     }
 
@@ -290,13 +291,13 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
         TrackedEntityDataValueAuditQueryParams params = new TrackedEntityDataValueAuditQueryParams()
             .setProgramStages( List.of( psA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaA, dvaB );
+        assertContainsOnly( List.of( dvaA, dvaB ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 2, auditStore.countTrackedEntityDataValueAudits( params ) );
 
         params = new TrackedEntityDataValueAuditQueryParams()
             .setProgramStages( List.of( psB ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaC );
+        assertContainsOnly( List.of( dvaC ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 1, auditStore.countTrackedEntityDataValueAudits( params ) );
     }
 
@@ -320,14 +321,14 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
             .setDataElements( List.of( deA, deB ) )
             .setStartDate( getDate( 2021, 6, 15 ) )
             .setEndDate( getDate( 2021, 8, 15 ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaB, dvaC );
+        assertContainsOnly( List.of( dvaB, dvaC ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 2, auditStore.countTrackedEntityDataValueAudits( params ) );
 
         params = new TrackedEntityDataValueAuditQueryParams()
             .setDataElements( List.of( deA, deB ) )
             .setStartDate( getDate( 2021, 6, 15 ) )
             .setEndDate( getDate( 2021, 7, 15 ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaB );
+        assertContainsOnly( List.of( dvaB ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 1, auditStore.countTrackedEntityDataValueAudits( params ) );
     }
 
@@ -346,7 +347,7 @@ class TrackedEntityDataValueAuditStoreTest extends SingleSetupIntegrationTestBas
 
         TrackedEntityDataValueAuditQueryParams params = new TrackedEntityDataValueAuditQueryParams()
             .setAuditTypes( List.of( AuditType.UPDATE, AuditType.DELETE ) );
-        assertContainsOnly( auditStore.getTrackedEntityDataValueAudits( params ), dvaB, dvaC );
+        assertContainsOnly( List.of( dvaB, dvaC ), auditStore.getTrackedEntityDataValueAudits( params ) );
         assertEquals( 2, auditStore.countTrackedEntityDataValueAudits( params ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceAuditStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceAuditStoreTest.java
@@ -68,27 +68,27 @@ class TrackedEntityInstanceAuditStoreTest extends SingleSetupIntegrationTestBase
         TrackedEntityInstanceAuditQueryParams params = new TrackedEntityInstanceAuditQueryParams()
             .setTrackedEntityInstances( List.of( "WGW7UnVcIIb" ) );
 
-        assertContainsOnly( store.getTrackedEntityInstanceAudits( params ), teiaA, teiaB );
+        assertContainsOnly( List.of( teiaA, teiaB ), store.getTrackedEntityInstanceAudits( params ) );
 
         params = new TrackedEntityInstanceAuditQueryParams()
             .setUsers( List.of( "userA" ) );
 
-        assertContainsOnly( store.getTrackedEntityInstanceAudits( params ), teiaA, teiaC );
+        assertContainsOnly( List.of( teiaA, teiaC ), store.getTrackedEntityInstanceAudits( params ) );
 
         params = new TrackedEntityInstanceAuditQueryParams()
             .setAuditTypes( List.of( AuditType.UPDATE ) );
 
-        assertContainsOnly( store.getTrackedEntityInstanceAudits( params ), teiaB, teiaC );
+        assertContainsOnly( List.of( teiaB, teiaC ), store.getTrackedEntityInstanceAudits( params ) );
 
         params = new TrackedEntityInstanceAuditQueryParams()
             .setAuditTypes( List.of( AuditType.CREATE, AuditType.DELETE ) );
 
-        assertContainsOnly( store.getTrackedEntityInstanceAudits( params ), teiaA, teiaD );
+        assertContainsOnly( List.of( teiaA, teiaD ), store.getTrackedEntityInstanceAudits( params ) );
 
         params = new TrackedEntityInstanceAuditQueryParams()
             .setTrackedEntityInstances( List.of( "WGW7UnVcIIb" ) )
             .setUsers( List.of( "userA" ) );
 
-        assertContainsOnly( store.getTrackedEntityInstanceAudits( params ), teiaA );
+        assertContainsOnly( List.of( teiaA ), store.getTrackedEntityInstanceAudits( params ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityattributevalue/TrackedEntityAttributeValueStoreTest.java
@@ -169,9 +169,9 @@ class TrackedEntityAttributeValueStoreTest extends SingleSetupIntegrationTestBas
         attributeValueStore.saveVoid( avB );
         attributeValueStore.saveVoid( avC );
         List<TrackedEntityAttributeValue> attributeValues = attributeValueStore.get( teiA );
-        assertContainsOnly( attributeValues, avA, avB );
+        assertContainsOnly( List.of( avA, avB ), attributeValues );
         attributeValues = attributeValueStore.get( teiB );
-        assertContainsOnly( attributeValues, avC );
+        assertContainsOnly( List.of( avC ), attributeValues );
     }
 
     @Test
@@ -199,22 +199,26 @@ class TrackedEntityAttributeValueStoreTest extends SingleSetupIntegrationTestBas
             .setTrackedEntityInstances( List.of( teiA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
 
-        assertContainsOnly( attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ), auditA );
+        assertContainsOnly( List.of( auditA ),
+            attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ) );
 
         params = new TrackedEntityAttributeValueAuditQueryParams()
             .setTrackedEntityInstances( List.of( teiA ) )
             .setAuditTypes( List.of( AuditType.UPDATE ) );
 
-        assertContainsOnly( attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ), auditA, auditB );
+        assertContainsOnly( List.of( auditA, auditB ),
+            attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ) );
 
         params = new TrackedEntityAttributeValueAuditQueryParams()
             .setAuditTypes( List.of( AuditType.CREATE ) );
 
-        assertContainsOnly( attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ), auditC );
+        assertContainsOnly( List.of( auditC ),
+            attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ) );
 
         params = new TrackedEntityAttributeValueAuditQueryParams()
             .setAuditTypes( List.of( AuditType.CREATE, AuditType.DELETE ) );
 
-        assertContainsOnly( attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ), auditC, auditD );
+        assertContainsOnly( List.of( auditC, auditD ),
+            attributeValueAuditStore.getTrackedEntityAttributeValueAudits( params ) );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
@@ -51,7 +51,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserService;
-import org.hisp.dhis.utils.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -189,8 +188,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
             false, false );
 
-        assertNotNull( teis );
-        Assertions.assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
+        assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
     }
 
     @Test
@@ -206,8 +204,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
             false, false );
 
-        assertNotNull( teis );
-        Assertions.assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
+        assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
     }
 
     @Test
@@ -225,7 +222,6 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
             false, false );
 
-        assertNotNull( teis );
-        Assertions.assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
+        assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.trackedentityinstance;
 
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -188,7 +189,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
             false, false );
 
-        assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
+        assertContainsOnly( List.of( tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() ), teis );
     }
 
     @Test
@@ -204,7 +205,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
             false, false );
 
-        assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
+        assertContainsOnly( List.of( tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() ), teis );
     }
 
     @Test
@@ -222,6 +223,6 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
             false, false );
 
-        assertContainsOnly( teis, tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() );
+        assertContainsOnly( List.of( tei1.getId(), tei2.getId(), tei3.getId(), tei4.getId() ), teis );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -503,7 +503,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "nxP7UnKhomJ" ) );
+            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
     }
 
     @Test
@@ -517,7 +517,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "nxP7UnKhomJ" ) );
+            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
     }
 
     @Test
@@ -531,7 +531,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
     }
 
     @Test
@@ -545,7 +545,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
     }
 
     @Test
@@ -585,7 +585,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "nxP7UnKhomJ" ) );
+            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
     }
 
     @Test
@@ -599,7 +599,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "nxP7UnKhomJ" ) );
+            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
     }
 
     @Test
@@ -613,7 +613,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
     }
 
     @Test
@@ -627,7 +627,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( enrollments, "TvctPPhpD8z" ) );
+            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
     }
 
     @Test
@@ -649,7 +649,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertContainsOnly( trackedEntities, "QS6w44flWAf" ) );
+            () -> assertContainsOnly( List.of( "QS6w44flWAf" ), trackedEntities ) );
     }
 
     @Test
@@ -681,7 +681,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertContainsOnly( trackedEntities, "dUE514NMOlo" ) );
+            () -> assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities ) );
     }
 
     @Test
@@ -706,7 +706,7 @@ class EventExporterTest extends TrackerTest
             .collect( Collectors.toList() );
 
         assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertContainsOnly( trackedEntities, "dUE514NMOlo" ) );
+            () -> assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/user/UserServiceTest.java
@@ -33,6 +33,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toSet;
 import static org.hisp.dhis.setting.SettingKey.CAN_GRANT_OWN_USER_ROLES;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -183,13 +184,15 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
     {
         User userA = addUser( "A", user -> user.setFirstName( "Chris" ) );
         User userB = addUser( "B", user -> user.setFirstName( "Chris" ) );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "Chris" ) ), userA, userB );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "hris SURNAM" ) ), userA, userB );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "hris SurnameA" ) ), userA );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "urnameB" ) ), userB );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "MAilA" ) ), userA );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "userNAME" ) ), userA, userB );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setQuery( "ernameA" ) ), userA );
+        assertContainsOnly( List.of( userA, userB ), userService.getUsers( getDefaultParams().setQuery( "Chris" ) ) );
+        assertContainsOnly( List.of( userA, userB ),
+            userService.getUsers( getDefaultParams().setQuery( "hris SURNAM" ) ) );
+        assertContainsOnly( List.of( userA ), userService.getUsers( getDefaultParams().setQuery( "hris SurnameA" ) ) );
+        assertContainsOnly( List.of( userB ), userService.getUsers( getDefaultParams().setQuery( "urnameB" ) ) );
+        assertContainsOnly( List.of( userA ), userService.getUsers( getDefaultParams().setQuery( "MAilA" ) ) );
+        assertContainsOnly( List.of( userA, userB ),
+            userService.getUsers( getDefaultParams().setQuery( "userNAME" ) ) );
+        assertContainsOnly( List.of( userA ), userService.getUsers( getDefaultParams().setQuery( "ernameA" ) ) );
     }
 
     @Test
@@ -200,9 +203,9 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         User userC = addUser( "C", unitC );
         addUser( "D", unitD );
         UserQueryParams params = getDefaultParams().addOrganisationUnit( unitA ).setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userA );
+        assertContainsOnly( List.of( userA ), userService.getUsers( params ) );
         params = getDefaultParams().addOrganisationUnit( unitA ).setIncludeOrgUnitChildren( true ).setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userA, userC );
+        assertContainsOnly( List.of( userA, userC ), userService.getUsers( params ) );
     }
 
     @Test
@@ -221,10 +224,10 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         userD.getDataViewOrganisationUnits().add( unitD );
         userService.updateUser( userD );
         UserQueryParams params = getDefaultParams().addDataViewOrganisationUnit( unitA ).setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userA, userB );
+        assertContainsOnly( List.of( userA, userB ), userService.getUsers( params ) );
         params = getDefaultParams().addDataViewOrganisationUnit( unitA ).setIncludeOrgUnitChildren( true )
             .setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userA, userB, userC );
+        assertContainsOnly( List.of( userA, userB, userC ), userService.getUsers( params ) );
     }
 
     @Test
@@ -243,10 +246,10 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         userD.getTeiSearchOrganisationUnits().add( unitD );
         userService.updateUser( userD );
         UserQueryParams params = getDefaultParams().addTeiSearchOrganisationUnit( unitA ).setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userA, userB );
+        assertContainsOnly( List.of( userA, userB ), userService.getUsers( params ) );
         params = getDefaultParams().addTeiSearchOrganisationUnit( unitA ).setIncludeOrgUnitChildren( true )
             .setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userA, userB, userC );
+        assertContainsOnly( List.of( userA, userB, userC ), userService.getUsers( params ) );
     }
 
     @Test
@@ -262,12 +265,12 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         userGroupService.addUserGroup( ugA );
         userGroupService.addUserGroup( ugB );
         userGroupService.addUserGroup( ugC );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setUserGroups( newHashSet( ugA ) ) ), userA,
-            userB );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setUserGroups( newHashSet( ugA, ugB ) ) ), userA,
-            userB, userC );
-        assertContainsOnly( userService.getUsers( getDefaultParams().setUserGroups( newHashSet( ugA, ugC ) ) ), userA,
-            userB, userD );
+        assertContainsOnly( List.of( userA,
+            userB ), userService.getUsers( getDefaultParams().setUserGroups( newHashSet( ugA ) ) ) );
+        assertContainsOnly( List.of( userA,
+            userB, userC ), userService.getUsers( getDefaultParams().setUserGroups( newHashSet( ugA, ugB ) ) ) );
+        assertContainsOnly( List.of( userA,
+            userB, userD ), userService.getUsers( getDefaultParams().setUserGroups( newHashSet( ugA, ugC ) ) ) );
     }
 
     @Test
@@ -280,9 +283,9 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         User userD = addUser( "D", unitD );
         addUser( "E", unitE );
         UserQueryParams params = getDefaultParams().setUser( currentUser ).setUserOrgUnits( true );
-        assertContainsOnly( userService.getUsers( params ), currentUser, userA, userB );
+        assertContainsOnly( List.of( currentUser, userA, userB ), userService.getUsers( params ) );
         params = getDefaultParams().setUser( currentUser ).setUserOrgUnits( true ).setIncludeOrgUnitChildren( true );
-        assertContainsOnly( userService.getUsers( params ), currentUser, userA, userB, userC, userD );
+        assertContainsOnly( List.of( currentUser, userA, userB, userC, userD ), userService.getUsers( params ) );
     }
 
     @Test
@@ -419,13 +422,13 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         userGroupService.addUserGroup( userGroup1 );
         userGroupService.addUserGroup( userGroup2 );
         UserQueryParams params = new UserQueryParams().setCanManage( true ).setAuthSubset( true ).setUser( userA );
-        assertContainsOnly( userService.getUsers( params ), userD, userF );
+        assertContainsOnly( List.of( userD, userF ), userService.getUsers( params ) );
         assertEquals( 2, userService.getUserCount( params ) );
         params.setUser( userB );
-        assertContainsOnly( userService.getUsers( params ) );
+        assertIsEmpty( userService.getUsers( params ) );
         assertEquals( 0, userService.getUserCount( params ) );
         params.setUser( userC );
-        assertContainsOnly( userService.getUsers( params ) );
+        assertIsEmpty( userService.getUsers( params ) );
         assertEquals( 0, userService.getUserCount( params ) );
     }
 
@@ -439,7 +442,7 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         addUser( "E" );
         addUser( "F" );
         UserQueryParams params = getDefaultParams().setQuery( "rstnameA" );
-        assertContainsOnly( userService.getUsers( params ), userA );
+        assertContainsOnly( List.of( userA ), userService.getUsers( params ) );
         assertEquals( 1, userService.getUserCount( params ) );
     }
 
@@ -451,7 +454,7 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         User userC = addUser( "C", User::setSelfRegistered, true );
         addUser( "D" );
         UserQueryParams params = getDefaultParams().setSelfRegistered( true );
-        assertContainsOnly( userService.getUsers( params ), userA, userC );
+        assertContainsOnly( List.of( userA, userC ), userService.getUsers( params ) );
         assertEquals( 2, userService.getUserCount( params ) );
     }
 
@@ -463,7 +466,7 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         User userC = addUser( "C", unitA );
         addUser( "D", unitB );
         UserQueryParams params = getDefaultParams().addOrganisationUnit( unitA );
-        assertContainsOnly( userService.getUsers( params ), userA, userC );
+        assertContainsOnly( List.of( userA, userC ), userService.getUsers( params ) );
         assertEquals( 2, userService.getUserCount( params ) );
     }
 
@@ -475,10 +478,10 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         addUser( "C" );
         User userD = addUser( "D", User::setInvitation, true );
         UserQueryParams params = getDefaultParams().setInvitationStatus( UserInvitationStatus.ALL );
-        assertContainsOnly( userService.getUsers( params ), userB, userD );
+        assertContainsOnly( List.of( userB, userD ), userService.getUsers( params ) );
         assertEquals( 2, userService.getUserCount( params ) );
         params.setInvitationStatus( UserInvitationStatus.EXPIRED );
-        assertContainsOnly( userService.getUsers( params ) );
+        assertIsEmpty( userService.getUsers( params ) );
         assertEquals( 0, userService.getUserCount( params ) );
     }
 
@@ -579,7 +582,7 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
 
         User admin = createAndAddAdminUser( "ALL" );
         List<ErrorReport> errors = new ArrayList<>();
-        userService.disableTwoFA( admin, userToModify.getUid(), error -> errors.add( error ) );
+        userService.disableTwoFA( admin, userToModify.getUid(), errors::add );
         assertTrue( errors.isEmpty() );
     }
 
@@ -606,7 +609,7 @@ class UserServiceTest extends SingleSetupIntegrationTestBase
         userService.updateUser( currentUser );
 
         List<ErrorReport> errors = new ArrayList<>();
-        userService.disableTwoFA( currentUser, userToModify.getUid(), error -> errors.add( error ) );
+        userService.disableTwoFA( currentUser, userToModify.getUid(), errors::add );
         assertTrue( errors.isEmpty() );
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationRuleStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/validation/ValidationRuleStoreTest.java
@@ -31,9 +31,12 @@ import static java.util.Arrays.asList;
 import static org.hisp.dhis.expression.Operator.equal_to;
 import static org.hisp.dhis.expression.Operator.greater_than;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
 
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.expression.Expression;
@@ -125,7 +128,7 @@ class ValidationRuleStoreTest extends TransactionalIntegrationTest
     {
         ValidationRule ruleA = addValidationRule( 'A', equal_to, expressionA, expressionB, periodType );
         ValidationRule ruleB = addValidationRule( 'B', equal_to, expressionC, expressionD, periodType );
-        assertContainsOnly( validationRuleStore.getAll(), ruleA, ruleB );
+        assertContainsOnly( List.of( ruleA, ruleB ), validationRuleStore.getAll() );
     }
 
     @Test
@@ -133,7 +136,7 @@ class ValidationRuleStoreTest extends TransactionalIntegrationTest
     {
         addValidationRule( 'A', equal_to, expressionA, expressionB, periodType, true );
         ValidationRule ruleB = addValidationRule( 'B', equal_to, expressionC, expressionD, periodType );
-        assertContainsOnly( validationRuleStore.getAllFormValidationRules(), ruleB );
+        assertContainsOnly( List.of( ruleB ), validationRuleStore.getAllFormValidationRules() );
     }
 
     @Test
@@ -164,14 +167,14 @@ class ValidationRuleStoreTest extends TransactionalIntegrationTest
     {
         ValidationRule ruleA = addValidationRule( 'A', equal_to, expressionA, expressionB, periodType );
         ValidationRule ruleB = addValidationRule( 'B', equal_to, expressionC, expressionD, periodType );
-        // Test empty
-        assertContainsOnly( validationRuleStore.getValidationRulesWithNotificationTemplates() );
+        assertIsEmpty( validationRuleStore.getValidationRulesWithNotificationTemplates() );
         // Add template
         addValidationNotificationTemplate( 'A', ruleA );
-        assertContainsOnly( validationRuleStore.getValidationRulesWithNotificationTemplates(), ruleA );
+        assertContainsOnly( List.of( ruleA ), validationRuleStore.getValidationRulesWithNotificationTemplates() );
         // Add one more
         addValidationNotificationTemplate( 'B', ruleB );
-        assertContainsOnly( validationRuleStore.getValidationRulesWithNotificationTemplates(), ruleA, ruleB );
+        assertContainsOnly( List.of( ruleA, ruleB ),
+            validationRuleStore.getValidationRulesWithNotificationTemplates() );
     }
 
     @Test
@@ -180,7 +183,7 @@ class ValidationRuleStoreTest extends TransactionalIntegrationTest
         ValidationRule ruleA = addValidationRule( 'A', equal_to, expressionA, expressionB, periodType );
         ValidationRule ruleB = addValidationRule( 'B', equal_to, expressionC, expressionD, periodType );
         addValidationRuleGroup( 'A', ruleA );
-        assertContainsOnly( validationRuleStore.getValidationRulesWithoutGroups(), ruleB );
+        assertContainsOnly( List.of( ruleB ), validationRuleStore.getValidationRulesWithoutGroups() );
     }
 
     private ValidationNotificationTemplate addValidationNotificationTemplate( char uniqueCharacter,

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AccountControllerTest.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.webapi.controller;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Set;
+
 import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
@@ -138,7 +140,7 @@ class AccountControllerTest extends DhisControllerConvenienceTest
 
     private static void assertMessage( String key, String value, String message, JsonResponse response )
     {
-        assertContainsOnly( response.node().members().keySet(), key, "message" );
+        assertContainsOnly( Set.of( key, "message" ), response.node().members().keySet() );
         assertEquals( value, response.getString( key ).string() );
         assertEquals( message, response.getString( "message" ).string() );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityReportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityReportControllerTest.java
@@ -37,6 +37,8 @@ import static org.hisp.dhis.web.WebClientUtils.objectReferences;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.hisp.dhis.jsontree.JsonDocument.JsonNodeType;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
@@ -131,9 +133,8 @@ class DataIntegrityReportControllerTest extends AbstractDataIntegrityControllerT
         ouA.setParent( ouB );
         ouB.getChildren().add( ouA );
         organisationUnitStore.save( ouB );
-        assertContainsOnly(
-            getDataIntegrityReport().getOrganisationUnitsWithCyclicReferences().toList( JsonString::string ),
-            "A:" + ouIdA, "B:" + ouIdB );
+        assertContainsOnly( List.of( "A:" + ouIdA, "B:" + ouIdB ),
+            getDataIntegrityReport().getOrganisationUnitsWithCyclicReferences().toList( JsonString::string ) );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
@@ -40,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.hisp.dhis.datastore.DatastoreEntry;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection;
@@ -104,7 +105,7 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest
             GET( "/dataStore/{namespace}", METADATA_STORE_NS ).content().stringValues() );
         assertStatus( HttpStatus.CREATED, POST( "/dataStore/pets/cat", "{'answer': 42}" ) );
         assertStatus( HttpStatus.CREATED, POST( "/dataStore/pets/dog", "{'answer': true}" ) );
-        assertContainsOnly( GET( "/dataStore/pets" ).content().stringValues(), "cat", "dog" );
+        assertContainsOnly( List.of( "cat", "dog" ), GET( "/dataStore/pets" ).content().stringValues() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistFieldsControllerTest.java
@@ -35,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Set;
+
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.jsontree.JsonString;
@@ -101,7 +103,8 @@ class GistFieldsControllerTest extends AbstractGistControllerTest
         switchToGuestUser();
         JsonArray users = GET( "/users/gist?headless=true" ).content();
         JsonObject user0 = users.getObject( 0 );
-        assertContainsOnly( user0.node().members().keySet(), "id", "code", "surname", "firstName", "username" );
+        assertContainsOnly( Set.of( "id", "code", "surname", "firstName", "username" ),
+            user0.node().members().keySet() );
         switchToSuperuser();
         users = GET( "/users/gist?headless=true" ).content();
         user0 = users.getObject( 0 );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/JobConfigurationControllerTest.java
@@ -69,8 +69,9 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest
         JsonObject parameters = assertJobConfigurationExists( jobId, "CONTINUOUS_ANALYTICS_TABLE" );
         assertEquals( 1, parameters.getNumber( "fullUpdateHourOfDay" ).intValue() );
         assertEquals( 2, parameters.getNumber( "lastYears" ).intValue() );
-        assertContainsOnly( parameters.getArray( "skipTableTypes" ).stringValues(), "ENROLLMENT", "VALIDATION_RESULT",
-            "DATA_VALUE", "COMPLETENESS", "EVENT", "ORG_UNIT_TARGET", "COMPLETENESS_TARGET" );
+        assertContainsOnly( List.of( "ENROLLMENT", "VALIDATION_RESULT",
+            "DATA_VALUE", "COMPLETENESS", "EVENT", "ORG_UNIT_TARGET", "COMPLETENESS_TARGET" ),
+            parameters.getArray( "skipTableTypes" ).stringValues() );
     }
 
     @Test
@@ -110,9 +111,9 @@ class JobConfigurationControllerTest extends DhisControllerConvenienceTest
         JsonObject parameters = assertJobConfigurationExists( jobId, "ANALYTICS_TABLE" );
         assertEquals( 1, parameters.getNumber( "lastYears" ).intValue() );
         assertTrue( parameters.getBoolean( "skipResourceTables" ).booleanValue() );
-        assertContainsOnly( parameters.getArray( "skipTableTypes" ).stringValues(), "DATA_VALUE", "COMPLETENESS",
-            "ENROLLMENT" );
-        assertContainsOnly( parameters.getArray( "skipPrograms" ).stringValues(), UID1, UID2 );
+        assertContainsOnly( List.of( "DATA_VALUE", "COMPLETENESS",
+            "ENROLLMENT" ), parameters.getArray( "skipTableTypes" ).stringValues() );
+        assertContainsOnly( List.of( UID1, UID2 ), parameters.getArray( "skipPrograms" ).stringValues() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserDatastoreSuperuserControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserDatastoreSuperuserControllerTest.java
@@ -206,6 +206,7 @@ class UserDatastoreSuperuserControllerTest extends DhisControllerConvenienceTest
         assertStatus( HttpStatus.CREATED, POST( "/userDataStore/test2/key1", "42" ) );
 
         switchToSuperuser();
-        assertContainsOnly( GET( "/userDataStore?username=Paul" ).content().stringValues(), "test", "test2" );
+        assertContainsOnly( List.of( "test", "test2" ),
+            GET( "/userDataStore?username=Paul" ).content().stringValues() );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -401,9 +401,8 @@ class EventRequestToSearchParamsMapperTest
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
-        assertContainsOnly( params.getOrders(),
-            new OrderParam( "programStage", OrderParam.SortDirection.DESC ),
-            new OrderParam( "dueDate", OrderParam.SortDirection.ASC ) );
+        assertContainsOnly( List.of( new OrderParam( "programStage", OrderParam.SortDirection.DESC ),
+            new OrderParam( "dueDate", OrderParam.SortDirection.ASC ) ), params.getOrders() );
     }
 
     @Test
@@ -414,8 +413,8 @@ class EventRequestToSearchParamsMapperTest
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
-        assertContainsOnly( params.getOrders(),
-            new OrderParam( "enrolledAt", OrderParam.SortDirection.ASC ) );
+        assertContainsOnly( List.of( new OrderParam( "enrolledAt", OrderParam.SortDirection.ASC ) ),
+            params.getOrders() );
     }
 
     @Test
@@ -467,9 +466,8 @@ class EventRequestToSearchParamsMapperTest
         assertNotNull( items );
         // mapping to UIDs as the error message by just relying on QueryItem
         // equals() is not helpful
-        assertContainsOnly( items.stream().map( i -> i.getItem().getUid() ).collect( Collectors.toList() ),
-            tea1.getUid(),
-            tea2.getUid() );
+        assertContainsOnly( List.of( tea1.getUid(),
+            tea2.getUid() ), items.stream().map( i -> i.getItem().getUid() ).collect( Collectors.toList() ) );
 
         // QueryItem equals() does not take the QueryFilter into account so
         // assertContainsOnly alone does not ensure operators and filter value
@@ -558,9 +556,10 @@ class EventRequestToSearchParamsMapperTest
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
-        assertContainsOnly( params.getFilterAttributes(),
-            new QueryItem( tea1, null, tea1.getValueType(), tea1.getAggregationType(), tea1.getOptionSet(),
-                tea1.isUnique() ) );
+        assertContainsOnly(
+            List.of( new QueryItem( tea1, null, tea1.getValueType(), tea1.getAggregationType(), tea1.getOptionSet(),
+                tea1.isUnique() ) ),
+            params.getFilterAttributes() );
     }
 
     private Date date( String date )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/MetadataIdentifierMapperTest.java
@@ -254,7 +254,8 @@ class MetadataIdentifierMapperTest
 
         Set<MetadataIdentifier> ids = MAPPER.fromAttributeCategoryOptions( " RiNIt1yJoge;AiNIt1yJoge  ; ", params );
 
-        assertContainsOnly( ids, MetadataIdentifier.ofUid( "RiNIt1yJoge" ), MetadataIdentifier.ofUid( "AiNIt1yJoge" ) );
+        assertContainsOnly(
+            Set.of( MetadataIdentifier.ofUid( "RiNIt1yJoge" ), MetadataIdentifier.ofUid( "AiNIt1yJoge" ) ), ids );
     }
 
     @Test
@@ -268,8 +269,8 @@ class MetadataIdentifierMapperTest
 
         Set<MetadataIdentifier> ids = MAPPER.fromAttributeCategoryOptions( "clouds;fruits", params );
 
-        assertContainsOnly( ids, MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ),
-            MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "fruits" ) );
+        assertContainsOnly( Set.of( MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "clouds" ),
+            MetadataIdentifier.ofAttribute( "RiNIt1yJoge", "fruits" ) ), ids );
     }
 
     @Test


### PR DESCRIPTION
* print not only the missing elements but also the elements that are in the actual collection but where not expected
* print the elements of both actual and expected collections in case they contain duplicates (previously only `expected: <1> but was: <2>` was shown)
* switched order of actual and expected in accordance with [backend wow on assertions](https://github.com/dhis2/wow-backend/blob/8e9bd4ccdfd8997b1f2f03d9e21543c902d225a6/guides/testing.md?plain=1#L104)
* `assertNotNull` on actual to get an assertion error instead of a NPE
* use `assertIsEmpty` instead of previous `assertContainsOnly(collection)` which makes the intent clearer

## Example messages

### Missing/Extra elements

```java
assertContainsOnly(List.of("3", "5", "6"), List.of("2", "3", "5"));
```

`actual` (right) is missing `6` from the `expected` list (left).
`actual` (right) contains `2` which is not in the `expected` list (left).

Leads to assertion error

```
org.opentest4j.MultipleFailuresError: assertContainsOnly found mismatch (2 failures)
	org.opentest4j.AssertionFailedError: Expected [6] to be in [2, 3, 5] ==> expected: <true> but was: <false>
	org.opentest4j.AssertionFailedError: Expected [2] NOT to be in [2, 3, 5] ==> expected: <true> but was: <false>
```

### Duplicate elements

```java
assertContainsOnly(List.of("3"), List.of("3", "3"));
```

`actual` (right) contains duplicate `3` which is not in the `expected` list (left).

Leads to assertion error

```
org.opentest4j.MultipleFailuresError: assertContainsOnly found mismatch (1 failure)
	org.opentest4j.AssertionFailedError: Expected [3] or actual [3, 3] contains unexpected duplicates ==> expected: <1> but was: <2>
```

Right now duplicates are not highlighted in the assertion message. This could be improved. Not sure how often that is the case though. Decided to print the collections so we can debug this in a (flaky) test failing on CI using our human super power 🦸🏻 
