### PR TITLE
chore: make detecting junit 4 ignore easier

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -787,6 +787,7 @@
                     https://github.com/testcontainers/testcontainers-java/issues/970</reason>
                   <bannedImports>
                     <bannedImport>org.junit.Test</bannedImport>
+                    <bannedImport>org.junit.Ignore</bannedImport>
                     <bannedImport>org.junit.Assert.**</bannedImport>
                   </bannedImports>
                 </RestrictImports>


### PR DESCRIPTION
since we cannot yet remove/ban JUnit 4 due to testcontainers still relying on it, all we can do is ban JUnit 4 imports. This will print out the reason and lead devs to the solution.