### PR TITLE
fix: only create data value audit if value changes - single update [DHIS2-13705]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -34,6 +34,7 @@ import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsZeroAndInsign
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -167,7 +168,8 @@ public class DefaultDataValueService
         {
             dataValue.setLastUpdated( new Date() );
 
-            if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
+            if ( config.isEnabled( CHANGELOG_AGGREGATE )
+                && !Objects.equals( dataValue.getAuditValue(), dataValue.getValue() ) )
             {
                 DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
                     dataValue.getStoredBy(), AuditType.UPDATE );


### PR DESCRIPTION
Same goal as #11691 but for single data value updates.

### Manual Testing
* goto data entry app (old)
* open some form
* change a value, check audit entry is created (might need database access, or new data entry)
* add a comment on a value, check no audit is created
