### PR TITLE
fix: validation of assigned users in /tracker/events DHIS2-13648 [2.39]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -302,7 +302,8 @@ class TrackerEventCriteriaMapper
     private static void validateAssignedUsers( AssignedUserSelectionMode assignedUserSelectionMode,
         Set<String> assignedUserIds )
     {
-        if ( !assignedUserIds.isEmpty() && AssignedUserSelectionMode.PROVIDED == assignedUserSelectionMode )
+        if ( assignedUserSelectionMode != null && !assignedUserIds.isEmpty()
+            && AssignedUserSelectionMode.PROVIDED != assignedUserSelectionMode )
         {
             throw new IllegalQueryException(
                 "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );


### PR DESCRIPTION
while using == instead of equals we missed the ! (negation). For some reason the mode has no default (so it is null) and are only checking and throwing an exception if it is not null and not PROVIDED

This will be addressed in https://dhis2.atlassian.net/browse/DHIS2-13765 For now keep the logic as it was in

https://github.com/dhis2/dhis2-core/pull/11797/files#diff-3f0399270e47bfe544d4ab0b3fa9d71c4edc117f71b520979957d18f343f5af9L215-L220

```java
        if ( assignedUserSelectionMode != null && assignedUserIds != null && !assignedUserIds.isEmpty()
            && !assignedUserSelectionMode.equals( AssignedUserSelectionMode.PROVIDED ) )
        {
            throw new IllegalQueryException(
                "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
        }
```