### PR TITLE
chore: Bump dev and stable pipelines timeout [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -14,7 +14,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(daysToKeepStr: '5'))
-        timeout(time: 30)
+        timeout(time: 60)
     }
 
     environment {

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -8,7 +8,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 30)
+        timeout(time: 60)
     }
 
     environment {


### PR DESCRIPTION
With the changes introduced in [TECH-1433](https://dhis2.atlassian.net/browse/TECH-1433) the total build time is now about 30-35 minutes, so we need to increase the timeout for potentially stuck builds. 