### PR TITLE
chore: only use @Nonnull and ban similar annotations

### DIFF
--- a/dhis-2/dhis-api/pom.xml
+++ b/dhis-2/dhis-api/pom.xml
@@ -91,10 +91,6 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hisp.dhis.rules</groupId>
       <artifactId>rule-engine</artifactId>
     </dependency>

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/audit/AuditQuery.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/audit/AuditQuery.java
@@ -31,10 +31,11 @@ import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
 import lombok.Value;
 
 /**
@@ -109,7 +110,7 @@ public class AuditQuery
         /**
          * From date to fetch audits from.
          */
-        private @NonNull LocalDateTime from;
+        private @Nonnull LocalDateTime from;
 
         /**
          * To date to fetch audits from.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateInterval.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateInterval.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.calendar;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 /**
  * Class representing a date interval.
@@ -41,13 +41,13 @@ public class DateInterval
     /**
      * Start of interval. Required.
      */
-    @NotNull
+    @Nonnull
     private final DateTimeUnit from;
 
     /**
      * End of interval. Required.
      */
-    @NotNull
+    @Nonnull
     private final DateTimeUnit to;
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateTimeUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/calendar/DateTimeUnit.java
@@ -30,7 +30,7 @@ package org.hisp.dhis.calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import org.joda.time.Chronology;
 import org.joda.time.DateTime;
@@ -53,19 +53,19 @@ public class DateTimeUnit
     /**
      * Year of date. Required.
      */
-    @NotNull
+    @Nonnull
     private int year;
 
     /**
      * Month of date. Required.
      */
-    @NotNull
+    @Nonnull
     private int month;
 
     /**
      * Day of date. Required.
      */
-    @NotNull
+    @Nonnull
     private int day;
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventRepetition.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventRepetition.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -62,7 +62,7 @@ public class EventRepetition implements Serializable, EmbeddedObject
      */
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    @NotNull
+    @Nonnull
     private Attribute parent;
 
     /**
@@ -70,7 +70,7 @@ public class EventRepetition implements Serializable, EmbeddedObject
      */
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    @NotNull
+    @Nonnull
     private String dimension;
 
     /**
@@ -91,6 +91,6 @@ public class EventRepetition implements Serializable, EmbeddedObject
      */
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    @NotNull
+    @Nonnull
     private List<Integer> indexes = new ArrayList<>();
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimension.java
@@ -43,6 +43,7 @@ import lombok.Data;
 
 import org.hisp.dhis.common.DimensionType;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 
@@ -120,7 +121,23 @@ public class SimpleDimension implements Serializable
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
     @Nonnull
-    private List<String> values = new ArrayList<>();
+    private List<String> values;
+
+    public SimpleDimension( @Nonnull Attribute parent, @Nonnull String dimension )
+    {
+        this( parent, dimension, new ArrayList<>() );
+    }
+
+    @JsonCreator
+    public SimpleDimension(
+        @JsonProperty( "parent" ) @Nonnull Attribute parent,
+        @JsonProperty( "dimension" ) @Nonnull String dimension,
+        @JsonProperty( "values" ) @Nonnull List<String> values )
+    {
+        this.parent = parent;
+        this.dimension = dimension;
+        this.values = values;
+    }
 
     boolean belongsTo( final Attribute parent )
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimension.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimension.java
@@ -37,7 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import lombok.Data;
 
@@ -109,17 +109,17 @@ public class SimpleDimension implements Serializable
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    @NotNull
+    @Nonnull
     private Attribute parent;
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    @NotNull
+    @Nonnull
     private String dimension;
 
     @JsonProperty
     @JacksonXmlProperty( namespace = DXF_2_0 )
-    @NotNull
+    @Nonnull
     private List<String> values = new ArrayList<>();
 
     boolean belongsTo( final Attribute parent )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimensionHandler.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/SimpleDimensionHandler.java
