### PR TITLE
fix: set default API version to 2.39

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DhisApiVersion.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DhisApiVersion.java
@@ -59,7 +59,7 @@ public enum DhisApiVersion
     V37( 37 ),
     V38( 38 ),
     V39( 39 ),
-    DEFAULT( V38.getVersion() );
+    DEFAULT( V39.getVersion() );
 
     final int version;
 


### PR DESCRIPTION
## Summary

Default API version was still set to `V38`. This PR updates it to the correct `V39` (there should be no changes other than internal).