### PR TITLE
ci: download demo DB for local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,54 @@ To contribute to the software read the [contributor guidelines](https://develope
 
 The software is open source and released under the [BSD license](https://opensource.org/licenses/BSD-2-Clause).
 
+## Run DHIS2 in Docker
+
+The following guides use [Docker Compose](https://docs.docker.com/compose/install/) to run DHIS2
+using Docker.
+
+A DB dump is downloaded automatically the first time you start DHIS2. If you switch between
+different DHIS2 versions and/or need to download a different DB dump you will need to remove the
+shared volume `db-dump` using
+
+```sh
+docker compose down --volumes
+```
+
+### Pre-built Image
+
+We push pre-built DHIS2 Docker images to Dockerhub. You can pick an `<image name>` from one of the following
+repositories
+
+* releases or release candidates [dhis2/core](https://hub.docker.com/r/dhis2/core/tags)
+* development (branches master, 2.39, ...) [dhis2/core-dev](https://hub.docker.com/r/dhis2/core-dev/tags)
+* PRs labeled with `publish-docker-image` [dhis2/core-pr](https://hub.docker.com/r/dhis2/core-pr/tags)
+
+To run DHIS2 from latest master (as it is on GitHub) run
+
+```sh
+DHIS2_IMAGE=dhis2/core-dev:master docker compose up
+```
+
+### Local Image
+
+Build a DHIS2 Docker image first as described in [Docker image](#docker-image). Then execute
+
+```sh
+docker compose up
+```
+
+DHIS2 should become available at `http://localhost:8080` with the Sierra Leone Demo DB.
+
+### Demo DB
+
+If you want to start DHIS2 with a specific demo DB you can pass a URL like
+
+```sh
+DHIS2_DB_DUMP_URL=https://databases.dhis2.org/sierra-leone/2.39/dhis2-db-sierra-leone.sql.gz docker compose up
+```
+
+using versions we for example publish to https://databases.dhis2.org/
+
 ## Build process
 
 This repository contains the source code for the server-side component of DHIS 2, which is developed in [Java](https://www.java.com/en/) and built with [Maven](https://maven.apache.org/). 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,43 @@
-version: "3"
+version: "3.8"
 
 services:
   web:
-    image: dhis2/core-dev:local
+    image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
     ports:
       - "8080:8080"
     volumes:
       - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db:
     image: postgis/postgis:10-2.5-alpine
+    volumes:
+      - db-dump:/docker-entrypoint-initdb.d/
     environment:
       POSTGRES_USER: dhis
       POSTGRES_DB: dhis2
-      POSTGRES_PASSWORD: dhis
+      POSTGRES_PASSWORD: &postgres_password dhis
+      PGPASSWORD: *postgres_password # needed by psql in healthcheck
+    healthcheck:
+      test: ["CMD-SHELL", "psql --no-password --quiet --username $$POSTGRES_USER postgres://127.0.0.1/$$POSTGRES_DB -p 5432 --command \"SELECT 'ok'\" > /dev/null"]
+      start_period: 120s
+      interval: 1s
+      timeout: 3s
+      retries: 5
+    depends_on:
+      db-dump:
+        condition: service_completed_successfully # make sure the DB dump has been downloaded
+
+  db-dump:
+    image: busybox # busybox wget version does not have --no-clobber, so we need to do the [ -f ] test
+    command: sh -c '[ -f dump.sql.gz ] && echo "dump.sql.gz exists" || wget --output-document dump.sql.gz $$DHIS2_DB_DUMP_URL' # only download file if it does not exist
+    environment:
+      DHIS2_DB_DUMP_URL: "${DHIS2_DB_DUMP_URL:-https://databases.dhis2.org/sierra-leone/dev/dhis2-db-sierra-leone.sql.gz}"
+    working_dir: /opt/dump
+    volumes:
+      - db-dump:/opt/dump
+
+volumes:
+  db-dump:


### PR DESCRIPTION
Use the init container style pattern with the `db-dump` container running first to ensure a demo DB exists in the db-dump volume. `db-dump` volume is shared with the db so it will be picked up during postgres initialization.

* Allow us to start an arbitrary DHIS2 version via `DHIS2_IMAGE=dhis2/core-dev:2.39 docker compose up`

```sh
docker compose images
Container           Repository          Tag                 Image Id            Size
core-db-1           postgis/postgis     10-2.5-alpine       82cadaebf2ad        215MB
core-web-1          dhis2/core-dev      2.39                43115e22363c        1.03GB
```

also useful for the PR images we push to https://hub.docker.com/r/dhis2/core-pr/tags

* Use `DHIS2_IMAGE` instead of `IMAGE_NAME` to be more specific which service this affects. I took `IMAGE_NAME` from our e2e docker compose file.
* Allow us to init DB with an arbitrary DB dump via `DHIS2_DB_DUMP_URL=https://databases.dhis2.org/sierra-leone/2.39/dhis2-db-sierra-leone.sql.gz docker compose up`
* DB dump is is only downloaded the first time
