### PR TITLE
chore: move new TrackerRelationshipCriteria to tracker package DHIS2-13648

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteria.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.event.webrequest.tracker;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.badRequest;
 import static org.hisp.dhis.webapi.controller.event.webrequest.tracker.FieldTranslatorSupport.translate;
@@ -47,7 +47,7 @@ import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteria
 
 @NoArgsConstructor
 @EqualsAndHashCode( exclude = { "identifier", "identifierName", "identifierClass" } )
-public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
+class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
 {
 
     private String trackedEntity;
@@ -165,7 +165,7 @@ public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
          * this enum names must be the same as
          * org.hisp.dhis.tracker.domain.Enrollment fields, just with different
          * case
-         *
+         * <p>
          * example: org.hisp.dhis.tracker.domain.Enrollment.updatedAtClient -->
          * UPDATED_AT_CLIENT
          */
@@ -188,7 +188,7 @@ public class TrackerRelationshipCriteria extends PagingAndSortingCriteriaAdapter
          * this enum names must be the same as
          * org.hisp.dhis.dxf2.events.enrollment.Enrollment fields, just with
          * different case
-         *
+         * <p>
          * example: org.hisp.dhis.dxf2.events.enrollment.Enrollment.lastUpdated
          * --> LAST_UPDATED
          */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
@@ -58,7 +58,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingAndSortingCriteriaAdapter;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
-import org.hisp.dhis.webapi.controller.event.webrequest.tracker.TrackerRelationshipCriteria;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteriaTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipCriteriaTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.webapi.controller.event.webrequest.tracker;
+package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
Moving all new tracker web related code into the `org.hisp.dhis.webapi.controller.tracker` packages. When old tracker is removed one day, we should at least for the web portions only have to delete one package.