### PR TITLE
fix: export metadata uncompressed missing filename

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -400,6 +400,12 @@ public class DefaultMetadataExportService implements MetadataExportService
         MetadataExportParams params = new MetadataExportParams();
         Map<Class<? extends IdentifiableObject>, Map<String, List<String>>> map = new HashMap<>();
 
+        if ( parameters.containsKey( "download" ) )
+        {
+            params.setDownload( Boolean.parseBoolean( parameters.get( "download" ).get( 0 ) ) );
+            parameters.remove( "download" );
+        }
+
         if ( parameters.containsKey( "fields" ) )
         {
             params.setDefaultFields( parameters.get( "fields" ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataExportParams.java
@@ -111,6 +111,8 @@ public class MetadataExportParams
      */
     private IdentifiableObject objectExportWithDependencies;
 
+    private boolean download = false;
+
     public MetadataExportParams()
     {
     }
@@ -267,5 +269,15 @@ public class MetadataExportParams
     public void setObjectExportWithDependencies( IdentifiableObject object )
     {
         this.objectExportWithDependencies = object;
+    }
+
+    public boolean isDownload()
+    {
+        return download;
+    }
+
+    public void setDownload( boolean download )
+    {
+        this.download = download;
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
@@ -92,4 +92,13 @@ class DataSetControllerTest extends DhisControllerConvenienceTest
         assertEquals( "application/json+zip", res.header( "Content-Type" ) );
         assertEquals( "binary", res.header( "Content-Transfer-Encoding" ) );
     }
+
+    @Test
+    void testGetWithDependenciesAsUncompressedFile()
+    {
+        HttpResponse res = GET( "/dataSets/{id}/metadata.json?skipSharing=false&download=true", dsId );
+        assertEquals( HttpStatus.OK, res.status() );
+        assertEquals( "attachment; filename=metadata.json", res.header( "Content-Disposition" ) );
+        assertEquals( "application/json", res.header( "Content-Type" ) );
+    }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/MessageConverterUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/MessageConverterUtils.java
@@ -34,6 +34,7 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.webapi.utils.ContextUtils;
+import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
 
 import com.google.common.collect.ImmutableList;
@@ -94,5 +95,28 @@ public final class MessageConverterUtils
     {
         final String filename = ContextUtils.getAttachmentFileName( contentDispositionHeaderValue );
         return (filename != null) && extensibleAttachmentFilenames.contains( filename ) ? filename : null;
+    }
+
+    /**
+     * Get Content-Disposition value from header. If not exist then generate a
+     * default value for metadata export.
+     *
+     * @param outputMessage {@link HttpOutputMessage} for retrieving header
+     *        value.
+     * @param isDownload Indicate whether the current request expects a file to
+     *        be return.
+     * @return Content-Disposition value or default value "attachment;
+     *         filename=metadata.json".
+     */
+    public static String getContentDisposition( HttpOutputMessage outputMessage, boolean isDownload )
+    {
+        String contentDisposition = outputMessage.getHeaders().getFirst( ContextUtils.HEADER_CONTENT_DISPOSITION );
+
+        if ( contentDisposition == null && isDownload )
+        {
+            contentDisposition = getContentDispositionHeaderValue( null, null );
+        }
+
+        return contentDisposition;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/MetadataExportParamsMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/MetadataExportParamsMessageConverter.java
@@ -99,8 +99,8 @@ public class MetadataExportParamsMessageConverter extends AbstractHttpMessageCon
         throws IOException,
         HttpMessageNotWritableException
     {
-        final String contentDisposition = outputMessage.getHeaders()
-            .getFirst( ContextUtils.HEADER_CONTENT_DISPOSITION );
+        final String contentDisposition = MessageConverterUtils.getContentDisposition( outputMessage,
+            params.isDownload() );
         final boolean attachment = isAttachment( contentDisposition );
         final String extensibleAttachmentFilename = getExtensibleAttachmentFilename(
             contentDisposition, List.of( "metadata" ) );
@@ -138,6 +138,10 @@ public class MetadataExportParamsMessageConverter extends AbstractHttpMessageCon
             {
                 outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION,
                     getContentDispositionHeaderValue( extensibleAttachmentFilename, null ) );
+            }
+            else
+            {
+                outputMessage.getHeaders().set( ContextUtils.HEADER_CONTENT_DISPOSITION, contentDisposition );
             }
 
             metadataExportService.getMetadataAsObjectNodeStream( params, outputMessage.getBody() );


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13869

### Issue
- The `download` parameter is not forwarded to the `MetadataExportParamsMessageConverter`. Therefore, for a request with extension `.json` the message converter doesn't add `Content-Disposition` to the response header. Which in result, return a response body with json instead of a `metadata.json` file as expected.

### Fix
- Use the `MetadataExportParams` to hold and forward the parameter `download` to `MetadataExportParamsMessageConverter`.

### Test
- Added controller test.
- This can be test manually in Import/Export app, just select `uncompressed` option and export any metadata.