### PR TITLE
chore: split old/new tracker enrollment export mappers TECH-1414

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentController.java
@@ -68,7 +68,6 @@ import org.hisp.dhis.program.ProgramInstanceQueryParams;
 import org.hisp.dhis.program.ProgramInstanceService;
 import org.hisp.dhis.scheduling.JobConfiguration;
 import org.hisp.dhis.user.CurrentUserService;
-import org.hisp.dhis.webapi.controller.event.mapper.EnrollmentCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.EnrollmentCriteria;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EnrollmentCriteriaMapper.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.event.mapper;
+package org.hisp.dhis.webapi.controller.event;
 
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 
@@ -40,7 +40,6 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
@@ -54,11 +53,10 @@ import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
-import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerEnrollmentCriteria;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Service
+@Service( "org.hisp.dhis.webapi.controller.event.EnrollmentCriteriaMapper" )
 @RequiredArgsConstructor
 public class EnrollmentCriteriaMapper
 {
@@ -178,28 +176,5 @@ public class EnrollmentCriteriaMapper
         params.setOrder( toOrderParams( orderCriteria ) );
 
         return params;
-    }
-
-    @Transactional( readOnly = true )
-    public ProgramInstanceQueryParams getFromUrl( TrackerEnrollmentCriteria trackerEnrollmentCriteria )
-    {
-        return getFromUrl(
-            TextUtils.splitToSet( trackerEnrollmentCriteria.getOrgUnit(), TextUtils.SEMICOLON ),
-            trackerEnrollmentCriteria.getOuMode(),
-            trackerEnrollmentCriteria.getUpdatedAfter(),
-            trackerEnrollmentCriteria.getUpdatedWithin(),
-            trackerEnrollmentCriteria.getProgram(),
-            trackerEnrollmentCriteria.getProgramStatus(),
-            trackerEnrollmentCriteria.getEnrolledAfter(),
-            trackerEnrollmentCriteria.getEnrolledBefore(),
-            trackerEnrollmentCriteria.getTrackedEntityType(),
-            trackerEnrollmentCriteria.getTrackedEntity(),
-            trackerEnrollmentCriteria.getFollowUp(),
-            trackerEnrollmentCriteria.getPage(),
-            trackerEnrollmentCriteria.getPageSize(),
-            trackerEnrollmentCriteria.isTotalPages(),
-            trackerEnrollmentCriteria.isSkipPaging(),
-            trackerEnrollmentCriteria.isIncludeDeleted(),
-            trackerEnrollmentCriteria.getOrder() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteria.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.event.webrequest.tracker;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
 
@@ -41,6 +41,10 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 
+/**
+ * Represents query parameters sent to
+ * {@link TrackerEnrollmentsExportController}.
+ */
 @Data
 @NoArgsConstructor
 public class TrackerEnrollmentCriteria extends PagingAndSortingCriteriaAdapter

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.commons.util.TextUtils;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstanceQueryParams;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Maps query parameters from {@link TrackerEnrollmentsExportController} stored
+ * in {@link TrackerEnrollmentCriteria} to {@link ProgramInstanceQueryParams}
+ * which is used to fetch enrollments from the DB.
+ */
+@Service( "org.hisp.dhis.webapi.controller.tracker.export.TrackerEnrollmentCriteriaMapper" )
+@RequiredArgsConstructor
+public class TrackerEnrollmentCriteriaMapper
+{
+
+    private final CurrentUserService currentUserService;
+
+    private final OrganisationUnitService organisationUnitService;
+
+    private final ProgramService programService;
+
+    private final TrackedEntityTypeService trackedEntityTypeService;
+
+    private final TrackedEntityInstanceService trackedEntityInstanceService;
+
+    @Transactional( readOnly = true )
+    public ProgramInstanceQueryParams getFromUrl( TrackerEnrollmentCriteria trackerEnrollmentCriteria )
+    {
+        Set<String> ou = TextUtils.splitToSet( trackerEnrollmentCriteria.getOrgUnit(), TextUtils.SEMICOLON );
+        String program = trackerEnrollmentCriteria.getProgram();
+        String trackedEntityType = trackerEnrollmentCriteria.getTrackedEntityType();
+        String trackedEntityInstance = trackerEnrollmentCriteria.getTrackedEntity();
+        ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
+
+        Set<OrganisationUnit> possibleSearchOrgUnits = new HashSet<>();
+
+        User user = currentUserService.getCurrentUser();
+
+        if ( user != null )
+        {
+            possibleSearchOrgUnits = user.getTeiSearchOrganisationUnitsWithFallback();
+        }
+
+        if ( ou != null )
+        {
+            for ( String orgUnit : ou )
+            {
+                OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( orgUnit );
+
+                if ( organisationUnit == null )
+                {
+                    throw new IllegalQueryException( "Organisation unit does not exist: " + orgUnit );
+                }
+
+                if ( !organisationUnitService.isInUserHierarchy( organisationUnit.getUid(), possibleSearchOrgUnits ) )
+                {
+                    throw new IllegalQueryException( "Organisation unit is not part of the search scope: " + orgUnit );
+                }
+
+                params.getOrganisationUnits().add( organisationUnit );
+            }
+        }
+
+        Program pr = program != null ? programService.getProgram( program ) : null;
+
+        if ( program != null && pr == null )
+        {
+            throw new IllegalQueryException( "Program does not exist: " + program );
+        }
+
+        TrackedEntityType te = trackedEntityType != null
+            ? trackedEntityTypeService.getTrackedEntityType( trackedEntityType )
+            : null;
+
+        if ( trackedEntityType != null && te == null )
+        {
+            throw new IllegalQueryException( "Tracked entity does not exist: " + trackedEntityType );
+        }
+
+        TrackedEntityInstance tei = trackedEntityInstance != null
+            ? trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstance )
+            : null;
+
+        if ( trackedEntityInstance != null && tei == null )
+        {
+            throw new IllegalQueryException( "Tracked entity instance does not exist: " + trackedEntityInstance );
+        }
+
+        params.setProgram( pr );
+        params.setProgramStatus( trackerEnrollmentCriteria.getProgramStatus() );
+        params.setFollowUp( trackerEnrollmentCriteria.getFollowUp() );
+        params.setLastUpdated( trackerEnrollmentCriteria.getUpdatedAfter() );
+        params.setLastUpdatedDuration( trackerEnrollmentCriteria.getUpdatedWithin() );
+        params.setProgramStartDate( trackerEnrollmentCriteria.getEnrolledAfter() );
+        params.setProgramEndDate( trackerEnrollmentCriteria.getEnrolledBefore() );
+        params.setTrackedEntityType( te );
+        params.setTrackedEntityInstanceUid(
+            Optional.ofNullable( tei ).map( BaseIdentifiableObject::getUid ).orElse( null ) );
+        params.setOrganisationUnitMode( trackerEnrollmentCriteria.getOuMode() );
+        params.setPage( trackerEnrollmentCriteria.getPage() );
+        params.setPageSize( trackerEnrollmentCriteria.getPageSize() );
+        params.setTotalPages( trackerEnrollmentCriteria.isTotalPages() );
+        params.setSkipPaging( trackerEnrollmentCriteria.isSkipPaging() );
+        params.setIncludeDeleted( trackerEnrollmentCriteria.isIncludeDeleted() );
+        params.setUser( user );
+        params.setOrder( toOrderParams( trackerEnrollmentCriteria.getOrder() ) );
+
+        return params;
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -44,9 +44,7 @@ import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.events.enrollment.Enrollments;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
-import org.hisp.dhis.webapi.controller.event.mapper.EnrollmentCriteriaMapper;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
-import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerEnrollmentCriteria;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
@@ -73,7 +71,7 @@ public class TrackerEnrollmentsExportController
     private static final EnrollmentMapper ENROLLMENT_MAPPER = Mappers.getMapper( EnrollmentMapper.class );
 
     @NonNull
-    private final EnrollmentCriteriaMapper enrollmentCriteriaMapper;
+    private final TrackerEnrollmentCriteriaMapper enrollmentCriteriaMapper;
 
     @NonNull
     private final EnrollmentService enrollmentService;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.organisationunit.OrganisationUnitService;
+import org.hisp.dhis.program.Program;
+import org.hisp.dhis.program.ProgramInstanceQueryParams;
+import org.hisp.dhis.program.ProgramService;
+import org.hisp.dhis.trackedentity.TrackedEntityInstance;
+import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
+import org.hisp.dhis.trackedentity.TrackedEntityType;
+import org.hisp.dhis.trackedentity.TrackedEntityTypeService;
+import org.hisp.dhis.user.CurrentUserService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.webapi.controller.event.mapper.OrderParam;
+import org.hisp.dhis.webapi.controller.event.webrequest.OrderCriteria;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@MockitoSettings( strictness = Strictness.LENIENT )
+@ExtendWith( MockitoExtension.class )
+class TrackerEnrollmentCriteriaMapperTest
+{
+
+    private static final String ORG_UNIT_1_UID = "lW0T2U7gZUi";
+
+    private static final String ORG_UNIT_2_UID = "TK4KA0IIWqa";
+
+    private static final String PROGRAM_UID = "XhBYIraw7sv";
+
+    private static final String TRACKED_ENTITY_TYPE_UID = "Dp8baZYrLtr";
+
+    private static final String TRACKED_ENTITY_UID = "DGbr8GHG4li";
+
+    @Mock
+    private CurrentUserService currentUserService;
+
+    @Mock
+    private OrganisationUnitService organisationUnitService;
+
+    @Mock
+    private ProgramService programService;
+
+    @Mock
+    private TrackedEntityTypeService trackedEntityTypeService;
+
+    @Mock
+    private TrackedEntityInstanceService trackedEntityInstanceService;
+
+    @InjectMocks
+    private TrackerEnrollmentCriteriaMapper mapper;
+
+    private OrganisationUnit orgUnit1;
+
+    private OrganisationUnit orgUnit2;
+
+    private User user;
+
+    private Program program;
+
+    private TrackedEntityType trackedEntityType;
+
+    private TrackedEntityInstance trackedEntityInstance;
+
+    @BeforeEach
+    void setUp()
+    {
+        user = new User();
+        when( currentUserService.getCurrentUser() ).thenReturn( user );
+
+        orgUnit1 = new OrganisationUnit( "orgUnit1" );
+        orgUnit1.setUid( ORG_UNIT_1_UID );
+        when( organisationUnitService.getOrganisationUnit( orgUnit1.getUid() ) ).thenReturn( orgUnit1 );
+        when( organisationUnitService.isInUserHierarchy( orgUnit1.getUid(),
+            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
+        orgUnit2 = new OrganisationUnit( "orgUnit2" );
+        orgUnit2.setUid( ORG_UNIT_2_UID );
+        when( organisationUnitService.getOrganisationUnit( orgUnit2.getUid() ) ).thenReturn( orgUnit2 );
+        when( organisationUnitService.isInUserHierarchy( orgUnit2.getUid(),
+            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( true );
+
+        program = new Program();
+        program.setUid( PROGRAM_UID );
+        when( programService.getProgram( PROGRAM_UID ) ).thenReturn( program );
+
+        trackedEntityType = new TrackedEntityType();
+        trackedEntityType.setUid( TRACKED_ENTITY_TYPE_UID );
+        when( trackedEntityTypeService.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) )
+            .thenReturn( trackedEntityType );
+
+        trackedEntityInstance = new TrackedEntityInstance();
+        trackedEntityInstance.setUid( TRACKED_ENTITY_UID );
+        when( trackedEntityInstanceService.getTrackedEntityInstance( TRACKED_ENTITY_UID ) )
+            .thenReturn( trackedEntityInstance );
+    }
+
+    @Test
+    void testMappingOrgUnit()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
+
+        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+
+        assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
+    }
+
+    @Test
+    void testMappingOrgUnitNotFound()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setOrgUnit( "unknown;" + ORG_UNIT_2_UID );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> mapper.getFromUrl( criteria ) );
+        assertEquals( "Organisation unit does not exist: unknown", exception.getMessage() );
+    }
+
+    @Test
+    void testMappingOrgUnitNotPartOfSearchScope()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setOrgUnit( ORG_UNIT_1_UID );
+        when( organisationUnitService.isInUserHierarchy( ORG_UNIT_1_UID,
+            user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( false );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> mapper.getFromUrl( criteria ) );
+        assertEquals( "Organisation unit is not part of the search scope: " + ORG_UNIT_1_UID, exception.getMessage() );
+    }
+
+    @Test
+    void testMappingProgram()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setProgram( PROGRAM_UID );
+
+        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+
+        assertEquals( program, params.getProgram() );
+    }
+
+    @Test
+    void testMappingProgramNotFound()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setProgram( "unknown" );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> mapper.getFromUrl( criteria ) );
+        assertEquals( "Program does not exist: unknown", exception.getMessage() );
+    }
+
+    @Test
+    void testMappingTrackedEntityType()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setTrackedEntityType( TRACKED_ENTITY_TYPE_UID );
+
+        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+
+        assertEquals( trackedEntityType, params.getTrackedEntityType() );
+    }
+
+    @Test
+    void testMappingTrackedEntityTypeNotFound()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setTrackedEntityType( "unknown" );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> mapper.getFromUrl( criteria ) );
+        assertEquals( "Tracked entity does not exist: unknown", exception.getMessage() );
+    }
+
+    @Test
+    void testMappingTrackedEntity()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setTrackedEntity( TRACKED_ENTITY_UID );
+
+        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+
+        assertEquals( TRACKED_ENTITY_UID, params.getTrackedEntityInstanceUid() );
+    }
+
+    @Test
+    void testMappingTrackedEntityNotFound()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        criteria.setTrackedEntity( "unknown" );
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> mapper.getFromUrl( criteria ) );
+        assertEquals( "Tracked entity instance does not exist: unknown", exception.getMessage() );
+    }
+
+    @Test
+    void testMappingOrderParams()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+        OrderCriteria order1 = OrderCriteria.of( "field1", OrderParam.SortDirection.ASC );
+        OrderCriteria order2 = OrderCriteria.of( "field2", OrderParam.SortDirection.DESC );
+        criteria.setOrder( List.of( order1, order2 ) );
+
+        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+
+        assertEquals( List.of(
+            new OrderParam( "field1", OrderParam.SortDirection.ASC ),
+            new OrderParam( "field2", OrderParam.SortDirection.DESC ) ), params.getOrder() );
+    }
+
+    @Test
+    void testMappingOrderParamsNoOrder()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+
+        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+
+        assertIsEmpty( params.getOrder() );
+    }
+}


### PR DESCRIPTION
so we can safely adapt the new tracker endpoints without affecting old tracker endpoints

* duplicate mappers so we can have one dedicated for old and one for new tracker. Deliberate duplication, just so you know sonarqube 😋 
* adhere to
https://github.com/dhis2/wow-backend/blob/master/guides/spring_conventions.md#bean-id