### PR TITLE
fix: Empty event table when OU is not defined in PSI [DHIS2-13754]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -373,7 +373,7 @@ public class JdbcEventAnalyticsTableManager
             "left join _organisationunitgroupsetstructure ougs on psi.organisationunitid=ougs.organisationunitid " +
             "and (cast(date_trunc('month', " + getDateLinkedToStatus() + ") as date)" +
             "=ougs.startdate or ougs.startdate is null) " +
-            "inner join organisationunit enrollmentou on pi.organisationunitid=enrollmentou.organisationunitid " +
+            "left join organisationunit enrollmentou on pi.organisationunitid=enrollmentou.organisationunitid " +
             "inner join _categorystructure acs on psi.attributeoptioncomboid=acs.categoryoptioncomboid " +
             "left join _dateperiodstructure dps on cast(" + getDateLinkedToStatus() + " as date)=dps.dateperiod " +
             "where psi.lastupdated < '" + getLongDateString( params.getStartTime() ) + "' " + partitionClause +

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -458,6 +458,44 @@ class JdbcEventAnalyticsTableManagerTest
     }
 
     @Test
+    void verifyOrgUnitOwnershipJoinsWhenPopulatingEventAnalyticsTable()
+    {
+        // Given fixtures/expectations
+        ArgumentCaptor<String> sql = ArgumentCaptor.forClass( String.class );
+        when( databaseInfo.isSpatialSupport() ).thenReturn( true );
+        Program programA = createProgram( 'A' );
+
+        TrackedEntityAttribute tea = createTrackedEntityAttribute( 'a', ValueType.ORGANISATION_UNIT );
+        tea.setId( 9999 );
+
+        ProgramTrackedEntityAttribute programTrackedEntityAttribute = createProgramTrackedEntityAttribute( programA,
+            tea );
+
+        programA.setProgramAttributes( Lists.newArrayList( programTrackedEntityAttribute ) );
+
+        when( idObjectManager.getAllNoAcl( Program.class ) ).thenReturn( Lists.newArrayList( programA ) );
+
+        AnalyticsTableUpdateParams params = AnalyticsTableUpdateParams.newBuilder().withLastYears( 2 )
+            .withStartTime( START_TIME ).withToday( today ).build();
+
+        when( jdbcTemplate.queryForList( getYearQueryForCurrentYear( programA, true ), Integer.class ) )
+            .thenReturn( Lists.newArrayList( 2018, 2019 ) );
+
+        // When
+        subject.populateTable( params,
+            PartitionUtils.getTablePartitions( subject.getAnalyticsTables( params ) ).get( 0 ) );
+
+        // Then
+        verify( jdbcTemplate ).execute( sql.capture() );
+
+        String ouEnrollmentLeftJoin = "left join organisationunit enrollmentou on pi.organisationunitid=enrollmentou.organisationunitid";
+        String ouRegistrationLeftJoin = "left join organisationunit registrationou on tei.organisationunitid=registrationou.organisationunitid";
+
+        assertThat( sql.getValue(), containsString( ouEnrollmentLeftJoin ) );
+        assertThat( sql.getValue(), containsString( ouRegistrationLeftJoin ) );
+    }
+
+    @Test
     void verifyGetAnalyticsTableWithOuLevels()
     {
         List<OrganisationUnitLevel> ouLevels = rnd.objects( OrganisationUnitLevel.class, 2 )


### PR DESCRIPTION
Without this fix, the analytics event table for some Programs may not be populated. This small change should address this problem. This can be reproduced in Sierra Leone (Program `1150221`).

Some ProgramInstances may not have an OrgUnit associated (defined as null in such cases).
In Sierra Leone we have this particular case for Program `1150221`:
```
SELECT * FROM programinstance p WHERE organisationunitid IS NULL AND programid = 1150221;
```
This query will bring the column `organisationunitid` set to `NULL`.

Because of such cases, that might show up in production, we are changing how we join the respective statement (see the code changes). Instead of a `inner join` we are now using `left join`.

This brings back the population of the analytics events tables even in cases where there are no OrgUnit associated with a ProgramInstance.

