### PR TITLE
fix: Remove order by from ownership export [DHIS2-13758]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -229,8 +229,8 @@ public class JdbcOwnershipAnalyticsTableManager
             "and tei.deleted is false " +
             "inner join organisationunit ou on o.organisationunitid=ou.organisationunitid " +
             "left join _orgunitstructure ous on o.organisationunitid=ous.organisationunitid " +
-            "left join _organisationunitgroupsetstructure ougs on o.organisationunitid=ougs.organisationunitid " +
-            "order by tei.uid, o.ownatstart" ).toString();
+            "left join _organisationunitgroupsetstructure ougs on o.organisationunitid=ougs.organisationunitid" )
+            .toString();
     }
 
     private Map<String, Object> getRowMap( List<String> columnNames, SqlRowSet rowSet )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
@@ -278,8 +278,7 @@ class JdbcOwnershipAnalyticsTableManagerTest
             "and tei.deleted is false " +
             "inner join organisationunit ou on o.organisationunitid=ou.organisationunitid " +
             "left join _orgunitstructure ous on o.organisationunitid=ous.organisationunitid " +
-            "left join _organisationunitgroupsetstructure ougs on o.organisationunitid=ougs.organisationunitid " +
-            "order by tei.uid, o.ownatstart",
+            "left join _organisationunitgroupsetstructure ougs on o.organisationunitid=ougs.organisationunitid",
             sqlMasked );
 
         List<Invocation> writerInvocations = getInvocations( writer );


### PR DESCRIPTION
On the Debug/Dev environment, the Analytics export process cannot complete due to a query that seems to be timing out.
We get the exception:
```
SQL state [NULL]; error code [0]; IllegalAccessException:
com/sun/rowset/providers/RIOptimisticProvider;
nested EXCEPTION IS javax.sql.rowset.spi.SyncFactoryException:
IllegalAccessException: com/sun/rowset/providers/RIOptimisticProvider;
``` 

When connecting to the DB on Debug/Dev, we are not able to execute the following query because it keeps running for a very long period of time (I cancelled the query as it never returned on my tests). The slowness seems to be caused by the `order by` clause.

_There is also a suspicious "NULL" column, being SELECTED. It may require some investigation at some point._
```
SELECT
	ous."uidlevel1",
	ous."uidlevel2",
	ous."uidlevel3",
	ous."uidlevel4",
	ougs."uIuxlbV1vRT",
	ougs."Cbuj0VCyDjL",
	ougs."Bpx0589u8y0",
	ougs."J5jldMd8OHv",
	tei.uid,
	o.ownatstart,
	NULL,
	ou.uid
FROM
	(
	SELECT
		trackedentityinstanceid,
		owndate + 1 AS ownatstart,
		RIGHT(max(owns),-23)::bigint AS organisationunitid
	FROM
		(
		SELECT
			pi.trackedentityinstanceid,
			pi.enrollmentdate::date AS owndate,
			rpad(pi.enrollmentdate::TEXT, 23) || pi.organisationunitid::TEXT AS owns
		FROM
			programinstance pi
		WHERE
			pi.programid = 1150449
			AND pi.trackedentityinstanceid IS NOT NULL
			AND pi.organisationunitid IS NOT NULL
			AND pi.lastupdated <= '2022-09-19T08:03:16'
	UNION
		SELECT
			poh.trackedentityinstanceid,
			poh.startdate::date AS owndate,
			rpad(poh.startdate::TEXT, 23) || poh.organisationunitid::TEXT AS owns
		FROM
			programownershiphistory poh
		WHERE
			poh.programid = 1150449
			AND poh.trackedentityinstanceid IS NOT NULL
			AND poh.organisationunitid IS NOT NULL ) o2
	GROUP BY
		trackedentityinstanceid,
		owndate ) o
INNER JOIN trackedentityinstance tei ON
	o.trackedentityinstanceid = tei.trackedentityinstanceid
	AND tei.deleted IS FALSE
INNER JOIN organisationunit ou ON
	o.organisationunitid = ou.organisationunitid
LEFT JOIN _orgunitstructure ous ON
	o.organisationunitid = ous.organisationunitid
LEFT JOIN _organisationunitgroupsetstructure ougs ON
	o.organisationunitid = ougs.organisationunitid
ORDER BY
	tei.uid,
	o.ownatstart;
```

