### PR TITLE
fix: yearToDate with periodOffset DHIS2-13774

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/PeriodType.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.period;
 
+import static java.lang.Math.abs;
+
 import java.io.Serializable;
 import java.sql.ResultSet;
 import java.time.DayOfWeek;
@@ -643,6 +645,23 @@ public abstract class PeriodType
     // -------------------------------------------------------------------------
     // CalendarPeriodType
     // -------------------------------------------------------------------------
+
+    /**
+     * Returns a period shifted from the given period. If the offset is
+     * positive, the result will be from following periods. If the offset is
+     * negative, the result will be from previous periods. If the offset is
+     * zero, the same period will be returned.
+     *
+     * @param period the Period to base the offset on.
+     * @param periodOffset the offset from the given Period.
+     * @return a Period which is offset from the given Period.
+     */
+    public final Period getShiftedPeriod( Period period, int periodOffset )
+    {
+        return (periodOffset >= 0)
+            ? getNextPeriod( period, periodOffset )
+            : getPreviousPeriod( period, abs( periodOffset ) );
+    }
 
     /**
      * Returns a Period which is the next of the given Period. Only valid

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/period/PeriodTypeTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/period/PeriodTypeTest.java
@@ -131,4 +131,40 @@ class PeriodTypeTest
         assertEquals( PeriodTypeEnum.YEARLY,
             PeriodType.getPeriodType( PeriodTypeEnum.YEARLY ).getPeriodTypeEnum() );
     }
+
+    @Test
+    void testGetShiftedPeriod()
+    {
+        Period aug2022 = PeriodType.getPeriodFromIsoString( "202208" );
+        Period sep2022 = PeriodType.getPeriodFromIsoString( "202209" );
+        PeriodType monthly = aug2022.getPeriodType();
+
+        assertEquals( aug2022, monthly.getShiftedPeriod( aug2022, 0 ) );
+        assertEquals( sep2022, monthly.getShiftedPeriod( aug2022, 1 ) );
+        assertEquals( aug2022, monthly.getShiftedPeriod( sep2022, -1 ) );
+    }
+
+    @Test
+    void testGetNextPeriod()
+    {
+        Period aug2022 = PeriodType.getPeriodFromIsoString( "202208" );
+        Period sep2022 = PeriodType.getPeriodFromIsoString( "202209" );
+        PeriodType monthly = aug2022.getPeriodType();
+
+        assertEquals( sep2022, monthly.getNextPeriod( aug2022 ) );
+        assertEquals( aug2022, monthly.getNextPeriod( aug2022, 0 ) );
+        assertEquals( sep2022, monthly.getNextPeriod( aug2022, 1 ) );
+    }
+
+    @Test
+    void testGetPreviousPeriod()
+    {
+        Period aug2022 = PeriodType.getPeriodFromIsoString( "202208" );
+        Period sep2022 = PeriodType.getPeriodFromIsoString( "202209" );
+        PeriodType monthly = aug2022.getPeriodType();
+
+        assertEquals( aug2022, monthly.getPreviousPeriod( sep2022 ) );
+        assertEquals( sep2022, monthly.getPreviousPeriod( sep2022, 0 ) );
+        assertEquals( aug2022, monthly.getPreviousPeriod( sep2022, 1 ) );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemPeriodBase.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemPeriodBase.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.expression.dataitem;
+
+import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import java.util.List;
+
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.PeriodType;
+
+/**
+ * Abstract class for expression items that need only the period type and period
+ * such as {@link ItemPeriodInYear} and {@link ItemYearlyPeriodCount}.
+ *
+ * @author Jim Grace
+ */
+public abstract class ItemPeriodBase
+    implements ExpressionItem
+{
+    @Override
+    public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        return DOUBLE_VALUE_IF_NULL;
+    }
+
+    @Override
+    public Double evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        List<Period> periods = visitor.getParams().getPeriods();
+
+        if ( periods.size() != 1 )
+        {
+            return 0.0; // Not applicable
+        }
+
+        PeriodType periodType = periods.get( 0 ).getPeriodType();
+
+        int periodOffset = (visitor.getState().getQueryMods() == null)
+            ? 0
+            : visitor.getState().getQueryMods().getPeriodOffset();
+
+        Period period = periodType.getShiftedPeriod( periods.get( 0 ), periodOffset );
+
+        return evaluate( periodType, period );
+    }
+
+    // -------------------------------------------------------------------------
+    // Abstract methods
+    // -------------------------------------------------------------------------
+
+    protected abstract Double evaluate( PeriodType periodType, Period period );
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYear.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYear.java
@@ -29,16 +29,11 @@ package org.hisp.dhis.expression.dataitem;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Calendar.DAY_OF_YEAR;
-import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 
 import java.util.Calendar;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.period.BiMonthlyPeriodType;
 import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.period.MonthlyPeriodType;
@@ -52,29 +47,13 @@ import org.hisp.dhis.period.YearlyPeriodType;
  * @author Jim Grace
  */
 public class ItemPeriodInYear
