### PR TITLE
chore: refactoring duplication TECH-1414 

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -45,6 +45,11 @@ import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
+/**
+ * RequestParamUtils are functions used to parse and transform tracker request
+ * parameters. This class is intended to only house functions without any
+ * dependencies on services or components.
+ */
 class RequestParamUtils
 {
     private RequestParamUtils()
@@ -59,7 +64,7 @@ class RequestParamUtils
      * @param func function to be called if arg is not empty
      * @param arg arg to be checked
      * @return result of func
-     * @param <T>
+     * @param <T> base identifiable object to be returned from func
      */
     static <T extends BaseIdentifiableObject> T applyIfNonEmpty( Function<String, T> func, String arg )
     {
@@ -105,7 +110,7 @@ class RequestParamUtils
     /**
      * Parse request parameter to filter tracked entity attributes using
      * identifier, operator and values. Refer to
-     * {@link #parseAttributeQueryItem(String, Map)} for details on the expected
+     * {@link #parseQueryItem(String, Function)} for details on the expected
      * item format.
      *
      * @param item query item string composed of identifier, operator and value
@@ -136,13 +141,13 @@ class RequestParamUtils
     }
 
     /**
-     * Creates a QueryItem with QueryFilters from the given item string. Item is
-     * on format
-     * {identifier}:{operator}:{filter-value}[:{operator}:{filter-value}]. Only
-     * the identifier is mandatory.
+     * Creates a QueryItem with QueryFilters from the given item string.
+     * Expected item format is
+     * {identifier}:{operator}:{value}[:{operator}:{value}]. Only the identifier
+     * is mandatory. Multiple operator:value pairs are allowed.
      * <p>
      * The identifier is passed to given map function which translates the
-     * identifier to a QueryItem. A QueryFilter for each operator:value pair are
+     * identifier to a QueryItem. A QueryFilter for each operator:value pair is
      * then added to this QueryItem.
      */
     public static QueryItem parseQueryItem( String item, Function<String, QueryItem> map )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -105,6 +106,27 @@ class RequestParamUtils
     {
         return CollectionUtils.emptyIfNull( TextUtils.splitToSet( input, TextUtils.SEMICOLON ) )
             .stream();
+    }
+
+    /**
+     * Parse request parameter to filter tracked entity attributes using
+     * identifier, operator and values. Refer to
+     * {@link #parseQueryItem(String, Function)} for details on the expected
+     * item format.
+     *
+     * @param items query item strings each composed of identifier, operator and
+     *        value
+     * @param attributes tracked entity attribute map from identifiers to
+     *        attributes
+     * @return query items each of a tracked entity attribute with attached
+     *         query filters
+     */
+    public static List<QueryItem> parseAttributeQueryItems( Set<String> items,
+        Map<String, TrackedEntityAttribute> attributes )
+    {
+        return items.stream()
+            .map( i -> parseAttributeQueryItem( i, attributes ) )
+            .collect( Collectors.toUnmodifiableList() );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAttributeQueryItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -313,7 +313,7 @@ class TrackerEventCriteriaMapper
         List<QueryItem> result = new ArrayList<>();
         for ( String filter : filterAttributes )
         {
-            result.add( parseQueryItem( filter, attributes ) );
+            result.add( parseAttributeQueryItem( filter, attributes ) );
         }
         addAttributeQueryItemsFromOrder( result, attributes, attributeOrderParams );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -312,7 +313,7 @@ class TrackerEventCriteriaMapper
         List<QueryItem> result = new ArrayList<>();
         for ( String filter : filterAttributes )
         {
-            result.add( getQueryItem( filter, attributes ) );
+            result.add( parseQueryItem( filter, attributes ) );
         }
         addAttributeQueryItemsFromOrder( result, attributes, attributeOrderParams );
 
@@ -436,50 +437,6 @@ class TrackerEventCriteriaMapper
         }
 
         return new QueryItem( de, null, de.getValueType(), de.getAggregationType(), de.getOptionSet() );
-    }
-
-    /**
-     * Creates a QueryItem from the given item string. Item is on format
-     * {attribute-id}:{operator}:{filter-value}[:{operator}:{filter-value}].
-     * Only the attribute-id is mandatory.
-     */
-    private QueryItem getQueryItem( String item, Map<String, TrackedEntityAttribute> attributes )
-    {
-        String[] split = item.split( DimensionalObject.DIMENSION_NAME_SEP );
-
-        if ( split.length % 2 != 1 )
-        {
-            throw new IllegalQueryException( "Query item or filter is invalid: " + item );
-        }
-
-        QueryItem queryItem = getItem( split[0], attributes );
-
-        if ( split.length > 1 ) // Filters specified
-        {
-            for ( int i = 1; i < split.length; i += 2 )
-            {
-                QueryOperator operator = QueryOperator.fromString( split[i] );
-                queryItem.getFilters().add( new QueryFilter( operator, split[i + 1] ) );
-            }
-        }
-
-        return queryItem;
-    }
-
-    private QueryItem getItem( String item, Map<String, TrackedEntityAttribute> attributes )
-    {
-        if ( attributes.isEmpty() )
-        {
-            throw new IllegalQueryException( "Attribute does not exist: " + item );
-        }
-
-        TrackedEntityAttribute at = attributes.get( item );
-        if ( at == null )
-        {
-            throw new IllegalQueryException( "Attribute does not exist: " + item );
-        }
-
-        return new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(), at.isUnique() );
     }
 
     private List<OrderParam> getOrderParams( List<OrderCriteria> order )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.Order
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAttributeQueryItem;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
 
 import java.util.HashSet;
