### PR TITLE
chore: avoid mockito strictness LENIENT #5 [TECH-1195]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/utils/Assertions.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.utils;
 
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -37,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.hisp.dhis.common.ErrorCodeException;
 import org.hisp.dhis.commons.collection.CollectionUtils;
@@ -199,5 +202,37 @@ public final class Assertions
     {
         assertTrue( actual <= upper,
             () -> String.format( "Expected actual %d to be <= than upper bound %d", actual, upper ) );
+    }
+
+    /**
+     * Compares 2 relative URLs for equality. That means they are functionally
+     * equivalent but their parameters might occur in a different order.
+     *
+     * Example of equivalent URLs:
+     *
+     * <pre>
+     * /context/endpoint?a=b&c=d
+     * /context/endpoint?c=d&a=b
+     * </pre>
+     *
+     * @param expected the expected URL with path and optional parameters
+     * @param actual the actual URL with path and optional parameters
+     */
+    public static void assertEquivalentRelativeUrls( String expected, String actual )
+    {
+        int paramsStart = expected.indexOf( '?' );
+        if ( paramsStart < 0 )
+        {
+            assertEquals( expected, actual );
+        }
+        else
+        {
+            Function<String, List<String>> toParameterList = url -> {
+                String params = url.substring( url.indexOf( '?' ) + 1 );
+                return stream( params.split( "&" ) ).collect( toUnmodifiableList() );
+            };
+            assertStartsWith( expected.substring( 0, paramsStart + 1 ), actual );
+            assertContainsOnly( toParameterList.apply( expected ), toParameterList.apply( actual ) );
+        }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/DefaultLinkService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/service/DefaultLinkService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.webapi.service;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
 import java.io.UnsupportedEncodingException;
@@ -41,6 +40,7 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
@@ -58,6 +58,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @Slf4j
+@AllArgsConstructor
 public class DefaultLinkService implements LinkService
 {
     /**
@@ -69,18 +70,9 @@ public class DefaultLinkService implements LinkService
 
     private final ContextService contextService;
 
-    public DefaultLinkService( SchemaService schemaService, ContextService contextService )
-    {
-        checkNotNull( schemaService );
-        checkNotNull( contextService );
-
-        this.schemaService = schemaService;
-        this.contextService = contextService;
-    }
-
     // since classes won't change during runtime, use a map to cache setHref
     // lookups
-    private Map<Class<?>, Method> setterCache = new HashMap<>();
+    private final Map<Class<?>, Method> setterCache = new HashMap<>();
 
     @Override
     public void generatePagerLinks( Pager pager, Class<?> klass )


### PR DESCRIPTION
`noLinks` test scenario did unnecessary mocking that I simply removed.

Also updated to use `List.of` and `Map.of` which showed that the pager next/prev URLs are dependent on the order in the map of parameters. To preserve the order that map presents the parameters assuming this is the order they where present in the URL originally I opted to add a dedicated new assert method that would compare relative URLs for functional equality allowing the parameters to occur in a different order than in the expected URL string.