### PR TITLE
ci: Keep dev build history for 5 days and always save reports [skip ci] [2.38]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -11,7 +11,7 @@ pipeline {
     }
 
     options {
-        buildDiscarder(logRotator(numToKeepStr: '5'))
+        buildDiscarder(logRotator(daysToKeepStr: '5'))
         timeout(time: 30)
     }
 
@@ -88,7 +88,7 @@ pipeline {
     }
 
     post {
-        success {
+        always {
             archiveArtifacts artifacts: '**/target/surefire-reports/TEST-*.xml'
         }
 


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/11694