@@ -122,11 +122,11 @@ public class TrackerTrackedEntityCriteriaMapper
             .stream().collect( Collectors.toMap( TrackedEntityAttribute::getUid, att -> att ) );
 
         List<QueryItem> attributeItems = criteria.getAttribute().stream()
-            .map( a -> parseQueryItem( a, attributes ) )
+            .map( a -> parseAttributeQueryItem( a, attributes ) )
             .collect( Collectors.toUnmodifiableList() );
 
         List<QueryItem> filters = criteria.getFilter().stream()
-            .map( f -> parseQueryItem( f, attributes ) )
+            .map( f -> parseAttributeQueryItem( f, attributes ) )
             .collect( Collectors.toUnmodifiableList() );
 
         List<OrderParam> orderParams = toOrderParams( criteria.getOrder() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.Order
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
-import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAttributeQueryItem;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAttributeQueryItems;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
 
 import java.util.HashSet;
@@ -121,13 +121,9 @@ public class TrackerTrackedEntityCriteriaMapper
         Map<String, TrackedEntityAttribute> attributes = attributeService.getAllTrackedEntityAttributes()
             .stream().collect( Collectors.toMap( TrackedEntityAttribute::getUid, att -> att ) );
 
-        List<QueryItem> attributeItems = criteria.getAttribute().stream()
-            .map( a -> parseAttributeQueryItem( a, attributes ) )
-            .collect( Collectors.toUnmodifiableList() );
+        List<QueryItem> attributeItems = parseAttributeQueryItems( criteria.getAttribute(), attributes );
 
-        List<QueryItem> filters = criteria.getFilter().stream()
-            .map( f -> parseAttributeQueryItem( f, attributes ) )
-            .collect( Collectors.toUnmodifiableList() );
+        List<QueryItem> filters = parseAttributeQueryItems( criteria.getFilter(), attributes );
 
         List<OrderParam> orderParams = toOrderParams( criteria.getOrder() );
         validateOrderParams( orderParams, attributes );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.Order
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseAndFilterUids;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
 import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
 
 import java.util.HashSet;
@@ -121,11 +122,11 @@ public class TrackerTrackedEntityCriteriaMapper
             .stream().collect( Collectors.toMap( TrackedEntityAttribute::getUid, att -> att ) );
 
         List<QueryItem> attributeItems = criteria.getAttribute().stream()
-            .map( a -> this.getQueryItem( a, attributes ) )
+            .map( a -> parseQueryItem( a, attributes ) )
             .collect( Collectors.toUnmodifiableList() );
 
         List<QueryItem> filters = criteria.getFilter().stream()
-            .map( f -> this.getQueryItem( f, attributes ) )
+            .map( f -> parseQueryItem( f, attributes ) )
             .collect( Collectors.toUnmodifiableList() );
 
         List<OrderParam> orderParams = toOrderParams( criteria.getOrder() );
@@ -223,51 +224,6 @@ public class TrackerTrackedEntityCriteriaMapper
 
             return new QueryFilter( op, split[1] );
         }
