### PR TITLE
test: be more lenient in cache header assertion

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -147,4 +147,46 @@ public final class Assertions
         assertTrue( actual.contains( expected ), () -> String
             .format( "expected actual to contain '%s', got '%s' instead", expected, actual ) );
     }
+
+    /**
+     * Asserts that the given value is within the range of lower and upper bound
+     * (inclusive i.e. [lower, upper]).
+     *
+     * @param lower lower bound
+     * @param upper upper bound
+     * @param actual actual value to be checked
+     */
+    public static void assertWithinRange( long lower, long upper, long actual )
+    {
+        assertTrue( lower < upper,
+            () -> String.format( "lower bound %d must be < than the upper bound %d", lower, upper ) );
+
+        assertAll(
+            () -> assertGreaterOrEqual( lower, actual ),
+            () -> assertLessOrEqual( upper, actual ) );
+    }
+
+    /**
+     * Asserts that the given value is greater or equal than lower bound.
+     *
+     * @param lower lower bound
+     * @param actual actual value to be checked
+     */
+    public static void assertGreaterOrEqual( long lower, long actual )
+    {
+        assertTrue( actual >= lower,
+            () -> String.format( "Expected actual %d to be >= than lower bound %d", actual, lower ) );
+    }
+
+    /**
+     * Asserts that the given value is less or equal than upper bound.
+     *
+     * @param upper upper bound
+     * @param actual actual value to be checked
+     */
+    public static void assertLessOrEqual( long upper, long actual )
+    {
+        assertTrue( actual <= upper,
+            () -> String.format( "Expected actual %d to be <= than upper bound %d", actual, upper ) );
+    }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -34,14 +34,9 @@ import static java.util.Calendar.getInstance;
 import static org.hisp.dhis.analytics.AnalyticsCacheTtlMode.FIXED;
 import static org.hisp.dhis.analytics.AnalyticsCacheTtlMode.PROGRESSIVE;
 import static org.hisp.dhis.analytics.DataQueryParams.newBuilder;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_10_MINUTES;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_15_MINUTES;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_1_HOUR;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_1_MINUTE;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_30_MINUTES;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_5_MINUTES;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_6AM_TOMORROW;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_TWO_WEEKS;
 import static org.hisp.dhis.common.cache.CacheStrategy.NO_CACHE;
 import static org.hisp.dhis.common.cache.CacheStrategy.RESPECT_SYSTEM_SETTING;
 import static org.hisp.dhis.common.cache.Cacheability.PRIVATE;
@@ -51,8 +46,11 @@ import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_TTL_MODE;
 import static org.hisp.dhis.setting.SettingKey.CACHEABILITY;
 import static org.hisp.dhis.setting.SettingKey.CACHE_STRATEGY;
 import static org.hisp.dhis.setting.SettingKey.getAsRealClass;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.utils.Assertions.assertWithinRange;
 import static org.hisp.dhis.webapi.utils.ContextUtils.getAttachmentFileName;
 import static org.hisp.dhis.webapi.utils.ContextUtils.stripFormatCompressionExtension;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -61,10 +59,12 @@ import java.util.Calendar;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -90,6 +90,12 @@ class ContextUtilsTest extends DhisWebSpringTest
         response = new MockHttpServletResponse();
     }
 
+    @AfterEach
+    void afterEach()
+    {
+        response.reset();
+    }
+
     @Test
     void testConfigureResponseReturnsCorrectTypeAndNumberOfHeaders()
     {
@@ -101,38 +107,45 @@ class ContextUtilsTest extends DhisWebSpringTest
     }
 
     @Test
-    void testConfigureResponseReturnsCorrectHeaderValueForAllCacheStrategies()
+    void testConfigureResponseReturnsConfiguredNoCacheStrategy()
     {
         contextUtils.configureResponse( response, null, NO_CACHE, null, false );
+
         assertEquals( "no-cache", response.getHeader( "Cache-Control" ) );
-        response.reset();
+    }
+
+    @Test
+    void testConfigureResponseReturnsConfiguredCacheStrategy()
+    {
         contextUtils.configureResponse( response, null, CACHE_1_MINUTE, null, false );
+
         assertEquals( "max-age=60, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_5_MINUTES, null, false );
-        assertEquals( "max-age=300, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_10_MINUTES, null, false );
-        assertEquals( "max-age=600, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_15_MINUTES, null, false );
-        assertEquals( "max-age=900, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_30_MINUTES, null, false );
-        assertEquals( "max-age=1800, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_1_HOUR, null, false );
-        assertEquals( "max-age=3600, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_TWO_WEEKS, null, false );
-        assertEquals( "max-age=1209600, public", response.getHeader( "Cache-Control" ) );
-        response.reset();
+    }
+
+    @Test
+    void testConfigureResponseReturnsConfiguredCacheStrategy6AMTomorrow()
+    {
         contextUtils.configureResponse( response, null, CACHE_6AM_TOMORROW, null, false );
-        assertEquals( "max-age=" + CACHE_6AM_TOMORROW.toSeconds() + ", public", response.getHeader( "Cache-Control" ) );
-        response.reset();
+
+        String header = response.getHeader( "Cache-Control" );
+        assertAll(
+            () -> assertStartsWith( "max-age", header ),
+            () -> {
+                long maxAgeSeconds = Long.parseLong( StringUtils.getDigits( header ) );
+                Long expected = CACHE_6AM_TOMORROW.toSeconds();
+                long delta = 60; // 1 minute
+                assertWithinRange( expected - delta, expected + delta, maxAgeSeconds );
+            } );
+    }
+
+    @Test
+    void testConfigureResponseRespectsCacheStrategyInSystemSetting()
+    {
         systemSettingManager.saveSystemSetting( CACHE_STRATEGY,
             getAsRealClass( CACHE_STRATEGY.getName(), CACHE_1_HOUR.toString() ) );
+
         contextUtils.configureResponse( response, null, RESPECT_SYSTEM_SETTING, null, false );
+
         assertEquals( "max-age=3600, public", response.getHeader( "Cache-Control" ) );
     }
 


### PR DESCRIPTION
A few tests like `NO_CACHE` and `CACHE_1_MINUTE` are enough to assert that the `CacheStrategy` passed to configureResponse is making it into the max-age=60 response header value. Most other durations just delegate to TimeUnit for making the calculation which we do not need to test.

`CACHE_6AM_TOMORROW` calls new Date(). So testing this we make 2 calls to it once in the test for the expected value and once in the implementation. Since we cannot control the time in the test, we can be a bit more lenient in the expectation of the max-age seconds.

## Example errors

```java
assertWithinRange(100, 20, 100);
```

leads to

```
org.opentest4j.AssertionFailedError: lower bound 100 must be < than the upper bound 20 ==> 
Expected :true
Actual   :false
```

```java
assertWithinRange(10, 20, 21);
```

leads to

```
Expected actual 21 to be <= than upper bound 20 ==> expected: <true> but was: <false>
Comparison Failure: 
Expected :true
Actual   :false
```

```java
assertWithinRange(10, 20, 9);
```

leads to

```
Expected actual 9 to be >= than lower bound 10 ==> expected: <true> but was: <false>
Comparison Failure: 
Expected :true
Actual   :false
```