### PR TITLE
fix: Force ForkJoinPool in JobProgress DHIS2-13758

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -484,8 +484,6 @@ public interface JobProgress
             runStage( items, description, work );
             return;
         }
-        int cores = Runtime.getRuntime().availableProcessors();
-        boolean useCustomPool = parallelism >= cores;
         AtomicInteger success = new AtomicInteger();
         AtomicInteger failed = new AtomicInteger();
 
@@ -510,7 +508,7 @@ public interface JobProgress
             }
         } ).reduce( Boolean::logicalAnd ).orElse( false );
 
-        ForkJoinPool pool = useCustomPool ? new ForkJoinPool( parallelism ) : null;
+        ForkJoinPool pool = new ForkJoinPool( parallelism );
         try
         {
             // this might not be obvious but running a parallel stream

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -513,9 +513,7 @@ public interface JobProgress
         {
             // this might not be obvious but running a parallel stream
             // as task in a FJP makes the stream use the pool
-            boolean allSuccessful = pool == null
-                ? task.call()
-                : pool.submit( task ).get();
+            boolean allSuccessful = pool.submit( task ).get();
             if ( allSuccessful )
             {
                 completedStage( null );


### PR DESCRIPTION
See [DHIS2-13758](https://dhis2.atlassian.net/browse/DHIS2-13758). This changes `JobProgress.runStageInrunStageInParallel` to always use `ForkJoinPool`. This gets around problems observed on https://debug.dhis2.org/dev which could possibly exist on other servers as well.

This fix has been tested on https://debug.dhis2.org/dev and it works.