### PR TITLE
chore: move tracker CSV package close to its usage DHIS2-13648

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/csv/CsvEventDataValue.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/csv/CsvEventDataValue.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.csv;
+package org.hisp.dhis.webapi.controller.tracker.export.csv;
 
 import org.springframework.util.Assert;
 
@@ -68,7 +68,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
     "createAtDataValue",
     "updatedAtDataValue"
 } )
-public class CsvEventDataValue
+class CsvEventDataValue
 {
     private String event;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/csv/TrackerCsvEventService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/csv/TrackerCsvEventService.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.csv;
+package org.hisp.dhis.webapi.controller.tracker.export.csv;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,7 +58,7 @@ import com.google.common.collect.Lists;
 /**
  * @author Enrico Colasante
  */
-@Service( "org.hisp.dhis.webapi.controller.tracker.CsvEventService" )
+@Service( "org.hisp.dhis.webapi.controller.tracker.export.csv.CsvEventService" )
 public class TrackerCsvEventService
     implements CsvEventService<Event>
 {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/csv/TrackerCsvEventServiceTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/csv/TrackerCsvEventServiceTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.tracker.csv;
+package org.hisp.dhis.webapi.controller.tracker.export.csv;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;


### PR DESCRIPTION
its only used in the export, so moving it there. The high level view of the tracker web package

now more closely resembles our domain. Tracker supports import/export both of which have a package. The view package exists to tigh import/export together as we support importing exported data directly.

If you want to know more about each feature you can drill down in the packages. csv was not at the same level of abstraction

![image](https://user-images.githubusercontent.com/4661144/189620580-0d59fa8b-bc4f-4c06-927c-2d01aa3a7c00.png)
