### PR TITLE
fix: Skip failing SQL, so the process can continue [DHIS2-13514]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -537,7 +537,7 @@ public abstract class AbstractJdbcTableManager
 
         Timer timer = new SystemTimer().start();
 
-        jdbcTemplate.execute( sql );
+        executeSafely( sql );
 
         log.info( "{} in: {}", logMessage, timer.stop().toString() );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -161,8 +161,9 @@ public class DefaultAnalyticsTableService
 
         if ( params.isLatestUpdate() )
         {
-            progress.startingStage( "Removing updated and deleted data " + tableType );
+            progress.startingStage( "Removing updated and deleted data " + tableType, SKIP_STAGE );
             tableManager.removeUpdatedData( tables );
+            progress.completedStage( "Completed removal of updated and deleted data" );
             clock.logTime( "Removed updated and deleted data" );
         }
 
@@ -176,8 +177,7 @@ public class DefaultAnalyticsTableService
     {
         Set<String> tables = tableManager.getExistingDatabaseTables();
 
-        tables.stream()
-            .forEach( tableManager::dropTableCascade );
+        tables.stream().forEach( tableManager::dropTableCascade );
 
         log.info( "Analytics tables dropped" );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.analytics.table;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexName;
 import static org.hisp.dhis.analytics.util.AnalyticsIndexHelper.getIndexes;
 import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_ITEM_OUTLIER;
+import static org.hisp.dhis.scheduling.JobProgress.FailurePolicy.SKIP_STAGE;
 import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.util.Collection;


### PR DESCRIPTION
[Backport from master/2.40]

_This PR adds a method call that was missed in the original PR:_ https://github.com/dhis2/dhis2-core/pull/11774

We should not fail the analytics export if the SQL execution fails.
It's better to log the exception related to the specific SQL/program and allow the process to continue.

Besides that, this change will allow brand new Programs to be exported through the analytics continuous process (`table_0`).
Without this fix, the continuous process fails when we execute the `removeUpdatedData` method making new Programs impossible to be exported into analytics `table_0`.
