### PR TITLE
chore: consistent naming and validation at top TECH-1414

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstanceQueryParams.java
@@ -171,6 +171,11 @@ public class ProgramInstanceQueryParams
         this.organisationUnits.add( unit );
     }
 
+    public void addOrganisationUnits( Set<OrganisationUnit> orgUnits )
+    {
+        this.organisationUnits.addAll( orgUnits );
+    }
+
     /**
      * Indicates whether this params specifies last updated.
      */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -62,18 +63,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrackerEnrollmentCriteriaMapper
 {
 
+    @NonNull
     private final CurrentUserService currentUserService;
 
+    @NonNull
     private final OrganisationUnitService organisationUnitService;
 
+    @NonNull
     private final ProgramService programService;
 
+    @NonNull
     private final TrackedEntityTypeService trackedEntityTypeService;
 
+    @NonNull
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Transactional( readOnly = true )
-    public ProgramInstanceQueryParams getFromUrl( TrackerEnrollmentCriteria trackerEnrollmentCriteria )
+    public ProgramInstanceQueryParams map( TrackerEnrollmentCriteria trackerEnrollmentCriteria )
     {
         Set<String> ou = TextUtils.splitToSet( trackerEnrollmentCriteria.getOrgUnit(), TextUtils.SEMICOLON );
         String program = trackerEnrollmentCriteria.getProgram();

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.applyIfNonEmpty;
+import static org.hisp.dhis.webapi.controller.tracker.export.RequestParamUtils.parseUids;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -38,7 +41,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
-import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.program.Program;
@@ -79,87 +81,100 @@ public class TrackerEnrollmentCriteriaMapper
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Transactional( readOnly = true )
-    public ProgramInstanceQueryParams map( TrackerEnrollmentCriteria trackerEnrollmentCriteria )
+    public ProgramInstanceQueryParams map( TrackerEnrollmentCriteria criteria )
     {
-        Set<String> ou = TextUtils.splitToSet( trackerEnrollmentCriteria.getOrgUnit(), TextUtils.SEMICOLON );
-        String program = trackerEnrollmentCriteria.getProgram();
-        String trackedEntityType = trackerEnrollmentCriteria.getTrackedEntityType();
-        String trackedEntityInstance = trackerEnrollmentCriteria.getTrackedEntity();
-        ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
+        Program program = applyIfNonEmpty( programService::getProgram, criteria.getProgram() );
+        validateProgram( criteria.getProgram(), program );
 
-        Set<OrganisationUnit> possibleSearchOrgUnits = new HashSet<>();
+        TrackedEntityType trackedEntityType = applyIfNonEmpty( trackedEntityTypeService::getTrackedEntityType,
+            criteria.getTrackedEntityType() );
+        validateTrackedEntityType( criteria.getTrackedEntityType(), trackedEntityType );
+
+        TrackedEntityInstance trackedEntity = applyIfNonEmpty( trackedEntityInstanceService::getTrackedEntityInstance,
+            criteria.getTrackedEntity() );
+        validateTrackedEntityInstance( criteria.getTrackedEntity(), trackedEntity );
 
         User user = currentUserService.getCurrentUser();
+        Set<String> orgUnitIds = parseUids( criteria.getOrgUnit() );
+        Set<OrganisationUnit> orgUnits = validateOrgUnits( orgUnitIds, user );
 
+        ProgramInstanceQueryParams params = new ProgramInstanceQueryParams();
+        params.setProgram( program );
+        params.setProgramStatus( criteria.getProgramStatus() );
+        params.setFollowUp( criteria.getFollowUp() );
+        params.setLastUpdated( criteria.getUpdatedAfter() );
+        params.setLastUpdatedDuration( criteria.getUpdatedWithin() );
+        params.setProgramStartDate( criteria.getEnrolledAfter() );
+        params.setProgramEndDate( criteria.getEnrolledBefore() );
+        params.setTrackedEntityType( trackedEntityType );
+        params.setTrackedEntityInstanceUid(
+            Optional.ofNullable( trackedEntity ).map( BaseIdentifiableObject::getUid ).orElse( null ) );
+        params.addOrganisationUnits( orgUnits );
+        params.setOrganisationUnitMode( criteria.getOuMode() );
+        params.setPage( criteria.getPage() );
+        params.setPageSize( criteria.getPageSize() );
+        params.setTotalPages( criteria.isTotalPages() );
+        params.setSkipPaging( criteria.isSkipPaging() );
+        params.setIncludeDeleted( criteria.isIncludeDeleted() );
+        params.setUser( user );
+        params.setOrder( toOrderParams( criteria.getOrder() ) );
+
+        return params;
+    }
+
+    private static void validateProgram( String id, Program program )
+    {
+        if ( isNotEmpty( id ) && program == null )
+        {
+            throw new IllegalQueryException( "Program is specified but does not exist: " + id );
+        }
+    }
+
+    private void validateTrackedEntityType( String id, TrackedEntityType trackedEntityType )
+    {
+        if ( isNotEmpty( id ) && trackedEntityType == null )
+        {
+            throw new IllegalQueryException( "Tracked entity type is specified but does not exist: " + id );
+        }
+    }
+
+    private void validateTrackedEntityInstance( String id, TrackedEntityInstance trackedEntityInstance )
+    {
+        if ( isNotEmpty( id ) && trackedEntityInstance == null )
+        {
+            throw new IllegalQueryException( "Tracked entity instance is specified but does not exist: " + id );
+        }
+    }
+
+    private Set<OrganisationUnit> validateOrgUnits( Set<String> orgUnitIds, User user )
+    {
+
+        Set<OrganisationUnit> possibleSearchOrgUnits = new HashSet<>();
         if ( user != null )
         {
             possibleSearchOrgUnits = user.getTeiSearchOrganisationUnitsWithFallback();
         }
-
-        if ( ou != null )
+        Set<OrganisationUnit> orgUnits = new HashSet<>();
+        if ( orgUnitIds != null )
         {
-            for ( String orgUnit : ou )
+            for ( String orgUnitId : orgUnitIds )
             {
-                OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( orgUnit );
+                OrganisationUnit organisationUnit = organisationUnitService.getOrganisationUnit( orgUnitId );
 
                 if ( organisationUnit == null )
                 {
-                    throw new IllegalQueryException( "Organisation unit does not exist: " + orgUnit );
+                    throw new IllegalQueryException( "Organisation unit does not exist: " + orgUnitId );
                 }
 
                 if ( !organisationUnitService.isInUserHierarchy( organisationUnit.getUid(), possibleSearchOrgUnits ) )
                 {
-                    throw new IllegalQueryException( "Organisation unit is not part of the search scope: " + orgUnit );
+                    throw new IllegalQueryException(
+                        "Organisation unit is not part of the search scope: " + orgUnitId );
                 }
-
-                params.getOrganisationUnits().add( organisationUnit );
+                orgUnits.add( organisationUnit );
             }
         }
 
-        Program pr = program != null ? programService.getProgram( program ) : null;
-
-        if ( program != null && pr == null )
-        {
-            throw new IllegalQueryException( "Program does not exist: " + program );
-        }
-
-        TrackedEntityType te = trackedEntityType != null
-            ? trackedEntityTypeService.getTrackedEntityType( trackedEntityType )
-            : null;
-
-        if ( trackedEntityType != null && te == null )
-        {
-            throw new IllegalQueryException( "Tracked entity does not exist: " + trackedEntityType );
-        }
-
-        TrackedEntityInstance tei = trackedEntityInstance != null
-            ? trackedEntityInstanceService.getTrackedEntityInstance( trackedEntityInstance )
-            : null;
-
-        if ( trackedEntityInstance != null && tei == null )
-        {
-            throw new IllegalQueryException( "Tracked entity instance does not exist: " + trackedEntityInstance );
-        }
-
-        params.setProgram( pr );
-        params.setProgramStatus( trackerEnrollmentCriteria.getProgramStatus() );
-        params.setFollowUp( trackerEnrollmentCriteria.getFollowUp() );
-        params.setLastUpdated( trackerEnrollmentCriteria.getUpdatedAfter() );
-        params.setLastUpdatedDuration( trackerEnrollmentCriteria.getUpdatedWithin() );
-        params.setProgramStartDate( trackerEnrollmentCriteria.getEnrolledAfter() );
-        params.setProgramEndDate( trackerEnrollmentCriteria.getEnrolledBefore() );
-        params.setTrackedEntityType( te );
-        params.setTrackedEntityInstanceUid(
-            Optional.ofNullable( tei ).map( BaseIdentifiableObject::getUid ).orElse( null ) );
-        params.setOrganisationUnitMode( trackerEnrollmentCriteria.getOuMode() );
-        params.setPage( trackerEnrollmentCriteria.getPage() );
-        params.setPageSize( trackerEnrollmentCriteria.getPageSize() );
-        params.setTotalPages( trackerEnrollmentCriteria.isTotalPages() );
-        params.setSkipPaging( trackerEnrollmentCriteria.isSkipPaging() );
-        params.setIncludeDeleted( trackerEnrollmentCriteria.isIncludeDeleted() );
-        params.setUser( user );
-        params.setOrder( toOrderParams( trackerEnrollmentCriteria.getOrder() ) );
-
-        return params;
+        return orgUnits;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -90,7 +90,7 @@ public class TrackerEnrollmentsExportController
 
         if ( trackerEnrollmentCriteria.getEnrollment() == null )
         {
-            ProgramInstanceQueryParams params = enrollmentCriteriaMapper.getFromUrl( trackerEnrollmentCriteria );
+            ProgramInstanceQueryParams params = enrollmentCriteriaMapper.map( trackerEnrollmentCriteria );
 
             Enrollments enrollments = enrollmentService.getEnrollments( params );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -133,58 +133,58 @@ class TrackerEventCriteriaMapper
         }
     }
 
-    public EventSearchParams map( TrackerEventCriteria eventCriteria )
+    public EventSearchParams map( TrackerEventCriteria criteria )
     {
-        Program program = applyIfNonEmpty( programService::getProgram, eventCriteria.getProgram() );
-        validateProgram( eventCriteria.getProgram(), program );
+        Program program = applyIfNonEmpty( programService::getProgram, criteria.getProgram() );
+        validateProgram( criteria.getProgram(), program );
 
         ProgramStage programStage = applyIfNonEmpty( programStageService::getProgramStage,
-            eventCriteria.getProgramStage() );
-        validateProgramStage( eventCriteria.getProgramStage(), programStage );
+            criteria.getProgramStage() );
+        validateProgramStage( criteria.getProgramStage(), programStage );
 
         OrganisationUnit orgUnit = applyIfNonEmpty( organisationUnitService::getOrganisationUnit,
-            eventCriteria.getOrgUnit() );
-        validateOrgUnit( eventCriteria.getOrgUnit(), orgUnit );
+            criteria.getOrgUnit() );
+        validateOrgUnit( criteria.getOrgUnit(), orgUnit );
 
         User user = currentUserService.getCurrentUser();
         validateUser( user, program, programStage );
 
         TrackedEntityInstance trackedEntityInstance = applyIfNonEmpty( entityInstanceService::getTrackedEntityInstance,
-            eventCriteria.getTrackedEntity() );
-        validateTrackedEntity( eventCriteria.getTrackedEntity(), trackedEntityInstance );
+            criteria.getTrackedEntity() );
+        validateTrackedEntity( criteria.getTrackedEntity(), trackedEntityInstance );
 
         CategoryOptionCombo attributeOptionCombo = inputUtils.getAttributeOptionCombo(
-            eventCriteria.getAttributeCc(),
-            eventCriteria.getAttributeCos(),
+            criteria.getAttributeCc(),
+            criteria.getAttributeCos(),
             true );
         validateAttributeOptionCombo( attributeOptionCombo, user );
 
