### PR TITLE
chore: turn skipPaging into primitive

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
@@ -32,7 +32,6 @@ import static java.util.stream.Collectors.partitioningBy;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -74,7 +73,7 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     /**
      * Indicates whether paging should be skipped.
      */
-    private Boolean skipPaging;
+    private boolean skipPaging;
 
     /**
      * order params
@@ -101,12 +100,6 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     public boolean isPagingRequest()
     {
         return !isSkipPaging();
-    }
-
-    public boolean isSkipPaging()
-    {
-        return Optional.ofNullable( skipPaging )
-            .orElse( false );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingCriteria.java
@@ -59,7 +59,7 @@ public interface PagingCriteria
     /**
      * Indicates whether paging should be skipped.
      */
-    Boolean getSkipPaging();
+    boolean isSkipPaging();
 
     default Integer getFirstResult()
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -158,7 +158,7 @@ public class EnrollmentController
                 enrollmentCriteria.getPage(),
                 enrollmentCriteria.getPageSize(),
                 enrollmentCriteria.isTotalPages(),
-                PagerUtils.isSkipPaging( enrollmentCriteria.getSkipPaging(), enrollmentCriteria.getPaging() ),
+                PagerUtils.isSkipPaging( enrollmentCriteria.isSkipPaging(), enrollmentCriteria.getPaging() ),
                 enrollmentCriteria.isIncludeDeleted(),
                 enrollmentCriteria.getOrder() );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapper.java
@@ -365,7 +365,7 @@ class EventRequestToSearchParamsMapper
         if ( !duplicates.isEmpty() )
         {
             throw new IllegalQueryException( String.format(
-                "filterAttributes can only have one filter per tracked entity attribute (TEA). The following TEA have more than one: %s",
+                "filterAttributes contains duplicate tracked entity attribute (TEA): %s. Multiple filters for the same TEA can be specified like 'uid:gt:2:lt:10'",
                 String.join( ", ", duplicates ) ) );
         }
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/EventRequestToSearchParamsMapperTest.java
@@ -611,7 +611,7 @@ class EventRequestToSearchParamsMapperTest
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> requestToSearchParamsMapper.map( eventCriteria ) );
         assertAll(
-            () -> assertStartsWith( "filterAttributes can only have one filter per tracked entity attribute (TEA).",
+            () -> assertStartsWith( "filterAttributes contains duplicate tracked entity attribute",
                 exception.getMessage() ),
             // order of TEA UIDs might not always be the same; therefore using
             // contains


### PR DESCRIPTION
* saves us from dealing with nulls which we turn into false anyway
* make it clear how users can add multiple filters on one TEA if they provide the invalid syntax