@@ -139,9 +139,7 @@ public class SimpleDimensionHandler
     private SimpleDimension createSimpleEventDimensionFor( final DimensionalObject dimensionalObject,
         final Attribute attribute )
     {
-        final SimpleDimension simpleDimension = new SimpleDimension();
-        simpleDimension.setParent( attribute );
-        simpleDimension.setDimension( dimensionalObject.getUid() );
+        final SimpleDimension simpleDimension = new SimpleDimension( attribute, dimensionalObject.getUid() );
 
         if ( isNotEmpty( dimensionalObject.getItems() ) )
         {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
@@ -152,8 +152,8 @@ public class IndicatorGroup
 
     @JsonProperty
     @JsonSerialize( contentAs = BaseIdentifiableObject.class )
-    @JacksonXmlElementWrapper( localName = "indicatorGroupSets", namespace = DxfNamespaces.DXF_2_0 )
-    @JacksonXmlProperty( localName = "indicatorGroupSet", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlElementWrapper( localName = "groupSets", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "groupSet", namespace = DxfNamespaces.DXF_2_0 )
     public Set<IndicatorGroupSet> getGroupSets()
     {
         return groupSets;

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroup.java
@@ -54,7 +54,7 @@ public class IndicatorGroup
 
     private Set<Indicator> members = new HashSet<>();
 
-    private IndicatorGroupSet groupSet;
+    private Set<IndicatorGroupSet> groupSets = new HashSet<>();
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -147,11 +147,20 @@ public class IndicatorGroup
     @Property( value = PropertyType.REFERENCE, required = Property.Value.FALSE )
     public IndicatorGroupSet getGroupSet()
     {
-        return groupSet;
+        return groupSets.isEmpty() ? null : groupSets.iterator().next();
     }
 
-    public void setGroupSet( IndicatorGroupSet groupSet )
+    @JsonProperty
+    @JsonSerialize( contentAs = BaseIdentifiableObject.class )
+    @JacksonXmlElementWrapper( localName = "indicatorGroupSets", namespace = DxfNamespaces.DXF_2_0 )
+    @JacksonXmlProperty( localName = "indicatorGroupSet", namespace = DxfNamespaces.DXF_2_0 )
+    public Set<IndicatorGroupSet> getGroupSets()
     {
-        this.groupSet = groupSet;
+        return groupSets;
+    }
+
+    public void setGroupSets( Set<IndicatorGroupSet> groupSets )
+    {
+        this.groupSets = groupSets;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSet.java
@@ -157,13 +157,13 @@ public class IndicatorGroupSet
     public void addIndicatorGroup( IndicatorGroup indicatorGroup )
     {
         members.add( indicatorGroup );
-        indicatorGroup.setGroupSet( this );
+        indicatorGroup.getGroupSets().add( this );
     }
 
     public void removeIndicatorGroup( IndicatorGroup indicatorGroup )
     {
         members.remove( indicatorGroup );
-        indicatorGroup.setGroupSet( null );
+        indicatorGroup.getGroupSets().remove( this );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translatable.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/translation/Translatable.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
 
@@ -48,7 +48,7 @@ public @interface Translatable
     /**
      * Property name for enabling translation
      */
-    @NotNull
+    @Nonnull
     String propertyName();
 
     /**

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/eventvisualization/SimpleDimensionHandlerTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/eventvisualization/SimpleDimensionHandlerTest.java
@@ -130,10 +130,8 @@ class SimpleDimensionHandlerTest
 
     private SimpleDimension stubSimpleEventDimension( final String dimension )
     {
-        final SimpleDimension simpleDimension = new SimpleDimension();
+        final SimpleDimension simpleDimension = new SimpleDimension( COLUMN, dimension );
 
-        simpleDimension.setDimension( dimension );
-        simpleDimension.setParent( COLUMN );
         simpleDimension.setValues( asList( "value1", "value2" ) );
 
         return simpleDimension;

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -106,10 +106,6 @@
       <artifactId>postgresql</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/analyze/RequestExecutionPlanStore.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/analyze/RequestExecutionPlanStore.java
@@ -35,7 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,7 +59,7 @@ public class RequestExecutionPlanStore implements ExecutionPlanStore
 {
     private final Map<String, List<ExecutionPlan>> executionPlanMap = new HashMap<>();
 
-    @NotNull
+    @Nonnull
     private final JdbcTemplate jdbcTemplate;
 
     private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool( 10 );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsDimensionsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventAnalyticsDimensionsService.java
@@ -37,7 +37,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.analytics.event.EventAnalyticsDimensionsService;
@@ -57,10 +58,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DefaultEventAnalyticsDimensionsService implements EventAnalyticsDimensionsService
 {
-    @NonNull
+    @Nonnull
     private final ProgramStageService programStageService;
 
-    @NonNull
+    @Nonnull
     private final CategoryService categoryService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventCoordinateService.java
@@ -32,7 +32,8 @@ import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.IllegalQueryException;
@@ -68,13 +69,13 @@ public class DefaultEventCoordinateService implements EventCoordinateService
     public static final List<String> COL_NAME_PROGRAM_NO_REGISTRATION_GEOMETRY_LIST = List.of( COL_NAME_PSI_GEOMETRY,
         COL_NAME_PI_GEOMETRY, COL_NAME_OU_GEOMETRY );
 
-    @NonNull
+    @Nonnull
     private final ProgramService programService;
 
-    @NonNull
+    @Nonnull
     private final DataElementService dataElementService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityAttributeService attributeService;
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -162,10 +162,6 @@
       <artifactId>commons-validator</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>net.sf.jasperreports</groupId>
       <artifactId>jasperreports</artifactId>
     </dependency>

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSetDeletionHandler.java
@@ -50,9 +50,7 @@ public class IndicatorGroupSetDeletionHandler extends DeletionHandler
 
     private void deleteIndicatorGroup( IndicatorGroup indicatorGroup )
     {
-        IndicatorGroupSet groupSet = indicatorGroup.getGroupSet();
-
-        if ( groupSet != null )
+        for ( IndicatorGroupSet groupSet : indicatorGroup.getGroupSets() )
         {
             groupSet.getMembers().remove( indicatorGroup );
             idObjectManager.updateNoAcl( groupSet );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultProgramNotificationService.java
@@ -43,11 +43,11 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -102,31 +102,31 @@ public class DefaultProgramNotificationService
     // Dependencies
     // -------------------------------------------------------------------------
 
-    @NonNull
+    @Nonnull
     private final ProgramMessageService programMessageService;
 
-    @NonNull
+    @Nonnull
     private final MessageService messageService;
 
-    @NonNull
+    @Nonnull
     private final ProgramInstanceStore programInstanceStore;
 
-    @NonNull
+    @Nonnull
     private final ProgramStageInstanceStore programStageInstanceStore;
 
-    @NonNull
+    @Nonnull
     private final IdentifiableObjectManager identifiableObjectManager;
 
-    @NonNull
+    @Nonnull
     private final NotificationMessageRenderer<ProgramInstance> programNotificationRenderer;
 
-    @NonNull
+    @Nonnull
     private final NotificationMessageRenderer<ProgramStageInstance> programStageNotificationRenderer;
 
-    @NonNull
+    @Nonnull
     private final ProgramNotificationTemplateService notificationTemplateService;
 
-    @NonNull
+    @Nonnull
     private final NotificationTemplateMapper notificationTemplateMapper;
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/notification/DefaultTrackerNotificationWebHookService.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.notification.ProgramNotificationMessageRenderer;
@@ -76,8 +75,8 @@ public class DefaultTrackerNotificationWebHookService implements TrackerNotifica
 
     private final RenderService renderService;
 
-    public DefaultTrackerNotificationWebHookService( @NonNull ProgramInstanceService programInstanceService,
-        @NonNull ProgramStageInstanceService programStageInstanceService,
+    public DefaultTrackerNotificationWebHookService( @Nonnull ProgramInstanceService programInstanceService,
+        @Nonnull ProgramStageInstanceService programStageInstanceService,
         @Nonnull RestTemplate restTemplate, @Nonnull RenderService renderService,
         @Nonnull ProgramNotificationTemplateService templateService )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sharing/DefaultSharingService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sharing/DefaultSharingService.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.sharing;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,22 +59,22 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class DefaultSharingService implements SharingService
 {
-    @NotNull
+    @Nonnull
     private final AclService aclService;
 
-    @NotNull
+    @Nonnull
     private final IdentifiableObjectManager manager;
 
-    @NotNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
-    @NotNull
+    @Nonnull
     private final UserGroupService userGroupService;
 
-    @NotNull
+    @Nonnull
     private final UserService userService;
 
-    @NotNull
+    @Nonnull
     private final SchemaService schemaService;
 
     public DefaultSharingService( AclService aclService, IdentifiableObjectManager manager,
@@ -90,8 +90,8 @@ public class DefaultSharingService implements SharingService
     }
 
     @Override
-    public <T extends IdentifiableObject> ObjectReport saveSharing( @NotNull Class<T> entityClass, @NotNull T entity,
-        @NotNull Sharing sharing )
+    public <T extends IdentifiableObject> ObjectReport saveSharing( @Nonnull Class<T> entityClass, @Nonnull T entity,
+        @Nonnull Sharing sharing )
     {
         ObjectReport objectReport = new ObjectReport( Sharing.class, 0 );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroup.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/indicator/hibernate/IndicatorGroup.hbm.xml
@@ -36,10 +36,11 @@
     <!-- Dynamic attribute values -->
     <property name="attributeValues" type="jsbAttributeValues"/>
 
-    <join table="indicatorgroupsetmembers" inverse="true">
+    <set name="groupSets" table="indicatorgroupsetmembers" inverse="true">
+      <cache usage="read-write" />
       <key column="indicatorgroupid" />
-      <many-to-one column="indicatorgroupsetid" name="groupSet" />
-    </join>
+      <many-to-many class="org.hisp.dhis.indicator.IndicatorGroupSet" column="indicatorgroupsetid" />
+    </set>
 
   </class>
 

--- a/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/pom.xml
@@ -81,6 +81,10 @@
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/auth/AccessTokenAuthentication.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/auth/AccessTokenAuthentication.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.dataexchange.client.auth;
 
+import javax.annotation.Nonnull;
+
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpHeaders;
@@ -38,7 +39,7 @@ import org.springframework.http.HttpHeaders;
 public class AccessTokenAuthentication
     implements Authentication
 {
-    @NonNull
+    @Nonnull
     private final String accessToken;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/auth/BasicAuthentication.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/auth/BasicAuthentication.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.dataexchange.client.auth;
 
+import javax.annotation.Nonnull;
+
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpHeaders;
@@ -38,10 +39,10 @@ import org.springframework.http.HttpHeaders;
 public class BasicAuthentication
     implements Authentication
 {
-    @NonNull
+    @Nonnull
     private final String username;
 
-    @NonNull
+    @Nonnull
     private final String password;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/auth/CookieAuthentication.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/client/auth/CookieAuthentication.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.dataexchange.client.auth;
 
+import javax.annotation.Nonnull;
+
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpHeaders;
@@ -38,7 +39,7 @@ import org.springframework.http.HttpHeaders;
 public class CookieAuthentication
     implements Authentication
 {
-    @NonNull
+    @Nonnull
     private final String sessionId;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SimpleDataValueSetReader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/SimpleDataValueSetReader.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.dxf2.datavalueset;
 
+import javax.annotation.Nonnull;
+
 import lombok.AllArgsConstructor;
-import lombok.NonNull;
 
 /**
  * Simple implementation of {@link DataValueSetReader} which wraps an in-memory
@@ -39,7 +40,7 @@ import lombok.NonNull;
 @AllArgsConstructor
 public class SimpleDataValueSetReader implements DataValueSetReader
 {
-    @NonNull
+    @Nonnull
     private final DataValueSet dataValueSet;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EnrollmentAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EnrollmentAggregate.java
@@ -36,7 +36,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dxf2.events.enrollment.Enrollment;
@@ -57,10 +58,10 @@ public class EnrollmentAggregate
     extends
     AbstractAggregate
 {
-    @NonNull
+    @Nonnull
     private final EnrollmentStore enrollmentStore;
 
-    @NonNull
+    @Nonnull
     private final EventAggregate eventAggregate;
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EventAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/EventAggregate.java
@@ -38,7 +38,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dxf2.events.event.DataValue;
@@ -59,7 +60,7 @@ public class EventAggregate
     extends
     AbstractAggregate
 {
-    @NonNull
+    @Nonnull
     private final EventStore eventStore;
 
     /**

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregate.java
@@ -42,9 +42,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.cache.Cache;
@@ -79,22 +79,22 @@ public class TrackedEntityInstanceAggregate
     extends
     AbstractAggregate
 {
-    @NonNull
+    @Nonnull
     private final TrackedEntityInstanceStore trackedEntityInstanceStore;
 
-    @NonNull
+    @Nonnull
     private final EnrollmentAggregate enrollmentAggregate;
 
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
-    @NonNull
+    @Nonnull
     private final AclStore aclStore;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityAttributeService trackedEntityAttributeService;
 
-    @NonNull
+    @Nonnull
     private final CacheProvider cacheProvider;
 
     private Cache<Set<TrackedEntityAttribute>> teiAttributesCache;

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/DefaultEventPersistenceService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/persistence/DefaultEventPersistenceService.java
@@ -33,7 +33,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dxf2.events.event.Event;
@@ -54,10 +55,10 @@ public class DefaultEventPersistenceService
     implements
     EventPersistenceService
 {
-    @NonNull
+    @Nonnull
     private final EventStore jdbcEventStore;
 
-    @NonNull
+    @Nonnull
     private final EventCommentStore jdbcEventCommentStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventImporterUserService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventImporterUserService.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.dxf2.events.importer;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Delegate;
 
@@ -40,11 +41,11 @@ import org.springframework.stereotype.Component;
 public class EventImporterUserService
 {
 
-    @NonNull
+    @Nonnull
     @Delegate
     private final CurrentUserService currentUserService;
 
-    @NonNull
+    @Nonnull
     private final UsernameSupplier usernameSupplier;
 
     public String getAuditUsername()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -50,7 +50,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -84,28 +85,28 @@ import com.google.common.collect.ImmutableList;
 @RequiredArgsConstructor
 public class EventManager
 {
-    @NonNull
+    @Nonnull
     @Qualifier( "checkersRunOnInsert" )
     private final List<Checker> checkersRunOnInsert;
 
-    @NonNull
+    @Nonnull
     @Qualifier( "checkersRunOnUpdate" )
     private final List<Checker> checkersRunOnUpdate;
 
-    @NonNull
+    @Nonnull
     @Qualifier( "checkersRunOnDelete" )
     private final List<Checker> checkersRunOnDelete;
 
-    @NonNull
+    @Nonnull
     private final Map<EventProcessorPhase, EventProcessorExecutor> executorsByPhase;
 
-    @NonNull
+    @Nonnull
     private final EventPersistenceService eventPersistenceService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityDataValueAuditService entityDataValueAuditService;
 
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
     private static final String IMPORT_ERROR_STRING = "Invalid or conflicting data";

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ServiceDelegatorSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/ServiceDelegatorSupplier.java
@@ -29,7 +29,8 @@ package org.hisp.dhis.dxf2.events.importer.context;
 
 import java.util.function.Supplier;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.artemis.audit.AuditManager;
@@ -54,35 +55,35 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 public class ServiceDelegatorSupplier implements Supplier<ServiceDelegator>
 {
-    @NonNull
+    @Nonnull
     private final ProgramInstanceStore programInstanceStore;
 
-    @NonNull
+    @Nonnull
     private final TrackerAccessManager trackerAccessManager;
 
-    @NonNull
+    @Nonnull
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    @NonNull
+    @Nonnull
     private final ProgramRuleVariableService programRuleVariableService;
 
-    @NonNull
+    @Nonnull
     private final EventImporterUserService eventImporterUserService;
 
-    @NonNull
+    @Nonnull
     private final ObjectMapper jsonMapper;
 
-    @NonNull
+    @Nonnull
     @Qualifier( "readOnlyJdbcTemplate" )
     private final JdbcTemplate jdbcTemplate;
 
-    @NonNull
+    @Nonnull
     private final AuditManager auditManager;
 
-    @NonNull
+    @Nonnull
     private final FileResourceService fileResourceService;
 
-    @NonNull
+    @Nonnull
     private final OrganisationUnitService organisationUnitService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/hooks/ProgramRuleActionObjectBundleHook.java
@@ -32,8 +32,6 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
 
-import lombok.NonNull;
-
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.programrule.ProgramRuleAction;
@@ -50,14 +48,14 @@ import org.springframework.stereotype.Component;
 @Component( "programRuleActionObjectBundle" )
 public class ProgramRuleActionObjectBundleHook extends AbstractObjectBundleHook<ProgramRuleAction>
 {
-    @NonNull
+    @Nonnull
     private final Map<ProgramRuleActionType, ProgramRuleActionValidator> programRuleActionValidatorMap;
 
     @Nonnull
     private final ProgramRuleActionValidationContextLoader contextLoader;
 
     public ProgramRuleActionObjectBundleHook(
-        @NonNull Map<ProgramRuleActionType, ProgramRuleActionValidator> programRuleActionValidatorMap,
+        @Nonnull Map<ProgramRuleActionType, ProgramRuleActionValidator> programRuleActionValidatorMap,
         @Nonnull ProgramRuleActionValidationContextLoader contextLoader )
     {
         this.programRuleActionValidatorMap = programRuleActionValidatorMap;

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.programrule.engine;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,19 +60,19 @@ public class ProgramRuleEngine
 {
     private static final String ERROR = "Program cannot be null";
 
-    @NonNull
+    @Nonnull
     private final ProgramRuleEntityMapperService programRuleEntityMapperService;
 
-    @NonNull
+    @Nonnull
     private final ProgramRuleVariableService programRuleVariableService;
 
-    @NonNull
+    @Nonnull
     private final ConstantService constantService;
 
-    @NonNull
+    @Nonnull
     private final ImplementableRuleService implementableRuleService;
 
-    @NonNull
+    @Nonnull
     private final SupplementaryDataProvider supplementaryDataProvider;
 
     public List<RuleEffect> evaluate( ProgramInstance enrollment, Set<ProgramStageInstance> events )

--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/SupplementaryDataProvider.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/SupplementaryDataProvider.java
@@ -34,7 +34,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
@@ -58,10 +59,10 @@ public class SupplementaryDataProvider
 
     private static final Pattern PATTERN = Pattern.compile( REGEX );
 
-    @NonNull
+    @Nonnull
     private final OrganisationUnitGroupService organisationUnitGroupService;
 
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
     public Map<String, List<String>> getSupplementaryData( List<ProgramRule> programRules )

--- a/dhis-2/dhis-services/dhis-service-tracker/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-tracker/pom.xml
@@ -154,8 +154,8 @@
       <artifactId>jts-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
       <groupId>org.cache2k</groupId>

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -43,7 +43,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -75,19 +76,19 @@ import com.google.common.collect.ImmutableMap;
 public class DefaultTrackerImportService
     implements TrackerImportService
 {
-    @NonNull
+    @Nonnull
     private final TrackerBundleService trackerBundleService;
 
-    @NonNull
+    @Nonnull
     private final TrackerValidationService trackerValidationService;
 
-    @NonNull
+    @Nonnull
     private final TrackerPreprocessService trackerPreprocessService;
 
-    @NonNull
+    @Nonnull
     private final TrackerUserService trackerUserService;
 
-    @NonNull
+    @Nonnull
     private final Notifier notifier;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/CommitService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/CommitService.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.tracker.bundle.persister;
 
+import javax.annotation.Nonnull;
+
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -43,15 +44,15 @@ import org.springframework.stereotype.Service;
 @Getter
 public class CommitService
 {
-    @NonNull
+    @Nonnull
     private TrackedEntityPersister trackerPersister;
 
-    @NonNull
+    @Nonnull
     private EnrollmentPersister enrollmentPersister;
 
-    @NonNull
+    @Nonnull
     private EventPersister eventPersister;
 
-    @NonNull
+    @Nonnull
     private RelationshipPersister relationshipPersister;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/TrackedEntityPersister.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/persister/TrackedEntityPersister.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.tracker.bundle.persister;
 
 import java.util.Collections;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import org.hibernate.Session;
 import org.hisp.dhis.reservedvalue.ReservedValueService;
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class TrackedEntityPersister extends AbstractTrackerPersister<TrackedEntity, TrackedEntityInstance>
 {
-    @NotNull
+    @Nonnull
     private final TrackerConverterService<TrackedEntity, TrackedEntityInstance> teConverter;
 
     public TrackedEntityPersister( ReservedValueService reservedValueService,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/DefaultTrackerPreheatService.java
@@ -32,7 +32,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.beans.Introspector;
 import java.util.List;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,7 +56,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class DefaultTrackerPreheatService implements TrackerPreheatService, ApplicationContextAware
 {
-    @NonNull
+    @Nonnull
     private final IdentifiableObjectManager manager;
 
     private ApplicationContext ctx;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DefaultsSupplier.java
@@ -29,7 +29,8 @@ package org.hisp.dhis.tracker.preheat.supplier;
 
 import java.util.Optional;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.category.Category;
@@ -57,10 +58,10 @@ public class DefaultsSupplier extends AbstractPreheatSupplier
 
     private static final long CACHE_CAPACITY = 10;
 
-    @NonNull
+    @Nonnull
     private final IdentifiableObjectManager manager;
 
-    @NonNull
+    @Nonnull
     private final PreheatCacheService cache;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DuplicateRelationshipSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/DuplicateRelationshipSupplier.java
@@ -31,7 +31,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.relationship.RelationshipStore;
@@ -47,7 +48,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class DuplicateRelationshipSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final RelationshipStore relationshipStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/EventCategoryOptionComboSupplier.java
@@ -32,7 +32,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -63,7 +64,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class EventCategoryOptionComboSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final CategoryService categoryService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/FileResourceSupplier.java
@@ -32,7 +32,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
@@ -55,7 +56,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class FileResourceSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final FileResourceService fileResourceService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/OrgUnitValueTypeSupplier.java
@@ -32,7 +32,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
@@ -58,7 +59,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class OrgUnitValueTypeSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final IdentifiableObjectManager manager;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/PeriodTypeSupplier.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.tracker.preheat.supplier;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.IdentifiableObject;
@@ -49,10 +50,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class PeriodTypeSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final PeriodStore periodStore;
 
-    @NonNull
+    @Nonnull
     private final PreheatCacheService cache;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramInstanceSupplier.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.tracker.preheat.supplier;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.Program;
@@ -50,10 +51,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProgramInstanceSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final ProgramInstanceStore programInstanceStore;
 
-    @NonNull
+    @Nonnull
     private final ProgramStore programStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/ProgramOwnerSupplier.java
@@ -33,7 +33,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramInstance;
@@ -54,7 +55,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProgramOwnerSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final TrackedEntityProgramOwnerStore trackedEntityProgramOwnerStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UniqueAttributesSupplier.java
@@ -43,7 +43,8 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -74,10 +75,10 @@ import com.google.common.collect.Sets;
 @Component
 public class UniqueAttributesSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final TrackedEntityAttributeService trackedEntityAttributeService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityAttributeValueService trackedEntityAttributeValueService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UserSupplier.java
@@ -33,7 +33,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
@@ -54,10 +55,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class UserSupplier extends AbstractPreheatSupplier
 {
-    @NonNull
+    @Nonnull
     private final IdentifiableObjectManager manager;
 
-    @NonNull
+    @Nonnull
     private final UserService userService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UsernameValueTypeSupplier.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/UsernameValueTypeSupplier.java
@@ -32,7 +32,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
@@ -57,7 +58,7 @@ import org.springframework.stereotype.Component;
 public class UsernameValueTypeSupplier extends AbstractPreheatSupplier
 {
 
-    @NonNull
+    @Nonnull
     private final UserService userService;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EnrollmentStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EnrollmentStrategy.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.tracker.preheat.supplier.strategy;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramInstance;
@@ -50,7 +51,7 @@ import org.springframework.stereotype.Component;
 @StrategyFor( value = Enrollment.class, mapper = ProgramInstanceMapper.class )
 public class EnrollmentStrategy implements ClassBasedSupplierStrategy
 {
-    @NonNull
+    @Nonnull
     private final ProgramInstanceStore programInstanceStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EventStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/EventStrategy.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.tracker.preheat.supplier.strategy;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramStageInstance;
@@ -50,7 +51,7 @@ import org.springframework.stereotype.Component;
 @StrategyFor( value = Event.class, mapper = ProgramStageInstanceMapper.class )
 public class EventStrategy implements ClassBasedSupplierStrategy
 {
-    @NonNull
+    @Nonnull
     private final ProgramStageInstanceStore programStageInstanceStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/NoteStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/NoteStrategy.java
@@ -29,7 +29,8 @@ package org.hisp.dhis.tracker.preheat.supplier.strategy;
 
 import java.util.List;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.trackedentitycomment.TrackedEntityComment;
@@ -48,7 +49,7 @@ import org.springframework.stereotype.Component;
 @StrategyFor( value = TrackedEntityComment.class, mapper = NoteMapper.class )
 public class NoteStrategy implements ClassBasedSupplierStrategy
 {
-    @NonNull
+    @Nonnull
     private final TrackedEntityCommentStore trackedEntityCommentStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/RelationshipStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/RelationshipStrategy.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.tracker.preheat.supplier.strategy;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.CodeGenerator;
@@ -50,7 +51,7 @@ import org.springframework.stereotype.Component;
 @StrategyFor( value = Relationship.class, mapper = RelationshipMapper.class )
 public class RelationshipStrategy implements ClassBasedSupplierStrategy
 {
-    @NonNull
+    @Nonnull
     private final RelationshipStore relationshipStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategy.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/supplier/strategy/TrackerEntityInstanceStrategy.java
@@ -30,7 +30,8 @@ package org.hisp.dhis.tracker.preheat.supplier.strategy;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -50,7 +51,7 @@ import org.springframework.stereotype.Component;
 @StrategyFor( value = TrackedEntity.class, mapper = TrackedEntityInstanceMapper.class )
 public class TrackerEntityInstanceStrategy implements ClassBasedSupplierStrategy
 {
-    @NonNull
+    @Nonnull
     private TrackedEntityInstanceStore trackedEntityInstanceStore;
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -34,7 +34,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
@@ -68,17 +69,17 @@ import com.google.common.collect.Sets;
 public class DefaultTrackerProgramRuleService
     implements TrackerProgramRuleService
 {
-    @NonNull
+    @Nonnull
     @Qualifier( "serviceTrackerRuleEngine" )
     private final ProgramRuleEngine programRuleEngine;
 
-    @NonNull
+    @Nonnull
     private final RuleEngineConverterService<Enrollment, ProgramInstance> enrollmentTrackerConverterService;
 
-    @NonNull
+    @Nonnull
     private final RuleEngineConverterService<Event, ProgramStageInstance> eventTrackerConverterService;
 
-    @NonNull
+    @Nonnull
     private final TrackerConverterService<Attribute, TrackedEntityAttributeValue> attributeValueTrackerConverterService;
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/Timing.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.tracker.report;
 
+import javax.annotation.Nonnull;
+
 import lombok.EqualsAndHashCode;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
@@ -45,11 +46,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @EqualsAndHashCode
 public class Timing
 {
-    @NonNull
+    @Nonnull
     @JsonProperty
     public final String totalTime;
 
-    @NonNull
+    @Nonnull
     @JsonProperty
     public final String name;
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -43,7 +43,8 @@ import static org.hisp.dhis.tracker.validation.hooks.TrackerImporterAssertErrors
 
 import java.util.Map;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -85,13 +86,13 @@ import org.springframework.stereotype.Component;
 public class PreCheckSecurityOwnershipValidationHook
     extends AbstractTrackerDtoValidationHook
 {
-    @NonNull
+    @Nonnull
     private final AclService aclService;
 
-    @NonNull
+    @Nonnull
     private final TrackerOwnershipManager ownershipAccessManager;
 
-    @NonNull
+    @Nonnull
     private final OrganisationUnitService organisationUnitService;
 
     private static final String ORG_UNIT_NO_USER_ASSIGNED = " has no organisation unit assigned, so we skip user validation";

--- a/dhis-2/dhis-services/dhis-service-validation/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-validation/pom.xml
@@ -110,8 +110,8 @@
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <!-- Test -->

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/notification/DefaultValidationNotificationService.java
@@ -50,7 +50,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -471,7 +471,7 @@ public class DefaultValidationNotificationService implements ValidationNotificat
         }
 
         @Override
-        public int compareTo( @NotNull MessagePair other )
+        public int compareTo( @Nonnull MessagePair other )
         {
             return new CompareToBuilder()
                 .append( this.result, other.result )

--- a/dhis-2/dhis-support/dhis-support-artemis/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-artemis/pom.xml
@@ -39,6 +39,10 @@
 
     <!-- Other -->
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-server</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/HibernateListenerConfigurer.java
+++ b/dhis-2/dhis-support/dhis-support-artemis/src/main/java/org/hisp/dhis/artemis/audit/listener/HibernateListenerConfigurer.java
@@ -27,11 +27,11 @@
  */
 package org.hisp.dhis.artemis.audit.listener;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.PersistenceUnit;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hibernate.event.service.spi.EventListenerRegistry;
@@ -74,22 +74,22 @@ public class HibernateListenerConfigurer
     @PersistenceUnit
     private EntityManagerFactory emf;
 
-    @NonNull
+    @Nonnull
     private final PostInsertAuditListener postInsertAuditListener;
 
-    @NonNull
+    @Nonnull
     private final PostUpdateAuditListener postUpdateEventListener;
 
-    @NonNull
+    @Nonnull
     private final PostDeleteAuditListener postDeleteEventListener;
 
-    @NonNull
+    @Nonnull
     private final PostLoadAuditListener postLoadEventListener;
 
-    @NonNull
+    @Nonnull
     private final AuditMatrix auditMatrix;
 
-    @NonNull
+    @Nonnull
     private DhisConfigurationProvider config;
 
     @PostConstruct

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -238,10 +238,6 @@
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jfree</groupId>
       <artifactId>jfreechart</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/filter/IndicatorGroupWithoutGroupSetFilter.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/filter/IndicatorGroupWithoutGroupSetFilter.java
@@ -39,6 +39,6 @@ public class IndicatorGroupWithoutGroupSetFilter
     @Override
     public boolean retain( IndicatorGroup object )
     {
-        return object == null || object.getGroupSet() == null;
+        return object == null || object.getGroupSets().isEmpty();
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLoggerUtil.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/NotificationLoggerUtil.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.system.notification;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 
 import org.slf4j.Logger;
 
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 public class NotificationLoggerUtil
 {
 
-    @NotNull
+    @Nonnull
     public static void log( Logger logger, NotificationLevel notificationLevel, String message )
     {
         switch ( notificationLevel )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/HibernateIdentifiableObjectStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/HibernateIdentifiableObjectStoreTest.java
@@ -38,6 +38,7 @@ import java.util.Set;
 
 import org.hisp.dhis.category.CategoryOption;
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementStore;
 import org.hisp.dhis.datavalue.AggregateAccessManager;
@@ -77,6 +78,9 @@ class HibernateIdentifiableObjectStoreTest extends TransactionalIntegrationTest
 
     @Autowired
     private UserService _userService;
+
+    @Autowired
+    private CategoryService categoryService;
 
     @BeforeEach
     void init()
@@ -172,6 +176,7 @@ class HibernateIdentifiableObjectStoreTest extends TransactionalIntegrationTest
         DataElement dataElement = createDataElement( 'A' );
         dataElement.setValueType( ValueType.TEXT );
         CategoryOptionCombo defaultCategoryOptionCombo = createCategoryOptionCombo( 'D' );
+        defaultCategoryOptionCombo.setCategoryCombo( categoryService.getDefaultCategoryCombo() );
         OrganisationUnit organisationUnitA = createOrganisationUnit( 'A' );
         Period period = createPeriod( new Date(), new Date() );
         period.setPeriodType( PeriodType.getPeriodType( PeriodTypeEnum.MONTHLY ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/security/acl/AclServiceTest.java
@@ -1005,6 +1005,8 @@ class AclServiceTest extends TransactionalIntegrationTest
         // Given
         User userA = makeUser( "A" );
         manager.save( userA );
+        Program program = createProgram( 'A' );
+        manager.save( program );
         EventVisualization eventVisualization = new EventVisualization();
         eventVisualization.setAutoFields();
         eventVisualization.setName( "FavA" );
@@ -1012,6 +1014,7 @@ class AclServiceTest extends TransactionalIntegrationTest
         eventVisualization.getSharing().setOwner( userA );
         eventVisualization.setPublicAccess( AccessStringHelper.DEFAULT );
         eventVisualization.setType( EventVisualizationType.COLUMN );
+        eventVisualization.setProgram( program );
         assertTrue( aclService.canUpdate( userA, eventVisualization ) );
         manager.save( eventVisualization );
         // Then
@@ -1060,6 +1063,8 @@ class AclServiceTest extends TransactionalIntegrationTest
         // Given
         User userA = makeUser( "A" );
         manager.save( userA );
+        Program program = createProgram( 'A' );
+        manager.save( program );
         EventVisualization eventVisualization = new EventVisualization();
         eventVisualization.setAutoFields();
         eventVisualization.setName( "FavA" );
@@ -1067,6 +1072,7 @@ class AclServiceTest extends TransactionalIntegrationTest
         eventVisualization.getSharing().setOwner( userA );
         eventVisualization.setPublicAccess( AccessStringHelper.DEFAULT );
         eventVisualization.setType( EventVisualizationType.COLUMN );
+        eventVisualization.setProgram( program );
         assertTrue( aclService.canUpdate( userA, eventVisualization ) );
         manager.save( eventVisualization );
         // Then
@@ -1109,6 +1115,8 @@ class AclServiceTest extends TransactionalIntegrationTest
         // Given
         User userA = makeUser( "A" );
         manager.save( userA );
+        Program program = createProgram( 'A' );
+        manager.save( program );
         EventVisualization eventVisualization = new EventVisualization();
         eventVisualization.setAutoFields();
         eventVisualization.setName( "FavA" );
@@ -1116,6 +1124,7 @@ class AclServiceTest extends TransactionalIntegrationTest
         eventVisualization.getSharing().setOwner( userA );
         eventVisualization.setPublicAccess( AccessStringHelper.DEFAULT );
         eventVisualization.setType( EventVisualizationType.COLUMN );
+        eventVisualization.setProgram( program );
         assertTrue( aclService.canUpdate( userA, eventVisualization ) );
         manager.save( eventVisualization );
         // Then
@@ -1135,6 +1144,7 @@ class AclServiceTest extends TransactionalIntegrationTest
         CategoryOptionGroupSet categoryOptionGroupSet = new CategoryOptionGroupSet();
         categoryOptionGroupSet.setAutoFields();
         categoryOptionGroupSet.setName( "cogA" );
+        categoryOptionGroupSet.setShortName( "cogA" );
         manager.save( categoryOptionGroupSet );
         assertTrue( aclService.canDataOrMetadataRead( user1, categoryOptionGroupSet ) );
         // data shareable object //

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
@@ -32,10 +32,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.AllArgsConstructor;
-import lombok.NonNull;
 
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.analytics.AnalyticsTableType;
@@ -72,13 +72,13 @@ public class AnalyticsController
 
     private static final String RAW_DATA_PATH = "/rawData";
 
-    @NonNull
+    @Nonnull
     private final DataQueryService dataQueryService;
 
-    @NonNull
+    @Nonnull
     private final AnalyticsService analyticsService;
 
-    @NonNull
+    @Nonnull
     private final ContextUtils contextUtils;
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EnrollmentAnalyticsController.java
@@ -31,8 +31,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
 
@@ -75,28 +75,28 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @AllArgsConstructor
 public class EnrollmentAnalyticsController
 {
-    @NotNull
+    @Nonnull
     private final EventDataQueryService eventDataQueryService;
 
-    @NotNull
+    @Nonnull
     private final EnrollmentAnalyticsService analyticsService;
 
-    @NotNull
+    @Nonnull
     private final ContextUtils contextUtils;
 
-    @NotNull
+    @Nonnull
     private final ExecutionPlanStore executionPlanStore;
 
-    @NotNull
+    @Nonnull
     private DimensionFilteringAndPagingService dimensionFilteringAndPagingService;
 
-    @NotNull
+    @Nonnull
     private EnrollmentAnalyticsDimensionsService enrollmentAnalyticsDimensionsService;
 
-    @NotNull
+    @Nonnull
     private DimensionMapperService dimensionMapperService;
 
-    @NotNull
+    @Nonnull
     private final SystemSettingManager systemSettingManager;
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_ANALYTICS_EXPLAIN')" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/EventAnalyticsController.java
@@ -32,11 +32,10 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotNull;
 
 import lombok.AllArgsConstructor;
-import lombok.NonNull;
 
 import org.hisp.dhis.analytics.Rectangle;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
@@ -80,28 +79,28 @@ public class EventAnalyticsController
 
     private static final String EXPLAIN_PATH = "/explain";
 
-    @NonNull
+    @Nonnull
     private final EventDataQueryService eventDataService;
 
-    @NonNull
+    @Nonnull
     private final EventAnalyticsService analyticsService;
 
-    @NonNull
+    @Nonnull
     private final ContextUtils contextUtils;
 
-    @NonNull
+    @Nonnull
     private final DimensionFilteringAndPagingService dimensionFilteringAndPagingService;
 
-    @NonNull
+    @Nonnull
     private final EventAnalyticsDimensionsService eventAnalyticsDimensionsService;
 
-    @NotNull
+    @Nonnull
     private final ExecutionPlanStore executionPlanStore;
 
-    @NotNull
+    @Nonnull
     private final DimensionMapperService dimensionMapperService;
 
-    @NotNull
+    @Nonnull
     private final SystemSettingManager systemSettingManager;
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationDataController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/VisualizationDataController.java
@@ -35,10 +35,10 @@ import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_JSON;
 import java.io.IOException;
 import java.util.Date;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 
 import lombok.AllArgsConstructor;
-import lombok.NonNull;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
@@ -81,37 +81,37 @@ import org.springframework.web.bind.annotation.RestController;
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
 public class VisualizationDataController
 {
-    @NonNull
+    @Nonnull
     private OrganisationUnitService organisationUnitService;
 
-    @NonNull
+    @Nonnull
     private final ContextUtils contextUtils;
 
-    @NonNull
+    @Nonnull
     private final VisualizationService visualizationService;
 
-    @NonNull
+    @Nonnull
     private final VisualizationGridService visualizationGridService;
 
-    @NonNull
+    @Nonnull
     private final ChartService chartService;
 
-    @NonNull
+    @Nonnull
     private final DataElementService dataElementService;
 
-    @NonNull
+    @Nonnull
     private final CategoryService categoryService;
 
-    @NonNull
+    @Nonnull
     private final IndicatorService indicatorService;
 
-    @NonNull
+    @Nonnull
     private final I18nManager i18nManager;
 
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
-    @NonNull
+    @Nonnull
     private final RenderService renderService;
 
     @GetMapping( value = "/visualizations/{uid}/data.html" )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
@@ -35,7 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
@@ -74,22 +75,22 @@ class TrackedEntitiesSupportService
 
     private static final String FIELD_EVENTS = "events";
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
-    @NonNull
+    @Nonnull
     private final ProgramService programService;
 
-    @NonNull
+    @Nonnull
     private final TrackerAccessManager trackerAccessManager;
 
-    @NonNull
+    @Nonnull
     private final org.hisp.dhis.trackedentity.TrackedEntityInstanceService instanceService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityTypeService trackedEntityTypeService;
 
     @SneakyThrows

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentCriteriaMapper.java
@@ -36,7 +36,8 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.BaseIdentifiableObject;
@@ -65,19 +66,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrackerEnrollmentCriteriaMapper
 {
 
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
-    @NonNull
+    @Nonnull
     private final OrganisationUnitService organisationUnitService;
 
-    @NonNull
+    @Nonnull
     private final ProgramService programService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityTypeService trackedEntityTypeService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
     @Transactional( readOnly = true )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -35,7 +35,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.DhisApiVersion;
@@ -70,13 +71,13 @@ public class TrackerEnrollmentsExportController
 
     private static final EnrollmentMapper ENROLLMENT_MAPPER = Mappers.getMapper( EnrollmentMapper.class );
 
-    @NonNull
+    @Nonnull
     private final TrackerEnrollmentCriteriaMapper enrollmentCriteriaMapper;
 
-    @NonNull
+    @Nonnull
     private final EnrollmentService enrollmentService;
 
-    @NonNull
+    @Nonnull
     private final FieldFilterService fieldFilterService;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -39,10 +39,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.DhisApiVersion;
@@ -86,22 +86,22 @@ public class TrackerEventsExportController
 
     private static final EventMapper EVENTS_MAPPER = Mappers.getMapper( EventMapper.class );
 
-    @NonNull
+    @Nonnull
     private final EventService eventService;
 
-    @NonNull
+    @Nonnull
     private final ContextService contextService;
 
-    @NonNull
+    @Nonnull
     private final TrackerEventCriteriaMapper requestToSearchParams;
 
-    @NonNull
+    @Nonnull
     private final ProgramStageInstanceService programStageInstanceService;
 
-    @NonNull
+    @Nonnull
     private final CsvEventService<org.hisp.dhis.webapi.controller.tracker.view.Event> csvEventService;
 
-    @NonNull
+    @Nonnull
     private final FieldFilterService fieldFilterService;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerRelationshipsExportController.java
@@ -38,9 +38,9 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 
@@ -85,19 +85,19 @@ public class TrackerRelationshipsExportController
     private static final org.hisp.dhis.webapi.controller.tracker.export.RelationshipMapper RELATIONSHIP_MAPPER = Mappers
         .getMapper( org.hisp.dhis.webapi.controller.tracker.export.RelationshipMapper.class );
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    @NonNull
+    @Nonnull
     private final ProgramInstanceService programInstanceService;
 
-    @NonNull
+    @Nonnull
     private final ProgramStageInstanceService programStageInstanceService;
 
-    @NonNull
+    @Nonnull
     private final RelationshipService relationshipService;
 
-    @NonNull
+    @Nonnull
     private final FieldFilterService fieldFilterService;
 
     private Map<Class<?>, Function<String, ?>> objectRetrievers;

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -35,9 +35,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.DhisApiVersion;
@@ -67,19 +67,19 @@ public class TrackerTrackedEntitiesExportController
 
     private static final TrackedEntityMapper TRACKED_ENTITY_MAPPER = Mappers.getMapper( TrackedEntityMapper.class );
 
-    @NonNull
+    @Nonnull
     private final TrackerTrackedEntityCriteriaMapper criteriaMapper;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityInstanceService trackedEntityInstanceService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntitiesSupportService trackedEntitiesSupportService;
 
-    @NonNull
+    @Nonnull
     private final FieldFilterService fieldFilterService;
 
-    @NonNull
+    @Nonnull
     private final CsvEventService<TrackedEntity> csvEventService;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -41,7 +41,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.AssignedUserSelectionMode;
@@ -79,19 +80,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class TrackerTrackedEntityCriteriaMapper
 {
-    @NonNull
+    @Nonnull
     private final CurrentUserService currentUserService;
 
-    @NonNull
+    @Nonnull
     private final OrganisationUnitService organisationUnitService;
 
-    @NonNull
+    @Nonnull
     private final ProgramService programService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityTypeService trackedEntityTypeService;
 
-    @NonNull
+    @Nonnull
     private final TrackedEntityAttributeService attributeService;
 
     @Transactional( readOnly = true )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DefaultTrackerImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/DefaultTrackerImporter.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.scheduling.JobConfiguration;
@@ -53,10 +54,10 @@ public class DefaultTrackerImporter implements TrackerImporter
 
     private static final RelationshipMapper RELATIONSHIP_MAPPER = Mappers.getMapper( RelationshipMapper.class );
 
-    @NonNull
+    @Nonnull
     private final TrackerSyncImporter syncImporter;
 
-    @NonNull
+    @Nonnull
     private final TrackerAsyncImporter asyncImporter;
 
     @Override

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerAsyncImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerAsyncImporter.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.artemis.MessageManager;
@@ -46,7 +47,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TrackerAsyncImporter
 {
-    @NonNull
+    @Nonnull
     private final MessageManager messageManager;
 
     public TrackerImportReport importTracker( TrackerImportParams params, Authentication authentication, String uid )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerSyncImporter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerSyncImporter.java
@@ -27,7 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.tracker.TrackerBundleReportMode;
@@ -44,7 +45,7 @@ import org.springframework.stereotype.Component;
 public class TrackerSyncImporter
 {
 
-    @NonNull
+    @Nonnull
     private final TrackerImportService trackerImportService;
 
     public TrackerImportReport importTracker( TrackerImportParams params, TrackerBundleReportMode reportMode )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/DimensionFilteringAndPagingService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/dimension/DimensionFilteringAndPagingService.java
@@ -40,7 +40,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import lombok.NonNull;
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.analytics.dimensions.AnalyticsDimensionsPagingWrapper;
@@ -58,7 +59,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class DimensionFilteringAndPagingService
 {
 
-    @NonNull
+    @Nonnull
     private final FieldFilterService fieldFilterService;
 
     private static final Comparator<DimensionResponse> DEFAULT_COMPARATOR = comparing( DimensionResponse::getCreated,

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -837,6 +837,13 @@
                     <bannedImport>javax.transaction.Transactional</bannedImport>
                   </bannedImports>
                 </RestrictImports>
+                <RestrictImports>
+                  <reason>Use javax.annotation.Nonnull and javax.annotation.CheckForNull instead</reason>
+                  <bannedImports>
+                    <bannedImport>javax.validation.constraints.NotNull</bannedImport>
+                    <bannedImport>lombok.NonNull</bannedImport>
+                  </bannedImports>
+                </RestrictImports>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Uses `@Nonnull` (javax annotation) instead of `@NotNull` (javax validation) or `@NonNull` (lombok).

Switching to `@Nonnull` also caused hibernate to run nullness analysis in tests so that all non-null database fields need to have a value when stored. This required some more changes to tests to provide a value.

In case of `IndicatorGroup.groupSet` this mapping was not updated similar to what had been done to `DateElementGroup`.
A `IndicatorGroup` can be member of multiple `IndicatorGroupSet`s. Therefore the `IndicatorGroup.groupSet` was changed to a `Set<IndicatorGroupSet>` called `IndicatorGroup.groupSets`. This change was mande now as hibernate otherwise considered the relation as non-null and complained about missing value in tests.