### PR TITLE
refactor: Move date methods to DateUtils [DHIS2-13643]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -85,6 +85,7 @@ public class DateUtils
     private static final Pattern DEFAULT_DATE_REGEX_PATTERN = Pattern.compile( DEFAULT_DATE_REGEX );
 
     private static final DateTimeParser[] SUPPORTED_DATE_ONLY_PARSERS = {
+        DateTimeFormat.forPattern( "yyyyMMdd" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM-dd" ).getParser(),
         DateTimeFormat.forPattern( "yyyy-MM" ).getParser(),
         DateTimeFormat.forPattern( "yyyy" ).getParser()
@@ -714,9 +715,28 @@ public class DateUtils
      * @param dateString the date string.
      * @return a date.
      */
-    public static Date parseDate( final String dateString )
+    public static Date parseDate( String dateString )
     {
         return safeParseDateTime( dateString, DATE_FORMATTER );
+    }
+
+    /**
+     * Parses the given string into a Date using the supported date formats.
+     * Returns null if the string cannot be parsed.
+     *
+     * @param dateString the date string.
+     * @return a date or null
+     */
+    public static Date safeParseDate( String dateString )
+    {
+        try
+        {
+            return safeParseDateTime( dateString, DATE_FORMATTER );
+        }
+        catch ( Exception e )
+        {
+            return null;
+        }
     }
 
     /**
@@ -726,7 +746,7 @@ public class DateUtils
      * @param date
      * @return TimeStamp with Time Zone
      */
-    public static OffsetDateTime offSetDateTimeFrom( final Date date )
+    public static OffsetDateTime offSetDateTimeFrom( Date date )
     {
         return OffsetDateTime.of( date.toInstant()
             .atZone( ZoneOffset.UTC ).toLocalDateTime(),
@@ -739,7 +759,7 @@ public class DateUtils
      * @param instant the instant
      * @return a date.
      */
-    public static Date fromInstant( final Instant instant )
+    public static Date fromInstant( Instant instant )
     {
         return convertOrNull( instant, Date::from );
     }
@@ -750,7 +770,7 @@ public class DateUtils
      * @param date the date
      * @return an instant.
      */
-    public static Instant instantFromDate( final Date date )
+    public static Instant instantFromDate( Date date )
     {
         return convertOrNull( date, Date::toInstant );
     }
@@ -761,7 +781,7 @@ public class DateUtils
      * @param epochMillis the date expressed as milliseconds from epoch
      * @return an instant.
      */
-    public static Instant instantFromEpoch( final Long epochMillis )
+    public static Instant instantFromEpoch( Long epochMillis )
     {
         return convertOrNull( new Date( epochMillis ), Date::toInstant );
     }
@@ -913,9 +933,9 @@ public class DateUtils
      *
      * @param dateString The string to parse
      * @param formatter The formatter to use for parsing
-     * @return Parsed Date object. Null if the supplied dateString is empty.
+     * @return Parsed Date object. Null if the supplied dateString is empty
      */
-    private static Date safeParseDateTime( final String dateString, final DateTimeFormatter formatter )
+    private static Date safeParseDateTime( String dateString, DateTimeFormatter formatter )
     {
         if ( StringUtils.isEmpty( dateString ) )
         {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.util.DateUtils.getMediumDate;
 import static org.hisp.dhis.util.DateUtils.minusOneDay;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.util.DateUtils.plusOneDay;
+import static org.hisp.dhis.util.DateUtils.safeParseDate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,7 +48,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.Date;
@@ -335,9 +338,11 @@ class DateUtilsTest
     void testCalculateDateFromUsingPositiveDays()
     {
         // Given
-        final Date anyInitialDate = new Date();
+        Date anyInitialDate = new Date();
+
         // When
-        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, 1, DATE );
+        Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, 1, DATE );
+
         // Then
         assertThat( theNewDate, is( greaterThan( anyInitialDate ) ) );
     }
@@ -346,9 +351,11 @@ class DateUtilsTest
     void testCalculateDateFromUsingNegativeDays()
     {
         // Given
-        final Date anyInitialDate = new Date();
+        Date anyInitialDate = new Date();
+
         // When
-        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, -1, DATE );
+        Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, -1, DATE );
+
         // Then
         assertThat( theNewDate, is( lessThan( anyInitialDate ) ) );
     }
@@ -357,9 +364,11 @@ class DateUtilsTest
     void testCalculateDateFromUsingPositiveMilis()
     {
         // Given
-        final Date anyInitialDate = new Date();
+        Date anyInitialDate = new Date();
+
         // When
-        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, 1, MILLISECOND );
+        Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, 1, MILLISECOND );
+
         // Then
         assertThat( theNewDate, is( greaterThan( anyInitialDate ) ) );
     }
