### PR TITLE
feat: Adds API version 40 and sets as default

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DhisApiVersion.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/DhisApiVersion.java
@@ -59,7 +59,8 @@ public enum DhisApiVersion
     V37( 37 ),
     V38( 38 ),
     V39( 39 ),
-    DEFAULT( V38.getVersion() );
+    V40( 40 ),
+    DEFAULT( V40.getVersion() );
 
     final int version;
 


### PR DESCRIPTION
## Summary

Adds API version `40` to our endpoints, and sets as default for.