### PR TITLE
fix: Broken user group add and removal in user app

### DIFF
--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
@@ -40,6 +40,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Utility methods for operations on various collections.
@@ -290,5 +292,17 @@ public class CollectionUtils
             Map.entry( k9, v9 ),
             Map.entry( k10, v10 ),
             Map.entry( k11, v11 ) );
+    }
+
+    /**
+     * Convert an Iterator to a Stream.
+     *
+     * @param iterator The Iterator to convert to a stream.
+     * @return A stream of the iterable.
+     */
+    public static <E> Stream<E> iterableToStream( Iterator<E> iterator )
+    {
+        Iterable<E> iterable = () -> iterator;
+        return StreamSupport.stream( iterable.spliterator(), false );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/JobConfigurationController.java
@@ -34,6 +34,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import java.util.Map;
 
 import org.hisp.dhis.common.IdentifiableObjects;
+import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatch;
 import org.hisp.dhis.dxf2.webmessage.WebMessageException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
@@ -146,7 +147,7 @@ public class JobConfigurationController
     }
 
     @Override
-    protected void postPatchEntity( JobConfiguration jobConfiguration )
+    protected void postPatchEntity( JsonPatch patch, JobConfiguration jobConfiguration )
     {
         if ( !jobConfiguration.isEnabled() )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/user/UserController.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -65,6 +66,9 @@ import org.hisp.dhis.common.MergeMode;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.UserOrgUnitType;
 import org.hisp.dhis.commons.collection.CollectionUtils;
+import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatch;
+import org.hisp.dhis.commons.jackson.jsonpatch.JsonPatchOperation;
+import org.hisp.dhis.commons.jackson.jsonpatch.operations.AddOperation;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.dxf2.common.TranslateParams;
 import org.hisp.dhis.dxf2.metadata.MetadataImportParams;
@@ -123,6 +127,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 
@@ -653,7 +659,8 @@ public class UserController
         validateAndThrowErrors( () -> schemaValidator.validate( persistedObject ) );
 
         manager.update( persistedObject );
-        postPatchEntity( persistedObject );
+
+        postPatchEntity( null, persistedObject );
     }
 
     /*
@@ -711,7 +718,7 @@ public class UserController
         HttpServletRequest request )
         throws Exception
     {
-        User parsed = renderService.fromJson( request.getInputStream(), getEntityClass() );
+        User inputUser = renderService.fromJson( request.getInputStream(), getEntityClass() );
 
         List<User> users = getEntity( pvUid, NO_WEB_OPTIONS );
         if ( users.isEmpty() )
@@ -721,13 +728,13 @@ public class UserController
         }
 
         // TODO: To remove when we remove old UserCredentials compatibility
-        populateUserCredentialsDtoCopyOnlyChanges( users.get( 0 ), parsed );
+        populateUserCredentialsDtoCopyOnlyChanges( users.get( 0 ), inputUser );
 
-        return importReport( updateUser( pvUid, parsed ) )
+        return importReport( updateUser( pvUid, inputUser ) )
             .withPlainResponseBefore( DhisApiVersion.V38 );
     }
 
-    protected ImportReport updateUser( String userUid, User parsedUserObject )
+    protected ImportReport updateUser( String userUid, User inputUser )
         throws WebMessageException
     {
         List<User> users = getEntity( userUid, NO_WEB_OPTIONS );
@@ -750,13 +757,13 @@ public class UserController
         // (in case it gets detached)
         currentUser.getAllAuthorities();
 
-        parsedUserObject.setId( users.get( 0 ).getId() );
-        parsedUserObject.setUid( userUid );
-        mergeLastLoginAttribute( users.get( 0 ), parsedUserObject );
+        inputUser.setId( users.get( 0 ).getId() );
+        inputUser.setUid( userUid );
+        mergeLastLoginAttribute( users.get( 0 ), inputUser );
 
-        boolean isPasswordChangeAttempt = parsedUserObject.getPassword() != null;
+        boolean isPasswordChangeAttempt = inputUser.getPassword() != null;
 
-        List<String> groupsUids = getUids( parsedUserObject.getGroups() );
+        List<String> groupsUids = getUids( inputUser.getGroups() );
 
         if ( !userService.canAddOrUpdateUser( groupsUids, currentUser )
             || !currentUser.canModifyUser( users.get( 0 ) ) )
@@ -769,13 +776,13 @@ public class UserController
         MetadataImportParams params = importService.getParamsFromMap( contextService.getParameterValuesMap() );
         params.setImportReportMode( ImportReportMode.FULL );
         params.setImportStrategy( ImportStrategy.UPDATE );
-        params.addObject( parsedUserObject );
+        params.addObject( inputUser );
 
         ImportReport importReport = importService.importMetadata( params );
 
         if ( importReport.getStatus() == Status.OK && importReport.getStats().getUpdated() == 1 )
         {
-            updateUserGroups( userUid, parsedUserObject, currentUser );
+            updateUserGroups( userUid, inputUser, currentUser );
 
             // If it was a pw change attempt (input.pw != null) and update was
             // success we assume password has changed...
@@ -783,16 +790,16 @@ public class UserController
             // same. i.e. no before & after equals pw check
             if ( isPasswordChangeAttempt )
             {
-                userService.expireActiveSessions( parsedUserObject );
+                userService.expireActiveSessions( inputUser );
             }
         }
 
         return importReport;
     }
 
-    protected void updateUserGroups( String pvUid, User parsed, User currentUser )
+    protected void updateUserGroups( String userUid, User parsed, User currentUser )
     {
-        User user = userService.getUser( pvUid );
+        User user = userService.getUser( userUid );
 
         if ( currentUser != null && currentUser.getId() == user.getId() )
         {
@@ -816,13 +823,31 @@ public class UserController
     }
 
     @Override
-    protected void postPatchEntity( User user )
+    protected void postPatchEntity( JsonPatch patch, User entityAfter )
     {
         // Make sure we always expire all the user's active sessions if we
         // have disabled the user.
-        if ( user != null && user.isDisabled() )
+        if ( entityAfter != null && entityAfter.isDisabled() )
         {
-            userService.expireActiveSessions( user );
+            userService.expireActiveSessions( entityAfter );
+        }
+
+        if ( entityAfter != null && patch != null )
+        {
+            for ( JsonPatchOperation op : patch.getOperations() )
+            {
+                JsonPointer userGroups = op.getPath().matchProperty( "userGroups" );
+                String opName = op.getOp();
+                if ( userGroups != null && opName.equals( "add" ) )
+                {
+                    AddOperation addOp = (AddOperation) op;
+                    Stream<JsonNode> targetStream = CollectionUtils.iterableToStream( addOp.getValue().elements() );
+                    List<String> uids = targetStream.map( node -> node.get( "id" ).asText() )
+                        .collect( Collectors.toList() );
+
+                    userGroupService.updateUserGroups( entityAfter, uids, currentUserService.getCurrentUser() );
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

The user app was broken and did not work when trying to add or remove a user group on the user.
This was broken because the new patch method in the AbstractCrudController, that now the UI uses, don't support inverted relationship operations. 
To fix this, the relationship had be inverted and let the UserGroup service handle the operations, by using the pre and post patch hooks.  