-    }
-
-    /**
-     * Creates a QueryItem from the given item string. Item is on format
-     * {attribute-id}:{operator}:{filter-value}[:{operator}:{filter-value}].
-     * Only the attribute-id is mandatory.
-     */
-    private QueryItem getQueryItem( String item, Map<String, TrackedEntityAttribute> attributes )
-    {
-        String[] split = item.split( DimensionalObject.DIMENSION_NAME_SEP );
-
-        if ( split.length % 2 != 1 )
-        {
-            throw new IllegalQueryException( "Query item or filter is invalid: " + item );
-        }
-
-        QueryItem queryItem = getItem( split[0], attributes );
-
-        if ( split.length > 1 ) // Filters specified
-        {
-            for ( int i = 1; i < split.length; i += 2 )
-            {
-                QueryOperator operator = QueryOperator.fromString( split[i] );
-                queryItem.getFilters().add( new QueryFilter( operator, split[i + 1] ) );
-            }
-        }
-
-        return queryItem;
-    }
-
-    private QueryItem getItem( String item, Map<String, TrackedEntityAttribute> attributes )
-    {
-        if ( attributes.isEmpty() )
-        {
-            throw new IllegalQueryException( "Attribute does not exist: " + item );
-        }
-
-        TrackedEntityAttribute at = attributes.get( item );
-
-        if ( at == null )
-        {
-            throw new IllegalQueryException( "Attribute does not exist: " + item );
-        }
-
-        return new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet(), at.isUnique() );
     }
 
     private static void validateProgram( String id, Program program )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -80,7 +80,7 @@ class RequestParamUtilsTest
     }
 
     @Test
-    void testParseQueryItemWithIdentifier()
+    void testParseQueryItemWithOnlyIdentifier()
     {
         String param = TEA_1_UID;
 
@@ -106,7 +106,7 @@ class RequestParamUtilsTest
     }
 
     @Test
-    void testParseQueryItemMissingValue()
+    void testParseQueryItemWithMissingValue()
     {
         String param = TEA_1_UID + ":lt";
 
@@ -116,7 +116,7 @@ class RequestParamUtilsTest
     }
 
     @Test
