### PR TITLE
fix: Skip failing SQL, so the process can continue [DHIS2-13514]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -588,7 +588,7 @@ public abstract class AbstractJdbcTableManager
 
         Timer timer = new SystemTimer().start();
 
-        jdbcTemplate.execute( sql );
+        executeSafely( sql );
 
         log.info( "{} in: {}", logMessage, timer.stop().toString() );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -272,13 +272,13 @@ public abstract class AbstractJdbcTableManager
     @Override
     public void dropTable( String tableName )
     {
-        executeSilently( "drop table if exists " + tableName );
+        executeSafely( "drop table if exists " + tableName );
     }
 
     @Override
     public void dropTableCascade( String tableName )
     {
-        executeSilently( "drop table if exists " + tableName + " cascade" );
+        executeSafely( "drop table if exists " + tableName + " cascade" );
     }
 
     @Override
@@ -286,7 +286,7 @@ public abstract class AbstractJdbcTableManager
     {
         String sql = StringUtils.trimToEmpty( statementBuilder.getAnalyze( tableName ) );
 
-        executeSilently( sql );
+        executeSafely( sql );
     }
 
     @Override
@@ -381,12 +381,12 @@ public abstract class AbstractJdbcTableManager
     }
 
     /**
-     * Executes a SQL statement. Ignores existing tables/indexes when attempting
-     * to create new.
+     * Executes a SQL statement "safely" (without throwing any exception).
+     * Instead, exceptions are simply logged.
      *
      * @param sql the SQL statement.
      */
-    protected void executeSilently( String sql )
+    protected void executeSafely( String sql )
     {
         try
         {
@@ -659,7 +659,7 @@ public abstract class AbstractJdbcTableManager
         String sql = "drop table if exists " + realTableName + " cascade; " +
             "alter table " + tempTableName + " rename to " + realTableName + ";";
 
-        executeSilently( sql );
+        executeSafely( sql );
     }
 
     /**
@@ -675,6 +675,6 @@ public abstract class AbstractJdbcTableManager
         String sql = "alter table " + partitionTableName + " inherit " + realMasterTableName + ";" +
             "alter table " + partitionTableName + " no inherit " + tempMasterTableName + ";";
 
-        executeSilently( sql );
+        executeSafely( sql );
     }
 }


### PR DESCRIPTION
[Backport from master/2.40]

We should not fail the analytics export if the SQL execution fails.
It's better to log the exception related to the specific SQL/program and allow the process to continue.

Besides that, this change will allow brand new Programs to be exported through the analytics continuous process (`table_0`).
Without this fix, the continuous process fails when we execute the `removeUpdatedData` method making new Programs impossible to be exported into analytics `table_0`.
