### PR TITLE
fix: check for empty objectUids

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -58,7 +58,7 @@ public class JdbcOrgUnitAssociationsStore
     {
         Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
 
-        if ( userOrgUnitPaths.isEmpty() || objectUids.isEmpty() )
+        if ( userOrgUnitPaths.isEmpty() )
         {
             return new HashSetValuedHashMap<>();
         }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -58,6 +58,11 @@ public class JdbcOrgUnitAssociationsStore
     {
         Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
 
+        if ( userOrgUnitPaths.isEmpty() || objectUids.isEmpty() )
+        {
+            return new HashSetValuedHashMap<>();
+        }
+
         return jdbcTemplate.query(
             queryBuilder.buildSqlQuery( objectUids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
             resultSet -> {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -54,17 +54,17 @@ public class JdbcOrgUnitAssociationsStore
 
     private final Cache<Set<String>> orgUnitAssociationCache;
 
-    public SetValuedMap<String, String> getOrganisationUnitsAssociationsForCurrentUser( Set<String> objectUids )
+    public SetValuedMap<String, String> getOrganisationUnitsAssociationsForCurrentUser( Set<String> uids )
     {
-        Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
-
-        if ( objectUids.isEmpty() )
+        if ( uids.isEmpty() )
         {
             return new HashSetValuedHashMap<>();
         }
 
+        Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
+
         return jdbcTemplate.query(
-            queryBuilder.buildSqlQuery( objectUids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
+            queryBuilder.buildSqlQuery( uids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
             resultSet -> {
                 SetValuedMap<String, String> setValuedMap = new HashSetValuedHashMap<>();
                 while ( resultSet.next() )
@@ -80,6 +80,11 @@ public class JdbcOrgUnitAssociationsStore
 
     public SetValuedMap<String, String> getOrganisationUnitsAssociations( Set<String> uids )
     {
+        if ( uids.isEmpty() )
+        {
+            return new HashSetValuedHashMap<>();
+        }
+
         SetValuedMap<String, String> setValuedMap = new HashSetValuedHashMap<>();
 
         boolean cached = true;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -58,11 +58,6 @@ public class JdbcOrgUnitAssociationsStore
     {
         Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
 
-        if ( userOrgUnitPaths.isEmpty() )
-        {
-            return new HashSetValuedHashMap<>();
-        }
-
         return jdbcTemplate.query(
             queryBuilder.buildSqlQuery( objectUids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
             resultSet -> {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -58,6 +58,11 @@ public class JdbcOrgUnitAssociationsStore
     {
         Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
 
+        if ( objectUids.isEmpty() )
+        {
+            return new HashSetValuedHashMap<>();
+        }
+
         return jdbcTemplate.query(
             queryBuilder.buildSqlQuery( objectUids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
             resultSet -> {


### PR DESCRIPTION
## Summary

Checks for empty object collection before running SQL query. Needed so that we don't do invalid `in (...)` queries.

[TECH-1437](https://dhis2.atlassian.net/browse/TECH-1437)