-    void testParseQueryItemMissingValueWithTrailingColon()
+    void testParseQueryItemWithMissingValueAndTrailingColon()
     {
         String param = TEA_1_UID + ":lt:";
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller.tracker.export;
+
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseQueryItem;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.hisp.dhis.common.IllegalQueryException;
+import org.hisp.dhis.common.QueryFilter;
+import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RequestParamUtilsTest
+{
+
+    private static final String TEA_1_UID = "TvjwTPToKHO";
+
+    private static final String TEA_2_UID = "cy2oRh2sNr6";
+
+    private Map<String, TrackedEntityAttribute> attributes;
+
+    @BeforeEach
+    void setUp()
+    {
+        attributes = Map.of( TEA_1_UID, trackedEntityAttribute( TEA_1_UID ), TEA_2_UID,
+            trackedEntityAttribute( TEA_2_UID ) );
+    }
+
+    @Test
+    void testParseQueryItem()
+    {
+        String param = TEA_1_UID + ":lt:20:gt:10";
+
+        QueryItem item = parseQueryItem( param, attributes );
+
+        assertNotNull( item );
+        assertAll(
+            () -> assertEquals( TEA_1_UID, item.getItemId() ),
+            // QueryItem equals() does not take the QueryFilter into account, so
+            // we need to assert on filters separately
+            () -> assertEquals( List.of(
+                new QueryFilter( QueryOperator.LT, "20" ),
+                new QueryFilter( QueryOperator.GT, "10" ) ), item.getFilters() ) );
+    }
+
+    @Test
+    void testParseQueryItemWithoutOperatorAndValue()
+    {
+        String param = TEA_1_UID + ":";
+
+        QueryItem item = parseQueryItem( param, attributes );
+
+        assertNotNull( item );
+        assertAll(
+            () -> assertEquals( TEA_1_UID, item.getItemId() ),
+            () -> assertIsEmpty( item.getFilters() ) );
+    }
+
+    @Test
+    void testParseQueryItemMissingValue()
+    {
+        String param = TEA_1_UID + ":lt";
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> parseQueryItem( param, attributes ) );
+        assertEquals( "Query item or filter is invalid: " + param, exception.getMessage() );
+    }
+
+    @Test
+    void testParseQueryItemWhenNoTEAExist()
+    {
+        String param = TEA_1_UID + ":eq:2";
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> parseQueryItem( param, Collections.emptyMap() ) );
+        assertEquals( "Attribute does not exist: " + TEA_1_UID, exception.getMessage() );
+    }
+
+    @Test
+    void testParseQueryItemWhenTEAInFilterDoesNotExist()
+    {
+        String param = "JM5zWuf1mkb:eq:2";
+
+        Exception exception = assertThrows( IllegalQueryException.class,
+            () -> parseQueryItem( param, attributes ) );
+        assertEquals( "Attribute does not exist: JM5zWuf1mkb", exception.getMessage() );
+    }
+
+    private TrackedEntityAttribute trackedEntityAttribute( String uid )
+    {
+        TrackedEntityAttribute tea = new TrackedEntityAttribute();
+        tea.setUid( uid );
+        return tea;
+    }
+}

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -87,9 +87,7 @@ class RequestParamUtilsTest
     @Test
     void testParseQueryItemWithOnlyIdentifier()
     {
-        String param = TEA_1_UID;
-
-        QueryItem item = parseQueryItem( param, id -> new QueryItem( attributes.get( id ) ) );
+        QueryItem item = parseQueryItem( TEA_1_UID, id -> new QueryItem( attributes.get( id ) ) );
 
         assertNotNull( item );
         assertAll(

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtilsTest.java
@@ -46,6 +46,10 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests
+ * {@link org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils}.
+ */
 class RequestParamUtilsTest
 {
 
@@ -58,8 +62,9 @@ class RequestParamUtilsTest
     @BeforeEach
     void setUp()
     {
-        attributes = Map.of( TEA_1_UID, trackedEntityAttribute( TEA_1_UID ), TEA_2_UID,
-            trackedEntityAttribute( TEA_2_UID ) );
+        attributes = Map.of(
+            TEA_1_UID, trackedEntityAttribute( TEA_1_UID ),
+            TEA_2_UID, trackedEntityAttribute( TEA_2_UID ) );
     }
 
     @Test
@@ -129,9 +134,10 @@ class RequestParamUtilsTest
     void testParseAttributeQueryItemWhenNoTEAExist()
     {
         String param = TEA_1_UID + ":eq:2";
+        Map<String, TrackedEntityAttribute> attributes = Collections.emptyMap();
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> RequestParamUtils.parseAttributeQueryItem( param, Collections.emptyMap() ) );
+            () -> RequestParamUtils.parseAttributeQueryItem( param, attributes ) );
         assertEquals( "Attribute does not exist: " + TEA_1_UID, exception.getMessage() );
     }
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
@@ -40,7 +40,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -603,17 +602,6 @@ class TrackerEventCriteriaMapperTest
     }
 
     @Test
