### PR TITLE
fix: remove non-persisted properties from identifiable token query (2.37) 

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/DefaultJpaQueryParser.java
@@ -103,7 +103,7 @@ public class DefaultJpaQueryParser
         disjunction.add( getRestriction( schema, "code", operator, arg ) );
         disjunction.add( getRestriction( schema, "name", operator, arg ) );
 
-        if ( schema.haveProperty( "shortName" ) )
+        if ( schema.havePersistedProperty( "shortName" ) )
         {
             disjunction.add( getRestriction( schema, "shortName", operator, arg ) );
         }


### PR DESCRIPTION
backport https://github.com/dhis2/dhis2-core/pull/11867