### PR TITLE
fix: check for empty objectUids (#11891)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/association/jdbc/JdbcOrgUnitAssociationsStore.java
@@ -54,12 +54,17 @@ public class JdbcOrgUnitAssociationsStore
 
     private final Cache<Set<String>> orgUnitAssociationCache;
 
-    public SetValuedMap<String, String> getOrganisationUnitsAssociationsForCurrentUser( Set<String> objectUids )
+    public SetValuedMap<String, String> getOrganisationUnitsAssociationsForCurrentUser( Set<String> uids )
     {
+        if ( uids.isEmpty() )
+        {
+            return new HashSetValuedHashMap<>();
+        }
+
         Set<String> userOrgUnitPaths = getUserOrgUnitPaths();
 
         return jdbcTemplate.query(
-            queryBuilder.buildSqlQuery( objectUids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
+            queryBuilder.buildSqlQuery( uids, userOrgUnitPaths, currentUserService.getCurrentUser() ),
             resultSet -> {
                 SetValuedMap<String, String> setValuedMap = new HashSetValuedHashMap<>();
                 while ( resultSet.next() )
@@ -75,6 +80,11 @@ public class JdbcOrgUnitAssociationsStore
 
     public SetValuedMap<String, String> getOrganisationUnitsAssociations( Set<String> uids )
     {
+        if ( uids.isEmpty() )
+        {
+            return new HashSetValuedHashMap<>();
+        }
+
         SetValuedMap<String, String> setValuedMap = new HashSetValuedHashMap<>();
 
         boolean cached = true;


### PR DESCRIPTION
## Summary

Checks for empty object collection before running SQL query. Needed so that we don't do invalid `in (...)` queries.

[TECH-1437](https://dhis2.atlassian.net/browse/TECH-1437)