### PR TITLE
fix: AttributeOptionCombo fixes for audit service

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueAuditService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueAuditService.java
@@ -39,6 +39,7 @@ import org.hisp.dhis.common.AuditType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.util.ObjectUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -120,11 +121,14 @@ public class DefaultDataValueAuditService
         List<DataValueAudit> dataValueAudits = new ArrayList<>();
         List<DataValueAudit> audits = new ArrayList<>();
 
-        CategoryOptionCombo defaultCoc = categoryOptionComboStore
-            .getByName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME );
+        CategoryOptionCombo coc = ObjectUtils.firstNonNull( categoryOptionCombo, categoryOptionComboStore
+            .getByName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME ) );
+
+        CategoryOptionCombo aoc = ObjectUtils.firstNonNull( attributeOptionCombo, categoryOptionComboStore
+            .getByName( CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME ) );
 
         DataValue dataValue = dataValueStore.getDataValue( dataElement, period, organisationUnit,
-            categoryOptionCombo, defaultCoc );
+            coc, aoc );
 
         // if for whatever reason the DV is null, we just return a empty list
         if ( dataValue == null )
@@ -142,8 +146,8 @@ public class DefaultDataValueAuditService
             .setDataElements( List.of( dataElement ) )
             .setPeriods( List.of( period ) )
             .setOrgUnits( List.of( organisationUnit ) )
-            .setCategoryOptionCombo( categoryOptionCombo )
-            .setAttributeOptionCombo( attributeOptionCombo );
+            .setCategoryOptionCombo( coc )
+            .setAttributeOptionCombo( aoc );
 
         dataValueAudits.addAll( dataValueAuditStore.getDataValueAudits( params ) );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/datavalue/DefaultDataValueService.java
@@ -146,6 +146,14 @@ public class DefaultDataValueService
             softDelete.setDeleted( false );
 
             dataValueStore.updateDataValue( softDelete );
+
+            if ( config.isEnabled( CHANGELOG_AGGREGATE ) )
+            {
+                DataValueAudit dataValueAudit = new DataValueAudit( dataValue, dataValue.getAuditValue(),
+                    dataValue.getStoredBy(), AuditType.CREATE );
+
+                dataValueAuditService.addDataValueAudit( dataValueAudit );
+            }
         }
         else
         {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueAuditServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/datavalue/DataValueAuditServiceTest.java
@@ -247,4 +247,118 @@ class DataValueAuditServiceTest extends SingleSetupIntegrationTestBase
 
         assertEquals( 0, dataValueAuditService.getDataValueAudits( params ).size() );
     }
+
+    @Test
+    void testGetDataValueAuditWithFakeCreate()
+    {
+        DataValueAuditQueryParams params = new DataValueAuditQueryParams()
+            .setDataElements( List.of( dataElementA ) )
+            .setPeriods( List.of( periodD ) )
+            .setOrgUnits( List.of( orgUnitA ) )
+            .setCategoryOptionCombo( optionCombo )
+            .setAuditTypes( List.of( AuditType.UPDATE ) );
+
+        assertEquals( 0, dataValueAuditService.getDataValueAudits( params ).size() );
+
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
+            dataElementA, periodA, orgUnitA, optionCombo, optionCombo );
+
+        assertEquals( 1, audits.size() );
+        assertEquals( AuditType.CREATE, audits.get( 0 ).getAuditType() );
+    }
+
+    @Test
+    void testGetDataValueAuditWithFakeCreate2()
+    {
+        dataValueA.setValue( "10" );
+        dataValueService.updateDataValue( dataValueA );
+
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
+            dataElementA, periodA, orgUnitA, optionCombo, optionCombo );
+
+        assertEquals( 2, audits.size() );
+        assertEquals( AuditType.UPDATE, audits.get( 0 ).getAuditType() );
+        assertEquals( AuditType.CREATE, audits.get( 1 ).getAuditType() );
+    }
+
+    @Test
+    void testGetDataValueAuditWithFakeCreateDeleteAndCreate()
+    {
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValueA, "10",
+            dataValueA.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValueA, "20",
+            dataValueA.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValueA, "30",
+            dataValueA.getStoredBy(), AuditType.UPDATE ) );
+
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
+            dataElementA, periodA, orgUnitA, optionCombo, optionCombo );
+
+        assertEquals( 4, audits.size() );
+        assertEquals( AuditType.CREATE, audits.get( 3 ).getAuditType() );
+        assertEquals( AuditType.UPDATE, audits.get( 2 ).getAuditType() );
+        assertEquals( AuditType.UPDATE, audits.get( 1 ).getAuditType() );
+        assertEquals( AuditType.UPDATE, audits.get( 0 ).getAuditType() );
+    }
+
+    @Test
+    void testGetDataValueAuditWithFakeCreateDelete2()
+    {
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValueA, "10",
+            dataValueA.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValueA, "20",
+            dataValueA.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValueA, "30",
+            dataValueA.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueService.deleteDataValue( dataValueA );
+
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
+            dataElementA, periodA, orgUnitA, optionCombo, optionCombo );
+
+        assertContainsOnly( List.of(), audits );
+    }
+
+    @Test
+    void testGetDataValueAuditWithFakeCreateDeleteAndUndelete()
+    {
+        DataElement dataElement = createDataElement( 'F' );
+        DataValue dataValue = createDataValue( dataElement, periodA, orgUnitA, optionCombo, optionCombo, "1" );
+
+        dataElementService.addDataElement( dataElement );
+        dataValueService.addDataValue( dataValue );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValue, "10",
+            dataValue.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValue, "20",
+            dataValue.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueAuditService.addDataValueAudit( new DataValueAudit( dataValue, "30",
+            dataValue.getStoredBy(), AuditType.UPDATE ) );
+
+        dataValueService.deleteDataValue( dataValue );
+
+        List<DataValueAudit> audits = dataValueAuditService.getDataValueAudits(
+            dataElement, periodA, orgUnitA, optionCombo, optionCombo );
+
+        assertContainsOnly( List.of(), audits );
+
+        dataValueService.addDataValue( dataValue );
+
+        audits = dataValueAuditService.getDataValueAudits(
+            dataElement, periodA, orgUnitA, optionCombo, optionCombo );
+
+        assertEquals( 6, audits.size() );
+        assertEquals( AuditType.UPDATE, audits.get( 0 ).getAuditType() );
+        assertEquals( AuditType.CREATE, audits.get( 1 ).getAuditType() );
+        assertEquals( AuditType.DELETE, audits.get( 2 ).getAuditType() );
+        assertEquals( AuditType.UPDATE, audits.get( 3 ).getAuditType() );
+        assertEquals( AuditType.UPDATE, audits.get( 4 ).getAuditType() );
+        assertEquals( AuditType.CREATE, audits.get( 5 ).getAuditType() );
+    }
 }


### PR DESCRIPTION
## Summary

Adds more tests to `DataValueAuditService` with a focus on the new `getDataValueAudits` that returns including the current data value as audit (even if there are no audits)

Also fixes

- [x] `AttributeOptionCombo` default bug, will fall back to default if none given
- [x] `CategoryOptionCombo` default bug, will fall back to default if none given
- [x] Add `CREATE` audit for undeleted data values
