### PR TITLE
test: be more lenient in cache header assertion [2.37]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
@@ -67,5 +68,60 @@ public final class Assertions
             assertEquals( "Did not expect value in " + actual.toString(),
                 e.getValue(), expected.get( e.getKey() ) );
         }
+    }
+
+    /**
+     * Asserts that the given string starts with the expected prefix.
+     *
+     * @param expected expected prefix of actual string
+     * @param actual actual string which should contain the expected prefix
+     */
+    public static void assertStartsWith( String expected, String actual )
+    {
+        assertNotNull( String
+            .format( "expected string to start with '%s', got null instead", expected ), actual );
+        assertTrue( String
+            .format( "expected string to start with '%s', got '%s' instead", expected, actual ),
+            actual.startsWith( expected ) );
+    }
+
+    /**
+     * Asserts that the given value is within the range of lower and upper bound
+     * (inclusive i.e. [lower, upper]).
+     *
+     * @param lower lower bound
+     * @param upper upper bound
+     * @param actual actual value to be checked
+     */
+    public static void assertWithinRange( long lower, long upper, long actual )
+    {
+        assertTrue( String.format( "lower bound %d must be < than the upper bound %d", lower, upper ), lower < upper );
+
+        assertGreaterOrEqual( lower, actual );
+        assertLessOrEqual( upper, actual );
+    }
+
+    /**
+     * Asserts that the given value is greater or equal than lower bound.
+     *
+     * @param lower lower bound
+     * @param actual actual value to be checked
+     */
+    public static void assertGreaterOrEqual( long lower, long actual )
+    {
+        assertTrue( String.format( "Expected actual %d to be >= than lower bound %d", actual, lower ),
+            actual >= lower );
+    }
+
+    /**
+     * Asserts that the given value is less or equal than upper bound.
+     *
+     * @param upper upper bound
+     * @param actual actual value to be checked
+     */
+    public static void assertLessOrEqual( long upper, long actual )
+    {
+        assertTrue( String.format( "Expected actual %d to be <= than upper bound %d", actual, upper ),
+            actual <= upper );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -34,14 +34,9 @@ import static java.util.Calendar.getInstance;
 import static org.hisp.dhis.analytics.AnalyticsCacheTtlMode.FIXED;
 import static org.hisp.dhis.analytics.AnalyticsCacheTtlMode.PROGRESSIVE;
 import static org.hisp.dhis.analytics.DataQueryParams.newBuilder;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_10_MINUTES;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_15_MINUTES;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_1_HOUR;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_1_MINUTE;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_30_MINUTES;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_5_MINUTES;
 import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_6AM_TOMORROW;
-import static org.hisp.dhis.common.cache.CacheStrategy.CACHE_TWO_WEEKS;
 import static org.hisp.dhis.common.cache.CacheStrategy.NO_CACHE;
 import static org.hisp.dhis.common.cache.CacheStrategy.RESPECT_SYSTEM_SETTING;
 import static org.hisp.dhis.common.cache.Cacheability.PRIVATE;
@@ -51,6 +46,8 @@ import static org.hisp.dhis.setting.SettingKey.ANALYTICS_CACHE_TTL_MODE;
 import static org.hisp.dhis.setting.SettingKey.CACHEABILITY;
 import static org.hisp.dhis.setting.SettingKey.CACHE_STRATEGY;
 import static org.hisp.dhis.setting.SettingKey.getAsRealClass;
+import static org.hisp.dhis.utils.Assertions.assertStartsWith;
+import static org.hisp.dhis.utils.Assertions.assertWithinRange;
 import static org.hisp.dhis.webapi.utils.ContextUtils.getAttachmentFileName;
 import static org.hisp.dhis.webapi.utils.ContextUtils.stripFormatCompressionExtension;
 import static org.junit.Assert.assertEquals;
@@ -61,12 +58,13 @@ import java.util.Calendar;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -91,6 +89,12 @@ public class ContextUtilsTest
         response = new MockHttpServletResponse();
     }
 
+    @After
+    public void afterEach()
+    {
+        response.reset();
+    }
+
     @Test
     public void testConfigureResponseReturnsCorrectTypeAndNumberOfHeaders()
     {
@@ -103,48 +107,42 @@ public class ContextUtilsTest
     }
 
     @Test
-    @Ignore
-    public void testConfigureResponseReturnsCorrectHeaderValueForAllCacheStrategies()
+    public void testConfigureResponseReturnsConfiguredNoCacheStrategy()
     {
         contextUtils.configureResponse( response, null, NO_CACHE, null, false );
+
         assertEquals( "no-cache", response.getHeader( "Cache-Control" ) );
+    }
 
-        response.reset();
+    @Test
+    public void testConfigureResponseReturnsConfiguredCacheStrategy()
+    {
         contextUtils.configureResponse( response, null, CACHE_1_MINUTE, null, false );
+
         assertEquals( "max-age=60, public", response.getHeader( "Cache-Control" ) );
+    }
 
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_5_MINUTES, null, false );
-        assertEquals( "max-age=300, public", response.getHeader( "Cache-Control" ) );
-
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_10_MINUTES, null, false );
-        assertEquals( "max-age=600, public", response.getHeader( "Cache-Control" ) );
-
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_15_MINUTES, null, false );
-        assertEquals( "max-age=900, public", response.getHeader( "Cache-Control" ) );
-
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_30_MINUTES, null, false );
-        assertEquals( "max-age=1800, public", response.getHeader( "Cache-Control" ) );
-
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_1_HOUR, null, false );
-        assertEquals( "max-age=3600, public", response.getHeader( "Cache-Control" ) );
-
-        response.reset();
-        contextUtils.configureResponse( response, null, CACHE_TWO_WEEKS, null, false );
-        assertEquals( "max-age=1209600, public", response.getHeader( "Cache-Control" ) );
-
-        response.reset();
+    @Test
+    public void testConfigureResponseReturnsConfiguredCacheStrategy6AMTomorrow()
+    {
         contextUtils.configureResponse( response, null, CACHE_6AM_TOMORROW, null, false );
-        assertEquals( "max-age=" + CACHE_6AM_TOMORROW.toSeconds() + ", public", response.getHeader( "Cache-Control" ) );
 
-        response.reset();
+        String header = response.getHeader( "Cache-Control" );
+        assertStartsWith( "max-age", header );
+        long maxAgeSeconds = Long.parseLong( StringUtils.getDigits( header ) );
+        Long expected = CACHE_6AM_TOMORROW.toSeconds();
+        long delta = 60; // 1 minute
+        assertWithinRange( expected - delta, expected + delta, maxAgeSeconds );
+    }
+
+    @Test
+    public void testConfigureResponseRespectsCacheStrategyInSystemSetting()
+    {
         systemSettingManager.saveSystemSetting( CACHE_STRATEGY,
             getAsRealClass( CACHE_STRATEGY.getName(), CACHE_1_HOUR.toString() ) );
+
         contextUtils.configureResponse( response, null, RESPECT_SYSTEM_SETTING, null, false );
+
         assertEquals( "max-age=3600, public", response.getHeader( "Cache-Control" ) );
     }
 


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/11775
for some reason the test was Disabled/Ignored in 2.37
note this backport is adapted to JUnit 4 in which the test is written in