@@ -368,42 +377,151 @@ class DateUtilsTest
     void testCalculateDateFromUsingNegativeMilis()
     {
         // Given
-        final Date anyInitialDate = new Date();
+        Date anyInitialDate = new Date();
+
         // When
-        final Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, -1, MILLISECOND );
+        Date theNewDate = DateUtils.calculateDateFrom( anyInitialDate, -1, MILLISECOND );
+
         // Then
         assertThat( theNewDate, is( lessThan( anyInitialDate ) ) );
     }
 
     @Test
+    void testParseDateSupportedDateFormats()
+    {
+        // Assert yyyyMMdd format
+        Date date = parseDate( "20031202" );
+        assertNotNull( date );
+        LocalDate localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2003 );
+        assertTrue( localDate.getMonthValue() == 12 );
+        assertTrue( localDate.getDayOfMonth() == 02 );
+
+        // Assert yyyy-MM-dd format
+        date = parseDate( "2005-10-12" );
+        assertNotNull( date );
+        localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2005 );
+        assertTrue( localDate.getMonthValue() == 10 );
+        assertTrue( localDate.getDayOfMonth() == 12 );
+
+        // Assert yyyy-MM format
+        date = parseDate( "2022-05" );
+        assertNotNull( date );
+        localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2022 );
+        assertTrue( localDate.getMonthValue() == 5 );
+
+        // Assert yyyy format
+        date = parseDate( "2023" );
+        assertNotNull( date );
+        localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2023 );
+    }
+
+    @Test
+    void testParseDateInvalidDateFormats()
+    {
+        // Assert yyyy-MMM-dd INVALID format
+        assertThrows( IllegalArgumentException.class, () -> parseDate( "2025-110-12" ) );
+
+        // Assert yyyy-MM-ddd INVALID format
+        assertThrows( IllegalArgumentException.class, () -> parseDate( "2025-11-120" ) );
+
+        // Assert yyyyyMMddd INVALID format
+        assertThrows( IllegalArgumentException.class, () -> parseDate( "2025011120" ) );
+    }
+
+    @Test
+    void testSafeParseDateSupportedDateFormats()
+    {
+        // Assert yyyyMMdd format
+        Date date = safeParseDate( "20031202" );
+        assertNotNull( date );
+        LocalDate localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2003 );
+        assertTrue( localDate.getMonthValue() == 12 );
+        assertTrue( localDate.getDayOfMonth() == 02 );
+
+        // Assert yyyy-MM-dd format
+        date = safeParseDate( "2005-10-12" );
+        assertNotNull( date );
+        localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2005 );
+        assertTrue( localDate.getMonthValue() == 10 );
+        assertTrue( localDate.getDayOfMonth() == 12 );
+
+        // Assert yyyy-MM format
+        date = safeParseDate( "2022-05" );
+        assertNotNull( date );
+        localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2022 );
+        assertTrue( localDate.getMonthValue() == 5 );
+
+        // Assert yyyy format
+        date = safeParseDate( "2023" );
+        assertNotNull( date );
+        localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
+        assertTrue( localDate.getYear() == 2023 );
+
+        // Assert yyyy-MMM-dd INVALID format
+        date = safeParseDate( "2025-110-12" );
+        assertNull( date );
+
+        // Assert yyyy-MM-ddd INVALID format
+        date = safeParseDate( "2025-11-120" );
+        assertNull( date );
+
+        // Assert yyyyyMMddd INVALID format
+        date = safeParseDate( "2025011120" );
+        assertNull( date );
+    }
+
+    @Test
+    void testSafeParseDateInvalidDateFormats()
+    {
+        // Assert yyyy-MMM-dd INVALID format
+        Date date = safeParseDate( "2025-110-12" );
+        assertNull( date );
+
+        // Assert yyyy-MMM INVALID format
+        date = safeParseDate( "2025-111" );
+        assertNull( date );
+
+        // Assert yyyyyMMddd INVALID format
+        date = safeParseDate( "2025011120" );
+        assertNull( date );
+    }
+
+    @Test
     void testPlusOneDay()
     {
-        final Date aDay = getMediumDate( "2021-01-01" );
-        final Date theDayAfter = getMediumDate( "2021-01-02" );
+        Date aDay = getMediumDate( "2021-01-01" );
+        Date theDayAfter = getMediumDate( "2021-01-02" );
         assertThat( theDayAfter, is( plusOneDay( aDay ) ) );
     }
 
     @Test
     void testPlusOneSqlDay()
     {
-        final java.sql.Date sqlDay = new java.sql.Date( getMediumDate( "2021-01-01" ).getTime() );
-        final Date theDayAfter = getMediumDate( "2021-01-02" );
+        java.sql.Date sqlDay = new java.sql.Date( getMediumDate( "2021-01-01" ).getTime() );
+        Date theDayAfter = getMediumDate( "2021-01-02" );
         assertThat( theDayAfter, is( plusOneDay( sqlDay ) ) );
     }
 
     @Test
     void testMinusOneDay()
     {
-        final Date aDay = getMediumDate( "2021-01-01" );
-        final Date theDayBefore = getMediumDate( "2020-12-31" );
+        Date aDay = getMediumDate( "2021-01-01" );
+        Date theDayBefore = getMediumDate( "2020-12-31" );
         assertThat( theDayBefore, is( minusOneDay( aDay ) ) );
     }
 
     @Test
     void testMinusOneSqlDay()
     {
-        final java.sql.Date sqlDay = new java.sql.Date( getMediumDate( "2021-01-01" ).getTime() );
-        final Date theDayBefore = getMediumDate( "2020-12-31" );
+        java.sql.Date sqlDay = new java.sql.Date( getMediumDate( "2021-01-01" ).getTime() );
+        Date theDayBefore = getMediumDate( "2020-12-31" );
         assertThat( theDayBefore, is( minusOneDay( sqlDay ) ) );
     }
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
@@ -393,30 +393,30 @@ class DateUtilsTest
         Date date = parseDate( "20031202" );
         assertNotNull( date );
         LocalDate localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2003 );
