### PR TITLE
chore: revert renaming TrackerEventCriteriaMapper DHIS2-13648

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -86,9 +86,9 @@ import org.springframework.stereotype.Component;
  * {@link TrackerEventCriteria} to {@link EventSearchParams} which is used to
  * fetch events from the DB.
  */
-@Component( "org.hisp.dhis.webapi.controller.tracker.export.EventRequestToSearchParamsMapper" )
+@Component( "org.hisp.dhis.webapi.controller.tracker.export.TrackerEventCriteriaMapper" )
 @RequiredArgsConstructor
-class EventRequestToSearchParamsMapper
+class TrackerEventCriteriaMapper
 {
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -93,7 +93,7 @@ public class TrackerEventsExportController
     private final ContextService contextService;
 
     @NonNull
-    private final EventRequestToSearchParamsMapper requestToSearchParams;
+    private final TrackerEventCriteriaMapper requestToSearchParams;
 
     @NonNull
     private final ProgramStageInstanceService programStageInstanceService;

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
@@ -86,7 +86,7 @@ import org.mockito.quality.Strictness;
 
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-class EventRequestToSearchParamsMapperTest
+class TrackerEventCriteriaMapperTest
 {
 
     public static final String TEA_1_UID = "TvjwTPToKHO";
@@ -126,7 +126,7 @@ class EventRequestToSearchParamsMapperTest
     private SchemaService schemaService;
 
     @InjectMocks
-    private EventRequestToSearchParamsMapper requestToSearchParamsMapper;
+    private TrackerEventCriteriaMapper mapper;
 
     private Program program;
 
@@ -183,15 +183,15 @@ class EventRequestToSearchParamsMapperTest
         prop3.setSimple( false );
         eventSchema.addProperty( prop3 );
         when( schemaService.getDynamicSchema( Event.class ) ).thenReturn( eventSchema );
-        requestToSearchParamsMapper.setSchema();
+        mapper.setSchema();
     }
 
     @Test
     void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
-        requestToSearchParamsMapper.map( eventCriteria );
+        mapper.map( criteria );
 
         verifyNoInteractions( programService );
         verifyNoInteractions( programStageService );
@@ -202,10 +202,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingProgram()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setProgram( PROGRAM_UID );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setProgram( PROGRAM_UID );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( program, params.getProgram() );
     }
@@ -213,21 +213,21 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingProgramNotFound()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setProgram( "unknown" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setProgram( "unknown" );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Program is specified but does not exist: unknown", exception.getMessage() );
     }
 
     @Test
     void testMappingProgramStage()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setProgramStage( "programstageuid" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setProgramStage( "programstageuid" );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( programStage, params.getProgramStage() );
     }
@@ -235,10 +235,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingTrackedEntity()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setTrackedEntity( "teiuid" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setTrackedEntity( "teiuid" );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( trackedEntityInstance, params.getTrackedEntityInstance() );
     }
@@ -246,14 +246,14 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingOccurredAfterBefore()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         Date occurredAfter = parseDate( "2020-01-01" );
-        eventCriteria.setOccurredAfter( occurredAfter );
+        criteria.setOccurredAfter( occurredAfter );
         Date occurredBefore = parseDate( "2020-09-12" );
-        eventCriteria.setOccurredBefore( occurredBefore );
+        criteria.setOccurredBefore( occurredBefore );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( occurredAfter, params.getStartDate() );
         assertEquals( occurredBefore, params.getEndDate() );
@@ -262,14 +262,14 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingScheduledAfterBefore()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         Date scheduledAfter = parseDate( "2021-01-01" );
-        eventCriteria.setScheduledAfter( scheduledAfter );
+        criteria.setScheduledAfter( scheduledAfter );
         Date scheduledBefore = parseDate( "2021-09-12" );
-        eventCriteria.setScheduledBefore( scheduledBefore );
+        criteria.setScheduledBefore( scheduledBefore );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( scheduledAfter, params.getDueDateStart() );
         assertEquals( scheduledBefore, params.getDueDateEnd() );
@@ -278,16 +278,16 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingUpdatedDates()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         Date updatedAfter = parseDate( "2022-01-01" );
-        eventCriteria.setUpdatedAfter( updatedAfter );
+        criteria.setUpdatedAfter( updatedAfter );
         Date updatedBefore = parseDate( "2022-09-12" );
-        eventCriteria.setUpdatedBefore( updatedBefore );
+        criteria.setUpdatedBefore( updatedBefore );
         String updatedWithin = "P6M";
