### PR TITLE
fix: Inconsistent context path parsing in OIDC custom request config …

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisCustomAuthorizationRequestResolver.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/oidc/DhisCustomAuthorizationRequestResolver.java
@@ -77,7 +77,7 @@ public class DhisCustomAuthorizationRequestResolver implements OAuth2Authorizati
     public OAuth2AuthorizationRequest resolve( HttpServletRequest servletRequest )
     {
         String requestURI = servletRequest.getRequestURI();
-        if ( requestURI.startsWith( DEFAULT_AUTHORIZATION_REQUEST_BASE_URI ) )
+        if ( requestURI.contains( DEFAULT_AUTHORIZATION_REQUEST_BASE_URI ) )
         {
             String[] split = requestURI.split( "/" );
             String clientRegistrationId = split[split.length - 1];


### PR DESCRIPTION
…(#11956)

(cherry picked from commit 78d87f1b6d8f4692b4b6d3dc9e25a0c992d9378a)