-        assertTrue( localDate.getMonthValue() == 12 );
-        assertTrue( localDate.getDayOfMonth() == 02 );
+        assertEquals( localDate.getYear(), 2003 );
+        assertEquals( localDate.getMonthValue(), 12 );
+        assertEquals( localDate.getDayOfMonth(), 02 );
 
         // Assert yyyy-MM-dd format
         date = parseDate( "2005-10-12" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2005 );
-        assertTrue( localDate.getMonthValue() == 10 );
-        assertTrue( localDate.getDayOfMonth() == 12 );
+        assertEquals( localDate.getYear(), 2005 );
+        assertEquals( localDate.getMonthValue(), 10 );
+        assertEquals( localDate.getDayOfMonth(), 12 );
 
         // Assert yyyy-MM format
         date = parseDate( "2022-05" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2022 );
-        assertTrue( localDate.getMonthValue() == 5 );
+        assertEquals( localDate.getYear(), 2022 );
+        assertEquals( localDate.getMonthValue(), 5 );
 
         // Assert yyyy format
         date = parseDate( "2023" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2023 );
+        assertEquals( localDate.getYear(), 2023 );
     }
 
     @Test
@@ -439,30 +439,30 @@ class DateUtilsTest
         Date date = safeParseDate( "20031202" );
         assertNotNull( date );
         LocalDate localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2003 );
-        assertTrue( localDate.getMonthValue() == 12 );
-        assertTrue( localDate.getDayOfMonth() == 02 );
+        assertEquals( localDate.getYear(), 2003 );
+        assertEquals( localDate.getMonthValue(), 12 );
+        assertEquals( localDate.getDayOfMonth(), 02 );
 
         // Assert yyyy-MM-dd format
         date = safeParseDate( "2005-10-12" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2005 );