-        Set<String> eventIds = parseAndFilterUids( eventCriteria.getEvent() );
-        validateFilter( eventCriteria.getFilter(), eventIds, eventCriteria.getProgramStage(), programStage );
+        Set<String> eventIds = parseAndFilterUids( criteria.getEvent() );
+        validateFilter( criteria.getFilter(), eventIds, criteria.getProgramStage(), programStage );
 
-        Set<String> assignedUserIds = parseAndFilterUids( eventCriteria.getAssignedUser() );
-        validateAssignedUsers( eventCriteria.getAssignedUserMode(), assignedUserIds );
+        Set<String> assignedUserIds = parseAndFilterUids( criteria.getAssignedUser() );
+        validateAssignedUsers( criteria.getAssignedUserMode(), assignedUserIds );
 
-        Map<String, SortDirection> dataElementOrders = getDataElementsFromOrder( eventCriteria.getOrder() );
+        Map<String, SortDirection> dataElementOrders = getDataElementsFromOrder( criteria.getOrder() );
         List<QueryItem> dataElements = dataElementOrders.keySet()
             .stream()
             .map( this::getQueryItem )
             .collect( Collectors.toList() );
 
-        Map<String, SortDirection> attributeOrders = getAttributesFromOrder( eventCriteria.getOrder() );
+        Map<String, SortDirection> attributeOrders = getAttributesFromOrder( criteria.getOrder() );
         List<OrderParam> attributeOrderParams = mapToOrderParams( attributeOrders );
         List<OrderParam> dataElementOrderParams = mapToOrderParams( dataElementOrders );
 
