### PR TITLE
fix: Use null instead of default ID scheme [DHIS2-13105]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -197,9 +197,7 @@ public class AggregateDataExchangeService
      */
     private ImportSummary pushToInternal( AggregateDataExchange exchange, DataValueSet dataValueSet )
     {
-        ImportOptions importOptions = toImportOptions( exchange );
-        System.out.println( "-- import options " + importOptions );
-        return dataValueSetService.importDataValueSet( dataValueSet, importOptions );
+        return dataValueSetService.importDataValueSet( dataValueSet, toImportOptions( exchange ) );
     }
 
     /**
@@ -214,9 +212,7 @@ public class AggregateDataExchangeService
      */
     private ImportSummary pushToExternal( AggregateDataExchange exchange, DataValueSet dataValueSet )
     {
-        ImportOptions importOptions = toImportOptions( exchange );
-
-        return getDhis2Client( exchange ).saveDataValueSet( dataValueSet, importOptions );
+        return getDhis2Client( exchange ).saveDataValueSet( dataValueSet, toImportOptions( exchange ) );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dataexchange.aggregate;
 
 import static java.lang.String.format;
 import static java.lang.String.join;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
@@ -196,7 +197,9 @@ public class AggregateDataExchangeService
      */
     private ImportSummary pushToInternal( AggregateDataExchange exchange, DataValueSet dataValueSet )
     {
-        return dataValueSetService.importDataValueSet( dataValueSet, toImportOptions( exchange ) );
+        ImportOptions importOptions = toImportOptions( exchange );
+        System.out.println( "-- import options " + importOptions );
+        return dataValueSetService.importDataValueSet( dataValueSet, importOptions );
     }
 
     /**
@@ -211,12 +214,17 @@ public class AggregateDataExchangeService
      */
     private ImportSummary pushToExternal( AggregateDataExchange exchange, DataValueSet dataValueSet )
     {
-        return getDhis2Client( exchange ).saveDataValueSet( dataValueSet, toImportOptions( exchange ) );
+        ImportOptions importOptions = toImportOptions( exchange );
+
+        return getDhis2Client( exchange ).saveDataValueSet( dataValueSet, importOptions );
     }
 
     /**
      * Converts the {@link TargetRequest} of the given
      * {@link AggregateDataExchange} to an {@link ImportOptions}.
+     * <p>
+     * Note that the data value set service does not using {@code null} values
+     * as specific ID schemes. When it does, this method can be simplified.
      *
      * @param exchange the {@link AggregateDataExchange}.
      * @return an {@link ImportOptions}.
@@ -225,11 +233,26 @@ public class AggregateDataExchangeService
     {
         TargetRequest request = exchange.getTarget().getRequest();
 
-        return new ImportOptions()
-            .setDataElementIdScheme( request.getDataElementIdScheme() )
-            .setOrgUnitIdScheme( request.getOrgUnitIdScheme() )
-            .setCategoryOptionComboIdScheme( request.getCategoryOptionComboIdScheme() )
-            .setIdScheme( request.getIdScheme() );
+        ImportOptions options = new ImportOptions();
+
+        if ( isNotBlank( request.getDataElementIdScheme() ) )
+        {
+            options.setDataElementIdScheme( request.getDataElementIdScheme() );
+        }
+        if ( isNotBlank( request.getOrgUnitIdScheme() ) )
+        {
+            options.setOrgUnitIdScheme( request.getOrgUnitIdScheme() );
+        }
+        if ( isNotBlank( request.getCategoryOptionComboIdScheme() ) )
+        {
+            options.setCategoryOptionComboIdScheme( request.getCategoryOptionComboIdScheme() );
+        }
+        if ( isNotBlank( request.getIdScheme() ) )
+        {
+            options.setIdScheme( request.getIdScheme() );
+        }
+
+        return options;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -42,7 +42,6 @@ import javax.annotation.Nonnull;
 
 import lombok.RequiredArgsConstructor;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.DataQueryService;
@@ -227,10 +226,10 @@ public class AggregateDataExchangeService
         TargetRequest request = exchange.getTarget().getRequest();
 
         return new ImportOptions()
-            .setDataElementIdScheme( getOrDefault( request.getDataElementIdScheme() ) )
-            .setOrgUnitIdScheme( getOrDefault( request.getOrgUnitIdScheme() ) )
-            .setCategoryOptionComboIdScheme( getOrDefault( request.getCategoryOptionComboIdScheme() ) )
-            .setIdScheme( getOrDefault( request.getIdScheme() ) );
+            .setDataElementIdScheme( request.getDataElementIdScheme() )
+            .setOrgUnitIdScheme( request.getOrgUnitIdScheme() )
+            .setCategoryOptionComboIdScheme( request.getCategoryOptionComboIdScheme() )
+            .setIdScheme( request.getIdScheme() );
     }
 
     /**
@@ -242,10 +241,10 @@ public class AggregateDataExchangeService
      */
     DataQueryParams toDataQueryParams( SourceRequest request )
     {
-        IdScheme inputIdScheme = toIdSchemeOrDefault( request.getInputIdScheme() );
-        IdScheme outputDataElementIdScheme = toIdSchemeOrDefault( request.getOutputDataElementIdScheme() );
-        IdScheme outputOrgUnitIdScheme = toIdSchemeOrDefault( request.getOutputOrgUnitIdScheme() );
-        IdScheme outputIdScheme = toIdSchemeOrDefault( request.getOutputIdScheme() );
+        IdScheme inputIdScheme = toIdScheme( request.getInputIdScheme() );
+        IdScheme outputDataElementIdScheme = toIdScheme( request.getOutputDataElementIdScheme() );
+        IdScheme outputOrgUnitIdScheme = toIdScheme( request.getOutputOrgUnitIdScheme() );
+        IdScheme outputIdScheme = toIdScheme( request.getOutputIdScheme() );
 
         List<DimensionalObject> filters = mapToList(
             request.getFilters(), f -> toDimensionalObject( f, inputIdScheme ) );
@@ -289,27 +288,15 @@ public class AggregateDataExchangeService
     }
 
     /**
-     * Returns the ID scheme string or the the default ID scheme if the given ID
-     * scheme string is null.
-     *
-     * @param idScheme the ID scheme string.
-     * @return the given ID scheme, or the default ID scheme string if null.
-     */
-    String getOrDefault( String idScheme )
-    {
-        return ObjectUtils.firstNonNull( idScheme, IdScheme.UID.name() );
-    }
-
-    /**
      * Returns the {@link IdScheme} based on the given ID scheme string, or the
-     * default ID scheme if the given ID scheme string is null.
+     * null if the given ID scheme string is null.
      *
      * @param idScheme the ID scheme string.
-     * @return the given ID scheme, or the default ID scheme if null.
+     * @return the given ID scheme, or null.
      */
-    IdScheme toIdSchemeOrDefault( String idScheme )
+    IdScheme toIdScheme( String idScheme )
     {
-        return idScheme != null ? IdScheme.from( idScheme ) : IdScheme.UID;
+        return idScheme != null ? IdScheme.from( idScheme ) : null;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.dataexchange.aggregate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -87,15 +88,15 @@ class AggregateDataExchangeServiceTest
         when( analyticsService.getAggregatedDataValueSet( any( DataQueryParams.class ) ) )
             .thenReturn( new DataValueSet() );
         when( dataQueryService.getDimension( eq( DimensionalObject.DATA_X_DIM_ID ), any(), any( Date.class ),
-            nullable( List.class ), anyBoolean(), any( IdScheme.class ) ) )
+            nullable( List.class ), anyBoolean(), nullable( IdScheme.class ) ) )
                 .thenReturn( new BaseDimensionalObject(
                     DimensionalObject.DATA_X_DIM_ID, DimensionType.DATA_X, List.of() ) );
         when( dataQueryService.getDimension( eq( DimensionalObject.PERIOD_DIM_ID ), any(), any( Date.class ),
-            nullable( List.class ), anyBoolean(), any( IdScheme.class ) ) )
+            nullable( List.class ), anyBoolean(), nullable( IdScheme.class ) ) )
                 .thenReturn( new BaseDimensionalObject(
                     DimensionalObject.PERIOD_DIM_ID, DimensionType.PERIOD, List.of() ) );
         when( dataQueryService.getDimension( eq( DimensionalObject.ORGUNIT_DIM_ID ), any(), any( Date.class ),
-            nullable( List.class ), anyBoolean(), any( IdScheme.class ) ) )
+            nullable( List.class ), anyBoolean(), nullable( IdScheme.class ) ) )
                 .thenReturn( new BaseDimensionalObject(
                     DimensionalObject.ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, List.of() ) );
         when( dataValueSetService.importDataValueSet( any( DataValueSet.class ), any( ImportOptions.class ) ) )
