### PR TITLE
feat: Program Attributes are now all presents with programUid prefix [DHIS2-13814]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EnrollmentAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EnrollmentAnalyticsDimensionsService.java
@@ -33,7 +33,7 @@ import org.hisp.dhis.common.PrefixedDimension;
 
 public interface EnrollmentAnalyticsDimensionsService
 {
-    List<PrefixedDimension> getQueryDimensionsByProgramStageId( String programId );
+    List<PrefixedDimension> getQueryDimensionsByProgramId( String programId );
 
     List<PrefixedDimension> getAggregateDimensionsByProgramStageId( String programId );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEnrollmentAnalyticsDimensionsService.java
@@ -57,7 +57,7 @@ public class DefaultEnrollmentAnalyticsDimensionsService implements EnrollmentAn
     private final ProgramService programService;
 
     @Override
-    public List<PrefixedDimension> getQueryDimensionsByProgramStageId( String programId )
+    public List<PrefixedDimension> getQueryDimensionsByProgramId( String programId )
     {
         return Optional.of( programId )
             .map( programService::getProgram )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsService.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.analytics.tei;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.hisp.dhis.common.PrefixedDimension;
@@ -39,5 +40,6 @@ public interface TeiAnalyticsDimensionsService
      * @param trackedEntityTypeId the uid of a tracked entity type
      * @return list of dimensions
      */
-    List<PrefixedDimension> getQueryDimensionsByTrackedEntityTypeId( String trackedEntityTypeId );
+    List<PrefixedDimension> getQueryDimensionsByTrackedEntityTypeId( String trackedEntityTypeId,
+        Collection<String> programUids );
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsDimensionsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsDimensionsServiceTest.java
@@ -73,7 +73,7 @@ class EnrollmentAnalyticsDimensionsServiceTest
     void testQueryDoesntContainDisallowedValueTypes()
     {
         Collection<BaseIdentifiableObject> analyticsDimensions = enrollmentAnalyticsDimensionsService
-            .getQueryDimensionsByProgramStageId( "anUid" ).stream()
+            .getQueryDimensionsByProgramId( "anUid" ).stream()
             .map( PrefixedDimension::getItem )
             .collect( Collectors.toList() );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/tei/TeiAnalyticsDimensionsServiceTest.java
@@ -81,7 +81,7 @@ class TeiAnalyticsDimensionsServiceTest
     void testQueryDoesNotContainDisallowedValueTypes()
     {
         Collection<BaseIdentifiableObject> analyticsDimensions = teiAnalyticsDimensionsService
-            .getQueryDimensionsByTrackedEntityTypeId( "aTeiId" ).stream()
+            .getQueryDimensionsByTrackedEntityTypeId( "aTeiId", Collections.emptyList() ).stream()
             .map( PrefixedDimension::getItem )
             .collect( Collectors.toList() );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
 
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
@@ -138,13 +139,13 @@ public class EnrollmentAnalyticsController
         return analyticsService.getEnrollments( params );
     }
 
+    @SneakyThrows
     @GetMapping( "/query/{program}.xml" )
     public void getQueryXml(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
         HttpServletResponse response )
-        throws Exception
     {
         EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
 
@@ -154,13 +155,13 @@ public class EnrollmentAnalyticsController
         GridUtils.toXml( grid, response.getOutputStream() );
     }
 
+    @SneakyThrows
     @GetMapping( "/query/{program}.xls" )
     public void getQueryXls(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
         HttpServletResponse response )
-        throws Exception
     {
         EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
 
@@ -170,13 +171,13 @@ public class EnrollmentAnalyticsController
         GridUtils.toXls( grid, response.getOutputStream() );
     }
 
+    @SneakyThrows
     @GetMapping( "/query/{program}.csv" )
     public void getQueryCsv(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
         HttpServletResponse response )
-        throws Exception
     {
         EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
 
@@ -186,13 +187,13 @@ public class EnrollmentAnalyticsController
         GridUtils.toCsv( grid, response.getWriter() );
     }
 
+    @SneakyThrows
     @GetMapping( "/query/{program}.html" )
     public void getQueryHtml(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
         HttpServletResponse response )
-        throws Exception
     {
         EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
 
@@ -202,13 +203,13 @@ public class EnrollmentAnalyticsController
         GridUtils.toHtml( grid, response.getWriter() );
     }
 
+    @SneakyThrows
     @GetMapping( "/query/{program}.html+css" )
     public void getQueryHtmlCss(
         @PathVariable String program,
         EnrollmentAnalyticsQueryCriteria criteria,
         DhisApiVersion apiVersion,
         HttpServletResponse response )
-        throws Exception
     {
         EventQueryParams params = getEventQueryParams( program, criteria, apiVersion, false );
 
@@ -231,7 +232,7 @@ public class EnrollmentAnalyticsController
         return dimensionFilteringAndPagingService
             .pageAndFilter(
                 dimensionMapperService.toDimensionResponse(
-                    enrollmentAnalyticsDimensionsService.getQueryDimensionsByProgramStageId( programId ),
+                    enrollmentAnalyticsDimensionsService.getQueryDimensionsByProgramId( programId ),
                     EnrollmentAnalyticsPrefixStrategy.INSTANCE ),
                 dimensionsCriteria,
                 fields );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tei/TeiQueryController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tei/TeiQueryController.java
@@ -37,6 +37,7 @@ import javax.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.hisp.dhis.analytics.common.CommonQueryRequest;
 import org.hisp.dhis.analytics.common.QueryRequest;
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
@@ -64,7 +65,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 /**
  * Controller class responsible exclusively for querying operations on top of
  * tracker entity instances objects.
- *
  * Methods in this controller should not change any state.
  */
 @RestController
@@ -136,6 +136,7 @@ class TeiQueryController
     @GetMapping( "/query/dimensions" )
     public AnalyticsDimensionsPagingWrapper<ObjectNode> getQueryDimensions(
         @RequestParam String trackedEntityType,
+        @RequestParam( required = false ) List<String> program,
         @RequestParam( defaultValue = "*" ) List<String> fields,
         DimensionsCriteria dimensionsCriteria,
         HttpServletResponse response )
@@ -144,7 +145,8 @@ class TeiQueryController
         return dimensionFilteringAndPagingService
             .pageAndFilter(
                 dimensionMapperService.toDimensionResponse(
-                    teiAnalyticsDimensionsService.getQueryDimensionsByTrackedEntityTypeId( trackedEntityType ),
+                    teiAnalyticsDimensionsService.getQueryDimensionsByTrackedEntityTypeId( trackedEntityType,
+                        CollectionUtils.emptyIfNull( program ) ),
                     TeiAnalyticsPrefixStrategy.INSTANCE ),
                 dimensionsCriteria,
                 fields );


### PR DESCRIPTION
Before this was implemented, CPL query dimension endpoint was returning
- Tracked Entity Attributes as single-level UID identifier
- Program Attribute as UID prefixed with programUid (but removing all tracked entity attribute already present in the above line).

Now we only return PA prefixed with programUid.

I also added an optional program parameter in the endpoint