### PR TITLE
chore: move validation to top TECH-1414

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -913,6 +913,12 @@ public class TrackedEntityInstanceQueryParams
         return organisationUnits;
     }
 
+    public TrackedEntityInstanceQueryParams addOrganisationUnits( Set<OrganisationUnit> organisationUnits )
+    {
+        this.organisationUnits.addAll( organisationUnits );
+        return this;
+    }
+
     public TrackedEntityInstanceQueryParams setOrganisationUnits( Set<OrganisationUnit> organisationUnits )
     {
         this.organisationUnits = organisationUnits;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.CodeGenerator;
+import org.hisp.dhis.commons.collection.CollectionUtils;
+import org.hisp.dhis.commons.util.TextUtils;
+
+public class RequestParamUtils
+{
+    /**
+     * Apply func to given arg only if given arg is not empty otherwise return
+     * null.
+     *
+     * @param func function to be called if arg is not empty
+     * @param arg arg to be checked
+     * @return result of func
+     * @param <T>
+     */
+    static <T extends BaseIdentifiableObject> T applyIfNonEmpty( Function<String, T> func, String arg )
+    {
+        if ( StringUtils.isEmpty( arg ) )
+        {
+            return null;
+        }
+
+        return func.apply( arg );
+    }
+
+    /**
+     * Parse semicolon separated string of UIDs. Filters out invalid UIDs.
+     *
+     * @param input string to parse
+     * @return set of uids
+     */
+    static Set<String> parseUids( String input )
+    {
+        return CollectionUtils.emptyIfNull( TextUtils.splitToSet( input, TextUtils.SEMICOLON ) )
+            .stream()
+            .filter( CodeGenerator::isValidUid )
+            .collect( Collectors.toUnmodifiableSet() );
+    }
+}

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -38,8 +38,13 @@ import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.TextUtils;
 
-public class RequestParamUtils
+class RequestParamUtils
 {
+    private RequestParamUtils()
+    {
+        throw new IllegalStateException( "Utility class" );
+    }
+
     /**
      * Apply func to given arg only if given arg is not empty otherwise return
      * null.

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -64,11 +65,28 @@ public class RequestParamUtils
      * @param input string to parse
      * @return set of uids
      */
-    static Set<String> parseUids( String input )
+    static Set<String> parseAndFilterUids( String input )
     {
-        return CollectionUtils.emptyIfNull( TextUtils.splitToSet( input, TextUtils.SEMICOLON ) )
-            .stream()
+        return parseUidString( input )
             .filter( CodeGenerator::isValidUid )
             .collect( Collectors.toUnmodifiableSet() );
+    }
+
+    /**
+     * Parse semicolon separated string of UIDs.
+     *
+     * @param input string to parse
+     * @return set of uids
+     */
+    static Set<String> parseUids( String input )
+    {
+        return parseUidString( input )
+            .collect( Collectors.toUnmodifiableSet() );
+    }
+
+    private static Stream<String> parseUidString( String input )
+    {
+        return CollectionUtils.emptyIfNull( TextUtils.splitToSet( input, TextUtils.SEMICOLON ) )
+            .stream();
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -28,7 +28,7 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -159,10 +159,10 @@ class TrackerEventCriteriaMapper
             true );
         validateAttributeOptionCombo( attributeOptionCombo, user );
 
-        Set<String> eventIds = parseUids( eventCriteria.getEvent() );
+        Set<String> eventIds = parseAndFilterUids( eventCriteria.getEvent() );
         validateFilter( eventCriteria.getFilter(), eventIds, eventCriteria.getProgramStage(), programStage );
 
-        Set<String> assignedUserIds = parseUids( eventCriteria.getAssignedUser() );
+        Set<String> assignedUserIds = parseAndFilterUids( eventCriteria.getAssignedUser() );
         validateAssignedUsers( eventCriteria.getAssignedUserMode(), assignedUserIds );
 
         Map<String, SortDirection> dataElementOrders = getDataElementsFromOrder( eventCriteria.getOrder() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -31,9 +31,9 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.isStaticColumn;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +50,6 @@ import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.QueryOperator;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
@@ -104,7 +103,7 @@ public class TrackerTrackedEntityCriteriaMapper
             criteria.getTrackedEntityType() );
         validateTrackedEntityType( criteria.getTrackedEntityType(), trackedEntityType );
 
-        Set<String> assignedUserIds = parseUids( criteria.getAssignedUser() );
+        Set<String> assignedUserIds = parseAndFilterUids( criteria.getAssignedUser() );
         validateAssignedUsers( criteria.getAssignedUserMode(), assignedUserIds );
 
         Set<OrganisationUnit> possibleSearchOrgUnits = new HashSet<>();
@@ -131,9 +130,7 @@ public class TrackerTrackedEntityCriteriaMapper
 
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
 
-        Set<String> orgUnits = criteria.getOrgUnit() != null
-            ? TextUtils.splitToSet( criteria.getOrgUnit(), TextUtils.SEMICOLON )
-            : Collections.emptySet();
+        Set<String> orgUnits = parseUids( criteria.getOrgUnit() );
         for ( String orgUnit : orgUnits )
         {
             OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( orgUnit );
@@ -160,9 +157,7 @@ public class TrackerTrackedEntityCriteriaMapper
         List<OrderParam> orderParams = toOrderParams( criteria.getOrder() );
         validateOrderParams( orderParams, attributes );
 
-        Set<String> trackedEntities = criteria.getTrackedEntity() != null
-            ? TextUtils.splitToSet( criteria.getTrackedEntity(), TextUtils.SEMICOLON )
-            : Collections.emptySet();
+        Set<String> trackedEntities = parseUids( criteria.getTrackedEntity() );
 
         params.setQuery( queryFilter )
             .setProgram( program )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -98,6 +98,7 @@ public class TrackerTrackedEntityCriteriaMapper
     {
         Program program = applyIfNonEmpty( programService::getProgram, criteria.getProgram() );
         validateProgram( criteria.getProgram(), program );
+        ProgramStage programStage = validateProgramStage( criteria, program );
 
         TrackedEntityType trackedEntityType = applyIfNonEmpty( trackedEntityTypeService::getTrackedEntityType,
             criteria.getTrackedEntityType() );
@@ -135,7 +136,7 @@ public class TrackerTrackedEntityCriteriaMapper
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         params.setQuery( queryFilter )
             .setProgram( program )
-            .setProgramStage( validateProgramStage( criteria, program ) )
+            .setProgramStage( programStage )
             .setProgramStatus( criteria.getProgramStatus() )
             .setFollowUp( criteria.getFollowUp() )
             .setLastUpdatedStartDate( criteria.getUpdatedAfter() )
@@ -291,6 +292,17 @@ public class TrackerTrackedEntityCriteriaMapper
         return ps;
     }
 
+    private ProgramStage getProgramStageFromProgram( Program program, String programStage )
+    {
+        if ( program == null )
+        {
+            return null;
+        }
+
+        return program.getProgramStages().stream().filter( ps -> ps.getUid().equals( programStage ) ).findFirst()
+            .orElse( null );
+    }
+
     private void validateTrackedEntityType( String id, TrackedEntityType trackedEntityType )
     {
         if ( isNotEmpty( id ) && trackedEntityType == null )
@@ -311,17 +323,6 @@ public class TrackerTrackedEntityCriteriaMapper
             throw new IllegalQueryException(
                 "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
         }
-    }
-
-    private ProgramStage getProgramStageFromProgram( Program program, String programStage )
-    {
-        if ( program == null )
-        {
-            return null;
-        }
-
-        return program.getProgramStages().stream().filter( ps -> ps.getUid().equals( programStage ) ).findFirst()
-            .orElse( null );
     }
 
     private void validateOrderParams( List<OrderParam> orderParams, Map<String, TrackedEntityAttribute> attributes )


### PR DESCRIPTION
like we already did in `/tracker/events` separate out validations, transformations before mapping/returning the TrackedEntityInstanceQueryParams. Goal is to only construct a valid
TrackedEntityInstanceQueryParams.

* Reuse some parsing functions from `/tracker/events` by moving them into RequestParamUtils
* Add tests to ensure we do not try to fetch things like a program is the optional query parameter is empty