### PR TITLE
fix: Use custom serializer which skips API credentials [DHIS2-13105]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchange.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchange.java
@@ -39,6 +39,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
+/**
+ * Domain entity representing a data exchange between a source instance and
+ * target instance of DHIS 2.
+ *
+ * @author Lars Helge Overland
+ */
 @Getter
 @Setter
 @Accessors( chain = true )

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/dataexchange/aggregate/TargetApiSerializerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/dataexchange/aggregate/TargetApiSerializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataexchange.aggregate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+class TargetApiSerializerTest
+{
+    /**
+     * Asserts that the sensitive {@code accessToken} and {@code password}
+     * properties are not serialized for {@link Api}.
+     */
+    @Test
+    void testSerializeTargetApiWithCustomSerializer()
+        throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer( Api.class, new ApiSerializer() );
+        mapper.registerModule( module );
+
+        Target target = new Target()
+            .setType( TargetType.EXTERNAL )
+            .setApi( new Api()
+                .setUrl( "https://myserver.org" )
+                .setAccessToken( "d2pat_abc123" )
+                .setUsername( "admin" )
+                .setPassword( "district" ) );
+
+        String json = mapper.writeValueAsString( target );
+
+        assertTrue( json.contains( "https://myserver.org" ) );
+        assertTrue( json.contains( "admin" ) );
+        assertFalse( json.contains( "d2pat_abc123" ) );
+        assertFalse( json.contains( "district" ) );
+    }
+
+    /**
+     * Asserts that the sensitive {@code accessToken} and {@code password}
+     * properties are serialized for {@link Api}.
+     */
+    @Test
+    void testSerializeTargetApiWithoutCustomSerializer()
+        throws Exception
+    {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Target target = new Target()
+            .setType( TargetType.EXTERNAL )
+            .setApi( new Api()
+                .setUrl( "https://myserver.org" )
+                .setAccessToken( "d2pat_abc123" )
+                .setUsername( "admin" )
+                .setPassword( "district" ) );
+
+        String json = mapper.writeValueAsString( target );
+
+        assertTrue( json.contains( "https://myserver.org" ) );
+        assertTrue( json.contains( "admin" ) );
+        assertTrue( json.contains( "d2pat_abc123" ) );
+        assertTrue( json.contains( "district" ) );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/jackson/config/JacksonObjectMapperConfig.java
@@ -33,6 +33,8 @@ import java.util.Date;
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.commons.jackson.config.geometry.GeometrySerializer;
 import org.hisp.dhis.commons.jackson.config.geometry.JtsXmlModule;
+import org.hisp.dhis.dataexchange.aggregate.Api;
+import org.hisp.dhis.dataexchange.aggregate.ApiSerializer;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.PrecisionModel;
@@ -149,7 +151,7 @@ public class JacksonObjectMapperConfig
     }
 
     /**
-     * Shared configuration for all Jackson mappers
+     * Provides shared configuration for all Jackson mappers.
      *
      * @param objectMapper an {@see ObjectMapper}
      * @param autoDetectGetters if true, enable `autoDetectGetters`
@@ -163,9 +165,9 @@ public class JacksonObjectMapperConfig
         module.addDeserializer( JsonPointer.class, new JsonPointerStdDeserializer() );
         module.addSerializer( Date.class, new WriteDateStdSerializer() );
         module.addSerializer( JsonPointer.class, new JsonPointerStdSerializer() );
+        module.addSerializer( Api.class, new ApiSerializer() );
 
-        // Registering a custom Instant serializer/deserializer for DTOs using
-        // Instant
+        // Registering a custom Instant serializer/deserializer for DTOs
         JavaTimeModule javaTimeModule = new JavaTimeModule();
         javaTimeModule.addSerializer( Instant.class, new WriteInstantStdSerializer() );
         javaTimeModule.addDeserializer( Instant.class, new ParseInstantStdDeserializer() );

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryType.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/jsonb/type/JsonBinaryType.java
@@ -71,7 +71,7 @@ public class JsonBinaryType implements UserType, ParameterizedType
 {
     public static final ObjectMapper MAPPER = new ObjectMapper();
 
-    public static final TypeReference<Map<String, Object>> MAP_STRING_OBJECT_TYPE_REFERENCE = new TypeReference<Map<String, Object>>()
+    public static final TypeReference<Map<String, Object>> MAP_STRING_OBJECT_TYPE_REFERENCE = new TypeReference<>()
     {
     };
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -1030,7 +1030,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( TargetType.EXTERNAL, aeB.getTarget().getType() );
         assertEquals( "https://play.dhis2.org/2.38.1", aeB.getTarget().getApi().getUrl() );
         assertEquals( "admin", aeB.getTarget().getApi().getUsername() );
-        assertNotNull( aeB.getTarget().getApi().getPassword() );
+        assertNotNull( aeB.getTarget().getApi().getPassword() ); // Encrypted
 
         AggregateDataExchange aeC = manager.get( AggregateDataExchange.class, "VpQ4qVEseyM" );
         assertNotNull( aeC );
@@ -1046,7 +1046,7 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( "VpQ4qVEseyM", aeC.getUid() );
         assertEquals( TargetType.EXTERNAL, aeC.getTarget().getType() );
         assertEquals( "https://play.dhis2.org/2.38.1", aeC.getTarget().getApi().getUrl() );
-        assertNotNull( aeC.getTarget().getApi().getAccessToken() );
+        assertNotNull( aeC.getTarget().getApi().getAccessToken() ); // Encrypted
     }
 
     private MetadataImportParams createParams( ImportStrategy importStrategy,


### PR DESCRIPTION
Introduces a custom Jackson serializer `ApiSerializer` which skips API credentials for aggregate data exchange.

This serializer exists becauseApi is persisted as a JSONB data type which relies on creating a deep copy by writing and reading the class to JSON, in which case the use of `JsonProperty.Access.WRITE_ONLY` at the property level leads to the property value being lost in the copy process.

Registering a custom serializer for the mapper used in the API, but not in JSONB conversion, solves the problem. This is not the ideal solution and a better, more standard solution could be investigated.