### PR TITLE
fix: Numeric filter in event analytics [DHIS2-13693]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -1106,7 +1106,11 @@ public abstract class AbstractJdbcEventAnalyticsManager
                 case NEQ:
                 case NE:
                 case NIEQ:
-                    return "(" + field + " is null or " + field + SPACE + filter.getSqlOperator() + SPACE
+                case NLIKE:
+                case NILIKE:
+                    // This ensures that null values will always match the
+                    // filters above.
+                    return "(coalesce(" + field + ", '') = '' or " + field + SPACE + filter.getSqlOperator() + SPACE
                         + getSqlFilter( filter, item ) + ") ";
                 }
             }


### PR DESCRIPTION
_[Backport from 2.39/master]_

The initial commit broke the numeric comparison for `!EQ, !IEQ, !LIKE, !ILIKE` filters.
Only text comparisons were working. This fix will make both text and non-text filtering work.

GET URLs for testing:

```
// Text filter
http://localhost:8080/dhis/api/29/analytics/events/query/IpHINAT79UW.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&dimension=ZzYYXq4fJie.OuJ6sgPyAbC:!LIKE:gff&stage=ZzYYXq4fJie&displayProperty=NAME&totalPages=false&outputType=EVENT&desc=eventdate&pageSize=100&page=1
```

```
// Numeric filter
http://localhost:8080/dhis/api/29/analytics/events/query/IpHINAT79UW.json?dimension=pe:LAST_12_MONTHS&dimension=ou:ImspTQPwCqd&dimension=ZzYYXq4fJie.GQY2lXrypjO:!EQ:3729&stage=ZzYYXq4fJie&displayProperty=NAME&totalPages=false&outputType=EVENT&desc=eventdate&pageSize=100&page=1
```

I also included a small code documentation clean-up.