### PR TITLE
ci: use JRE base image for DHIS2 Docker image TECH-1457 [2.37]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -98,7 +98,7 @@
     <properties>
         <rootDir>../../</rootDir>
         <jib.version>3.3.0</jib.version>
-        <jib.from.image>tomcat:9.0-jdk11-openjdk-slim</jib.from.image>
+        <jib.from.image>tomcat:9.0-jre11</jib.from.image>
         <jib.to.image>dhis2/core-dev:local</jib.to.image>
         <!-- uid=65534(nobody) present in Tomcat image -->
         <jib.container.user>65534</jib.container.user>

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -25,7 +25,7 @@ pipeline {
         DHIS2_VERSION = readMavenPom(file: 'dhis-2/pom.xml').getVersion()
         DOCKER_IMAGE_NAME = "${DOCKER_HUB_OWNER}/core-dev"
         DOCKER_IMAGE_TAG = "${env.GIT_BRANCH}"
-        DOCKER_IMAGE_NAME_PUBLISH_SOURCE = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-9.0-jdk11-openjdk-slim" // source of image to publish to Dockerhub (one of the matrix axes)
+        DOCKER_IMAGE_NAME_PUBLISH_SOURCE = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-9.0-jre11" // source of image to publish to Dockerhub (one of the matrix axes)
         DOCKER_IMAGE_NAME_PUBLISH_TARGET = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" // used to publish to Dockerhub
     }
 
@@ -73,7 +73,7 @@ pipeline {
                 axes {
                     axis {
                         name 'DOCKER_IMAGE_TAG_BASE'
-                        values '9.0-jdk11-openjdk-slim', '8.5-jdk11-openjdk-slim'
+                        values '9.0-jre11', '8.5-jre11'
                     }
                 }
                 environment {

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -17,7 +17,7 @@ pipeline {
         DHIS2_VERSION = readMavenPom(file: 'dhis-2/pom.xml').getVersion()
         DOCKER_IMAGE_NAME = "${DOCKER_HUB_OWNER}/core"
         DOCKER_IMAGE_TAG = "${env.DHIS2_VERSION.replace('SNAPSHOT', 'rc')}"
-        DOCKER_IMAGE_NAME_PUBLISH_SOURCE = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-9.0-jdk11-openjdk-slim" // source of image to publish to Dockerhub (one of the matrix axes)
+        DOCKER_IMAGE_NAME_PUBLISH_SOURCE = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}-9.0-jre11" // source of image to publish to Dockerhub (one of the matrix axes)
         DOCKER_IMAGE_NAME_PUBLISH_TARGET = "${DOCKER_IMAGE_NAME}:${DOCKER_IMAGE_TAG}" // used to publish to Dockerhub
     }
 
@@ -53,7 +53,7 @@ pipeline {
                 axes {
                     axis {
                         name 'DOCKER_IMAGE_TAG_BASE'
-                        values '9.0-jdk11-openjdk-slim', '8.5-jdk11-openjdk-slim'
+                        values '9.0-jre11', '8.5-jre11'
                     }
                 }
                 environment {


### PR DESCRIPTION
as we do not need to build DHIS2 within the image but only run it

backport of https://github.com/dhis2/dhis2-core/pull/12065