### PR TITLE
fix: always return text/plain content type for single user setting [DHIS2-12782]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/UserSettingController.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.notFound;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -121,12 +122,13 @@ public class UserSettingController
     }
 
     @GetMapping( value = "/{key}" )
-    public String getUserSettingByKey(
+    public void getUserSettingByKey(
         @PathVariable( value = "key" ) String key,
         @RequestParam( required = false, defaultValue = "true" ) boolean useFallback,
         @RequestParam( value = "user", required = false ) String username,
         @RequestParam( value = "userId", required = false ) String userId, HttpServletResponse response )
-        throws WebMessageException
+        throws WebMessageException,
+        IOException
     {
         UserSettingKey userSettingKey = getUserSettingKey( key );
         User user = getUser( userId, username );
@@ -137,7 +139,7 @@ public class UserSettingController
 
         response.setHeader( ContextUtils.HEADER_CACHE_CONTROL, CacheControl.noCache().cachePrivate().getHeaderValue() );
         response.setHeader( HttpHeaders.CONTENT_TYPE, ContextUtils.CONTENT_TYPE_TEXT );
-        return String.valueOf( value );
+        response.getWriter().print( value );
     }
 
     @PostMapping( value = "/{key}" )


### PR DESCRIPTION
3rd attempt to fix the content type returned consistently. By writing directly to the output we hopefully get not odd interaction from jackson or spring overriding what ends up at the client based on accept headers send in the request.