### PR TITLE
fix: Use progress job to improve reporting feedback [DHIS2-13514]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -537,7 +537,7 @@ public abstract class AbstractJdbcTableManager
 
         Timer timer = new SystemTimer().start();
 
-        executeSafely( sql );
+        jdbcTemplate.execute( sql );
 
         log.info( "{} in: {}", logMessage, timer.stop().toString() );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -163,8 +163,7 @@ public class DefaultAnalyticsTableService
         if ( params.isLatestUpdate() )
         {
             progress.startingStage( "Removing updated and deleted data " + tableType, SKIP_STAGE );
-            tableManager.removeUpdatedData( tables );
-            progress.completedStage( "Completed removal of updated and deleted data" );
+            progress.runStage( () -> tableManager.removeUpdatedData( tables ) );
             clock.logTime( "Removed updated and deleted data" );
         }
 


### PR DESCRIPTION
_[Backport from 2.40/master]_

I realized that using the job progress is a better choice in this case.
If the step fails, it will add the error to the final execution report and continue with the process (executing all the next steps).

This PR improves the previous fix related to `DHIS2-13514`.