### PR TITLE
wip: use Converter to parse fields request parameter

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
@@ -49,6 +49,11 @@ public class FieldFilterParser
         return expandField( StringUtils.join( fields, "," ) );
     }
 
+    public static List<FieldPath> parse( String fields )
+    {
+        return expandField( fields );
+    }
+
     public static List<FieldPath> parseWithPrefix( Set<String> fields, String prefix )
     {
         return expandField( StringUtils.join( fields, "," ), prefix );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/FieldPathConverterTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/FieldPathConverterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+
+class FieldPathConverterTest extends DhisControllerConvenienceTest
+{
+
+    @Autowired
+    private ConversionService conversionService;
+
+    @Test
+    void stringToFieldPath()
+    {
+        List<FieldPath> expected = FieldFilterParser.parse("*");
+        TypeDescriptor target = TypeDescriptor.forObject()
+        assertEquals( expected, conversionService.convert( "*", List.class ) );
+
+//        assertEquals( 25, conversionService.convert( "25", Integer.class ) );
+//        assertEquals( List.of( 25, 26 ), conversionService.convert( List.of( "25", "26" ), Collection.class ) );
+        // assertEquals(conversionService.convert("*", );
+        // assertEquals(List.of(25, 26), conversionService.convert("25,26",
+        // Collection.class));
+
+        // List<FieldPath> fieldPath = converter.convert( "*" );
+
+        // assertEquals("*", fieldPath.getFullPath());
+    }
+
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
@@ -52,12 +52,14 @@ import org.hisp.dhis.webapi.mvc.messageconverter.JsonMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.StreamingJsonRootMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
+import org.hisp.dhis.webapi.security.FieldPathConverter;
 import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
@@ -211,6 +213,13 @@ public class MvcTestConfig implements WebMvcConfigurer
 
         converters.add( mappingJackson2HttpMessageConverter() );
         converters.add( mappingJackson2XmlHttpMessageConverter() );
+    }
+
+    @Override
+    public void addFormatters( FormatterRegistry registry )
+    {
+        // TODO the WebMvcConfig adds another converter
+        registry.addConverter( new FieldPathConverter() );
     }
 
     @Bean

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportServiceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportServiceTest.java
@@ -33,10 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -49,7 +53,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithStar()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "*" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "*" ) );
 
         assertTrue( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );
@@ -61,7 +65,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithPresetAll()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( ":all" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( ":all" ) );
 
         assertTrue( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );
@@ -73,7 +77,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithAllExcluded()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "!*" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "!*" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -85,7 +89,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithOnlyRelationships()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "relationships" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "relationships" ) );
 
         assertTrue( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -97,7 +101,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithOnlyProgramOwners()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "programOwners" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "programOwners" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -109,7 +113,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithOnlyOneExclusion()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "!relationships" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "!relationships" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -121,7 +125,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithAllExceptRelationships()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "*", "!relationships" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "*", "!relationships" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );
@@ -133,7 +137,7 @@ class TrackedEntitiesSupportServiceTest
     void getTrackedEntityInstanceParamsWithAllExceptProgramOwners()
     {
 
-        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( List.of( "*", "!programOwners" ) );
+        TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields( "*", "!programOwners" ) );
 
         assertTrue( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );
