### PR TITLE
fix: Use callback handler for query execution [DHIS2-13873]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -171,19 +171,15 @@ public class JdbcOwnershipAnalyticsTableManager
         batchHandler.init();
 
         JdbcOwnershipWriter writer = JdbcOwnershipWriter.getInstance( batchHandler );
-
         AtomicInteger queryRowCount = new AtomicInteger();
 
         jdbcTemplate.query( sql, resultSet -> {
-            while ( resultSet.next() )
-            {
-                writer.write( getRowMap( columnNames, resultSet ) );
-                queryRowCount.getAndIncrement();
-            }
-
-            log.info( "OwnershipAnalytics query row count was {} for {}", queryRowCount, partition.getTempTableName() );
-            writer.flush();
+            writer.write( getRowMap( columnNames, resultSet ) );
+            queryRowCount.getAndIncrement();
         } );
+
+        log.info( "OwnershipAnalytics query row count was {} for {}", queryRowCount, partition.getTempTableName() );
+        writer.flush();
     }
 
     private String getInputSql( AnalyticsTableUpdateParams params, Program program )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
@@ -102,11 +102,6 @@ public class ResourceTableController
             skipTableTypes.add( AnalyticsTableType.ENROLLMENT );
         }
 
-        if ( skipEvents && skipEnrollment )
-        {
-            skipTableTypes.add( AnalyticsTableType.OWNERSHIP );
-        }
-
         if ( skipOrgUnitOwnership )
         {
             skipTableTypes.add( AnalyticsTableType.OWNERSHIP );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/ResourceTableController.java
@@ -79,6 +79,7 @@ public class ResourceTableController
         @RequestParam( required = false ) boolean skipAggregate,
         @RequestParam( required = false ) boolean skipEvents,
         @RequestParam( required = false ) boolean skipEnrollment,
+        @RequestParam( required = false ) boolean skipOrgUnitOwnership,
         @RequestParam( required = false ) Integer lastYears )
     {
         Set<AnalyticsTableType> skipTableTypes = new HashSet<>();
@@ -106,9 +107,13 @@ public class ResourceTableController
             skipTableTypes.add( AnalyticsTableType.OWNERSHIP );
         }
 
+        if ( skipOrgUnitOwnership )
+        {
+            skipTableTypes.add( AnalyticsTableType.OWNERSHIP );
+        }
+
         AnalyticsJobParameters analyticsJobParameters = new AnalyticsJobParameters( lastYears, skipTableTypes,
-            skipPrograms,
-            skipResourceTables );
+            skipPrograms, skipResourceTables );
 
         JobConfiguration analyticsTableJob = new JobConfiguration( "inMemoryAnalyticsJob", JobType.ANALYTICS_TABLE, "",
             analyticsJobParameters, true, true );


### PR DESCRIPTION
This PR aims to fix the out-of-memory error that happens in some environments.

The original approach where we were using `queryForRowSet` was using a local cache behind the scenes (see `CachedRowSet`), to load all DB rows. This was probably causing out-of-memory when the volume of data was larger than the JVM would expect.

Locally, I was able to reproduce the out-of-memory problem at the same point, by tweaking the Tomcat settings to something like this:
```
export CATALINA_OPTS="$CATALINA_OPT -Xms320m -Xmx320m -Xss1m"
```

With these changes, even with the low memory settings above, we are able to complete the analytics export process which used to fail due to out-of-memory.

We also tested this fix on the performance environment (`https://test.performance.dhis2.org/2.39.0-rc-2`), where we deployed a "patched" WAR to test the changes and confirm that the problem is gone.

More details about it can be found on the JIRA `https://dhis2.atlassian.net/browse/DHIS2-13873`