### PR TITLE
feat: provide default for DN driver class configuration [DHIS2-13708]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -105,7 +105,7 @@ public enum ConfigurationKey
     /**
      * JDBC driver class.
      */
-    CONNECTION_DRIVER_CLASS( "connection.driver_class", "", false ),
+    CONNECTION_DRIVER_CLASS( "connection.driver_class", "org.postgresql.Driver", false ),
 
     /**
      * Database connection URL.


### PR DESCRIPTION
### Summary
Provides a default for the DB driver class.

### Manual Testing
* remove `connection.driver_class` key-value from `dhis.conf` file
* start server and check startup and DB usage works