@@ -136,15 +137,15 @@ class AggregateDataExchangeServiceTest
     void testToDataQueryParams()
     {
         when( dataQueryService.getDimension( eq( DimensionalObject.DATA_X_DIM_ID ), any(), any( Date.class ),
-            nullable( List.class ), anyBoolean(), any( IdScheme.class ) ) )
+            nullable( List.class ), anyBoolean(), nullable( IdScheme.class ) ) )
                 .thenReturn( new BaseDimensionalObject(
                     DimensionalObject.DATA_X_DIM_ID, DimensionType.DATA_X, List.of() ) );
         when( dataQueryService.getDimension( eq( DimensionalObject.PERIOD_DIM_ID ), any(), any( Date.class ),
-            nullable( List.class ), anyBoolean(), any( IdScheme.class ) ) )
+            nullable( List.class ), anyBoolean(), nullable( IdScheme.class ) ) )
                 .thenReturn( new BaseDimensionalObject(
                     DimensionalObject.PERIOD_DIM_ID, DimensionType.PERIOD, List.of() ) );
         when( dataQueryService.getDimension( eq( DimensionalObject.ORGUNIT_DIM_ID ), any(), any( Date.class ),
-            nullable( List.class ), anyBoolean(), any( IdScheme.class ) ) )
+            nullable( List.class ), anyBoolean(), nullable( IdScheme.class ) ) )
                 .thenReturn( new BaseDimensionalObject(
                     DimensionalObject.ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT, List.of() ) );
 