-        assertTrue( localDate.getMonthValue() == 10 );
-        assertTrue( localDate.getDayOfMonth() == 12 );
+        assertEquals( localDate.getYear(), 2005 );
+        assertEquals( localDate.getMonthValue(), 10 );
+        assertEquals( localDate.getDayOfMonth(), 12 );
 
         // Assert yyyy-MM format
         date = safeParseDate( "2022-05" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2022 );
-        assertTrue( localDate.getMonthValue() == 5 );
+        assertEquals( localDate.getYear(), 2022 );
+        assertEquals( localDate.getMonthValue(), 5 );
 
         // Assert yyyy format
         date = safeParseDate( "2023" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertTrue( localDate.getYear() == 2023 );
+        assertEquals( localDate.getYear(), 2023 );
 
         // Assert yyyy-MMM-dd INVALID format
         date = safeParseDate( "2025-110-12" );

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/util/DateUtilsTest.java
@@ -393,30 +393,30 @@ class DateUtilsTest
         Date date = parseDate( "20031202" );
         assertNotNull( date );
         LocalDate localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2003 );
-        assertEquals( localDate.getMonthValue(), 12 );
-        assertEquals( localDate.getDayOfMonth(), 02 );
+        assertEquals( 2003, localDate.getYear() );
+        assertEquals( 12, localDate.getMonthValue() );
+        assertEquals( 02, localDate.getDayOfMonth() );
 
         // Assert yyyy-MM-dd format
         date = parseDate( "2005-10-12" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2005 );
-        assertEquals( localDate.getMonthValue(), 10 );
-        assertEquals( localDate.getDayOfMonth(), 12 );
+        assertEquals( 2005, localDate.getYear() );
+        assertEquals( 10, localDate.getMonthValue() );
+        assertEquals( 12, localDate.getDayOfMonth() );
 
         // Assert yyyy-MM format
         date = parseDate( "2022-05" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2022 );
-        assertEquals( localDate.getMonthValue(), 5 );
+        assertEquals( 2022, localDate.getYear() );
+        assertEquals( 5, localDate.getMonthValue() );
 
         // Assert yyyy format
         date = parseDate( "2023" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2023 );
+        assertEquals( 2023, localDate.getYear() );
     }
 
     @Test
@@ -439,30 +439,30 @@ class DateUtilsTest
         Date date = safeParseDate( "20031202" );
         assertNotNull( date );
         LocalDate localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2003 );
-        assertEquals( localDate.getMonthValue(), 12 );
-        assertEquals( localDate.getDayOfMonth(), 02 );
+        assertEquals( 2003, localDate.getYear() );
+        assertEquals( 12, localDate.getMonthValue() );
+        assertEquals( 2, localDate.getDayOfMonth() );
 
         // Assert yyyy-MM-dd format
         date = safeParseDate( "2005-10-12" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2005 );
-        assertEquals( localDate.getMonthValue(), 10 );
-        assertEquals( localDate.getDayOfMonth(), 12 );
+        assertEquals( 2005, localDate.getYear() );
+        assertEquals( 10, localDate.getMonthValue() );
+        assertEquals( 12, localDate.getDayOfMonth() );
 
         // Assert yyyy-MM format
         date = safeParseDate( "2022-05" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2022 );
-        assertEquals( localDate.getMonthValue(), 5 );
+        assertEquals( 2022, localDate.getYear() );
+        assertEquals( 5, localDate.getMonthValue() );
 
         // Assert yyyy format
         date = safeParseDate( "2023" );
         assertNotNull( date );
         localDate = date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
-        assertEquals( localDate.getYear(), 2023 );
+        assertEquals( 2023, localDate.getYear() );
 
         // Assert yyyy-MMM-dd INVALID format
         date = safeParseDate( "2025-110-12" );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -47,7 +47,6 @@ import static org.hisp.dhis.common.DimensionalObject.LONGITUDE_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_GROUP_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObject.PERIOD_FREE_RANGE_SEPARATOR;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.asTypedList;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getDimensionalItemIds;
