### PR TITLE
ci: use db healthcheck to wait for e2e DB

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -15,17 +15,24 @@ services:
     environment:
       POSTGRES_USER: dhis
       POSTGRES_DB: dhis2
-      POSTGRES_PASSWORD: dhis
+      POSTGRES_PASSWORD: &postgres_password dhis
+      PGPASSWORD: *postgres_password # needed by psql in healthcheck
+    healthcheck:
+      test: ["CMD-SHELL", "psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command \"SELECT 'ok'\" > /dev/null"]
+      start_period: 30s
+      interval: 1s
+      timeout: 3s
+      retries: 3
 
   web:
     image: "${IMAGE_NAME}"
     pull_policy: never
     volumes:
       - ./config/dhis2_home/dhis.conf:/opt/dhis2/dhis.conf:ro
-    environment:
-      - WAIT_FOR_DB_CONTAINER=db:5432 -t 0
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - "8080"


### PR DESCRIPTION
to become ready
https://github.com/compose-spec/compose-spec/blob/master/spec.md\#long-syntax-1

which is more accurate in understanding whether the DB initialization of the DHIS2 DB is done. Rather than just relying on the tcp port to be ready. Note that the pg_isready was not chosen as it does not take the DB actually existing into account. https://dba.stackexchange.com/questions/298643/monitoring-a-specific-database-with-pg-isready