-    void testFilterWhenTEAInFilterDoesNotExist()
-    {
-        TrackerEventCriteria criteria = new TrackerEventCriteria();
-        criteria.setFilter( Set.of( "JM5zWuf1mkb:eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Dataelement does not exist: JM5zWuf1mkb", exception.getMessage() );
-    }
-
-    @Test
     void testFilterAttributesWhenTEAHasMultipleFilters()
     {
         TrackerEventCriteria criteria = new TrackerEventCriteria();
@@ -637,43 +625,6 @@ class TrackerEventCriteriaMapperTest
     }
 
     @Test
-    void testFilterAttributesWhenNumberOfFilterSegmentsIsEven()
-    {
-        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
-
-        TrackerEventCriteria criteria = new TrackerEventCriteria();
-        criteria.setFilterAttributes( Set.of( "eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Query item or filter is invalid: eq:2", exception.getMessage() );
-    }
-
-    @Test
-    void testFilterAttributesWhenNoTEAExist()
-    {
-        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
-
-        TrackerEventCriteria criteria = new TrackerEventCriteria();
-        criteria.setFilterAttributes( Set.of( TEA_1_UID + ":eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Attribute does not exist: " + TEA_1_UID, exception.getMessage() );
-    }
-
-    @Test
-    void testFilterAttributesWhenTEAInFilterDoesNotExist()
-    {
-        TrackerEventCriteria criteria = new TrackerEventCriteria();
-        criteria.setFilterAttributes( Set.of( "JM5zWuf1mkb:eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Attribute does not exist: JM5zWuf1mkb", exception.getMessage() );
-    }
-
-    @Test
     void testFilterAttributesWhenTEAUidIsDuplicated()
     {
         TrackerEventCriteria criteria = new TrackerEventCriteria();
@@ -694,7 +645,6 @@ class TrackerEventCriteriaMapperTest
     @Test
     void testFilterAttributesUsingOnlyUID()
     {
-
         TrackerEventCriteria criteria = new TrackerEventCriteria();
         criteria.setFilterAttributes( Set.of( TEA_1_UID ) );
 

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -317,43 +317,6 @@ class TrackerTrackedEntityCriteriaMapperTest
     }
 
     @Test
-    void testFilterWhenNumberOfFilterSegmentsIsEven()
-    {
-        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
-
-        TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
-        criteria.setFilter( Set.of( "eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Query item or filter is invalid: eq:2", exception.getMessage() );
-    }
-
-    @Test
-    void testFilterWhenNoTEAExist()
-    {
-        when( attributeService.getAllTrackedEntityAttributes() ).thenReturn( Collections.emptyList() );
-
-        TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
-        criteria.setFilter( Set.of( TEA_1_UID + ":eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Attribute does not exist: " + TEA_1_UID, exception.getMessage() );
-    }
-
-    @Test
-    void testFilterWhenTEAInFilterDoesNotExist()
-    {
-        TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();
-        criteria.setFilter( Set.of( "JM5zWuf1mkb:eq:2" ) );
-
-        Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.map( criteria ) );
-        assertEquals( "Attribute does not exist: JM5zWuf1mkb", exception.getMessage() );
-    }
-
-    @Test
     void testAttributes()
     {
         TrackerTrackedEntityCriteria criteria = new TrackerTrackedEntityCriteria();


### PR DESCRIPTION
Parsing request parameters `filter` (on `/tracker/trackedEntities` and `/tracker/events` )/`filterAttribute` (on /tracker/events) is identical as it should also behave in the same way.

Strings like `uid1:gt:2:lt:10` or similar need to be turned into `QueryItem` with `QueryFilter`s which is then passed to the DB fetching code.

This PR moves the duplicated code into one place `RequestParamUtils`. Removes duplicate tests as the also moved into `RequestParamUtilsTest`.

The process is (see `parseQueryItem`)
* split strings like `identifier:gt:2:lt:10`
* pass the identifier to a mapping function `String -> QueryItem`. This function can for example calls a service to find an entity in the DB or get it from a prefetched map like `attributeToQueryItem.`
* add `QueryFilter`s to the above `QueryItem` for every operator, value pair