### PR TITLE
fix: allow mutation of query item collections TECH-1414

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/RequestParamUtils.java
@@ -87,7 +87,7 @@ class RequestParamUtils
     {
         return parseUidString( input )
             .filter( CodeGenerator::isValidUid )
-            .collect( Collectors.toUnmodifiableSet() );
+            .collect( Collectors.toSet() );
     }
 
     /**
@@ -99,7 +99,7 @@ class RequestParamUtils
     static Set<String> parseUids( String input )
     {
         return parseUidString( input )
-            .collect( Collectors.toUnmodifiableSet() );
+            .collect( Collectors.toSet() );
     }
 
     private static Stream<String> parseUidString( String input )
@@ -126,7 +126,7 @@ class RequestParamUtils
     {
         return items.stream()
             .map( i -> parseAttributeQueryItem( i, attributes ) )
-            .collect( Collectors.toUnmodifiableList() );
+            .collect( Collectors.toList() );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -311,7 +311,7 @@ class TrackerEventCriteriaMapper
         List<QueryItem> filterItems = parseAttributeQueryItems( filterAttributes, attributes );
         List<QueryItem> orderItems = attributeQueryItemsFromOrder( filterItems, attributes, attributeOrderParams );
 
-        return Stream.concat( filterItems.stream(), orderItems.stream() ).collect( Collectors.toUnmodifiableList() );
+        return Stream.concat( filterItems.stream(), orderItems.stream() ).collect( Collectors.toList() );
     }
 
     private List<QueryItem> attributeQueryItemsFromOrder( List<QueryItem> filterAttributes,
@@ -322,7 +322,7 @@ class TrackerEventCriteriaMapper
             .filter( att -> !containsAttributeFilter( filterAttributes, att ) )
             .map( attributes::get )
             .map( at -> new QueryItem( at, null, at.getValueType(), at.getAggregationType(), at.getOptionSet() ) )
-            .collect( Collectors.toUnmodifiableList() );
+            .collect( Collectors.toList() );
     }
 
     private boolean containsAttributeFilter( List<QueryItem> attributeFilters, String attributeUid )


### PR DESCRIPTION
We cannot yet fully deal with immutable collections all the way to the DB fetching code. Service/repo code is mutating the structures that represent the users request. Go back to mutable collections (at least for now). If we manage to move this responsibility into only the criteria mappers we might be able to make the param structures immutable.