### PR TITLE
test: clean up assertions DHIS2-13648

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -31,15 +31,11 @@ import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -99,7 +95,7 @@ class EventExporterTest extends TrackerTest
 
     final Function<EventSearchParams, List<String>> eventsFunction = ( params ) -> eventService.getEvents( params )
         .getEvents()
-        .stream().map( Event::getEvent ).sorted().collect( Collectors.toCollection( LinkedList::new ) );
+        .stream().map( Event::getEvent ).collect( Collectors.toList() );
 
     /**
      * EVENT_ID is at position 0 in column headers in events grid
@@ -107,7 +103,7 @@ class EventExporterTest extends TrackerTest
     final Function<EventSearchParams, List<String>> eventsGridFunction = ( params ) -> eventService
         .getEventsGrid( params )
         .getRows()
-        .stream().map( r -> r.get( 0 ).toString() ).sorted().collect( Collectors.toCollection( LinkedList::new ) );
+        .stream().map( r -> r.get( 0 ).toString() ).collect( Collectors.toList() );
 
     private TrackedEntityInstance trackedEntityInstance;
 
@@ -143,9 +139,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -159,9 +153,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events );
     }
 
     @Test
@@ -174,9 +166,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventsFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM" ), events );
     }
 
     @ParameterizedTest
@@ -194,9 +184,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM" ), events );
     }
 
     @ParameterizedTest
@@ -212,9 +200,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM" ), events );
     }
 
     @ParameterizedTest
@@ -236,9 +222,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM" ), events );
     }
 
     @ParameterizedTest
@@ -258,9 +242,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -282,9 +264,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -306,9 +286,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -329,9 +307,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -352,9 +328,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events );
     }
 
     @Test
@@ -377,9 +351,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventsFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @Test
@@ -405,9 +377,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventsFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM" ), events );
     }
 
     @ParameterizedTest
@@ -428,9 +398,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -451,9 +419,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 2, events.size() ),
-            () -> assertEquals( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events );
     }
 
     @ParameterizedTest
@@ -474,9 +440,7 @@ class EventExporterTest extends TrackerTest
 
         List<String> events = eventFunction.apply( params );
 
-        assertAll( () -> assertNotNull( events ),
-            () -> assertEquals( 1, events.size() ),
-            () -> assertEquals( List.of( "pTzf9KYMk72" ), events ) );
+        assertContainsOnly( List.of( "pTzf9KYMk72" ), events );
     }
 
     @Test
@@ -502,8 +466,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
+        assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
     }
 
     @Test
@@ -516,8 +479,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
+        assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
     }
 
     @Test
@@ -530,8 +492,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
+        assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
     }
 
     @Test
@@ -544,8 +505,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
+        assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
     }
 
     @Test
@@ -584,8 +544,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
+        assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
     }
 
     @Test
@@ -598,8 +557,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments ) );
+        assertContainsOnly( List.of( "nxP7UnKhomJ" ), enrollments );
     }
 
     @Test
@@ -612,8 +570,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
+        assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
     }
 
     @Test
@@ -626,8 +583,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments ) );
+        assertContainsOnly( List.of( "TvctPPhpD8z" ), enrollments );
     }
 
     @Test
@@ -648,8 +604,7 @@ class EventExporterTest extends TrackerTest
             .map( Event::getTrackedEntityInstance )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertContainsOnly( List.of( "QS6w44flWAf" ), trackedEntities ) );
+        assertContainsOnly( List.of( "QS6w44flWAf" ), trackedEntities );
     }
 
     @Test
@@ -680,8 +635,7 @@ class EventExporterTest extends TrackerTest
             .map( Event::getTrackedEntityInstance )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities ) );
+        assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities );
     }
 
     @Test
@@ -705,8 +659,7 @@ class EventExporterTest extends TrackerTest
             .map( Event::getTrackedEntityInstance )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities ) );
+        assertContainsOnly( List.of( "dUE514NMOlo" ), trackedEntities );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.tracker.Assertions.assertNoErrors;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.time.ZoneId;
@@ -681,9 +682,7 @@ class EventExporterTest extends TrackerTest
             .map( Event::getTrackedEntityInstance )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertEquals( 2, trackedEntities.size() ),
-            () -> assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities ) );
+        assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );
     }
 
     @Test
@@ -705,9 +704,7 @@ class EventExporterTest extends TrackerTest
             .map( Event::getTrackedEntityInstance )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( trackedEntities ),
-            () -> assertEquals( 2, trackedEntities.size() ),
-            () -> assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities ) );
+        assertEquals( List.of( "QS6w44flWAf", "dUE514NMOlo" ), trackedEntities );
     }
 
     @Test
@@ -733,9 +730,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertEquals( 2, enrollments.size() ),
-            () -> assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments ) );
+        assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments );
     }
 
     @Test
@@ -748,9 +743,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertEquals( 2, enrollments.size() ),
-            () -> assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments ) );
+        assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments );
     }
 
     @Test
@@ -763,9 +756,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertEquals( 2, enrollments.size() ),
-            () -> assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments ) );
+        assertEquals( List.of( "TvctPPhpD8z", "nxP7UnKhomJ" ), enrollments );
     }
 
     @Test
@@ -778,9 +769,7 @@ class EventExporterTest extends TrackerTest
         List<String> enrollments = eventService.getEvents( params ).getEvents().stream().map( Event::getEnrollment )
             .collect( Collectors.toList() );
 
-        assertAll( () -> assertNotNull( enrollments ),
-            () -> assertEquals( 2, enrollments.size() ),
-            () -> assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments ) );
+        assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments );
     }
 
     private DataElement dataElement( String uid )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -310,7 +311,6 @@ class EventRequestToSearchParamsMapperTest
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
         assertAll(
-            () -> assertNotNull( params.getAttributeOrders() ),
             () -> assertContainsOnly( params.getAttributeOrders(),
                 List.of( new OrderParam( TEA_1_UID, OrderParam.SortDirection.ASC ) ) ),
             () -> assertContainsOnly( params.getFilterAttributes(), List.of( new QueryItem( tea1 ) ) ) );
@@ -390,7 +390,7 @@ class EventRequestToSearchParamsMapperTest
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
-        assertEquals( Collections.emptySet(), params.getAssignedUsers() );
+        assertIsEmpty( params.getAssignedUsers() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertContains;
 import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertStartsWith;
@@ -37,12 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -132,17 +130,11 @@ class EventRequestToSearchParamsMapperTest
 
     private TrackedEntityInstance trackedEntityInstance;
 
-    private SimpleDateFormat dateFormatter;
-
     private TrackedEntityAttribute tea1;
-
-    private TrackedEntityAttribute tea2;
 
     @BeforeEach
     public void setUp()
     {
-        dateFormatter = new SimpleDateFormat( "yyyy-MM-dd", Locale.ENGLISH );
-
         User user = new User();
         when( currentUserService.getCurrentUser() ).thenReturn( user );
 
@@ -166,7 +158,7 @@ class EventRequestToSearchParamsMapperTest
         when( entityInstanceService.getTrackedEntityInstance( "teiuid" ) ).thenReturn( trackedEntityInstance );
         tea1 = new TrackedEntityAttribute();
         tea1.setUid( TEA_1_UID );
-        tea2 = new TrackedEntityAttribute();
+        TrackedEntityAttribute tea2 = new TrackedEntityAttribute();
         tea2.setUid( TEA_2_UID );
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( List.of( tea1, tea2 ) );
         when( attributeService.getTrackedEntityAttribute( TEA_1_UID ) ).thenReturn( tea1 );
@@ -228,9 +220,9 @@ class EventRequestToSearchParamsMapperTest
     {
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
 
-        Date occurredAfter = date( "2020-01-01" );
+        Date occurredAfter = parseDate( "2020-01-01" );
         eventCriteria.setOccurredAfter( occurredAfter );
-        Date occurredBefore = date( "2020-09-12" );
+        Date occurredBefore = parseDate( "2020-09-12" );
         eventCriteria.setOccurredBefore( occurredBefore );
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
@@ -244,9 +236,9 @@ class EventRequestToSearchParamsMapperTest
     {
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
 
-        Date scheduledAfter = date( "2021-01-01" );
+        Date scheduledAfter = parseDate( "2021-01-01" );
         eventCriteria.setScheduledAfter( scheduledAfter );
-        Date scheduledBefore = date( "2021-09-12" );
+        Date scheduledBefore = parseDate( "2021-09-12" );
         eventCriteria.setScheduledBefore( scheduledBefore );
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
@@ -260,9 +252,9 @@ class EventRequestToSearchParamsMapperTest
     {
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
 
-        Date updatedAfter = date( "2022-01-01" );
+        Date updatedAfter = parseDate( "2022-01-01" );
         eventCriteria.setUpdatedAfter( updatedAfter );
-        Date updatedBefore = date( "2022-09-12" );
+        Date updatedBefore = parseDate( "2022-09-12" );
         eventCriteria.setUpdatedBefore( updatedBefore );
         String updatedWithin = "P6M";
         eventCriteria.setUpdatedWithin( updatedWithin );
@@ -279,9 +271,9 @@ class EventRequestToSearchParamsMapperTest
     {
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
 
-        Date enrolledBefore = date( "2022-01-01" );
+        Date enrolledBefore = parseDate( "2022-01-01" );
         eventCriteria.setEnrollmentEnrolledBefore( enrolledBefore );
-        Date enrolledAfter = date( "2022-02-01" );
+        Date enrolledAfter = parseDate( "2022-02-01" );
         eventCriteria.setEnrollmentEnrolledAfter( enrolledAfter );
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
@@ -295,9 +287,9 @@ class EventRequestToSearchParamsMapperTest
     {
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
 
-        Date enrolledBefore = date( "2022-01-01" );
+        Date enrolledBefore = parseDate( "2022-01-01" );
         eventCriteria.setEnrollmentOccurredBefore( enrolledBefore );
-        Date enrolledAfter = date( "2022-02-01" );
+        Date enrolledAfter = parseDate( "2022-02-01" );
         eventCriteria.setEnrollmentOccurredAfter( enrolledAfter );
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
@@ -470,7 +462,7 @@ class EventRequestToSearchParamsMapperTest
     {
 
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( tea1.getUid() + ":eq:2", tea2.getUid() + ":like:foo" ) );
+        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -478,8 +470,8 @@ class EventRequestToSearchParamsMapperTest
         assertNotNull( items );
         // mapping to UIDs as the error message by just relying on QueryItem
         // equals() is not helpful
-        assertContainsOnly( List.of( tea1.getUid(),
-            tea2.getUid() ), items.stream().map( i -> i.getItem().getUid() ).collect( Collectors.toList() ) );
+        assertContainsOnly( List.of( TEA_1_UID,
+            TEA_2_UID ), items.stream().map( i -> i.getItem().getUid() ).collect( Collectors.toList() ) );
 
         // QueryItem equals() does not take the QueryFilter into account so
         // assertContainsOnly alone does not ensure operators and filter value
@@ -488,8 +480,8 @@ class EventRequestToSearchParamsMapperTest
         // assertion is order independent as the order of QueryItems is not
         // guaranteed
         Map<String, QueryFilter> expectedFilters = Map.of(
-            tea1.getUid(), new QueryFilter( QueryOperator.EQ, "2" ),
-            tea2.getUid(), new QueryFilter( QueryOperator.LIKE, "foo" ) );
+            TEA_1_UID, new QueryFilter( QueryOperator.EQ, "2" ),
+            TEA_2_UID, new QueryFilter( QueryOperator.LIKE, "foo" ) );
         assertAll( items.stream().map( i -> (Executable) () -> {
             String uid = i.getItem().getUid();
             QueryFilter expected = expectedFilters.get( uid );
@@ -517,11 +509,11 @@ class EventRequestToSearchParamsMapperTest
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
 
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( tea1.getUid() + ":eq:2" ) );
+        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
-        assertEquals( "Attribute does not exist: " + tea1.getUid(), exception.getMessage() );
+        assertEquals( "Attribute does not exist: " + TEA_1_UID, exception.getMessage() );
     }
 
     @Test
@@ -560,7 +552,7 @@ class EventRequestToSearchParamsMapperTest
     {
 
         TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( tea1.getUid() ) );
+        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID ) );
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -568,17 +560,5 @@ class EventRequestToSearchParamsMapperTest
             List.of( new QueryItem( tea1, null, tea1.getValueType(), tea1.getAggregationType(), tea1.getOptionSet(),
                 tea1.isUnique() ) ),
             params.getFilterAttributes() );
-    }
-
-    private Date date( String date )
-    {
-        try
-        {
-            return dateFormatter.parse( date );
-        }
-        catch ( ParseException e )
-        {
-            throw new RuntimeException( e );
-        }
     }
 }


### PR DESCRIPTION
* EventExporterTest did sort the UIDs in the parametrized test functions so that we could assert on UIDs irrespective of order. Use `assertContainsOnly` as it already asserts irrespective of order.
* use `assertEquals( List.of( "dUE514NMOlo", "QS6w44flWAf" ), trackedEntities );` is enough to assert the collection is not null, has the correct size and order
* use `DateUtils.parseDate` instead of `SimpleDateFormat` and UID constants in 
* use `assertIsEmpty` instead of `assertEquals( Collections.emptySet(), params.getAssignedUsers() )`