### PR TITLE
chore: avoid mockito strictness LENIENT #7 [TECH-1195]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/filter/RequestIdentifierFilterTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/filter/RequestIdentifierFilterTest.java
@@ -25,25 +25,23 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package org.hisp.dhis.servlet.filter;
+package org.hisp.dhis.webapi.filter;
 
 import static org.hisp.dhis.external.conf.ConfigurationKey.LOGGING_REQUEST_ID_ENABLED;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hisp.dhis.webapi.filter.RequestIdentifierFilter.hashToBase64;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.function.Consumer;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.hisp.dhis.external.conf.DhisConfigurationProvider;
-import org.hisp.dhis.webapi.filter.RequestIdentifierFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,7 +55,6 @@ import org.slf4j.MDC;
 @ExtendWith( MockitoExtension.class )
 class RequestIdentifierFilterTest
 {
-
     @Mock
     private DhisConfigurationProvider dhisConfigurationProvider;
 
@@ -71,8 +68,7 @@ class RequestIdentifierFilterTest
 
     @Test
     void testIsDisabled()
-        throws ServletException,
-        IOException
+        throws Exception
     {
         init( false );
         doFilter( request -> {
@@ -83,8 +79,7 @@ class RequestIdentifierFilterTest
 
     @Test
     void testIsEnabled()
-        throws ServletException,
-        IOException
+        throws Exception
     {
         init( true );
         doFilter( request -> {
@@ -93,12 +88,11 @@ class RequestIdentifierFilterTest
             when( session.getId() ).thenReturn( "ABCDEFGHILMNO" );
         } );
 
-        assertNotNull( MDC.get( "sessionId" ) );
+        assertEquals( "ID" + hashToBase64( "ABCDEFGHILMNO" ), MDC.get( "sessionId" ) );
     }
 
     private void doFilter( Consumer<HttpServletRequest> withRequest )
-        throws ServletException,
-        IOException
+        throws Exception
     {
         HttpServletRequest req = mock( HttpServletRequest.class );
         HttpServletResponse res = mock( HttpServletResponse.class );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/RequestIdentifierFilter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/filter/RequestIdentifierFilter.java
@@ -95,7 +95,7 @@ public class RequestIdentifierFilter
         chain.doFilter( req, res );
     }
 
-    private String hashToBase64( String sessionId )
+    static String hashToBase64( String sessionId )
         throws NoSuchAlgorithmException
     {
         byte[] data = sessionId.getBytes();

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapperTest.java
@@ -60,7 +60,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-@MockitoSettings( strictness = Strictness.LENIENT )
+@MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
 class TrackerEnrollmentCriteriaMapperTest
 {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
@@ -83,7 +83,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
-@MockitoSettings( strictness = Strictness.LENIENT )
+@MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
 class TrackerEventCriteriaMapperTest
 {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapperTest.java
@@ -86,7 +86,7 @@ import org.mockito.quality.Strictness;
  *
  * @author Luciano Fiandesio
  */
-@MockitoSettings( strictness = Strictness.LENIENT )
+@MockitoSettings( strictness = Strictness.LENIENT ) // common setup
 @ExtendWith( MockitoExtension.class )
 class TrackerTrackedEntityCriteriaMapperTest
 {


### PR DESCRIPTION
These tests do a general generic setup - does not make sense to adjust mocking per test scenario so I just commented to indicate that the `@MockitoSettings( strictness = Strictness.LENIENT )` is left intentionally.

Also sneaked in changes addressing @teleivo comment here https://github.com/dhis2/dhis2-core/pull/11993#discussion_r985762243