### PR TITLE
fix: Deny password login for external authentication only users (#11865)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/security/spring2fa/TwoFactorAuthenticationProvider.java
@@ -85,6 +85,14 @@ public class TwoFactorAuthenticationProvider extends DaoAuthenticationProvider
             throw new BadCredentialsException( "Invalid username or password" );
         }
 
+        if ( userCredentials.isExternalAuth() )
+        {
+            log.info(
+                String.format( "User '%s' is using external authentication, password login attempt aborted",
+                    username ) );
+            throw new BadCredentialsException( "Invalid login method, user is using external authentication." );
+        }
+
         // Initialize all required properties of user credentials since these
         // will become detached
 


### PR DESCRIPTION
* fix: Deny password login for external authentication only users

(cherry picked from commit 7fa3abe2284f00a4a0c0db8700f0e0cf54979672)