### PR TITLE
fix: Check if value is numeric before parsing as double [DHIS2-13842]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -38,6 +38,7 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.rules.models.RuleActionAssign;
 import org.hisp.dhis.setting.SettingKey;
 import org.hisp.dhis.setting.SystemSettingManager;
+import org.hisp.dhis.system.util.MathUtils;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Attribute;
@@ -167,7 +168,7 @@ public class AssignValueImplementer
             .findAny();
         if ( optionalDataValue.isPresent() )
         {
-            return areEquals( dataValue, optionalDataValue.get().getValue(), dataElement.getValueType() );
+            return isEqual( dataValue, optionalDataValue.get().getValue(), dataElement.getValueType() );
         }
 
         return false;
@@ -182,22 +183,31 @@ public class AssignValueImplementer
             .findAny();
         if ( optionalAttribute.isPresent() )
         {
-            return areEquals( value, optionalAttribute.get().getValue(), attribute.getValueType() );
+            return isEqual( value, optionalAttribute.get().getValue(), attribute.getValueType() );
         }
 
         return false;
     }
 
-    private boolean areEquals( String dataValue, String value, ValueType valueType )
+    /**
+     * Tests whether the given values are equal. If the given value type is
+     * numeric, the values are converted to doubles before checked for equality.
+     *
+     * @param value1 the first value.
+     * @param value2 the second value.
+     * @param valueType the value type.
+     * @return true if the values are equal, false if not.
+     */
+    boolean isEqual( String value1, String value2, ValueType valueType )
     {
         if ( valueType.isNumeric() )
         {
-            return NumberUtils.isParsable( dataValue ) &&
-                Double.parseDouble( value ) == Double.parseDouble( dataValue );
+            return NumberUtils.isParsable( value1 ) && NumberUtils.isParsable( value2 ) &&
+                MathUtils.isEqual( Double.parseDouble( value1 ), Double.parseDouble( value2 ) );
         }
         else
         {
-            return value.equals( dataValue );
+            return value2.equals( value1 );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -191,7 +191,8 @@ public class AssignValueImplementer
 
     /**
      * Tests whether the given values are equal. If the given value type is
-     * numeric, the values are converted to doubles before checked for equality.
+     * numeric, the values are converted to doubles before being checked for
+     * equality.
      *
      * @param value1 the first value.
      * @param value2 the second value.
@@ -207,7 +208,7 @@ public class AssignValueImplementer
         }
         else
         {
-            return value2.equals( value1 );
+            return value1 != null && value1.equals( value2 );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -199,7 +199,7 @@ public class AssignValueImplementer
      * @param valueType the value type.
      * @return true if the values are equal, false if not.
      */
-    boolean isEqual( String value1, String value2, ValueType valueType )
+    protected boolean isEqual( String value1, String value2, ValueType valueType )
     {
         if ( valueType.isNumeric() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementerTest.java
@@ -505,6 +505,17 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertFalse( implementerToTest.isEqual( "32", "33", ValueType.INTEGER ) );
     }
 
+    @Test
+    void testIsEqualDataTypeIntegrity()
+    {
+        assertFalse( implementerToTest.isEqual( "first_dose", "46.2", ValueType.NUMBER ) );
+        assertFalse( implementerToTest.isEqual( "24", "second_dose", ValueType.NUMBER ) );
+        assertFalse( implementerToTest.isEqual( null, "46.2", ValueType.NUMBER ) );
+        assertFalse( implementerToTest.isEqual( "26.4", null, ValueType.NUMBER ) );
+        assertFalse( implementerToTest.isEqual( "first_dose", null, ValueType.TEXT ) );
+        assertFalse( implementerToTest.isEqual( null, "second_dose", ValueType.TEXT ) );
+    }
+
     private Event getEventWithDataValueSet()
     {
         Event event = new Event();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.programrule;
+package org.hisp.dhis.tracker.programrule.implementers;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
@@ -64,7 +64,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.programrule.implementers.AssignValueImplementer;
+import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -485,6 +485,24 @@ class AssignValueImplementerTest extends DhisConvenienceTest
         assertEquals( 1, enrollmentIssues.size() );
         assertEquals( 1, enrollmentIssues.size() );
         assertEquals( WARNING, enrollmentIssues.get( 0 ).getIssueType() );
+    }
+
+    @Test
+    void testIsEqual()
+    {
+        assertTrue( implementerToTest.isEqual( "first_dose", "first_dose", ValueType.TEXT ) );
+        assertTrue( implementerToTest.isEqual( "2020-01-01", "2020-01-01", ValueType.DATE ) );
+        assertTrue( implementerToTest.isEqual( "true", "true", ValueType.BOOLEAN ) );
+        assertTrue( implementerToTest.isEqual( "26.4", "26.4", ValueType.TEXT ) );
+        assertTrue( implementerToTest.isEqual( "24.8", "24.8", ValueType.NUMBER ) );
+        assertTrue( implementerToTest.isEqual( "32", "32", ValueType.INTEGER ) );
+
+        assertFalse( implementerToTest.isEqual( "first_dose", "second_dose", ValueType.TEXT ) );
+        assertFalse( implementerToTest.isEqual( "2020-01-01", "2020-01-02", ValueType.DATE ) );
+        assertFalse( implementerToTest.isEqual( "true", "false", ValueType.BOOLEAN ) );
+        assertFalse( implementerToTest.isEqual( "26.4", "26.5", ValueType.TEXT ) );
+        assertFalse( implementerToTest.isEqual( "24.8", "24.9", ValueType.NUMBER ) );
+        assertFalse( implementerToTest.isEqual( "32", "33", ValueType.INTEGER ) );
     }
 
     private Event getEventWithDataValueSet()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/RuleEngineErrorToTrackerWarningConverterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/RuleEngineErrorToTrackerWarningConverterTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.programrule;
+package org.hisp.dhis.tracker.programrule.implementers;
 
 import static org.hisp.dhis.tracker.programrule.IssueType.WARNING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -45,7 +45,7 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.programrule.implementers.RuleEngineErrorToTrackerWarningConverter;
+import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/SetMandatoryFieldValidatorTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.programrule;
+package org.hisp.dhis.tracker.programrule.implementers;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.TRACKED_ENTITY_ATTRIBUTE;
@@ -57,7 +57,8 @@ import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.programrule.implementers.SetMandatoryFieldValidator;
+import org.hisp.dhis.tracker.programrule.IssueType;
+import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/ShowErrorWarningImplementerTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/programrule/implementers/ShowErrorWarningImplementerTest.java
@@ -25,7 +25,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.tracker.programrule;
+package org.hisp.dhis.tracker.programrule.implementers;
 
 import static org.hisp.dhis.rules.models.AttributeType.DATA_ELEMENT;
 import static org.hisp.dhis.rules.models.AttributeType.UNKNOWN;
@@ -54,10 +54,8 @@ import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.programrule.implementers.ShowErrorOnCompleteValidator;
-import org.hisp.dhis.tracker.programrule.implementers.ShowErrorValidator;
-import org.hisp.dhis.tracker.programrule.implementers.ShowWarningOnCompleteValidator;
-import org.hisp.dhis.tracker.programrule.implementers.ShowWarningValidator;
+import org.hisp.dhis.tracker.programrule.IssueType;
+import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This fix is related to program rules and the assign value action.

* Checks if the second value being compared for equality is numeric before attempting to parse it as as double, to avoid a crash for non-numeric values.

* Checks if the first value is not null before comparing it with the second value, to avoid a crash for null values.

* Introduces proper double equality check for the assign value program rule action. Double values were compared using the `==` operator which means comparison by reference or memory location of the values is done. This is error prone as it relies on the JVM to re-use the same memory allocation for the same value. Instead, comparison should be done by value, i.e. comparing the content/value of the doubles. In addition, when comparing doubles (floating points), using a _delta_ is recommended, as comparison of doubles depend on the precision of the floating point, which means that exact comparison is unreliable and defining an accepted difference is more appropriate.

* Adds test cases.

* Moves test cases to the same package as the program rule action classes themselves, to allow for testing default and package scoped methods and to avoid unnecessary imports.