-        List<QueryItem> filterAttributes = parseFilterAttributes( eventCriteria.getFilterAttributes(),
+        List<QueryItem> filterAttributes = parseFilterAttributes( criteria.getFilterAttributes(),
             attributeOrderParams );
         validateFilterAttributes( filterAttributes );
 
-        List<QueryItem> filters = eventCriteria.getFilter()
+        List<QueryItem> filters = criteria.getFilter()
             .stream()
             .map( this::getQueryItem )
             .collect( Collectors.toList() );
 
-        Set<String> programInstances = eventCriteria.getEnrollments().stream()
+        Set<String> programInstances = criteria.getEnrollments().stream()
             .filter( CodeGenerator::isValidUid )
             .collect( Collectors.toSet() );
 
@@ -192,32 +192,32 @@ class TrackerEventCriteriaMapper
 
         return params.setProgram( program ).setProgramStage( programStage ).setOrgUnit( orgUnit )
             .setTrackedEntityInstance( trackedEntityInstance )
-            .setProgramStatus( eventCriteria.getProgramStatus() ).setFollowUp( eventCriteria.getFollowUp() )
-            .setOrgUnitSelectionMode( eventCriteria.getOuMode() )
-            .setAssignedUserSelectionMode( eventCriteria.getAssignedUserMode() )
+            .setProgramStatus( criteria.getProgramStatus() ).setFollowUp( criteria.getFollowUp() )
+            .setOrgUnitSelectionMode( criteria.getOuMode() )
+            .setAssignedUserSelectionMode( criteria.getAssignedUserMode() )
             .setAssignedUsers( assignedUserIds )
-            .setStartDate( eventCriteria.getOccurredAfter() ).setEndDate( eventCriteria.getOccurredBefore() )
-            .setDueDateStart( eventCriteria.getScheduledAfter() ).setDueDateEnd( eventCriteria.getScheduledBefore() )
-            .setLastUpdatedStartDate( eventCriteria.getUpdatedAfter() )
-            .setLastUpdatedEndDate( eventCriteria.getUpdatedBefore() )
-            .setLastUpdatedDuration( eventCriteria.getUpdatedWithin() )
-            .setEnrollmentEnrolledBefore( eventCriteria.getEnrollmentEnrolledBefore() )
-            .setEnrollmentEnrolledAfter( eventCriteria.getEnrollmentEnrolledAfter() )
-            .setEnrollmentOccurredBefore( eventCriteria.getEnrollmentOccurredBefore() )
-            .setEnrollmentOccurredAfter( eventCriteria.getEnrollmentOccurredAfter() )
-            .setEventStatus( eventCriteria.getStatus() )
-            .setCategoryOptionCombo( attributeOptionCombo ).setIdSchemes( eventCriteria.getIdSchemes() )
-            .setPage( eventCriteria.getPage() )
-            .setPageSize( eventCriteria.getPageSize() ).setTotalPages( eventCriteria.isTotalPages() )
-            .setSkipPaging( eventCriteria.isSkipPaging() )
-            .setSkipEventId( eventCriteria.getSkipEventId() ).setIncludeAttributes( false )
+            .setStartDate( criteria.getOccurredAfter() ).setEndDate( criteria.getOccurredBefore() )
+            .setDueDateStart( criteria.getScheduledAfter() ).setDueDateEnd( criteria.getScheduledBefore() )
+            .setLastUpdatedStartDate( criteria.getUpdatedAfter() )
+            .setLastUpdatedEndDate( criteria.getUpdatedBefore() )
+            .setLastUpdatedDuration( criteria.getUpdatedWithin() )
+            .setEnrollmentEnrolledBefore( criteria.getEnrollmentEnrolledBefore() )
+            .setEnrollmentEnrolledAfter( criteria.getEnrollmentEnrolledAfter() )
+            .setEnrollmentOccurredBefore( criteria.getEnrollmentOccurredBefore() )
+            .setEnrollmentOccurredAfter( criteria.getEnrollmentOccurredAfter() )
+            .setEventStatus( criteria.getStatus() )
+            .setCategoryOptionCombo( attributeOptionCombo ).setIdSchemes( criteria.getIdSchemes() )
+            .setPage( criteria.getPage() )
+            .setPageSize( criteria.getPageSize() ).setTotalPages( criteria.isTotalPages() )
+            .setSkipPaging( criteria.isSkipPaging() )
+            .setSkipEventId( criteria.getSkipEventId() ).setIncludeAttributes( false )
             .setIncludeAllDataElements( false ).addDataElements( dataElements )
             .addFilters( filters ).addFilterAttributes( filterAttributes )
-            .addOrders( getOrderParams( eventCriteria.getOrder() ) )
+            .addOrders( getOrderParams( criteria.getOrder() ) )
             .addGridOrders( dataElementOrderParams )
             .addAttributeOrders( attributeOrderParams )
             .setEvents( eventIds ).setProgramInstances( programInstances )
-            .setIncludeDeleted( eventCriteria.isIncludeDeleted() );
+            .setIncludeDeleted( criteria.isIncludeDeleted() );
     }
 
     private static void validateProgram( String program, Program pr )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -137,12 +138,25 @@ class TrackerEnrollmentCriteriaMapperTest
     }
 
     @Test
