### PR TITLE
chore: do not fetch optional ids from DB if empty

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
@@ -29,15 +29,16 @@ package org.hisp.dhis.webapi.controller.event.webrequest;
 
 import static java.util.stream.Collectors.partitioningBy;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +52,7 @@ import org.apache.commons.collections4.CollectionUtils;
  */
 @Data
 @Slf4j
+@AllArgsConstructor
 @NoArgsConstructor( access = AccessLevel.PROTECTED )
 public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria, SortingCriteria
 {
@@ -74,12 +76,12 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     /**
      * Indicates whether paging should be skipped.
      */
-    private Boolean skipPaging;
+    private boolean skipPaging;
 
     /**
      * order params
      */
-    private List<OrderCriteria> order;
+    private List<OrderCriteria> order = new ArrayList<>();
 
     /**
      * TODO: legacy flag can be removed when new tracker will have it's own
@@ -101,12 +103,6 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     public boolean isPagingRequest()
     {
         return !isSkipPaging();
-    }
-
-    public boolean isSkipPaging()
-    {
-        return Optional.ofNullable( skipPaging )
-            .orElse( false );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingCriteria.java
@@ -59,7 +59,7 @@ public interface PagingCriteria
     /**
      * Indicates whether paging should be skipped.
      */
-    Boolean getSkipPaging();
+    boolean isSkipPaging();
 
     default Integer getFirstResult()
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -158,7 +158,7 @@ public class EnrollmentController
                 enrollmentCriteria.getPage(),
                 enrollmentCriteria.getPageSize(),
                 enrollmentCriteria.isTotalPages(),
-                PagerUtils.isSkipPaging( enrollmentCriteria.getSkipPaging(), enrollmentCriteria.getPaging() ),
+                PagerUtils.isSkipPaging( enrollmentCriteria.isSkipPaging(), enrollmentCriteria.getPaging() ),
                 enrollmentCriteria.isIncludeDeleted(),
                 enrollmentCriteria.getOrder() );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
@@ -200,7 +200,7 @@ class EventRequestToSearchParamsMapper
 
         return params.setProgram( program ).setProgramStage( programStage ).setOrgUnit( orgUnit )
             .setTrackedEntityInstance( trackedEntityInstance )
-            .setProgramStatus( eventCriteria.getProgramStatus() ).setFollowUp( eventCriteria.getFollowUp() )
+            .setProgramStatus( eventCriteria.getProgramStatus() ).setFollowUp( eventCriteria.isFollowUp() )
             .setOrgUnitSelectionMode( eventCriteria.getOuMode() )
             .setAssignedUserSelectionMode( eventCriteria.getAssignedUserMode() )
             .setAssignedUsers( assignedUserIds )
@@ -218,7 +218,7 @@ class EventRequestToSearchParamsMapper
             .setPage( eventCriteria.getPage() )
             .setPageSize( eventCriteria.getPageSize() ).setTotalPages( eventCriteria.isTotalPages() )
             .setSkipPaging( eventCriteria.isSkipPaging() )
-            .setSkipEventId( eventCriteria.getSkipEventId() ).setIncludeAttributes( false )
+            .setSkipEventId( eventCriteria.isSkipEventId() ).setIncludeAttributes( false )
             .setIncludeAllDataElements( false ).setOrders( getOrderParams( eventCriteria.getOrder() ) )
             .setGridOrders( getGridOrderParams( eventCriteria.getOrder(), dataElementOrders ) )
             .setAttributeOrders( attributeOrderParams )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteria.java
@@ -29,21 +29,25 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import lombok.Data;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.program.ProgramStatus;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
 /**
@@ -51,73 +55,138 @@ import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteria
  *
  * @author Giuseppe Nespolino <g.nespolino@gmail.com>
  */