-    implements ExpressionItem
+    extends ItemPeriodBase
 {
     private static final Pattern TRAILING_DIGITS = Pattern.compile( "\\d+$" );
 
     @Override
-    public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
+    public Double evaluate( PeriodType periodType, Period period )
     {
-        return DOUBLE_VALUE_IF_NULL;
-    }
-
-    @Override
-    public Double evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        List<Period> periods = visitor.getParams().getPeriods();
-
-        if ( periods.size() != 1 )
-        {
-            return 0.0; // Not applicable
-        }
-
-        Period period = periods.get( 0 );
-        PeriodType periodType = period.getPeriodType();
-
         if ( periodType instanceof DailyPeriodType )
         {
             return dayOfYear( period );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCount.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/ItemYearlyPeriodCount.java
@@ -29,15 +29,9 @@ package org.hisp.dhis.expression.dataitem;
 
 import static java.lang.String.valueOf;
 import static org.hisp.dhis.calendar.DateTimeUnit.fromJdkDate;
-import static org.hisp.dhis.parser.expression.ParserUtils.DOUBLE_VALUE_IF_NULL;
-import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
 import static org.hisp.dhis.period.PeriodType.getPeriodFromIsoString;
 
-import java.util.List;
-
 import org.hisp.dhis.calendar.DateTimeUnit;
-import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
-import org.hisp.dhis.parser.expression.ExpressionItem;
 import org.hisp.dhis.period.BiWeeklyAbstractPeriodType;
 import org.hisp.dhis.period.CalendarPeriodType;
 import org.hisp.dhis.period.Period;
@@ -51,7 +45,7 @@ import org.hisp.dhis.period.YearlyPeriodType;
  * @author Jim Grace
  */
 public class ItemYearlyPeriodCount
-    implements ExpressionItem
+    extends ItemPeriodBase
 {
     private static final int WEEKS_PER_YEAR_MINIMUM = 52;
 
@@ -60,24 +54,8 @@ public class ItemYearlyPeriodCount
     private static final int DECEMBER = 12;
 
     @Override
-    public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
+    public Double evaluate( PeriodType periodType, Period period )
     {
-        return DOUBLE_VALUE_IF_NULL;
-    }
-
-    @Override
-    public Double evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
-    {
-        List<Period> periods = visitor.getParams().getPeriods();
-
-        if ( periods.size() != 1 )
-        {
-            return 0.0; // Not applicable
-        }
-
-        Period period = periods.get( 0 );
-        PeriodType periodType = period.getPeriodType();
-
         if ( periodType instanceof WeeklyAbstractPeriodType )
         {
             return weeksInYearContaining( period );

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYearTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/dataitem/ItemPeriodInYearTest.java
@@ -35,8 +35,10 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 
 import org.hisp.dhis.DhisConvenienceTest;
+import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.expression.ExpressionParams;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -59,6 +61,12 @@ class ItemPeriodInYearTest
 
     @Mock
     private ExpressionParams params;
+
+    @Mock
+    private ExpressionState expressionState;
+
+    @Mock
+    private QueryModifiers queryMods;
 
     private final ItemPeriodInYear target = new ItemPeriodInYear();
 
@@ -130,14 +138,37 @@ class ItemPeriodInYearTest
         assertEquals( 1, evalWith( "2022Oct" ) );
     }
 
+    @Test
+    void testEvaluateMonthlyWithPeriodOffset()
+    {
+        assertEquals( 5, evalWith( "202209", -4 ) );
+        assertEquals( 1, evalWith( "202209", 4 ) );
+    }
+
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------
 
     private long evalWith( String period )
     {
+        return evalWith( period, 0 );
+    }
+
+    private long evalWith( String period, int periodOffset )
+    {
         when( visitor.getParams() ).thenReturn( params );
         when( params.getPeriods() ).thenReturn( List.of( createPeriod( period ) ) );
+        when( visitor.getState() ).thenReturn( expressionState );
+
+        if ( periodOffset == 0 )
+        {
+            when( expressionState.getQueryMods() ).thenReturn( null );
+        }
+        else
+        {
+            when( expressionState.getQueryMods() ).thenReturn( queryMods );
+            when( queryMods.getPeriodOffset() ).thenReturn( periodOffset );
+        }
 
         return round( target.evaluate( ctx, visitor ) );
     }


### PR DESCRIPTION
See [DHIS2-13774](https://dhis2.atlassian.net/browse/DHIS2-13774). There are two problems with the yearToDate() function and associated expression constructs [periodInYear] and [yearlyPeriodCount] when used in combination with periodOffset():

1. The [periodInYear] and [yearlyPeriodCount] items do not take into account .periodOffset(), which means they cannot be used meaningfully together with yearToDate() when it is being used together with the .periodOffset() function.
2. When yearToDate() is used with multiple different and overlapping periodOffsets in a single analytics query, some of the data values are double-counted.

`ItemPeriodInYear` and `ItemYearlyPeriodCount` added code to shift the period by a periodOffset if present, before evaluating the period. Since this added even more common logic to these two classes, this logic was moved to a new class `ItemPeriodBase` which these two classes extend.

The ability to move to next or previous periods according to a positive or negative (or zero) number is now needed by `ItemPeriodBase` as well as `PeriodOffsetUtils`. This logic was moved to `PeriodType` so it would be only in one place.

The problem with double counting was because `DataHandler.getAggregatedValueMapFromGrid` was building the yearToDate values for each `DimensionalItemObject`, but yearToDate items with different periodOffsets were causing the same values to be counted multiple times. This was fixed by adding the values only once for each collection of yearToDate items that differ only in periodOffsets.

Appropriate unit test cases were added. In `AnalyticsServiceTest` the overloaded methods `withIndicator` were changed to accept an indicator argument to make it easy to set up a test with multiple indicators. A second indicator was added and the indicators were named `inA` and `inB` rather than the former `indicatorA`. This makes them easier to fit into the calls to `withIndicator` and is consistent with other variable naming like `deA`, `ouA`, `peJan`, etc.

See also the test description in [DHIS2-13774](https://dhis2.atlassian.net/browse/DHIS2-13774) for how the fix was tested through the frontend.