-        eventCriteria.setUpdatedWithin( updatedWithin );
+        criteria.setUpdatedWithin( updatedWithin );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( updatedAfter, params.getLastUpdatedStartDate() );
         assertEquals( updatedBefore, params.getLastUpdatedEndDate() );
@@ -297,14 +297,14 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEnrollmentEnrolledAtDates()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         Date enrolledBefore = parseDate( "2022-01-01" );
-        eventCriteria.setEnrollmentEnrolledBefore( enrolledBefore );
+        criteria.setEnrollmentEnrolledBefore( enrolledBefore );
         Date enrolledAfter = parseDate( "2022-02-01" );
-        eventCriteria.setEnrollmentEnrolledAfter( enrolledAfter );
+        criteria.setEnrollmentEnrolledAfter( enrolledAfter );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( enrolledBefore, params.getEnrollmentEnrolledBefore() );
         assertEquals( enrolledAfter, params.getEnrollmentEnrolledAfter() );
@@ -313,14 +313,14 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEnrollmentOcurredAtDates()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         Date enrolledBefore = parseDate( "2022-01-01" );
-        eventCriteria.setEnrollmentOccurredBefore( enrolledBefore );
+        criteria.setEnrollmentOccurredBefore( enrolledBefore );
         Date enrolledAfter = parseDate( "2022-02-01" );
-        eventCriteria.setEnrollmentOccurredAfter( enrolledAfter );
+        criteria.setEnrollmentOccurredAfter( enrolledAfter );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( enrolledBefore, params.getEnrollmentOccurredBefore() );
         assertEquals( enrolledAfter, params.getEnrollmentOccurredAfter() );
@@ -329,13 +329,13 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAttributeOrdering()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         OrderCriteria attributeOrder = OrderCriteria.of( TEA_1_UID, OrderParam.SortDirection.ASC );
         OrderCriteria unknownAttributeOrder = OrderCriteria.of( "unknownAtt1", OrderParam.SortDirection.ASC );
-        eventCriteria.setOrder( List.of( attributeOrder, unknownAttributeOrder ) );
+        criteria.setOrder( List.of( attributeOrder, unknownAttributeOrder ) );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertAll(
             () -> assertContainsOnly( params.getAttributeOrders(),
@@ -346,12 +346,12 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEnrollments()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
         Set<String> enrollments = Set.of( "NQnuK2kLm6e" );
-        eventCriteria.setEnrollments( enrollments );
+        criteria.setEnrollments( enrollments );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( enrollments, params.getProgramInstances() );
     }
@@ -359,10 +359,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEvents()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( Set.of( "XKrcfuM4Hcw", "M4pNmLabtXl" ), params.getEvents() );
     }
@@ -370,10 +370,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEventsStripsInvalidUid()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setEvent( "invalidUid;M4pNmLabtXl" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setEvent( "invalidUid;M4pNmLabtXl" );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( Set.of( "M4pNmLabtXl" ), params.getEvents() );
     }
@@ -381,9 +381,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEventIsNull()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertIsEmpty( params.getEvents() );
     }
@@ -391,10 +391,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingEventIsEmpty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setEvent( " " );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setEvent( " " );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertIsEmpty( params.getEvents() );
     }
@@ -402,10 +402,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUser()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setAssignedUser( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setAssignedUser( "XKrcfuM4Hcw;M4pNmLabtXl" );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertContainsOnly( Set.of( "XKrcfuM4Hcw", "M4pNmLabtXl" ), params.getAssignedUsers() );
     }
@@ -413,10 +413,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUserStripsInvalidUid()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setAssignedUser( "invalidUid;M4pNmLabtXl" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setAssignedUser( "invalidUid;M4pNmLabtXl" );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertEquals( Set.of( "M4pNmLabtXl" ), params.getAssignedUsers() );
     }
@@ -424,9 +424,9 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUserIsNull()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertIsEmpty( params.getAssignedUsers() );
     }
@@ -434,10 +434,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMappingAssignedUserIsEmpty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setAssignedUser( " " );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setAssignedUser( " " );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertIsEmpty( params.getAssignedUsers() );
     }
