### PR TITLE
fix: initialize contextPath before referencing app launchUrl or baseUrl [DHIS2-13837]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AppController.java
@@ -172,7 +172,8 @@ public class AppController
         throws IOException,
         WebMessageException
     {
-        App application = appManager.getApp( app );
+        String contextPath = ContextUtils.getContextPath( request );
+        App application = appManager.getApp( app, contextPath );
 
         // Get page requested
         String pageName = getUrl( request.getPathInfo(), app );
@@ -213,8 +214,6 @@ public class AppController
             if ( application.getActivities() != null && application.getActivities().getDhis() != null
                 && "*".equals( application.getActivities().getDhis().getHref() ) )
             {
-                String contextPath = ContextUtils.getContextPath( request );
-
                 log.debug( String.format( "Manifest context path: '%s'", contextPath ) );
 
                 application.getActivities().getDhis().setHref( contextPath );

--- a/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
+++ b/dhis-2/dhis-web/dhis-web-commons/src/main/java/org/hisp/dhis/servlet/filter/AppOverrideFilter.java
@@ -82,8 +82,6 @@ public class AppOverrideFilter
         HttpServletResponse response )
         throws IOException
     {
-        // Get page requested
-
         log.debug( String.format( "Serving app resource: '%s'", resourcePath ) );
 
         // Handling of 'manifest.webapp'
@@ -146,6 +144,7 @@ public class AppOverrideFilter
         ServletException
     {
         String requestPath = req.getServletPath();
+        String contextPath = ContextUtils.getContextPath( req );
 
         Pattern p = Pattern.compile( APP_PATH_PATTERN );
         Matcher m = p.matcher( requestPath );
@@ -157,7 +156,7 @@ public class AppOverrideFilter
 
             log.debug( "AppOverrideFilter :: Matched for path " + requestPath );
 
-            App app = appManager.getApp( appName );
+            App app = appManager.getApp( appName, contextPath );
 
             if ( app != null && app.getAppState() != AppStatus.DELETION_IN_PROGRESS )
             {


### PR DESCRIPTION
Fixes [DHIS2-13837](https://dhis2.atlassian.net/browse/DHIS2-13837) (`/<app>/index.action` -> `/<app>/index.html`)
Fixes [DHIS2-13836](https://dhis2.atlassian.net/browse/DHIS2-13836) (`/api/apps/<app>` -> `/dhis-web-<app>` for bundled overrides)

The way AppManager.java and App.java currently work is error-prone, as the App object is not guaranteed to have been initialized with `.init( contextPath )`.  Fixing this would require a larger refactor, but I'm keeping this change small to address the specific issues for 2.38.2 and 2.39.0.  Refactor issue [TECH-1450](https://dhis2.atlassian.net/browse/TECH-1450)

This will need to be backported to 2.39.0, 2.39, 2.38, 2.37, and earlier