@@ -111,7 +110,6 @@ import org.hisp.dhis.indicator.IndicatorGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroup;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
-import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.period.RelativePeriodEnum;
@@ -123,7 +121,6 @@ import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
-import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
@@ -445,7 +442,7 @@ public class DefaultDataQueryService
                     }
                     else
                     {
-                        Optional<Period> optionalPeriod = tryParsePeriodDateRange( isoPeriodHolder );
+                        Optional<Period> optionalPeriod = isoPeriodHolder.toDailyPeriod();
                         if ( optionalPeriod.isPresent() )
                         {
                             Period periodToAdd = optionalPeriod.get();
@@ -655,30 +652,6 @@ public class DefaultDataQueryService
         }
 
         throw new IllegalQueryException( new ErrorMessage( ErrorCode.E7125, dimension ) );
-    }
-
-    /**
-     * Parses periods in <code>YYYYMMDD_YYYYMMDD</code> or
-     * <code>YYYY-MM-DD_YYYY-MM-DD</code> format.
-     */
-    private Optional<Period> tryParsePeriodDateRange( IsoPeriodHolder isoPeriodHolder )
-    {
-        String[] dates = isoPeriodHolder.getIsoPeriod().split( PERIOD_FREE_RANGE_SEPARATOR );
-        if ( dates.length == 2 )
-        {
-            Date start = DateUtils.safeParseDate( dates[0] );
-            Date end = DateUtils.safeParseDate( dates[1] );
-            if ( start != null && end != null )
-            {
-                Period period = new Period();
-                period.setPeriodType( new DailyPeriodType() );
-                period.setStartDate( start );
-                period.setEndDate( end );
-                period.setDateField( isoPeriodHolder.getDateField() );
-                return Optional.of( period );
-            }
-        }
-        return Optional.empty();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/IsoPeriodHolder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/IsoPeriodHolder.java
@@ -27,13 +27,21 @@
  */
 package org.hisp.dhis.analytics.data;
 
+import static java.util.Optional.empty;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_NAME_SEP;
+import static org.hisp.dhis.common.DimensionalObject.PERIOD_FREE_RANGE_SEPARATOR;
+import static org.hisp.dhis.util.DateUtils.safeParseDate;
 
+import java.util.Date;
 import java.util.Objects;
+import java.util.Optional;
 
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.period.DailyPeriodType;
+import org.hisp.dhis.period.Period;
 
 @Getter
 @RequiredArgsConstructor( access = AccessLevel.PRIVATE )
@@ -56,5 +64,36 @@ public class IsoPeriodHolder
     public boolean hasDateField()
     {
         return Objects.nonNull( dateField );
+    }
+
+    /**
+     * Parses periods in <code>YYYYMMDD_YYYYMMDD</code> or
+     * <code>YYYY-MM-DD_YYYY-MM-DD</code> format into a {@link Period} of type
+     * {@link DailyPeriodType} with the respective start and end dates properly
+     * set.
+     *
+     * @return the Period object
+     */
+    public Optional<Period> toDailyPeriod()
+    {
+        String[] dates = getIsoPeriod().split( PERIOD_FREE_RANGE_SEPARATOR );
+
+        if ( dates.length == 2 )
+        {
+            Date start = safeParseDate( dates[0] );
+            Date end = safeParseDate( dates[1] );
+
+            if ( start != null && end != null )
+            {
+                Period period = new Period();
+                period.setPeriodType( new DailyPeriodType() );
+                period.setStartDate( start );
+                period.setEndDate( end );
+                period.setDateField( getDateField() );
+
+                return Optional.of( period );
+            }
+        }
+        return empty();
     }
 }


### PR DESCRIPTION
Refactor requested to align a few date methods:

_In DefaultDataQueryService we have custom handling of periods and dates.
Instead, the code should use existing classes such as `DateUtils`._

_It is important to centralize the handling of periods/dates and avoid different behaviour in different places. Methods such as safelyParseDate, tryParseDateRange and safelyParseDateUsingFormatter should be reviewed/avoided._

This is part of the ticket DHIS2-13618.