@@ -445,22 +445,22 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testMutualExclusionOfEventsAndFilter()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) );
-        eventCriteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilter( Set.of( "qrur9Dvnyt5:ge:1:le:2" ) );
+        criteria.setEvent( "XKrcfuM4Hcw;M4pNmLabtXl" );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Event UIDs and filters can not be specified at the same time", exception.getMessage() );
     }
 
     @Test
     void testOrderByEventSchemaProperties()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder( OrderCriteria.fromOrderString( "programStage:desc,dueDate:asc" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setOrder( OrderCriteria.fromOrderString( "programStage:desc,dueDate:asc" ) );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertContainsOnly( List.of( new OrderParam( "programStage", OrderParam.SortDirection.DESC ),
             new OrderParam( "dueDate", OrderParam.SortDirection.ASC ) ), params.getOrders() );
@@ -469,10 +469,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testOrderBySupportedPropertyNotInEventSchema()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder( OrderCriteria.fromOrderString( "enrolledAt:asc" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setOrder( OrderCriteria.fromOrderString( "enrolledAt:asc" ) );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertContainsOnly( List.of( new OrderParam( "enrolledAt", OrderParam.SortDirection.ASC ) ),
             params.getOrders() );
@@ -481,23 +481,23 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testOrderFailsForNonSimpleEventProperty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder( OrderCriteria.fromOrderString( "nonSimple:desc" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setOrder( OrderCriteria.fromOrderString( "nonSimple:desc" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertStartsWith( "Order by property `nonSimple` is not supported", exception.getMessage() );
     }
 
     @Test
     void testOrderFailsForUnsupportedProperty()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setOrder(
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setOrder(
             OrderCriteria.fromOrderString( "unsupportedProperty1:asc,enrolledAt:asc,unsupportedProperty2:desc" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertAll(
             () -> assertStartsWith( "Order by property `", exception.getMessage() ),
             // order of properties might not always be the same; therefore using
@@ -510,10 +510,10 @@ class EventRequestToSearchParamsMapperTest
     void testFilterAttributes()
     {
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2", TEA_2_UID + ":like:foo" ) );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         List<QueryItem> items = params.getFilterAttributes();
         assertNotNull( items );
@@ -542,10 +542,10 @@ class EventRequestToSearchParamsMapperTest
     @Test
     void testFilterAttributesWhenTEAHasMultipleFilters()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":gt:10:lt:20" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes( Set.of( TEA_1_UID + ":gt:10:lt:20" ) );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         List<QueryItem> items = params.getFilterAttributes();
         assertNotNull( items );
@@ -567,11 +567,11 @@ class EventRequestToSearchParamsMapperTest
     {
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( "eq:2" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes( Set.of( "eq:2" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Query item or filter is invalid: eq:2", exception.getMessage() );
     }
 
@@ -580,34 +580,34 @@ class EventRequestToSearchParamsMapperTest
     {
         when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Attribute does not exist: " + TEA_1_UID, exception.getMessage() );
     }
 
     @Test
     void testFilterAttributesWhenTEAInFilterDoesNotExist()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( "JM5zWuf1mkb:eq:2" ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes( Set.of( "JM5zWuf1mkb:eq:2" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Attribute does not exist: JM5zWuf1mkb", exception.getMessage() );
     }
 
     @Test
     void testFilterAttributesWhenTEAUidIsDuplicated()
     {
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes(
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes(
             Set.of( "TvjwTPToKHO:lt:20", "cy2oRh2sNr6:lt:20", "TvjwTPToKHO:gt:30", "cy2oRh2sNr6:gt:30" ) );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> requestToSearchParamsMapper.map( eventCriteria ) );
+            () -> mapper.map( criteria ) );
         assertAll(
             () -> assertStartsWith( "filterAttributes contains duplicate tracked entity attribute",
                 exception.getMessage() ),
@@ -621,10 +621,10 @@ class EventRequestToSearchParamsMapperTest
     void testFilterAttributesUsingOnlyUID()
     {
 
-        TrackerEventCriteria eventCriteria = new TrackerEventCriteria();
-        eventCriteria.setFilterAttributes( Set.of( TEA_1_UID ) );
+        TrackerEventCriteria criteria = new TrackerEventCriteria();
+        criteria.setFilterAttributes( Set.of( TEA_1_UID ) );
 
-        EventSearchParams params = requestToSearchParamsMapper.map( eventCriteria );
+        EventSearchParams params = mapper.map( criteria );
 
         assertContainsOnly(
             List.of( new QueryItem( tea1, null, tea1.getValueType(), tea1.getAggregationType(), tea1.getOptionSet(),


### PR DESCRIPTION
to be consistent with the other criteria mappers. Until we settle on a better name for all of them.

In tests just use variable names `mapper`, `criteria` to be consistent with other tests for criteria mappers.