### PR TITLE
fix: Unnecessary test in JobProgress DHIS2-13758

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobProgress.java
@@ -536,10 +536,7 @@ public interface JobProgress
         }
         finally
         {
-            if ( pool != null )
-            {
-                pool.shutdown();
-            }
+            pool.shutdown();
         }
     }
 


### PR DESCRIPTION
This test is no longer needed since `pool` is never null.