### PR TITLE
ci: Jenkins docker-compose does not support missing

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -26,7 +26,6 @@ services:
 
   web:
     image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
-    pull_policy: missing
     volumes:
       - ./config/dhis2_home/dhis.conf:/opt/dhis2/dhis.conf:ro
     depends_on:


### PR DESCRIPTION
as pull_policy. Ideally we would add this to ensure the locally built (available) image is used. We are using a tag that is not pushed to our Dockerhub repo. So this is likely the behaviour anyway. It would just be safer and highlight the intent of the e2e test setup better