### PR TITLE
fix: Column names in events/enrollments [DHIS2-13721]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsService.java
@@ -68,11 +68,11 @@ public class DefaultEnrollmentAnalyticsService
 
     private static final String NAME_STORED_BY = "Stored by";
 
-    private static final String NAME_CREATED_BY_DISPLAY_NAME = "Created by (display name)";
+    private static final String NAME_CREATED_BY_DISPLAY_NAME = "Created by";
 
-    private static final String NAME_LAST_UPDATED_BY_DISPLAY_NAME = "Last updated by (display name)";
+    private static final String NAME_LAST_UPDATED_BY_DISPLAY_NAME = "Last updated by";
 
-    private static final String NAME_LAST_UPDATED = "Last Updated";
+    private static final String NAME_LAST_UPDATED = "Last updated on";
 
     private static final String NAME_LONGITUDE = "Longitude";
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsService.java
@@ -131,11 +131,11 @@ public class DefaultEventAnalyticsService
 
     private static final String NAME_STORED_BY = "Stored by";
 
-    private static final String NAME_CREATED_BY_DISPLAY_NAME = "Created by (display name)";
+    private static final String NAME_CREATED_BY_DISPLAY_NAME = "Created by";
 
-    private static final String NAME_LAST_UPDATED_BY_DISPLAY_NAME = "Last updated by (display name)";
+    private static final String NAME_LAST_UPDATED_BY_DISPLAY_NAME = "Last updated by";
 
-    private static final String NAME_LAST_UPDATED = "Last Updated";
+    private static final String NAME_LAST_UPDATED = "Last updated on";
 
     private static final String NAME_SCHEDULED_DATE = "Scheduled date";
 


### PR DESCRIPTION
Some “headers” columns are returning incorrect values in the response of the analytics endpoints /query/events and /query/enrollments.

This is a small change to rename some of those columns.