### PR TITLE
fix: disallow double, starting, and ending hyphens in usernames

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -66,7 +66,7 @@ import com.google.common.collect.Sets;
 public class ValidationUtils
 {
     private static final Pattern USERNAME_PATTERN = Pattern.compile(
-        "^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-zA-Z0-9._@]+(?<![_.@])$" );
+        "^(?=.{4,255}$)(?![-_.@])(?!.*[-_.@]{2})[-_.@a-zA-Z0-9]+(?<![-_.@])$" );
 
     private static final String NUM_PAT = "((-?[0-9]+)(\\.[0-9]+)?)";
 
@@ -232,7 +232,7 @@ public class ValidationUtils
      * Validates whether a username is valid.
      *
      * @param username the username.
-     * @param isInvite
+     * @param isInvite if it's an invitation, allow null or empty username
      *
      * @return true if the username is valid, false otherwise.
      */

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -164,6 +164,7 @@ class ValidationUtilsTest
         assertTrue( usernameIsValid( "har_ry@gmail.com", false ) );
         assertTrue( usernameIsValid( "Harry@gmail.com", false ) );
         assertTrue( usernameIsValid( "TeD@johnSon.com", false ) );
+        assertTrue( usernameIsValid( "Harry-JohnSon", false ) );
         assertFalse( usernameIsValid( "_harry@gmail.com", false ) );
         assertFalse( usernameIsValid( "harry@gmail.com_", false ) );
         assertFalse( usernameIsValid( ".harry@gmail.com", false ) );
@@ -174,6 +175,10 @@ class ValidationUtilsTest
         assertFalse( usernameIsValid( "har__ry@gmail.com", false ) );
         assertFalse( usernameIsValid( "harry@@gmail.com", false ) );
         assertFalse( usernameIsValid( "harry..gmail.com", false ) );
+        assertFalse( usernameIsValid( "harry--gmail.com", false ) );
+        assertFalse( usernameIsValid( "-harry-gmail.com", false ) );
+        assertFalse( usernameIsValid( "harry-gmail.com-", false ) );
+
         assertFalse( usernameIsValid( null, false ) );
         assertFalse( usernameIsValid( CodeGenerator.generateCode( 400 ), false ) );
     }


### PR DESCRIPTION
fix: disallow double, starting, and ending hyphens in usernames

(cherry picked from commit 83b9b9e73db88bb4b492649557d182dfcbe0e09c)