+    void testMappingDoesNotFetchOptionalEmptyQueryParametersFromDB()
+    {
+        TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
+
+        mapper.map( criteria );
+
+        verifyNoInteractions( programService );
+        verifyNoInteractions( organisationUnitService );
+        verifyNoInteractions( trackedEntityTypeService );
+        verifyNoInteractions( trackedEntityInstanceService );
+    }
+
+    @Test
     void testMappingOrgUnit()
     {
         TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
         criteria.setOrgUnit( ORG_UNIT_1_UID + ";" + ORG_UNIT_2_UID );
 
-        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+        ProgramInstanceQueryParams params = mapper.map( criteria );
 
         assertContainsOnly( Set.of( orgUnit1, orgUnit2 ), params.getOrganisationUnits() );
     }
@@ -154,7 +168,7 @@ class TrackerEnrollmentCriteriaMapperTest
         criteria.setOrgUnit( "unknown;" + ORG_UNIT_2_UID );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.getFromUrl( criteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Organisation unit does not exist: unknown", exception.getMessage() );
     }
 
@@ -167,7 +181,7 @@ class TrackerEnrollmentCriteriaMapperTest
             user.getTeiSearchOrganisationUnitsWithFallback() ) ).thenReturn( false );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.getFromUrl( criteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Organisation unit is not part of the search scope: " + ORG_UNIT_1_UID, exception.getMessage() );
     }
 
