### PR TITLE
fix: Ensure filter valueType is applied in event query [DHIS2-13676] (2.39.0) - RCB APPROVED

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.events.event;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.hisp.dhis.common.ValueType.NUMERIC_TYPES;
 import static org.hisp.dhis.commons.util.TextUtils.splitToSet;
 import static org.hisp.dhis.dxf2.events.event.AbstractEventService.STATIC_EVENT_COLUMNS;
 import static org.hisp.dhis.dxf2.events.event.EventSearchParams.EVENT_ATTRIBUTE_OPTION_COMBO_ID;
@@ -130,6 +131,7 @@ import org.hisp.dhis.program.ProgramType;
 import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.query.JpaQueryUtils;
 import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.system.util.SqlUtils;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
@@ -200,6 +202,8 @@ public class JdbcEventStore implements EventStore
     private static final String SPACE = " ";
 
     private static final String EQUALS = " = ";
+
+    private static final String AND = " AND ";
 
     private static final Map<String, String> QUERY_PARAM_COL_MAP = ImmutableMap.<String, String> builder()
         .put( EVENT_ID, "psi_uid" )
@@ -1010,24 +1014,67 @@ public class JdbcEventStore implements EventStore
                 .append( teaValueCol + ".trackedentityattributeid" )
                 .append( EQUALS )
                 .append( teaCol + ".trackedentityattributeid" )
-                .append( " AND " )
+                .append( AND )
                 .append( teaCol + ".UID" )
                 .append( EQUALS )
                 .append( statementBuilder.encode( queryItem.getItem().getUid(), true ) );
 