-@Data
-@NoArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
 class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
 {
-    private String program;
+    private final String program;
 
-    private String programStage;
+    private final String programStage;
 
-    private ProgramStatus programStatus;
+    private final ProgramStatus programStatus;
 
-    private Boolean followUp;
+    private final boolean followUp;
 
-    private String trackedEntity;
+    private final String trackedEntity;
 
-    private String orgUnit;
+    private final String orgUnit;
 
-    private OrganisationUnitSelectionMode ouMode;
+    private final OrganisationUnitSelectionMode ouMode;
 
-    private AssignedUserSelectionMode assignedUserMode;
+    private final AssignedUserSelectionMode assignedUserMode;
 
-    private String assignedUser;
+    private final String assignedUser;
 
-    private Date occurredAfter;
+    private final Date occurredAfter;
 
-    private Date occurredBefore;
+    private final Date occurredBefore;
 
-    private Date scheduledAfter;
+    private final Date scheduledAfter;
 
-    private Date scheduledBefore;
+    private final Date scheduledBefore;
 
-    private Date updatedAfter;
+    private final Date updatedAfter;
 
-    private Date updatedBefore;
+    private final Date updatedBefore;
 
-    private String updatedWithin;
+    private final String updatedWithin;
 
-    private Date enrollmentEnrolledBefore;
+    private final Date enrollmentEnrolledBefore;
 
-    private Date enrollmentEnrolledAfter;
+    private final Date enrollmentEnrolledAfter;
 
-    private Date enrollmentOccurredBefore;
+    private final Date enrollmentOccurredBefore;
 
-    private Date enrollmentOccurredAfter;
+    private final Date enrollmentOccurredAfter;
 
-    private EventStatus status;
+    private final EventStatus status;
 
-    private String attributeCc;
+    private final String attributeCc;
 
-    private String attributeCos;
+    private final String attributeCos;
 
-    private boolean skipMeta;
+    private final boolean skipMeta;
 
-    private String attachment;
+    private final String attachment;
 
-    private boolean includeDeleted;
+    private final boolean includeDeleted;
 
-    private String event;
+    private final String event;
 
-    private Boolean skipEventId;
+    private final boolean skipEventId;
 
     private Set<String> filter = new HashSet<>();
 
     private Set<String> filterAttributes = new HashSet<>();
 
-    private Set<String> enrollments;
+    private Set<String> enrollments = new HashSet<>();
 
-    private IdSchemes idSchemes = new IdSchemes();
+    private final IdSchemes idSchemes = new IdSchemes();
+
+    @Builder
+    public TrackerEventCriteria( String program, String programStage, ProgramStatus programStatus, boolean followUp,
+        String trackedEntity, String orgUnit, OrganisationUnitSelectionMode ouMode,
+        AssignedUserSelectionMode assignedUserMode, String assignedUser, Date occurredAfter, Date occurredBefore,
+        Date scheduledAfter, Date scheduledBefore, Date updatedAfter, Date updatedBefore, String updatedWithin,
+        Set<String> enrollments, Date enrollmentEnrolledBefore, Date enrollmentEnrolledAfter,
+        Date enrollmentOccurredBefore, Date enrollmentOccurredAfter, EventStatus status, String attributeCc,
+        String attributeCos, boolean skipMeta, String attachment, boolean includeDeleted, String event,
+        boolean skipEventId, Set<String> filter, Set<String> filterAttributes, Integer page, Integer pageSize,
+        boolean totalPages, boolean skipPaging, List<OrderCriteria> order, boolean isLegacy )
+    {
+        // explicit constructor is necessary since this class extends another
+        // class
+        super( page, pageSize, totalPages, skipPaging, order, isLegacy );
+        this.program = program;
+        this.programStage = programStage;
+        this.programStatus = programStatus;
+        this.followUp = followUp;
+        this.trackedEntity = trackedEntity;
+        this.orgUnit = orgUnit;
+        this.ouMode = ouMode;
+        this.assignedUserMode = assignedUserMode;
+        this.assignedUser = assignedUser;
+        this.occurredAfter = occurredAfter;
+        this.occurredBefore = occurredBefore;
+        this.scheduledAfter = scheduledAfter;
+        this.scheduledBefore = scheduledBefore;
+        this.updatedAfter = updatedAfter;
+        this.updatedBefore = updatedBefore;
+        this.updatedWithin = updatedWithin;
+        this.enrollmentEnrolledBefore = enrollmentEnrolledBefore;
+        this.enrollmentEnrolledAfter = enrollmentEnrolledAfter;
+        this.enrollmentOccurredBefore = enrollmentOccurredBefore;
+        this.enrollmentOccurredAfter = enrollmentOccurredAfter;
+        this.status = status;
+        this.attributeCc = attributeCc;
+        this.attributeCos = attributeCos;
+        this.skipMeta = skipMeta;
+        this.attachment = attachment;
+        this.includeDeleted = includeDeleted;
+        this.event = event;
+        this.skipEventId = skipEventId;
+        // necessary since @Builder.Default does not work with an explicit
+        // constructor
+        this.filter = Optional.ofNullable( filter ).orElse( this.filter );
+        this.filterAttributes = Optional.ofNullable( filterAttributes ).orElse( this.filterAttributes );
+        this.enrollments = Optional.ofNullable( enrollments ).orElse( this.enrollments );
+    }
+
+    public Set<String> getFilter()
+    {
+        return Collections.unmodifiableSet( this.filter );
+    }
+
+    public Set<String> getFilterAttributes()
+    {
+        return Collections.unmodifiableSet( this.filterAttributes );
+    }
+
+    public Set<String> getEnrollments()
+    {
+        return Collections.unmodifiableSet( this.enrollments );
+    }
 
     @Override
     public boolean isLegacy()
@@ -142,7 +211,7 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
         /**
          * this enum names must be the same as
          * org.hisp.dhis.tracker.domain.Event fields, just with different case
-         *
+         * <br/>
          * example: org.hisp.dhis.tracker.domain.Event.updatedAtClient -->
          * UPDATED_AT_CLIENT
          */
@@ -166,8 +235,7 @@ class TrackerEventCriteria extends PagingAndSortingCriteriaAdapter
     {
         /**
          * this enum names must be the same as org.hisp.dhis.dxf2.events.Event
-         * fields, just with different case
-         *
+         * fields, just with different case <br/>
          * example: org.hisp.dhis.dxf2.events.Event.lastUpdated --> LAST_UPDATED
          */
         EVENT( "uid" );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -120,7 +120,7 @@ public class TrackerEventsExportController
 
         Events events = eventService.getEvents( eventSearchParams );
 
-        if ( hasHref( fields, eventCriteria.getSkipEventId() ) )
+        if ( hasHref( fields, eventCriteria.isSkipEventId() ) )
         {
             events.getEvents().forEach( e -> e.setHref( getUri( e.getEvent(), request ) ) );
         }
@@ -163,7 +163,7 @@ public class TrackerEventsExportController
 
         Events events = eventService.getEvents( eventSearchParams );
 
-        if ( hasHref( fields, eventCriteria.getSkipEventId() ) )
+        if ( hasHref( fields, eventCriteria.isSkipEventId() ) )
         {
             events.getEvents().forEach( e -> e.setHref( getUri( e.getEvent(), request ) ) );
         }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -189,7 +189,7 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder().build();
 
         requestToSearchParamsMapper.map( eventCriteria );
 
@@ -202,8 +202,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingProgram()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setProgram( PROGRAM_UID );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .program( PROGRAM_UID )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -213,8 +214,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingProgramNotFound()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setProgram( "unknown" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .program( "unknown" )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -224,8 +226,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingProgramStage()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setProgramStage( "programstageuid" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .programStage( "programstageuid" )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -235,8 +238,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingTrackedEntity()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setTrackedEntity( "teiuid" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .trackedEntity( "teiuid" )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -246,12 +250,12 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingOccurredAfterBefore()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         Date occurredAfter = parseDate( "2020-01-01" );
-        eventCriteria.setOccurredAfter( occurredAfter );
         Date occurredBefore = parseDate( "2020-09-12" );
-        eventCriteria.setOccurredBefore( occurredBefore );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .occurredAfter( occurredAfter )
+            .occurredBefore( occurredBefore )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -262,12 +266,12 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingScheduledAfterBefore()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         Date scheduledAfter = parseDate( "2021-01-01" );
-        eventCriteria.setScheduledAfter( scheduledAfter );
         Date scheduledBefore = parseDate( "2021-09-12" );
-        eventCriteria.setScheduledBefore( scheduledBefore );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .scheduledAfter( scheduledAfter )
+            .scheduledBefore( scheduledBefore )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -278,14 +282,14 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingUpdatedDates()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         Date updatedAfter = parseDate( "2022-01-01" );
-        eventCriteria.setUpdatedAfter( updatedAfter );
         Date updatedBefore = parseDate( "2022-09-12" );
-        eventCriteria.setUpdatedBefore( updatedBefore );
         String updatedWithin = "P6M";
-        eventCriteria.setUpdatedWithin( updatedWithin );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .updatedAfter( updatedAfter )
+            .updatedBefore( updatedBefore )
+            .updatedWithin( updatedWithin )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -297,12 +301,12 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEnrollmentEnrolledAtDates()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         Date enrolledBefore = parseDate( "2022-01-01" );
-        eventCriteria.setEnrollmentEnrolledBefore( enrolledBefore );
         Date enrolledAfter = parseDate( "2022-02-01" );
-        eventCriteria.setEnrollmentEnrolledAfter( enrolledAfter );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .enrollmentEnrolledBefore( enrolledBefore )
+            .enrollmentEnrolledAfter( enrolledAfter )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -313,12 +317,12 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEnrollmentOcurredAtDates()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         Date enrolledBefore = parseDate( "2022-01-01" );
-        eventCriteria.setEnrollmentOccurredBefore( enrolledBefore );
         Date enrolledAfter = parseDate( "2022-02-01" );
-        eventCriteria.setEnrollmentOccurredAfter( enrolledAfter );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .enrollmentOccurredBefore( enrolledBefore )
+            .enrollmentOccurredAfter( enrolledAfter )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -329,11 +333,11 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAttributeOrdering()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         OrderCriteria attributeOrder = OrderCriteria.of( TEA_1_UID, OrderParam.SortDirection.ASC );
         OrderCriteria unknownAttributeOrder = OrderCriteria.of( "unknownAtt1", OrderParam.SortDirection.ASC );
-        eventCriteria.setOrder( List.of( attributeOrder, unknownAttributeOrder ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .order( List.of( attributeOrder, unknownAttributeOrder ) )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -346,10 +350,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEnrollments()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-
         Set<String> enrollments = Set.of( "NQnuK2kLm6e" );
-        eventCriteria.setEnrollments( enrollments );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .enrollments( enrollments )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -359,8 +363,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEvents()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .event( "XKrcfuM4Hcw;M4pNmLabtXl" )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -370,8 +375,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEventsStripsInvalidUid()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setEvent( "invalidUid;M4pNmLabtXl" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .event( "invalidUid;M4pNmLabtXl" )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -381,7 +387,7 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEventIsNull()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder().build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -391,8 +397,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEventIsEmpty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setEvent( " " );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .event( " " )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -402,8 +409,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUser()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setAssignedUser( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .assignedUser( "XKrcfuM4Hcw;M4pNmLabtXl" )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -413,8 +421,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUserStripsInvalidUid()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setAssignedUser( "invalidUid;M4pNmLabtXl" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .assignedUser( "invalidUid;M4pNmLabtXl" )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -424,7 +433,7 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUserIsNull()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder().build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -434,8 +443,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUserIsEmpty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setAssignedUser( " " );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .assignedUser( " " )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -445,9 +455,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMutualExclusionOfEventsAndFilter()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) );
-        eventCriteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) )
+            .event( "XKrcfuM4Hcw;M4pNmLabtXl" )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -457,8 +468,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testOrderByEventSchemaProperties()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder( OrderCriteria.fromOrderString( "programStage:desc,dueDate:asc" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .order( OrderCriteria.fromOrderString( "programStage:desc,dueDate:asc" ) )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -469,8 +481,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testOrderBySupportedPropertyNotInEventSchema()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder( OrderCriteria.fromOrderString( "enrolledAt:asc" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .order( OrderCriteria.fromOrderString( "enrolledAt:asc" ) )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -481,8 +494,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testOrderFailsForNonSimpleEventProperty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder( OrderCriteria.fromOrderString( "nonSimple:desc" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .order( OrderCriteria.fromOrderString( "nonSimple:desc" ) )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -492,9 +506,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testOrderFailsForUnsupportedProperty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder(
-            OrderCriteria.fromOrderString( "unsupportedProperty1:asc,enrolledAt:asc,unsupportedProperty2:desc" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .order(
+                OrderCriteria.fromOrderString( "unsupportedProperty1:asc,enrolledAt:asc,unsupportedProperty2:desc" ) )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -510,8 +525,9 @@ class EventRequestToSearchParamsMapperTest
     void testFilterAttributes()
     {
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 
@@ -544,8 +560,9 @@ class EventRequestToSearchParamsMapperTest
     {
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( "eq:2" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filterAttributes( Set.of( "eq:2" ) )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -557,8 +574,9 @@ class EventRequestToSearchParamsMapperTest
     {
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filterAttributes( Set.of( TEA_1_UID + ":eq:2" ) )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -570,8 +588,9 @@ class EventRequestToSearchParamsMapperTest
     {
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( "JM5zWuf1mkb:eq:2" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filterAttributes( Set.of( "JM5zWuf1mkb:eq:2" ) )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -581,9 +600,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testFilterAttributesWhenSameTEAHasMultipleFilters()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes(
-            Set.of( "TvjwTPToKHO:lt:20", "cy2oRh2sNr6:lt:20", "TvjwTPToKHO:gt:30", "cy2oRh2sNr6:gt:30" ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filterAttributes(
+                Set.of( "TvjwTPToKHO:lt:20", "cy2oRh2sNr6:lt:20", "TvjwTPToKHO:gt:30", "cy2oRh2sNr6:gt:30" ) )
+            .build();
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
@@ -600,8 +620,9 @@ class EventRequestToSearchParamsMapperTest
     void testFilterAttributesUsingOnlyUID()
     {
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID ) );
+        TrackerEventCriteria eventCriteria = TrackerEventCriteria.builder()
+            .filterAttributes( Set.of( TEA_1_UID ) )
+            .build();
 
         EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
 


### PR DESCRIPTION
* do not fetch optional ids from DB if empty like `program`, `programStage`, ...
* reduce chance of mutation in TrackerEventCriteria by replacing `@Data` which adds setters. Use a `@Builder` as lots of these fields are optional. Return unmodifiable copies of the collections. Note that the date fields are still mutable. We need to use an explicit constructor with the parent class fields to get the Lombok builder to work. https://projectlombok.org/features/experimental/SuperBuilder is experimental and not on our https://github.com/dhis2/wow-backend/blob/master/guides/lombok.md#allowed-annotations list yet. 