### PR TITLE
fix: Use progress job to improve reporting feedback [DHIS2-13514]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractJdbcTableManager.java
@@ -569,6 +569,25 @@ public abstract class AbstractJdbcTableManager
 
         Timer timer = new SystemTimer().start();
 
+        jdbcTemplate.execute( sql );
+
+        log.info( "{} in: {}", logMessage, timer.stop().toString() );
+    }
+
+    /**
+     * Executes the given SQL statement "safely" (without throwing any
+     * exception). Instead, exceptions are simply logged. Also, it Logs and
+     * times the operation.
+     *
+     * @param sql the SQL statement.
+     * @param logMessage the custom log message to include in the log statement.
+     */
+    protected void invokeTimeAndLogSafely( String sql, String logMessage )
+    {
+        log.debug( "{} with SQL: '{}'", logMessage, sql );
+
+        Timer timer = new SystemTimer().start();
+
         executeSafely( sql );
 
         log.info( "{} in: {}", logMessage, timer.stop().toString() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableService.java
@@ -160,8 +160,7 @@ public class DefaultAnalyticsTableService
         if ( params.isLatestUpdate() )
         {
             progress.startingStage( "Removing updated and deleted data " + tableType );
-            tableManager.removeUpdatedData( tables );
-            progress.completedStage( "Completed removal of updated and deleted data" );
+            progress.runStage( () -> tableManager.removeUpdatedData( tables ) );
             clock.logTime( "Removed updated and deleted data" );
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -215,7 +215,7 @@ public class JdbcAnalyticsTableManager
             "where dv.lastupdated >= '" + getLongDateString( partition.getStartDate() ) + "' " +
             "and dv.lastupdated < '" + getLongDateString( partition.getEndDate() ) + "')";
 
-        invokeTimeAndLog( sql, "Remove updated data values" );
+        invokeTimeAndLogSafely( sql, "Remove updated data values" );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -160,7 +160,7 @@ public class JdbcCompletenessTableManager
             "where cdr.lastupdated >= '" + getLongDateString( partition.getStartDate() ) + "' " +
             "and cdr.lastupdated < '" + getLongDateString( partition.getEndDate() ) + "')";
 
-        invokeTimeAndLog( sql, "Remove updated data values" );
+        invokeTimeAndLogSafely( sql, "Remove updated data values" );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -312,7 +312,8 @@ public class JdbcEventAnalyticsTableManager
                 "and psi.lastupdated >= '" + getLongDateString( partition.getStartDate() ) + "' " +
                 "and psi.lastupdated < '" + getLongDateString( partition.getEndDate() ) + "')";
 
-            invokeTimeAndLog( sql, String.format( "Remove updated events for table: '%s'", table.getTableName() ) );
+            invokeTimeAndLog( sql,
+                String.format( "Remove updated events for table: '%s'", table.getTableName() ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -312,7 +312,7 @@ public class JdbcEventAnalyticsTableManager
                 "and psi.lastupdated >= '" + getLongDateString( partition.getStartDate() ) + "' " +
                 "and psi.lastupdated < '" + getLongDateString( partition.getEndDate() ) + "')";
 
-            invokeTimeAndLog( sql,
+            invokeTimeAndLogSafely( sql,
                 String.format( "Remove updated events for table: '%s'", table.getTableName() ) );
         }
     }


### PR DESCRIPTION
_[Backport from 2.40/master]_

I realized that using the job progress is a better choice in this case.
If the step fails, it will add the error to the final execution report and continue with the process (executing all the next steps).

This PR improves the previous fix related to `DHIS2-13514`.