+            attributes.append( getAttributeFilterQuery( queryItem, teaCol, teaValueCol ) );
+        }
+    }
+
+    private String getAttributeFilterQuery( QueryItem queryItem, String teaCol, String teaValueCol )
+    {
+        StringBuilder query = new StringBuilder();
+
+        if ( !queryItem.getFilters().isEmpty() )
+        {
+            query.append( AND );
+
+            // In SQL the order of expressions linked by AND is not
+            // guaranteed.
+            // So when casting to number we need to be sure that the value
+            // to cast is really a number.
+            if ( queryItem.isNumeric() )
+            {
+                query
+                    .append( " CASE WHEN " )
+                    .append( lower( teaCol + ".valueType" ) )
+                    .append( " in (" )
+                    .append( NUMERIC_TYPES.stream()
+                        .map( Enum::name )
+                        .map( StringUtils::lowerCase )
+                        .map( SqlUtils::singleQuote )
+                        .collect( Collectors.joining( "," ) ) )
+                    .append( ")" )
+                    .append( " THEN " );
+            }
+
+            List<String> filterStrings = new ArrayList<>();
             for ( QueryFilter filter : queryItem.getFilters() )
             {
-                String encodedFilter = statementBuilder.encode( filter.getFilter(), false );
-                attributes
-                    .append( " AND " )
-                    .append( "lower(" + teaValueCol + ".value)" )
+                StringBuilder filterString = new StringBuilder();
+                final String queryCol = queryItem.isNumeric() ? castToNumber( teaValueCol + ".value" )
+                    : lower( teaValueCol + ".value" );
+                final Object encodedFilter = queryItem.isNumeric() ? Double.valueOf( filter.getFilter() )
+                    : StringUtils.lowerCase( filter.getSqlFilter( filter.getFilter() ) );
+                filterString
+                    .append( queryCol )
                     .append( SPACE )
                     .append( filter.getSqlOperator() )
                     .append( SPACE )
-                    .append( StringUtils
-                        .lowerCase( filter.getSqlFilter( encodedFilter ) ) );
+                    .append( encodedFilter );
+                filterStrings.add( filterString.toString() );
+            }
+            query.append( String.join( AND, filterStrings ) );
+
+            if ( queryItem.isNumeric() )
+            {
+                query.append( " END " );
             }
         }
+
+        return query.toString();
     }
 
     private String getEventSelectQuery( EventSearchParams params, MapSqlParameterSource mapSqlParameterSource,
@@ -1408,9 +1455,11 @@ public class JdbcEventStore implements EventStore
             {
                 for ( QueryFilter filter : item.getFilters() )
                 {
-                    final String queryCol = " lower( " + dataValueValueSql + " )";
+                    final String queryCol = item.isNumeric() ? castToNumber( dataValueValueSql )
+                        : lower( dataValueValueSql );
 
                     String bindParameter = "parameter_" + filterCount;
+                    int itemType = item.isNumeric() ? Types.NUMERIC : Types.VARCHAR;
 
                     if ( !item.hasOptionSet() )
                     {
@@ -1420,14 +1469,14 @@ public class JdbcEventStore implements EventStore
                             .equalsIgnoreCase( filter.getSqlOperator() ) )
                         {
                             mapSqlParameterSource.addValue( bindParameter,
-                                QueryFilter.getFilterItems( StringUtils.lowerCase( filter.getFilter() ) ) );
+                                QueryFilter.getFilterItems( StringUtils.lowerCase( filter.getFilter() ) ), itemType );
 
                             eventDataValuesWhereSql.append( inCondition( filter, bindParameter, queryCol ) );
                         }
                         else
                         {
                             mapSqlParameterSource.addValue( bindParameter,
-                                StringUtils.lowerCase( filter.getSqlBindFilter() ) );
+                                StringUtils.lowerCase( filter.getSqlBindFilter() ), itemType );
 
                             eventDataValuesWhereSql.append( " " )
                                 .append( queryCol )
@@ -1445,7 +1494,7 @@ public class JdbcEventStore implements EventStore
                             .equalsIgnoreCase( filter.getSqlOperator() ) )
                         {
                             mapSqlParameterSource.addValue( bindParameter,
-                                QueryFilter.getFilterItems( StringUtils.lowerCase( filter.getFilter() ) ) );
+                                QueryFilter.getFilterItems( StringUtils.lowerCase( filter.getFilter() ) ), itemType );
 
                             optionValueConditionBuilder.append( " and " );
                             optionValueConditionBuilder.append( inCondition( filter, bindParameter, queryCol ) );
@@ -1453,7 +1502,7 @@ public class JdbcEventStore implements EventStore
                         else
                         {
                             mapSqlParameterSource.addValue( bindParameter,
-                                StringUtils.lowerCase( filter.getSqlBindFilter() ) );
+                                StringUtils.lowerCase( filter.getSqlBindFilter() ), itemType );
 
                             optionValueConditionBuilder.append( "and lower(" )
                                 .append( optValueTableAs )
@@ -1477,7 +1526,8 @@ public class JdbcEventStore implements EventStore
 
     private String inCondition( QueryFilter filter, String boundParameter, String queryCol )
     {
-        return new StringBuilder().append( queryCol )
+        return new StringBuilder().append( " " )
+            .append( queryCol )
             .append( " " )
             .append( filter.getSqlOperator() )
             .append( " " )

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/event_and_enrollment.json
@@ -63,6 +63,14 @@
             "identifier": "toUpdate000"
           },
           "value": "summer day"
+        },
+        {
+          "valueType": "INTEGER",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "numericAttr"
+          },
+          "value": 88
         }
       ],
       "enrollments": []
@@ -107,6 +115,14 @@
             "identifier": "notUpdated0"
           },
           "value": "winter day"
+        },
+        {
+          "valueType": "INTEGER",
+          "attribute": {
+            "idScheme": "UID",
+            "identifier": "numericAttr"
+          },
+          "value": 70
         }
       ],
       "enrollments": []
@@ -219,6 +235,17 @@
           "storedBy": null,
           "lastUpdated": "2022-07-01T12:05:00",
           "providedElsewhere": false