@@ -177,7 +191,7 @@ class TrackerEnrollmentCriteriaMapperTest
         TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
         criteria.setProgram( PROGRAM_UID );
 
-        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+        ProgramInstanceQueryParams params = mapper.map( criteria );
 
         assertEquals( program, params.getProgram() );
     }
@@ -189,7 +203,7 @@ class TrackerEnrollmentCriteriaMapperTest
         criteria.setProgram( "unknown" );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.getFromUrl( criteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Program does not exist: unknown", exception.getMessage() );
     }
 
@@ -199,7 +213,7 @@ class TrackerEnrollmentCriteriaMapperTest
         TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
         criteria.setTrackedEntityType( TRACKED_ENTITY_TYPE_UID );
 
-        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+        ProgramInstanceQueryParams params = mapper.map( criteria );
 
         assertEquals( trackedEntityType, params.getTrackedEntityType() );
     }
@@ -211,7 +225,7 @@ class TrackerEnrollmentCriteriaMapperTest
         criteria.setTrackedEntityType( "unknown" );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.getFromUrl( criteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Tracked entity does not exist: unknown", exception.getMessage() );
     }
 
@@ -221,7 +235,7 @@ class TrackerEnrollmentCriteriaMapperTest
         TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
         criteria.setTrackedEntity( TRACKED_ENTITY_UID );
 
