### PR TITLE
fix: Centralize and test cache methods

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -56,6 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -63,6 +64,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,7 +77,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
  */
 class ContextUtilsTest extends DhisWebSpringTest
 {
-
     @Autowired
     private ContextUtils contextUtils;
 
@@ -242,5 +243,15 @@ class ContextUtilsTest extends DhisWebSpringTest
         assertEquals( "data", stripFormatCompressionExtension( "data.json.gz", "json", "gz" ) );
         assertEquals( "data.....", stripFormatCompressionExtension( "data.....", "xml", "zip" ) );
         assertEquals( "", stripFormatCompressionExtension( null, "xml", "zip" ) );
+    }
+
+    @Test
+    void testGetEtag()
+    {
+        Date date = getDate( 2022, 03, 10 );
+        User user = new User();
+        user.setUid( "kYt56BgfED2" );
+
+        assertEquals( "", ContextUtils.getEtag( date, user ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -56,7 +56,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Calendar;
-import java.util.Date;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -64,7 +63,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.setting.SystemSettingManager;
-import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.DhisWebSpringTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -243,15 +241,5 @@ class ContextUtilsTest extends DhisWebSpringTest
         assertEquals( "data", stripFormatCompressionExtension( "data.json.gz", "json", "gz" ) );
         assertEquals( "data.....", stripFormatCompressionExtension( "data.....", "xml", "zip" ) );
         assertEquals( "", stripFormatCompressionExtension( null, "xml", "zip" ) );
-    }
-
-    @Test
-    void testGetEtag()
-    {
-        Date date = getDate( 2022, 03, 10 );
-        User user = new User();
-        user.setUid( "kYt56BgfED2" );
-
-        assertEquals( "", ContextUtils.getEtag( date, user ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/GeoFeatureService.java
@@ -170,10 +170,7 @@ public class GeoFeatureService
             .filter( object -> validateDimensionalItemObject( object, geoJsonAttribute ) )
             .collect( Collectors.toList() );
 
-        boolean modified = !ContextUtils.clearIfNotModified( parameters.getRequest(), parameters.getResponse(),
-            dimensionalItemObjects );
-
-        if ( !modified )
+        if ( ContextUtils.isNotModified( parameters.getRequest(), parameters.getResponse(), dimensionalItemObjects ) )
         {
             return null;
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.webapi.utils;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.common.cache.CacheStrategy.RESPECT_SYSTEM_SETTING;
-import static org.hisp.dhis.commons.util.TextUtils.SEP;
 
 import java.util.Collection;
 import java.util.Date;
@@ -293,10 +292,11 @@ public class ContextUtils
      */
     public static boolean isNotModified( HttpServletRequest request, HttpServletResponse response, String tag )
     {
+        System.out.println( "TAG '" + tag + "'" );
         tag = tag != null ? quote( tag ) : null;
 
         String inputTag = request.getHeader( HEADER_IF_NONE_MATCH );
-
+        System.out.println( "INPUT TAG '" + inputTag + "'" );
         response.setHeader( HEADER_ETAG, tag );
 
         if ( inputTag != null && inputTag.equals( tag ) )
@@ -323,7 +323,7 @@ public class ContextUtils
             return null;
         }
 
-        return String.format( "%s%s%s", DateUtils.getLongDateString( date ), SEP, user.getUid() );
+        return String.format( "%s-%s", DateUtils.getLongDateString( date ), user.getUid() );
     }
 
     /**
@@ -406,7 +406,7 @@ public class ContextUtils
     /**
      * Quotes the given strings using double quotes.
      *
-     * @param value the string.
+     * @param string the string.
      * @return a quoted value.
      */
     private static String quote( String string )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -292,11 +292,10 @@ public class ContextUtils
      */
     public static boolean isNotModified( HttpServletRequest request, HttpServletResponse response, String tag )
     {
-        System.out.println( "TAG '" + tag + "'" );
         tag = tag != null ? quote( tag ) : null;
 
         String inputTag = request.getHeader( HEADER_IF_NONE_MATCH );
-        System.out.println( "INPUT TAG '" + inputTag + "'" );
+
         response.setHeader( HEADER_ETAG, tag );
 
         if ( inputTag != null && inputTag.equals( tag ) )
@@ -409,7 +408,7 @@ public class ContextUtils
      * @param string the string.
      * @return a quoted value.
      */
-    private static String quote( String string )
+    static String quote( String string )
     {
         return String.format( "%s%s%s", QUOTE, string, QUOTE );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -35,7 +35,6 @@ import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -349,8 +348,7 @@ public class ContextUtils
      * @return the extracted file name or <code>null</code> content disposition
      *         has no filename.
      */
-    @Nullable
-    public static String getAttachmentFileName( @Nullable String contentDispositionHeaderValue )
+    public static String getAttachmentFileName( String contentDispositionHeaderValue )
     {
         if ( contentDispositionHeaderValue == null )
         {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.utils;
+
+import static org.hisp.dhis.DhisConvenienceTest.getDate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+
+import org.hisp.dhis.user.User;
+import org.junit.jupiter.api.Test;
+
+class ContextUtilsTest
+{
+    @Test
+    void testGetEtag()
+    {
+        Date date = getDate( 2022, 03, 10 );
+        User user = new User();
+        user.setUid( "kYt56BgfED2" );
+
+        assertEquals( "2022-03-10T00:00:00-kYt56BgfED2", ContextUtils.getEtag( date, user ) );
+    }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/utils/ContextUtilsTest.java
@@ -46,4 +46,10 @@ class ContextUtilsTest
 
         assertEquals( "2022-03-10T00:00:00-kYt56BgfED2", ContextUtils.getEtag( date, user ) );
     }
+
+    @Test
+    void testQuote()
+    {
+        assertEquals( "\"2022-03-10T00:00:00\"", ContextUtils.quote( "2022-03-10T00:00:00" ) );
+    }
 }

--- a/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-dataentry/pom.xml
@@ -61,10 +61,8 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-commons</artifactId>
-    </dependency>
+    <!-- Other -->
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/GetDataSetAssociationsAction.java
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/GetDataSetAssociationsAction.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.de.action;
 
-import static org.hisp.dhis.commons.util.TextUtils.SEP;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -97,9 +95,8 @@ public class GetDataSetAssociationsAction
         Date lastUpdated = DateUtils.max(
             identifiableObjectManager.getLastUpdated( DataSet.class ),
             identifiableObjectManager.getLastUpdated( OrganisationUnit.class ) );
-        String tag = lastUpdated != null && user != null
-            ? (DateUtils.getLongDateString( lastUpdated ) + SEP + level + SEP + user.getUid())
-            : null;
+
+        String tag = ContextUtils.getEtag( lastUpdated, user );
 
         if ( ContextUtils.isNotModified( ServletActionContext.getRequest(), ServletActionContext.getResponse(), tag ) )
         {

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/GetMetaDataAction.java
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/java/org/hisp/dhis/de/action/GetMetaDataAction.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.de.action;
 
-import static org.hisp.dhis.commons.util.TextUtils.SEP;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -66,7 +64,6 @@ import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.google.common.collect.Sets;
 import com.opensymphony.xwork2.Action;
 
 /**
@@ -216,7 +213,7 @@ public class GetMetaDataAction
         Locale dbLocale = getLocaleWithDefault( new TranslateParams( true ) );
         CurrentUserUtil.setUserSetting( UserSettingKey.DB_LOCALE, dbLocale );
 
-        Date lastUpdated = DateUtils.max( Sets.newHashSet(
+        Date lastUpdated = DateUtils.max( Set.of(
             identifiableObjectManager.getLastUpdated( DataElement.class ),
             identifiableObjectManager.getLastUpdated( OptionSet.class ),
             identifiableObjectManager.getLastUpdated( Indicator.class ),
@@ -224,9 +221,8 @@ public class GetMetaDataAction
             identifiableObjectManager.getLastUpdated( CategoryCombo.class ),
             identifiableObjectManager.getLastUpdated( Category.class ),
             identifiableObjectManager.getLastUpdated( CategoryOption.class ) ) );
-        String tag = lastUpdated != null && user != null
-            ? (DateUtils.getLongDateString( lastUpdated ) + SEP + user.getUid())
-            : null;
+
+        String tag = ContextUtils.getEtag( lastUpdated, user );
 
         if ( ContextUtils.isNotModified( ServletActionContext.getRequest(), ServletActionContext.getResponse(), tag ) )
         {


### PR DESCRIPTION
Centralizes and tests web cache related methods.

Note that the Struts data entry module does not send any `If-None-Match` header so this does not take affect currently.