+        },
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00006"
+          },
+          "value": "88",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
         }
       ],
       "notes": []
@@ -290,6 +317,17 @@
             "identifier": "DATAEL00005"
           },
           "value": "option2",
+          "created": "2021-07-01T12:05:00",
+          "storedBy": null,
+          "lastUpdated": "2022-07-01T12:05:00",
+          "providedElsewhere": false
+        },
+        {
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00006"
+          },
+          "value": "70",
           "created": "2021-07-01T12:05:00",
           "storedBy": null,
           "lastUpdated": "2022-07-01T12:05:00",

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/simple_metadata.json
@@ -215,6 +215,33 @@
       "userAccesses": [],
       "legendSets": [],
       "aggregationLevels": []
+    },
+    {
+      "lastUpdated": "2020-05-31T11:41:22.404",
+      "id": "DATAEL00006",
+      "created": "2020-05-31T08:58:48.406",
+      "name": "test-dataelement6",
+      "shortName": "test-dataelement6",
+      "aggregationType": "NONE",
+      "domainType": "TRACKER",
+      "publicAccess": "rw------",
+      "valueType": "INTEGER",
+      "zeroIsSignificant": false,
+      "categoryCombo": {
+        "id": "bjDvmb4bfuf"
+      },
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": [],
+      "aggregationLevels": []
     }
   ],
   "options": [
@@ -503,6 +530,39 @@
           },
           "dataElement": {
             "id": "DATAEL00005"
+          },
+          "favorites": [],
+          "translations": [],
+          "userGroupAccesses": [],
+          "attributeValues": [],
+          "userAccesses": []
+        },
+        {
+          "lastUpdated": "2019-01-28T11:23:20.855",
+          "id": "PSDE0000006",
+          "created": "2019-01-28T11:23:20.855",
+          "displayInReports": false,
+          "skipSynchronization": false,
+          "externalAccess": false,
+          "renderOptionsAsRadio": false,
+          "allowFutureDate": false,
+          "compulsory": false,
+          "allowProvidedElsewhere": false,
+          "sortOrder": 1,
+          "favorite": false,
+          "access": {
+            "read": true,
+            "update": true,
+            "externalize": true,
+            "delete": true,
+            "write": true,
+            "manage": true
+          },
+          "programStage": {
+            "id": "NpsdDv6kKSO"
+          },
+          "dataElement": {
+            "id": "DATAEL00006"
           },
           "favorites": [],
           "translations": [],
@@ -860,6 +920,37 @@
     }
   ],
   "trackedEntityAttributes": [
+    {
+      "lastUpdated": "2020-05-31T11:41:22.414",
+      "id": "numericAttr",
+      "created": "2020-05-31T09:00:51.347",
+      "name": "numeric-attribute",
+      "shortName": "numeric-attribute",
+      "aggregationType": "NONE",
+      "displayInListNoProgram": false,
+      "publicAccess": "rw------",
+      "pattern": "",
+      "skipSynchronization": false,
+      "generated": false,
+      "displayOnVisitSchedule": false,
+      "valueType": "INTEGER",
+      "formName": "numeric-attribute",
+      "orgunitScope": false,
+      "confidential": false,
+      "unique": false,
+      "inherit": false,
+      "lastUpdatedBy": {
+        "id": "M5zQapPyTZI"
+      },
+      "user": {
+        "id": "M5zQapPyTZI"
+      },
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userAccesses": [],
+      "legendSets": []
+    },
     {
       "lastUpdated": "2020-05-31T11:41:22.414",
       "id": "toUpdate000",


### PR DESCRIPTION
* fix: Ensure filter valueType is applied in event query

* chore: Code style

* test: Fix integration test failure

* fix: Add tests and fix numeric attribute filter [DHIS2-13676]

* fix: Make filter attribute query to not rely on order of expression in the join

* Fix sonar code smells

* Fix sonar code smells

Co-authored-by: Enrico Colasante <enrico@dhis2.org>