@@ -146,7 +150,7 @@ class TrackedEntitiesSupportServiceTest
     {
 
         TrackedEntityInstanceParams params = getTrackedEntityInstanceParams(
-            List.of( "programOwners[orgUnit]", "relationships[from[trackedEntity],to[*]]" ) );
+            fields( "programOwners[orgUnit]", "relationships[from[trackedEntity],to[*]]" ) );
 
         assertTrue( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -159,7 +163,7 @@ class TrackedEntitiesSupportServiceTest
     {
 
         TrackedEntityInstanceParams params = getTrackedEntityInstanceParams(
-            List.of( "!enrollments[uid,enrolledAt]", "relationships[relationship]" ) );
+            fields( "!enrollments[uid,enrolledAt]", "relationships[relationship]" ) );
 
         assertTrue( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -172,7 +176,7 @@ class TrackedEntitiesSupportServiceTest
     {
 
         TrackedEntityInstanceParams params = getTrackedEntityInstanceParams(
-            List.of( "enrollments[events,relationships]" ) );
+            fields( "enrollments[events,relationships]" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );
@@ -186,15 +190,14 @@ class TrackedEntitiesSupportServiceTest
 
         // is order independent
         TrackedEntityInstanceParams params = getTrackedEntityInstanceParams(
-            List.of( "relationships", "!relationships" ) );
+            fields( "relationships", "!relationships" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
         assertFalse( params.isIncludeEvents() );
         assertFalse( params.isIncludeProgramOwners() );
 
-        params = getTrackedEntityInstanceParams(
-            List.of( "!relationships", "relationships" ) );
+        params = getTrackedEntityInstanceParams( fields( "!relationships", "relationships" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertFalse( params.isIncludeEnrollments() );
@@ -207,7 +210,7 @@ class TrackedEntitiesSupportServiceTest
     {
 
         TrackedEntityInstanceParams params = getTrackedEntityInstanceParams(
-            List.of( "enrollments", "enrollments[!status]" ) );
+            fields( "enrollments", "enrollments[!status]" ) );
 
         assertFalse( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );
@@ -219,35 +222,52 @@ class TrackedEntitiesSupportServiceTest
     {
         // events is a child of enrollments not TEI
         return Stream.of(
-            arguments( List.of( "*", "!enrollments" ), false, false ),
-            arguments( List.of( "!events" ), false, false ),
-            arguments( List.of( "events" ), false, false ),
-            arguments( List.of( "!enrollments" ), false, false ),
-            arguments( List.of( "!enrollments", "enrollments" ), false, false ),
-            arguments( List.of( "!enrollments[*]" ), false, false ),
-            arguments( List.of( "enrollments[createdAt]", "enrollments", "enrollments", "!enrollments",
-                "enrollments[notes]", "enrollments[enrollment,updatedAt]" ), false, false ),
-            arguments( List.of( "enrollments[!events]" ), true, false ),
-            arguments( List.of( "enrollments[*,!events]" ), true, false ),
-            arguments( List.of( "enrollments", "enrollments[!events]" ), true, false ),
-            arguments( List.of( "enrollments[!status]" ), true, true ),
-            arguments( List.of( "enrollments" ), true, true ),
-            arguments( List.of( "enrollments", "!events" ), true, true ),
-            arguments( List.of( "enrollments[*]" ), true, true ),
-            arguments( List.of( "enrollments[events]" ), true, true ),
-            arguments( List.of( "enrollments[events[dataValues[*]]]" ), true, true ),
-            arguments( List.of( "enrollments[status,events]" ), true, true ) );
+            arguments( fields( "*", "!enrollments" ), false,
+                false ),
+            arguments( fields( "!events" ), false, false ),
+            arguments( fields( "events" ), false, false ),
+            arguments( fields( "!enrollments" ), false, false ),
+            arguments( fields( "!enrollments", "enrollments" ),
+                false, false ),
+            arguments( fields( "!enrollments[*]" ), false,
+                false ),
+            arguments( fields( "enrollments[createdAt]", "enrollments", "enrollments", "!enrollments",
+                "enrollments[notes]", "enrollments[enrollment,updatedAt]" ),
+                false, false ),
+            arguments( fields( "enrollments[!events]" ), true,
+                false ),
+            arguments( fields( "enrollments[*,!events]" ), true,
+                false ),
+            arguments( fields( "enrollments", "enrollments[!events]" ),
+                true, false ),
+            arguments( fields( "enrollments[!status]" ), true,
+                true ),
+            arguments( fields( "enrollments" ), true, true ),
+            arguments( fields( "enrollments", "!events" ), true,
+                true ),
+            arguments( fields( "enrollments[*]" ), true, true ),
+            arguments( fields( "enrollments[events]" ), true,
+                true ),
+            arguments( fields( "enrollments[events[dataValues[*]]]" ),
+                true, true ),
+            arguments( fields( "enrollments[status,events]" ),
+                true, true ) );
     }
 
     @MethodSource
     @ParameterizedTest
-    void getTrackedEntityInstanceParamsEnrollmentsAndEvents( List<String> fields, boolean expectEnrollments,
+    void getTrackedEntityInstanceParamsEnrollmentsAndEvents( List<FieldPath> fields, boolean expectEnrollments,
         boolean expectEvents )
     {
-
         TrackedEntityInstanceParams params = getTrackedEntityInstanceParams( fields );
 
         assertEquals( expectEvents, params.isIncludeEvents() );
         assertEquals( expectEnrollments, params.isIncludeEnrollments() );
+    }
+
+    private static List<FieldPath> fields( String... fields )
+    {
+        return FieldFilterParser
+            .parse( Collections.singleton( StringUtils.join( fields, "," ) ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,14 +38,12 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
-import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.AccessLevel;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.events.trackedentity.ProgramOwner;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
-import org.hisp.dhis.fieldfiltering.FieldFilterParser;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
 import org.hisp.dhis.program.Program;
@@ -93,7 +90,7 @@ class TrackedEntitiesSupportService
     private final TrackedEntityTypeService trackedEntityTypeService;
 
     @SneakyThrows
-    public TrackedEntityInstance getTrackedEntityInstance( String id, String pr, List<String> fields )
+    public TrackedEntityInstance getTrackedEntityInstance( String id, String pr, List<FieldPath> fields )
     {
         User user = currentUserService.getCurrentUser();
 
@@ -170,17 +167,15 @@ class TrackedEntitiesSupportService
      * @param fields fields query parameter values
      * @return tracked entity instance parameters
      */
-    public static TrackedEntityInstanceParams getTrackedEntityInstanceParams( List<String> fields )
+    public static TrackedEntityInstanceParams getTrackedEntityInstanceParams( List<FieldPath> fields )
     {
-        List<FieldPath> fieldPaths = FieldFilterParser
-            .parse( Collections.singleton( StringUtils.join( fields, "," ) ) );
-        Map<String, FieldPath> roots = rootFields( fieldPaths );
+        Map<String, FieldPath> roots = rootFields( fields );
 
         TrackedEntityInstanceParams params = initUsingAllOrNoFields( roots );
         params = withFieldRelationships( roots, params );
         params = withFieldEnrollmentsAndEvents( roots, params );
         params = withFieldProgramOwners( roots, params );
-        params = withFieldEvents( fieldPaths, roots, params );
+        params = withFieldEvents( fields, roots, params );
 
         return params;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -38,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.webapi.controller.event.mapper.TrackedEntityCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
@@ -80,7 +81,7 @@ public class TrackerTrackedEntitiesExportController
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     PagingWrapper<ObjectNode> getInstances( TrackerTrackedEntityCriteria criteria,
-        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
+        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
@@ -105,18 +106,19 @@ public class TrackerTrackedEntitiesExportController
                     .build() );
         }
 
-        List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes( trackedEntityInstances, fields );
+        List<ObjectNode> objectNodes = fieldFilterService.toObjectNodesAlternative( trackedEntityInstances, fields,
+            null, false );
         return pagingWrapper.withInstances( objectNodes );
     }
 
     @GetMapping( value = "{id}" )
     public ResponseEntity<ObjectNode> getTrackedEntityInstanceById( @PathVariable String id,
         @RequestParam( required = false ) String program,
-        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
+        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
     {
 
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
             trackedEntitiesSupportService.getTrackedEntityInstance( id, program, fields ) );
-        return ResponseEntity.ok( fieldFilterService.toObjectNode( trackedEntity, fields ) );
+        return ResponseEntity.ok( fieldFilterService.toObjectNodeAlternative( trackedEntity, fields, null, false ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/FieldPathConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/FieldPathConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+
+public class FieldPathConverter implements ConditionalGenericConverter
+{
+
+    @Override
+    public boolean matches( TypeDescriptor sourceType, TypeDescriptor targetType )
+    {
+        if ( targetType.getResolvableType().getGenerics().length != 1 ||
+            !FieldPath.class.equals( targetType.getResolvableType().getGeneric( 0 ).resolve() ) )
+        {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Set<ConvertiblePair> getConvertibleTypes()
+    {
+
+        // TODO we might only want to support List
+        return Set.of(
+            new ConvertiblePair( String.class, Collection.class ),
+            new ConvertiblePair( String[].class, Collection.class ) );
+    }
+
+    @Override
+    public Object convert( Object source, TypeDescriptor sourceType, TypeDescriptor targetType )
+    {
+        if ( sourceType.isArray() )
+        {
+            return FieldFilterParser.parse( Collections.singleton( StringUtils.join( (String[]) source, "," ) ) );
+        }
+        return FieldFilterParser.parse( (String) source );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.webapi.mvc.messageconverter.MetadataExportParamsMessageConv
 import org.hisp.dhis.webapi.mvc.messageconverter.StreamingJsonRootMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter;
 import org.hisp.dhis.webapi.mvc.messageconverter.XmlPathMappingJackson2XmlHttpMessageConverter;
+import org.hisp.dhis.webapi.security.FieldPathConverter;
 import org.hisp.dhis.webapi.view.CustomPathExtensionContentNegotiationStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -215,6 +216,7 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration
     protected void addFormatters( FormatterRegistry registry )
     {
         registry.addConverter( new StringToOrderCriteriaListConverter() );
+        registry.addConverter( new FieldPathConverter() );
     }
 
     @Primary


### PR DESCRIPTION
This allows devs to access FieldPath in their controllers. Enables for example only fetching things from the DB which will also be returned in the JSON after field filtering has been applied. Currently, parsing needs to be done twice as FieldPath are not exposed