### PR TITLE
ci: notify team-backend of e2e test failures on master

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -67,3 +67,19 @@ jobs:
         with:
           name: "tomcat_logs"
           path: '~/logs.txt'
+
+  send-slack-message:
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      contains(needs.*.result, 'failure') &&
+      github.ref == 'refs/heads/master'
+
+    needs: [ api-test ]
+    steps:
+      - uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_BACKEND_WEBHOOK }}
+          SLACK_CHANNEL: 'team-backend'
+          SLACK_MESSAGE: "Latest e2e test run on master failed and needs investigation :detective-duck:. \n Commit message: ${{ github.event.head_commit.message }}"
+          SLACK_COLOR: '#ff0000'


### PR DESCRIPTION
like we do for other types of tests