### PR TITLE
fix: support application/zip for /api/events [DHIS2-13890]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -52,6 +52,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -631,7 +633,7 @@ public class EventController
         }
     }
 
-    @GetMapping( produces = { "application/csv", "application/csv+gzip", "text/csv" } )
+    @GetMapping( produces = { "application/csv", "application/csv+gzip", "application/csv+zip", "text/csv" } )
     public void getCsvEvents(
         EventCriteria eventCriteria,
         @RequestParam( required = false, defaultValue = "false" ) boolean skipHeader,
@@ -651,6 +653,14 @@ public class EventController
             response.addHeader( ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary" );
             outputStream = new GZIPOutputStream( outputStream );
             response.setContentType( "application/csv+gzip" );
+        }
+        else if ( ContextUtils.isAcceptCsvZip( request ) )
+        {
+            response.addHeader( ContextUtils.HEADER_CONTENT_TRANSFER_ENCODING, "binary" );
+            response.setContentType( "application/csv+zip" );
+            ZipOutputStream zos = new ZipOutputStream( outputStream );
+            zos.putNextEntry( new ZipEntry( "events.csv" ) );
+            outputStream = zos;
         }
 
         if ( !StringUtils.isEmpty( eventCriteria.getAttachment() ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -341,7 +341,7 @@ public class ContextUtils
     public static boolean isAcceptCsvGzip( HttpServletRequest request )
     {
         return request != null && ((request.getPathInfo() != null && request.getPathInfo().endsWith( ".gz" ))
-            || (request.getHeader(HttpHeaders.ACCEPT) != null
+            || (request.getHeader( HttpHeaders.ACCEPT ) != null
                 && request.getHeader( HttpHeaders.ACCEPT ).contains( "application/csv+gzip" )));
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -345,6 +345,21 @@ public class ContextUtils
     }
 
     /**
+     * Indicates whether the given requests indicates that it accepts a
+     * compressed response.
+     *
+     * @param request the HttpServletRequest.
+     * @return whether the given requests indicates that it accepts a compressed
+     *         response.
+     */
+    public static boolean isAcceptCsvZip( HttpServletRequest request )
+    {
+        return request != null && ((request.getPathInfo() != null && request.getPathInfo().endsWith( ".zip" ))
+            || (request.getHeader( "Accept" ) != null
+                && request.getHeader( "Accept" ).contains( "application/csv+zip" )));
+    }
+
+    /**
      * Extracts and returns the file name from a content disposition header
      * value.
      *

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/utils/ContextUtils.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.service.WebCache;
 import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -340,8 +341,8 @@ public class ContextUtils
     public static boolean isAcceptCsvGzip( HttpServletRequest request )
     {
         return request != null && ((request.getPathInfo() != null && request.getPathInfo().endsWith( ".gz" ))
-            || (request.getHeader( "Accept" ) != null
-                && request.getHeader( "Accept" ).contains( "application/csv+gzip" )));
+            || (request.getHeader(HttpHeaders.ACCEPT) != null
+                && request.getHeader( HttpHeaders.ACCEPT ).contains( "application/csv+gzip" )));
     }
 
     /**
@@ -355,8 +356,8 @@ public class ContextUtils
     public static boolean isAcceptCsvZip( HttpServletRequest request )
     {
         return request != null && ((request.getPathInfo() != null && request.getPathInfo().endsWith( ".zip" ))
-            || (request.getHeader( "Accept" ) != null
-                && request.getHeader( "Accept" ).contains( "application/csv+zip" )));
+            || (request.getHeader( HttpHeaders.ACCEPT ) != null
+                && request.getHeader( HttpHeaders.ACCEPT ).contains( "application/csv+zip" )));
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds back support for `application/csv+zip` to `EventController`

[https://dhis2.atlassian.net/browse/DHIS2-13890](DHIS2-13890)