### PR TITLE
fix: Trying a fix for IllegalAccessException [DHIS2-13758]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -98,7 +98,9 @@ public class JdbcOwnershipAnalyticsTableManager
     private static final List<AnalyticsTableColumn> FIXED_COLS = List.of(
         new AnalyticsTableColumn( quote( "teiuid" ), CHARACTER_11, "tei.uid" ),
         new AnalyticsTableColumn( quote( "startdate" ), DATE, "o.owndate" ),
-        new AnalyticsTableColumn( quote( "enddate" ), DATE, "null" ),
+        // Repeating the same alias "o.owndate" is not a typo. It might avoid a
+        // bug that may appear in some environments. This column is not read.
+        new AnalyticsTableColumn( quote( "enddate" ), DATE, "o.owndate" ),
         new AnalyticsTableColumn( quote( "ou" ), CHARACTER_11, NOT_NULL, "ou.uid" ) );
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
@@ -257,10 +257,10 @@ class JdbcOwnershipAnalyticsTableManagerTest
         assertEquals( 1, jdbcInvocations.size() );
         assertEquals( "queryForRowSet", jdbcInvocations.get( 0 ).getMethod().getName() );
 
-        String sql = (String) jdbcInvocations.get( 0 ).getArgument( 0 );
+        String sql = jdbcInvocations.get( 0 ).getArgument( 0 );
         String sqlMasked = sql.replaceAll( "lastupdated <= '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}'",
             "lastupdated <= 'yyyy-mm-ddThh:mm:ss'" );
-        assertEquals( "select tei.uid,o.owndate,null,ou.uid from (" +
+        assertEquals( "select tei.uid,o.owndate,o.owndate,ou.uid from (" +
             "select pi.trackedentityinstanceid, pi.enrollmentDate as owndate, pi.organisationunitid " +
             "from programinstance pi " +
             "where pi.programid=0 and pi.trackedentityinstanceid is not null " +
@@ -306,7 +306,7 @@ class JdbcOwnershipAnalyticsTableManagerTest
         List<AnalyticsTableColumn> expected = List.of(
             new AnalyticsTableColumn( quote( "teiuid" ), CHARACTER_11, "tei.uid" ),
             new AnalyticsTableColumn( quote( "startdate" ), DATE, "o.owndate" ),
-            new AnalyticsTableColumn( quote( "enddate" ), DATE, "null" ),
+            new AnalyticsTableColumn( quote( "enddate" ), DATE, "o.owndate" ),
             new AnalyticsTableColumn( quote( "ou" ), CHARACTER_11, NOT_NULL, "ou.uid" ) );
 
         assertEquals( expected, target.getFixedColumns() );


### PR DESCRIPTION
This is another attempt to fix an issue that only manifests in "debug/dev".

This exception does not happen in other environments.

```
SQL state [null]; error code [0]; IllegalAccessException:
com/sun/rowset/providers/RIOptimisticProvider;
nested exception is javax.sql.rowset.spi.SyncFactoryException:
IllegalAccessException: com/sun/rowset/providers/RIOptimisticProvider
```