### PR TITLE
fix: Skip failing SQL, so the process can continue [DHIS2-13514]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -256,13 +256,13 @@ public abstract class AbstractJdbcTableManager
     @Override
     public void dropTable( String tableName )
     {
-        executeSilently( "drop table if exists " + tableName );
+        executeSafely( "drop table if exists " + tableName );
     }
 
     @Override
     public void dropTableCascade( String tableName )
     {
-        executeSilently( "drop table if exists " + tableName + " cascade" );
+        executeSafely( "drop table if exists " + tableName + " cascade" );
     }
 
     @Override
@@ -270,7 +270,7 @@ public abstract class AbstractJdbcTableManager
     {
         String sql = StringUtils.trimToEmpty( statementBuilder.getAnalyze( tableName ) );
 
-        executeSilently( sql );
+        executeSafely( sql );
     }
 
     @Override
@@ -351,12 +351,12 @@ public abstract class AbstractJdbcTableManager
     }
 
     /**
-     * Executes a SQL statement. Ignores existing tables/indexes when attempting
-     * to create new but log as an error.
+     * Executes a SQL statement "safely" (without throwing any exception).
+     * Instead, exceptions are simply logged.
      *
      * @param sql the SQL statement.
      */
-    protected void executeSilently( String sql )
+    protected void executeSafely( String sql )
     {
         try
         {
@@ -569,7 +569,7 @@ public abstract class AbstractJdbcTableManager
 
         Timer timer = new SystemTimer().start();
 
-        jdbcTemplate.execute( sql );
+        executeSafely( sql );
 
         log.info( "{} in: {}", logMessage, timer.stop().toString() );
     }
@@ -645,10 +645,10 @@ public abstract class AbstractJdbcTableManager
         for ( int i = 0; i < sqlSteps.length; i++ )
         {
             log.debug( sqlSteps[i] );
-            executeSilently( sqlSteps[i] );
+            executeSafely( sqlSteps[i] );
         }
 
-        executeSilently( sqlSteps, true );
+        executeSafely( sqlSteps, true );
     }
 
     /**
@@ -666,24 +666,32 @@ public abstract class AbstractJdbcTableManager
             "alter table " + partitionTableName + " no inherit " + tempMasterTableName
         };
 
-        executeSilently( sqlSteps, true );
+        executeSafely( sqlSteps, true );
     }
 
-    private void executeSilently( String[] sqlSteps, boolean atomically )
+    /**
+     * Executes a set of SQL statements "safely" (without throwing any
+     * exception). Instead, exceptions are simply logged.
+     *
+     * @param sqlStatements the SQL statements to be executed
+     * @param atomically if true, the statements are executed all together in a
+     *        single JDBC call
+     */
+    private void executeSafely( String[] sqlStatements, boolean atomically )
     {
         if ( atomically )
         {
-            String sql = String.join( ";", sqlSteps ) + ";";
+            String sql = String.join( ";", sqlStatements ) + ";";
             log.debug( sql );
 
-            executeSilently( sql );
+            executeSafely( sql );
         }
         else
         {
-            for ( int i = 0; i < sqlSteps.length; i++ )
+            for ( int i = 0; i < sqlStatements.length; i++ )
             {
-                log.debug( sqlSteps[i] );
-                executeSilently( sqlSteps[i] );
+                log.debug( sqlStatements[i] );
+                executeSafely( sqlStatements[i] );
             }
         }
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -161,6 +161,7 @@ public class DefaultAnalyticsTableService
         {
             progress.startingStage( "Removing updated and deleted data " + tableType );
             tableManager.removeUpdatedData( tables );
+            progress.completedStage( "Completed removal of updated and deleted data" );
             clock.logTime( "Removed updated and deleted data" );
         }
 


### PR DESCRIPTION
[Backport from master/2.40]

We should not fail the analytics export if the SQL execution fails.
It's better to log the exception related to the specific SQL/program and allow the process to continue.

Besides that, this change will allow brand new Programs to be exported through the analytics continuous process (`table_0`).
Without this fix, the continuous process fails when we execute the `removeUpdatedData` method making new Programs impossible to be exported into analytics `table_0`.