@@ -185,23 +186,17 @@ class AggregateDataExchangeServiceTest
 
         assertEquals( IdScheme.CODE, options.getIdSchemes().getDataElementIdScheme() );
         assertEquals( IdScheme.CODE, options.getIdSchemes().getOrgUnitIdScheme() );
-        assertEquals( IdScheme.UID, options.getIdSchemes().getCategoryOptionComboIdScheme() );
+        assertEquals( IdScheme.NULL, options.getIdSchemes().getCategoryOptionComboIdScheme() );
         assertEquals( IdScheme.UID, options.getIdSchemes().getIdScheme() );
     }
 
     @Test
-    void testGetOrDefault()
+    void testToIdScheme()
     {
-        assertEquals( "CODE", service.getOrDefault( "CODE" ) );
-        assertEquals( "UID", service.getOrDefault( null ) );
-    }
-
-    @Test
-    void testToIdSchemeOrDefault()
-    {
-        assertEquals( IdScheme.CODE, service.toIdSchemeOrDefault( "code" ) );
-        assertEquals( IdScheme.UID, service.toIdSchemeOrDefault( "UID" ) );
-        assertEquals( IdScheme.UID, service.toIdSchemeOrDefault( null ) );
+        assertEquals( IdScheme.CODE, service.toIdScheme( "code" ) );
+        assertEquals( IdScheme.UID, service.toIdScheme( "UID" ) );
+        assertEquals( IdScheme.UID, service.toIdScheme( "uid" ) );
+        assertNull( service.toIdScheme( null ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -169,7 +169,7 @@ class AggregateDataExchangeServiceTest
     }
 
     @Test
-    void testToImportOptions()
+    void testToImportOptionsA()
     {
         TargetRequest request = new TargetRequest()
             .setDataElementIdScheme( "code" )
@@ -186,7 +186,30 @@ class AggregateDataExchangeServiceTest
 
         assertEquals( IdScheme.CODE, options.getIdSchemes().getDataElementIdScheme() );
         assertEquals( IdScheme.CODE, options.getIdSchemes().getOrgUnitIdScheme() );
-        assertEquals( IdScheme.NULL, options.getIdSchemes().getCategoryOptionComboIdScheme() );
+        assertEquals( IdScheme.UID, options.getIdSchemes().getCategoryOptionComboIdScheme() );
+        assertEquals( IdScheme.UID, options.getIdSchemes().getCategoryOptionIdScheme() );
+        assertEquals( IdScheme.UID, options.getIdSchemes().getIdScheme() );
+    }
+
+    @Test
+    void testToImportOptionsB()
+    {
+        TargetRequest request = new TargetRequest()
+            .setDataElementIdScheme( "uid" )
+            .setOrgUnitIdScheme( "code" );
+        Target target = new Target()
+            .setType( TargetType.EXTERNAL )
+            .setApi( new Api() )
+            .setRequest( request );
+        AggregateDataExchange exchange = new AggregateDataExchange()
+            .setTarget( target );
+
+        ImportOptions options = service.toImportOptions( exchange );
+
+        assertEquals( IdScheme.UID, options.getIdSchemes().getDataElementIdScheme() );
+        assertEquals( IdScheme.CODE, options.getIdSchemes().getOrgUnitIdScheme() );
+        assertEquals( IdScheme.UID, options.getIdSchemes().getCategoryOptionComboIdScheme() );
+        assertEquals( IdScheme.UID, options.getIdSchemes().getCategoryOptionIdScheme() );
         assertEquals( IdScheme.UID, options.getIdSchemes().getIdScheme() );
     }
 


### PR DESCRIPTION
This PR is about aggregate data exchange.

1) For the source analytics request and the target data value import request, for ID schemes, the system would use the default ID scheme (UID) when no ID scheme (null) was specified. This was unfortunate in the (typical) use-case where only a general ID scheme was specified for the source or target request, as the system would inject the UID as the specific data element and org unit ID schemes, effectively overriding the general ID scheme and causing unintentional behavior.

2) The data value set Java API import options don't support supplying `null` for specific ID schemes, and setting `null` would lead to no data values being imported. Adjusted the code to not set the specific ID scheme if it was not set in the aggregate data exchange object.