### PR TITLE
ci: Check Jenkins build log for failures before sending Slack notification [skip ci] [2.36]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -42,11 +42,13 @@ pipeline {
 
                 failure {
                     script {
-                        slack.sendMessage(
-                            '#ff0000',
-                            slack.buildUrl() + "\nLatest test run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
-                            'team-backend'
-                        )
+                        if (buildLog.getLines().contains('There are test failures')) {
+                            slack.sendMessage(
+                                '#ff0000',
+                                slack.buildUrl() + "\nLatest test run on ${GIT_BRANCH} failed and needs investigation. :detective-duck:\nCommit: <${GIT_URL}/commit/${GIT_COMMIT}|${GIT_COMMIT}>",
+                                'team-backend'
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Backport of https://github.com/dhis2/dhis2-core/pull/11798