### PR TITLE
ci: use depends_on long form in e2e docker setup

### DIFF
--- a/dhis-2/dhis-e2e-test/docker-compose.yml
+++ b/dhis-2/dhis-e2e-test/docker-compose.yml
@@ -28,10 +28,10 @@ services:
     image: "${DHIS2_IMAGE:-dhis2/core-dev:local}"
     volumes:
       - ./config/dhis2_home/dhis.conf:/opt/dhis2/dhis.conf:ro
-    environment:
-      - WAIT_FOR_DB_CONTAINER=db:5432 -t 0
     depends_on:
-      - db
-      - redis
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
     ports:
       - "8080"


### PR DESCRIPTION
wait for it is not part of our DHIS2 Docker image anymore. We can rely on facilities provided by Docker Compose like the healthcheck and depends_on

backport of the missing portions of https://github.com/dhis2/dhis2-core/pull/12047