-        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+        ProgramInstanceQueryParams params = mapper.map( criteria );
 
         assertEquals( TRACKED_ENTITY_UID, params.getTrackedEntityInstanceUid() );
     }
@@ -233,7 +247,7 @@ class TrackerEnrollmentCriteriaMapperTest
         criteria.setTrackedEntity( "unknown" );
 
         Exception exception = assertThrows( IllegalQueryException.class,
-            () -> mapper.getFromUrl( criteria ) );
+            () -> mapper.map( criteria ) );
         assertEquals( "Tracked entity instance does not exist: unknown", exception.getMessage() );
     }
 
@@ -245,7 +259,7 @@ class TrackerEnrollmentCriteriaMapperTest
         OrderCriteria order2 = OrderCriteria.of( "field2", OrderParam.SortDirection.DESC );
         criteria.setOrder( List.of( order1, order2 ) );
 
-        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+        ProgramInstanceQueryParams params = mapper.map( criteria );
 
         assertEquals( List.of(
             new OrderParam( "field1", OrderParam.SortDirection.ASC ),
@@ -257,7 +271,7 @@ class TrackerEnrollmentCriteriaMapperTest
     {
         TrackerEnrollmentCriteria criteria = new TrackerEnrollmentCriteria();
 
-        ProgramInstanceQueryParams params = mapper.getFromUrl( criteria );
+        ProgramInstanceQueryParams params = mapper.map( criteria );
 
         assertIsEmpty( params.getOrder() );
     }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
@@ -103,8 +103,6 @@ class TrackerEnrollmentCriteriaMapperTest
 
     private TrackedEntityType trackedEntityType;
 
-    private TrackedEntityInstance trackedEntityInstance;
-
     @BeforeEach
     void setUp()
     {
@@ -131,7 +129,7 @@ class TrackerEnrollmentCriteriaMapperTest
         when( trackedEntityTypeService.getTrackedEntityType( TRACKED_ENTITY_TYPE_UID ) )
             .thenReturn( trackedEntityType );
 
-        trackedEntityInstance = new TrackedEntityInstance();
+        TrackedEntityInstance trackedEntityInstance = new TrackedEntityInstance();
         trackedEntityInstance.setUid( TRACKED_ENTITY_UID );
         when( trackedEntityInstanceService.getTrackedEntityInstance( TRACKED_ENTITY_UID ) )
             .thenReturn( trackedEntityInstance );
@@ -204,7 +202,7 @@ class TrackerEnrollmentCriteriaMapperTest
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Program does not exist: unknown", exception.getMessage() );
+        assertEquals( "Program is specified but does not exist: unknown", exception.getMessage() );
     }
 
     @Test
@@ -226,7 +224,7 @@ class TrackerEnrollmentCriteriaMapperTest
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Tracked entity does not exist: unknown", exception.getMessage() );
+        assertEquals( "Tracked entity type is specified but does not exist: unknown", exception.getMessage() );
     }
 
     @Test
@@ -248,7 +246,7 @@ class TrackerEnrollmentCriteriaMapperTest
 
         Exception exception = assertThrows( IllegalQueryException.class,
             () -> mapper.map( criteria ) );
-        assertEquals( "Tracked entity instance does not exist: unknown", exception.getMessage() );
+        assertEquals( "Tracked entity instance is specified but does not exist: unknown", exception.getMessage() );
     }
 
     @Test


### PR DESCRIPTION
* name all mapper methods `map`, the parameter `criteria`
* move validation in TrackerEnrollmentCriteriaMapper to the top using the same methods we use in other mappers