### PR TITLE
chore: reduce mutation in EventSearchParams DHIS2-13648

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -180,9 +180,9 @@ public class EventSearchParams
     /**
      * Filters for the response.
      */
-    private List<QueryItem> filters = new ArrayList<>();
+    private final List<QueryItem> filters = new ArrayList<>();
 
-    private List<QueryItem> filterAttributes = new ArrayList<>();
+    private final List<QueryItem> filterAttributes = new ArrayList<>();
 
     /**
      * DataElements to be included in the response. Can be used to filter
@@ -287,7 +287,7 @@ public class EventSearchParams
      */
     public boolean hasFilters()
     {
-        return filters != null && !filters.isEmpty();
+        return !filters.isEmpty();
     }
 
     /**
@@ -714,23 +714,29 @@ public class EventSearchParams
 
     public List<QueryItem> getFilters()
     {
-        return filters;
+        return Collections.unmodifiableList( this.filters );
     }
 
-    public EventSearchParams setFilters( List<QueryItem> filters )
+    public EventSearchParams addFilter( QueryItem item )
     {
-        this.filters = filters;
+        this.filters.add( item );
         return this;
     }
 
     public List<QueryItem> getFilterAttributes()
     {
-        return filterAttributes;
+        return Collections.unmodifiableList( this.filterAttributes );
     }
 
-    public EventSearchParams setFilterAttributes( List<QueryItem> filters )
+    public EventSearchParams addFilterAttributes( List<QueryItem> item )
     {
-        this.filterAttributes = filters;
+        this.filterAttributes.addAll( item );
+        return this;
+    }
+
+    public EventSearchParams addFilterAttributes( QueryItem item )
+    {
+        this.filterAttributes.add( item );
         return this;
     }
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -593,8 +593,7 @@ class EventExporterTest extends TrackerTest
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
 
-        params.setFilterAttributes( List.of(
-            queryItem( "toUpdate000", QueryOperator.EQ, "summer day" ) ) );
+        params.addFilterAttributes( queryItem( "toUpdate000", QueryOperator.EQ, "summer day" ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
             .map( Event::getTrackedEntityInstance )
@@ -609,7 +608,7 @@ class EventExporterTest extends TrackerTest
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
 
-        params.setFilterAttributes( List.of(
+        params.addFilterAttributes( List.of(
             queryItem( "toUpdate000", QueryOperator.EQ, "rainy day" ),
             queryItem( "notUpdated0", QueryOperator.EQ, "winter day" ) ) );
 
@@ -628,7 +627,7 @@ class EventExporterTest extends TrackerTest
 
         QueryItem item = queryItem( "toUpdate000", QueryOperator.LIKE, "day" );
         item.addFilter( new QueryFilter( QueryOperator.LIKE, "in" ) );
-        params.setFilterAttributes( List.of( item ) );
+        params.addFilterAttributes( item );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
             .map( Event::getTrackedEntityInstance )
@@ -643,7 +642,7 @@ class EventExporterTest extends TrackerTest
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
 
-        params.setFilterAttributes( List.of( queryItem( "toUpdate000" ) ) );
+        params.addFilterAttributes( queryItem( "toUpdate000" ) );
         params.setAttributeOrders( List.of( new OrderParam( "toUpdate000", OrderParam.SortDirection.ASC ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()
@@ -659,7 +658,7 @@ class EventExporterTest extends TrackerTest
         EventSearchParams params = new EventSearchParams();
         params.setOrgUnit( orgUnit );
 
-        params.setFilterAttributes( List.of( queryItem( "toUpdate000" ) ) );
+        params.addFilterAttributes( queryItem( "toUpdate000" ) );
         params.setAttributeOrders( List.of( new OrderParam( "toUpdate000", OrderParam.SortDirection.DESC ) ) );
 
         List<String> trackedEntities = eventService.getEvents( params ).getEvents().stream()

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -216,8 +216,7 @@ class EventRequestToSearchParamsMapper
 
             for ( String filter : filters )
             {
-                QueryItem item = getQueryItem( filter );
-                params.getFilters().add( item );
+                params.addFilter( getQueryItem( filter ) );
             }
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -115,9 +115,9 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
 
     private Boolean skipEventId;
 
-    private Set<String> filter;
+    private Set<String> filter = new HashSet<>();
 
-    private Set<String> filterAttributes;
+    private Set<String> filterAttributes = new HashSet<>();
 
     private Set<String> enrollments;
 


### PR DESCRIPTION
Remove some null checks for initialized fields and use guard clauses to reduce nesting.

Separate validation from constructing the EventSearchParams.