### PR TITLE
chore: add @Nonnull to generic store implementation [TECH-1460]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GenericDimensionalObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/GenericDimensionalObjectStore.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.common;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author Lars Helge Overland
  */
@@ -42,6 +44,7 @@ public interface GenericDimensionalObjectStore<T>
      *        dimensional.
      * @return a List of objects.
      */
+    @Nonnull
     List<T> getByDataDimension( boolean dataDimension );
 
     /**
@@ -51,6 +54,7 @@ public interface GenericDimensionalObjectStore<T>
      *        dimensional.
      * @return a List of objects.
      */
+    @Nonnull
     List<T> getByDataDimensionNoAcl( boolean dataDimension );
 
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.dataelement;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.IllegalQueryException;
@@ -216,7 +218,7 @@ public interface DataElementService
      * @param uids the uid collection.
      * @return the data element groups with the given uids.
      */
-    List<DataElementGroup> getDataElementGroupsByUid( Collection<String> uids );
+    List<DataElementGroup> getDataElementGroupsByUid( @Nonnull Collection<String> uids );
 
     /**
      * Returns the DataElementGroup with the given UID.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/document/DocumentService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/document/DocumentService.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.document;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.user.User;
 
 /**
@@ -87,7 +89,7 @@ public interface DocumentService
 
     int getDocumentCountByName( String name );
 
-    List<Document> getDocumentsByUid( List<String> uids );
+    List<Document> getDocumentsByUid( @Nonnull List<String> uids );
 
     long getCountDocumentByUser( User user );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/fileresource/FileResourceService.java
@@ -35,6 +35,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import javax.annotation.Nonnull;
+
 /**
  * @author Halvdan Hoem Grelland
  */
@@ -42,7 +44,7 @@ public interface FileResourceService
 {
     FileResource getFileResource( String uid );
 
-    List<FileResource> getFileResources( List<String> uids );
+    List<FileResource> getFileResources( @Nonnull List<String> uids );
 
     List<FileResource> getOrphanedFileResources();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitService.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.hierarchy.HierarchyViolationException;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.user.User;
@@ -141,7 +143,7 @@ public interface OrganisationUnitService extends OrganisationUnitDataIntegrityPr
      * @param uids the collection of uids.
      * @return a list of OrganisationUnits.
      */
-    List<OrganisationUnit> getOrganisationUnitsByUid( Collection<String> uids );
+    List<OrganisationUnit> getOrganisationUnitsByUid( @Nonnull Collection<String> uids );
 
     /**
      * Returns a list of OrganisationUnits based on the given params.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstanceService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstanceService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.program;
 import java.util.Date;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -108,7 +110,7 @@ public interface ProgramInstanceService
      * @param uids PSI UIDs to check
      * @return ProgramInstance list
      */
-    List<ProgramInstance> getProgramInstances( List<String> uids );
+    List<ProgramInstance> getProgramInstances( @Nonnull List<String> uids );
 
     /**
      * Checks for the existence of a PI by UID. Deleted values are not taken

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramService.java
@@ -32,6 +32,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.collections4.SetValuedMap;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -100,7 +102,7 @@ public interface ProgramService
      */
     List<Program> getAllPrograms();
 
-    Collection<Program> getPrograms( Collection<String> uids );
+    Collection<Program> getPrograms( @Nonnull Collection<String> uids );
 
     /**
      * Get all {@link Program} belong to a orgunit

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.relationship;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -98,7 +100,7 @@ public interface RelationshipService
 
     Relationship getRelationshipIncludeDeleted( String uid );
 
-    List<Relationship> getRelationships( List<String> uids );
+    List<Relationship> getRelationships( @Nonnull List<String> uids );
 
     default List<Relationship> getRelationshipsByTrackedEntityInstance( TrackedEntityInstance tei,
         boolean skipAccessValidation )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityAttributeService.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
@@ -96,7 +98,7 @@ public interface TrackedEntityAttributeService
      * @param uids list of UIDs.
      * @return all the TrackedEntityAttribute with the given UIDs.
      */
-    List<TrackedEntityAttribute> getTrackedEntityAttributes( List<String> uids );
+    List<TrackedEntityAttribute> getTrackedEntityAttributes( @Nonnull List<String> uids );
 
     /**
      * Returns the {@link TrackedEntityAttribute}s with the given UIDs.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
@@ -30,6 +30,8 @@ package org.hisp.dhis.user;
 import java.util.Collection;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 public interface UserGroupService
 {
     String ID = UserGroupService.class.getName();
@@ -58,15 +60,15 @@ public interface UserGroupService
 
     boolean canAddOrRemoveMember( String uid, User currentUser );
 
-    void addUserToGroups( User user, Collection<String> uids );
+    void addUserToGroups( User user, @Nonnull Collection<String> uids );
 
-    void addUserToGroups( User user, Collection<String> uids, User currentUser );
+    void addUserToGroups( User user, @Nonnull Collection<String> uids, User currentUser );
 
-    void removeUserFromGroups( User user, Collection<String> uids );
+    void removeUserFromGroups( User user, @Nonnull Collection<String> uids );
 
-    void updateUserGroups( User user, Collection<String> uids );
+    void updateUserGroups( User user, @Nonnull Collection<String> uids );
 
-    void updateUserGroups( User user, Collection<String> uids, User currentUser );
+    void updateUserGroups( User user, @Nonnull Collection<String> uids, User currentUser );
 
     List<UserGroup> getAllUserGroups();
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserService.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.hisp.dhis.dataset.DataSet;
@@ -122,7 +123,7 @@ public interface UserService
      * @param uids the identifiers of the collection of Users to retrieve.
      * @return the User.
      */
-    List<User> getUsers( Collection<String> uids );
+    List<User> getUsers( @Nonnull Collection<String> uids );
 
     /**
      * Retrieves a collection of User with the given usernames.
@@ -333,7 +334,7 @@ public interface UserService
      * @param uids the UIDs.
      * @return a List of UserRolea.
      */
-    List<UserRole> getUserRolesByUid( Collection<String> uids );
+    List<UserRole> getUserRolesByUid( @Nonnull Collection<String> uids );
 
     /**
      * Retrieves all UserRole.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationRuleService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/validation/ValidationRuleService.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 
@@ -193,7 +195,7 @@ public interface ValidationRuleService extends ValidationRuleDataIntegrityProvid
 
     List<ValidationRule> getValidationRulesBetweenByName( String name, int first, int max );
 
-    List<ValidationRule> getValidationRulesByUid( Collection<String> uids );
+    List<ValidationRule> getValidationRulesByUid( @Nonnull Collection<String> uids );
 
     int getValidationRuleCount();
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
@@ -55,7 +56,6 @@ import org.hisp.dhis.common.IdentifiableObject;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.dbms.DbmsManager;
 import org.hisp.dhis.feedback.ErrorCode;
-import org.hisp.dhis.hibernate.HibernateProxyUtils;
 import org.hisp.dhis.hibernate.JpaQueryParameters;
 import org.hisp.dhis.hibernate.exception.CreateAccessDeniedException;
 import org.hisp.dhis.hibernate.exception.DeleteAccessDeniedException;
@@ -107,19 +107,19 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     // -------------------------------------------------------------------------
 
     @Override
-    public void save( T object )
+    public void save( @Nonnull T object )
     {
         save( object, true );
     }
 
     @Override
-    public void save( T object, User user )
+    public void save( @Nonnull T object, @CheckForNull User user )
     {
         save( object, user, true );
     }
 
     @Override
-    public void save( T object, boolean clearSharing )
+    public void save( @Nonnull T object, boolean clearSharing )
     {
         save( object, currentUserService.getCurrentUser(), clearSharing );
     }
@@ -128,51 +128,45 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     {
         String username = user != null ? user.getUsername() : "system-process";
 
-        if ( IdentifiableObject.class.isAssignableFrom( HibernateProxyUtils.getRealClass( object ) ) )
+        object.setAutoFields();
+
+        object.setAutoFields();
+        object.setLastUpdatedBy( user );
+
+        if ( clearSharing )
         {
-            object.setAutoFields();
+            object.setPublicAccess( AccessStringHelper.DEFAULT );
+            SharingUtils.resetAccessCollections( object );
+        }
 
-            BaseIdentifiableObject identifiableObject = object;
-            identifiableObject.setAutoFields();
-            identifiableObject.setLastUpdatedBy( user );
+        if ( object.getCreatedBy() == null )
+        {
+            object.setCreatedBy( user );
+        }
 
-            if ( clearSharing )
-            {
-                identifiableObject.setPublicAccess( AccessStringHelper.DEFAULT );
-                SharingUtils.resetAccessCollections( identifiableObject );
-            }
-
-            if ( identifiableObject.getCreatedBy() == null )
-            {
-                identifiableObject.setCreatedBy( user );
-            }
-
-            if ( identifiableObject.getSharing().getOwner() == null )
-            {
-                identifiableObject.getSharing().setOwner( identifiableObject.getCreatedBy() );
-            }
+        if ( object.getSharing().getOwner() == null )
+        {
+            object.getSharing().setOwner( object.getCreatedBy() );
         }
 
         if ( user != null && aclService.isClassShareable( clazz ) )
         {
-            BaseIdentifiableObject identifiableObject = object;
-
             if ( clearSharing )
             {
-                if ( aclService.canMakePublic( user, identifiableObject ) )
+                if ( aclService.canMakePublic( user, (BaseIdentifiableObject) object ) )
                 {
-                    if ( aclService.defaultPublic( identifiableObject ) )
+                    if ( aclService.defaultPublic( (BaseIdentifiableObject) object ) )
                     {
-                        identifiableObject.setPublicAccess( AccessStringHelper.READ_WRITE );
+                        object.setPublicAccess( AccessStringHelper.READ_WRITE );
                     }
                 }
-                else if ( aclService.canMakePrivate( user, identifiableObject ) )
+                else if ( aclService.canMakePrivate( user, (BaseIdentifiableObject) object ) )
                 {
-                    identifiableObject.setPublicAccess( AccessStringHelper.newInstance().build() );
+                    object.setPublicAccess( AccessStringHelper.newInstance().build() );
                 }
             }
 
-            if ( !checkPublicAccess( user, identifiableObject ) )
+            if ( !checkPublicAccess( user, object ) )
             {
                 AuditLogUtil.infoWrapper( log, username, object, AuditLogUtil.ACTION_CREATE_DENIED );
                 throw new CreateAccessDeniedException( object.toString() );
@@ -184,32 +178,29 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public void update( T object )
+    public void update( @Nonnull T object )
     {
         update( object, currentUserService.getCurrentUser() );
     }
 
     @Override
-    public void update( T object, User user )
+    public void update( @Nonnull T object, @CheckForNull User user )
     {
         String username = user != null ? user.getUsername() : "system-process";
 
-        if ( object != null )
+        object.setAutoFields();
+
+        object.setAutoFields();
+        object.setLastUpdatedBy( user );
+
+        if ( object.getSharing().getOwner() == null )
         {
-            object.setAutoFields();
+            object.getSharing().setOwner( user );
+        }
 
-            object.setAutoFields();
-            object.setLastUpdatedBy( user );
-
-            if ( object.getSharing().getOwner() == null )
-            {
-                object.getSharing().setOwner( user );
-            }
-
-            if ( object.getCreatedBy() == null )
-            {
-                object.setCreatedBy( user );
-            }
+        if ( object.getCreatedBy() == null )
+        {
+            object.setCreatedBy( user );
         }
 
         if ( !isUpdateAllowed( object, user ) )
@@ -220,20 +211,17 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
 
         AuditLogUtil.infoWrapper( log, username, object, AuditLogUtil.ACTION_UPDATE );
 
-        if ( object != null )
-        {
-            getSession().update( object );
-        }
+        getSession().update( object );
     }
 
     @Override
-    public void delete( T object )
+    public void delete( @Nonnull T object )
     {
         this.delete( object, currentUserService.getCurrentUser() );
     }
 
     @Override
-    public final void delete( T object, User user )
+    public final void delete( @Nonnull T object, @CheckForNull User user )
     {
         String username = user != null ? user.getUsername() : "system-process";
 
@@ -245,10 +233,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
 
         AuditLogUtil.infoWrapper( log, username, object, AuditLogUtil.ACTION_DELETE );
 
-        if ( object != null )
-        {
-            super.delete( object );
-        }
+        super.delete( object );
     }
 
     @CheckForNull
@@ -267,6 +252,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return postProcessObject( object );
     }
 
+    @Nonnull
     @Override
     public final List<T> getAll()
     {
@@ -288,7 +274,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public final T getByUid( String uid )
+    public final T getByUid( @Nonnull String uid )
     {
         if ( isTransientIdentifiableProperties() )
         {
@@ -305,7 +291,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public final T getByUidNoAcl( String uid )
+    public final T getByUidNoAcl( @Nonnull String uid )
     {
         if ( isTransientIdentifiableProperties() )
         {
@@ -320,8 +306,9 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getSingleResult( builder, param );
     }
 
+    @Nonnull
     @Override
-    public final T loadByUid( String uid )
+    public final T loadByUid( @Nonnull String uid )
     {
         T object = getByUid( uid );
 
@@ -334,7 +321,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public final void updateNoAcl( T object )
+    public final void updateNoAcl( @Nonnull T object )
     {
         object.setAutoFields();
         getSession().update( object );
@@ -344,7 +331,8 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
      * Uses query since name property might not be unique.
      */
     @Override
-    public final T getByName( String name )
+    @CheckForNull
+    public final T getByName( @Nonnull String name )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -367,7 +355,8 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public final T getByCode( String code )
+    @CheckForNull
+    public final T getByCode( @Nonnull String code )
     {
         if ( isTransientIdentifiableProperties() )
         {
@@ -383,8 +372,9 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getSingleResult( builder, param );
     }
 
+    @Nonnull
     @Override
-    public final T loadByCode( String code )
+    public final T loadByCode( @Nonnull String code )
     {
         T object = getByCode( code );
 
@@ -397,9 +387,10 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public T getByUniqueAttributeValue( Attribute attribute, String value )
+    @CheckForNull
+    public T getByUniqueAttributeValue( @Nonnull Attribute attribute, @Nonnull String value )
     {
-        if ( attribute == null || StringUtils.isEmpty( value ) || !attribute.isUnique() )
+        if ( StringUtils.isEmpty( value ) || !attribute.isUnique() )
         {
             return null;
         }
@@ -417,9 +408,10 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public T getByUniqueAttributeValue( Attribute attribute, String value, User user )
+    @CheckForNull
+    public T getByUniqueAttributeValue( @Nonnull Attribute attribute, @Nonnull String value, @CheckForNull User user )
     {
-        if ( attribute == null || StringUtils.isEmpty( value ) || !attribute.isUnique() )
+        if ( StringUtils.isEmpty( value ) || !attribute.isUnique() )
         {
             return null;
         }
@@ -436,8 +428,9 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getSingleResult( builder, param );
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllEqName( String name )
+    public List<T> getAllEqName( @Nonnull String name )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -449,14 +442,16 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, param );
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllLikeName( String name )
+    public List<T> getAllLikeName( @Nonnull String name )
     {
         return getAllLikeName( name, true );
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllLikeName( String name, boolean caseSensitive )
+    public List<T> getAllLikeName( @Nonnull String name, boolean caseSensitive )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -479,14 +474,16 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, param );
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllLikeName( String name, int first, int max )
+    public List<T> getAllLikeName( @Nonnull String name, int first, int max )
     {
         return getAllLikeName( name, first, max, true );
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllLikeName( String name, int first, int max, boolean caseSensitive )
+    public List<T> getAllLikeName( @Nonnull String name, int first, int max, boolean caseSensitive )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -511,8 +508,9 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, param );
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllLikeName( Set<String> nameWords, int first, int max )
+    public List<T> getAllLikeName( @Nonnull Set<String> nameWords, int first, int max )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -541,43 +539,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, param );
     }
 
-    public List<T> getAllLikeNameAndEqualsAttribute( Set<String> nameWords, String attribute, String attributeValue,
-        int first, int max )
-    {
-        if ( StringUtils.isEmpty( attribute ) || StringUtils.isEmpty( attributeValue ) )
-        {
-            return new ArrayList<>();
-        }
-
-        CriteriaBuilder builder = getCriteriaBuilder();
-
-        JpaQueryParameters<T> param = new JpaQueryParameters<T>()
-            .addPredicates( getSharingPredicates( builder ) )
-            .addOrder( root -> builder.asc( root.get( "name" ) ) )
-            .setFirstResult( first )
-            .setMaxResults( max );
-
-        if ( nameWords.isEmpty() )
-        {
-            return getList( builder, param );
-        }
-
-        List<Function<Root<T>, Predicate>> conjunction = new ArrayList<>();
-
-        for ( String word : nameWords )
-        {
-            conjunction
-                .add( root -> builder.like( builder.lower( root.get( "name" ) ), "%" + word.toLowerCase() + "%" ) );
-        }
-
-        conjunction.add( root -> builder.equal( builder.lower( root.get( attribute ) ), attributeValue ) );
-
-        param.addPredicate( root -> builder.and( conjunction.stream().map( p -> p.apply( root ) )
-            .collect( Collectors.toList() ).toArray( new Predicate[0] ) ) );
-
-        return getList( builder, param );
-    }
-
+    @Nonnull
     @Override
     public List<T> getAllOrderedName()
     {
@@ -590,6 +552,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, param );
     }
 
+    @Nonnull
     @Override
     public List<T> getAllOrderedName( int first, int max )
     {
@@ -604,6 +567,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, param );
     }
 
+    @Nonnull
     @Override
     public List<T> getAllOrderedLastUpdated( int first, int max )
     {
@@ -617,7 +581,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public int getCountLikeName( String name )
+    public int getCountLikeName( @Nonnull String name )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -630,7 +594,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public int getCountGeLastUpdated( Date lastUpdated )
+    public int getCountGeLastUpdated( @Nonnull Date lastUpdated )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -642,8 +606,9 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getCount( builder, param ).intValue();
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllGeLastUpdated( Date lastUpdated )
+    public List<T> getAllGeLastUpdated( @Nonnull Date lastUpdated )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -656,7 +621,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
-    public int getCountGeCreated( Date created )
+    public int getCountGeCreated( @Nonnull Date created )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -668,8 +633,9 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getCount( builder, param ).intValue();
     }
 
+    @Nonnull
     @Override
-    public List<T> getAllLeCreated( Date created )
+    public List<T> getAllLeCreated( @Nonnull Date created )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -682,6 +648,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     @Override
+    @CheckForNull
     public Date getLastUpdated()
     {
         CriteriaBuilder builder = getCriteriaBuilder();
@@ -703,6 +670,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getSingleResult( typedQuery );
     }
 
+    @Nonnull
     @Override
     public List<T> getByDataDimension( boolean dataDimension )
     {
@@ -715,6 +683,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, jpaQueryParameters );
     }
 
+    @Nonnull
     @Override
     public List<T> getByDataDimensionNoAcl( boolean dataDimension )
     {
@@ -726,36 +695,40 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, jpaQueryParameters );
     }
 
+    @Nonnull
     @Override
-    public List<T> getById( Collection<Long> ids )
+    public List<T> getById( @Nonnull Collection<Long> ids )
     {
         return getById( ids, currentUserService.getCurrentUser() );
     }
 
+    @Nonnull
     @Override
-    public List<T> getById( Collection<Long> ids, User user )
+    public List<T> getById( @Nonnull Collection<Long> ids, User user )
     {
-        if ( ids == null || ids.isEmpty() )
+        if ( ids.isEmpty() )
         {
-            return new ArrayList<>();
+            return List.of();
         }
 
         CriteriaBuilder builder = getCriteriaBuilder();
         return getList( builder, createInQuery( builder, user, "id", ids ) );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByUid( Collection<String> uids )
+    public List<T> getByUid( @Nonnull Collection<String> uids )
     {
         return getByUid( uids, currentUserService.getCurrentUser() );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByUid( Collection<String> uids, User user )
+    public List<T> getByUid( @Nonnull Collection<String> uids, User user )
     {
-        if ( uids == null || uids.isEmpty() )
+        if ( uids.isEmpty() )
         {
-            return new ArrayList<>();
+            return List.of();
         }
 
         // TODO Include paging to avoid exceeding max query length
@@ -767,34 +740,38 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
             partition -> createInQuery( sharingPredicates, "uid", partition ) );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByUidNoAcl( Collection<String> uids )
+    public List<T> getByUidNoAcl( @Nonnull Collection<String> uids )
     {
         return getListFromPartitions( getCriteriaBuilder(), uids, OBJECT_FETCH_SIZE,
             partition -> createInQuery( List.of(), "uid", partition ) );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByCode( Collection<String> codes )
+    public List<T> getByCode( @Nonnull Collection<String> codes )
     {
         return getByCode( codes, currentUserService.getCurrentUser() );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByCode( Collection<String> codes, User user )
+    public List<T> getByCode( @Nonnull Collection<String> codes, User user )
     {
-        if ( codes == null || codes.isEmpty() )
+        if ( codes.isEmpty() )
         {
-            return new ArrayList<>();
+            return List.of();
         }
         CriteriaBuilder builder = getCriteriaBuilder();
         return getList( builder, createInQuery( builder, user, "code", codes ) );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByName( Collection<String> names, User user )
+    public List<T> getByName( @Nonnull Collection<String> names, User user )
     {
-        if ( names == null || names.isEmpty() )
+        if ( names.isEmpty() )
         {
             return new ArrayList<>();
         }
@@ -802,20 +779,23 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, createInQuery( builder, user, "name", names ) );
     }
 
+    @Nonnull
     @Override
-    public List<T> getByName( Collection<String> names )
+    public List<T> getByName( @Nonnull Collection<String> names )
     {
         return getByName( names, currentUserService.getCurrentUser() );
     }
 
+    @Nonnull
     @Override
     public List<T> getAllNoAcl()
     {
         return super.getAll();
     }
 
+    @Nonnull
     @Override
-    public List<String> getUidsCreatedBefore( Date date )
+    public List<String> getUidsCreatedBefore( @Nonnull Date date )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -836,12 +816,14 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     // Data sharing
     // ----------------------------------------------------------------------------------------------------------------
 
+    @Nonnull
     @Override
     public final List<T> getDataReadAll()
     {
         return getDataReadAll( currentUserService.getCurrentUser() );
     }
 
+    @Nonnull
     @Override
     public final List<T> getDataReadAll( User user )
     {
@@ -853,12 +835,14 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
         return getList( builder, parameters );
     }
 
+    @Nonnull
     @Override
     public final List<T> getDataWriteAll()
     {
         return getDataWriteAll( currentUserService.getCurrentUser() );
     }
 
+    @Nonnull
     @Override
     public final List<T> getDataWriteAll( User user )
     {
@@ -874,7 +858,7 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
      * Remove given UserGroup UID from all sharing records in given tableName
      */
     @Override
-    public void removeUserGroupFromSharing( String userGroupUid, String tableName )
+    public void removeUserGroupFromSharing( @Nonnull String userGroupUid, @Nonnull String tableName )
     {
         if ( !ObjectUtils.allNotNull( userGroupUid, tableName ) )
         {
@@ -908,46 +892,28 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
 
     private boolean isReadAllowed( T object, User user )
     {
-        if ( IdentifiableObject.class.isInstance( object ) )
+        if ( sharingEnabled( user ) )
         {
-            IdentifiableObject idObject = object;
-
-            if ( sharingEnabled( user ) )
-            {
-                return aclService.canRead( user, idObject );
-            }
+            return aclService.canRead( user, object );
         }
-
         return true;
     }
 
     private boolean isUpdateAllowed( T object, User user )
     {
-        if ( IdentifiableObject.class.isInstance( object ) )
+        if ( aclService.isClassShareable( clazz ) )
         {
-            IdentifiableObject idObject = object;
-
-            if ( aclService.isClassShareable( clazz ) )
-            {
-                return aclService.canUpdate( user, idObject );
-            }
+            return aclService.canUpdate( user, object );
         }
-
         return true;
     }
 
     private boolean isDeleteAllowed( T object, User user )
     {
-        if ( IdentifiableObject.class.isInstance( object ) )
+        if ( aclService.isClassShareable( clazz ) )
         {
-            IdentifiableObject idObject = object;
-
-            if ( aclService.isClassShareable( clazz ) )
-            {
-                return aclService.canDelete( user, idObject );
-            }
+            return aclService.canDelete( user, object );
         }
-
         return true;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/SoftDeleteHibernateObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/SoftDeleteHibernateObjectStore.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common.hibernate;
 
+import javax.annotation.Nonnull;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.ObjectDeletionRequestedEvent;
 import org.hisp.dhis.common.SoftDeletableObject;
@@ -50,7 +52,7 @@ public class SoftDeleteHibernateObjectStore<T extends SoftDeletableObject>
     }
 
     @Override
-    public void delete( SoftDeletableObject object )
+    public void delete( @Nonnull SoftDeletableObject object )
     {
         publisher.publishEvent( new ObjectDeletionRequestedEvent( object ) );
         object.setDeleted( true );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DefaultDataElementService.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import lombok.AllArgsConstructor;
 
 import org.hisp.dhis.attribute.Attribute;
@@ -248,7 +250,7 @@ public class DefaultDataElementService
 
     @Override
     @Transactional( readOnly = true )
-    public List<DataElementGroup> getDataElementGroupsByUid( Collection<String> uids )
+    public List<DataElementGroup> getDataElementGroupsByUid( @Nonnull Collection<String> uids )
     {
         return dataElementGroupStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/hibernate/HibernateDataElementOperandStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/hibernate/HibernateDataElementOperandStore.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.dataelement.hibernate;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.dataelement.DataElementOperand;
@@ -56,12 +58,14 @@ public class HibernateDataElementOperandStore
         transientIdentifiableProperties = true;
     }
 
+    @Nonnull
     @Override
     public List<DataElementOperand> getAllOrderedName()
     {
         return getQuery( "from DataElementOperand d" ).list();
     }
 
+    @Nonnull
     @Override
     public List<DataElementOperand> getAllOrderedName( int first, int max )
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/hibernate/HibernateDataSetStore.java
@@ -31,6 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.persistence.criteria.CriteriaBuilder;
 
 import org.hibernate.SessionFactory;
@@ -80,7 +81,7 @@ public class HibernateDataSetStore
     // -------------------------------------------------------------------------
 
     @Override
-    public void save( DataSet dataSet )
+    public void save( @Nonnull DataSet dataSet )
     {
         PeriodType periodType = periodService.reloadPeriodType( dataSet.getPeriodType() );
 
@@ -90,7 +91,7 @@ public class HibernateDataSetStore
     }
 
     @Override
-    public void update( DataSet dataSet )
+    public void update( @Nonnull DataSet dataSet )
     {
         PeriodType periodType = periodService.reloadPeriodType( dataSet.getPeriodType() );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/fileresource/DefaultFileResourceService.java
@@ -40,6 +40,8 @@ import java.util.NoSuchElementException;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -109,7 +111,7 @@ public class DefaultFileResourceService
 
     @Override
     @Transactional( readOnly = true )
-    public List<FileResource> getFileResources( List<String> uids )
+    public List<FileResource> getFileResources( @Nonnull List<String> uids )
     {
         return fileResourceStore.getByUid( uids ).stream()
             .map( this::checkStorageStatus )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/DefaultOrganisationUnitService.java
@@ -43,6 +43,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.cache.Cache;
 import org.hisp.dhis.cache.CacheProvider;
@@ -198,7 +200,7 @@ public class DefaultOrganisationUnitService
 
     @Override
     @Transactional( readOnly = true )
-    public List<OrganisationUnit> getOrganisationUnitsByUid( Collection<String> uids )
+    public List<OrganisationUnit> getOrganisationUnitsByUid( @Nonnull Collection<String> uids )
     {
         return organisationUnitStore.getByUid( new HashSet<>( uids ) );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/hibernate/HibernatePredictorStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/hibernate/HibernatePredictorStore.java
@@ -80,6 +80,6 @@ public class HibernatePredictorStore
     {
         predictor.setPeriodType( periodService.reloadPeriodType( predictor.getPeriodType() ) );
 
-        super.save( predictor );
+        super.update( predictor );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/hibernate/HibernatePredictorStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/hibernate/HibernatePredictorStore.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.predictor.hibernate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import javax.annotation.Nonnull;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.period.PeriodService;
@@ -66,7 +68,7 @@ public class HibernatePredictorStore
     // -------------------------------------------------------------------------
 
     @Override
-    public void save( Predictor predictor )
+    public void save( @Nonnull Predictor predictor )
     {
         predictor.setPeriodType( periodService.reloadPeriodType( predictor.getPeriodType() ) );
 
@@ -74,7 +76,7 @@ public class HibernatePredictorStore
     }
 
     @Override
-    public void update( Predictor predictor )
+    public void update( @Nonnull Predictor predictor )
     {
         predictor.setPeriodType( periodService.reloadPeriodType( predictor.getPeriodType() ) );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramInstanceService.java
@@ -36,6 +36,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -141,7 +143,7 @@ public class DefaultProgramInstanceService
 
     @Override
     @Transactional( readOnly = true )
-    public List<ProgramInstance> getProgramInstances( List<String> uids )
+    public List<ProgramInstance> getProgramInstances( @Nonnull List<String> uids )
     {
         return programInstanceStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramService.java
@@ -32,6 +32,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.collections4.SetValuedMap;
@@ -112,7 +114,7 @@ public class DefaultProgramService
 
     @Override
     @Transactional( readOnly = true )
-    public Collection<Program> getPrograms( Collection<String> uids )
+    public Collection<Program> getPrograms( @Nonnull Collection<String> uids )
     {
         return programStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/DefaultRelationshipService.java
@@ -32,6 +32,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
@@ -132,7 +134,7 @@ public class DefaultRelationshipService
 
     @Override
     @Transactional( readOnly = true )
-    public List<Relationship> getRelationships( List<String> uids )
+    public List<Relationship> getRelationships( @Nonnull List<String> uids )
     {
         return relationshipStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackedEntityAttributeService.java
@@ -32,6 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
 import javax.imageio.ImageIO;
 
 import org.apache.commons.lang3.StringUtils;
@@ -185,7 +186,7 @@ public class DefaultTrackedEntityAttributeService
 
     @Override
     @Transactional( readOnly = true )
-    public List<TrackedEntityAttribute> getTrackedEntityAttributes( List<String> uids )
+    public List<TrackedEntityAttribute> getTrackedEntityAttributes( @Nonnull List<String> uids )
     {
         return attributeStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserGroupService.java
@@ -31,6 +31,8 @@ import static com.google.common.base.Preconditions.*;
 
 import java.util.*;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.cache.*;
 import org.hisp.dhis.security.acl.*;
 import org.springframework.stereotype.*;
@@ -197,7 +199,7 @@ public class DefaultUserGroupService
 
     @Override
     @Transactional
-    public void updateUserGroups( User user, Collection<String> uids, User currentUser )
+    public void updateUserGroups( User user, @Nonnull Collection<String> uids, User currentUser )
     {
         Collection<UserGroup> updates = getUserGroupsByUid( uids );
 
@@ -219,7 +221,7 @@ public class DefaultUserGroupService
         }
     }
 
-    private Collection<UserGroup> getUserGroupsByUid( Collection<String> uids )
+    private Collection<UserGroup> getUserGroupsByUid( @Nonnull Collection<String> uids )
     {
         return userGroupStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/DefaultUserService.java
@@ -53,6 +53,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import lombok.extern.slf4j.Slf4j;
@@ -247,7 +248,7 @@ public class DefaultUserService
 
     @Override
     @Transactional( readOnly = true )
-    public List<User> getUsers( Collection<String> uids )
+    public List<User> getUsers( @Nonnull Collection<String> uids )
     {
         return userStore.getByUid( uids );
     }
@@ -508,7 +509,7 @@ public class DefaultUserService
 
     @Override
     @Transactional( readOnly = true )
-    public List<UserRole> getUserRolesByUid( Collection<String> uids )
+    public List<UserRole> getUserRolesByUid( @Nonnull Collection<String> uids )
     {
         return userRoleStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserGroupStore.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.user.hibernate;
 
+import javax.annotation.Nonnull;
+
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.common.hibernate.HibernateIdentifiableObjectStore;
 import org.hisp.dhis.security.acl.AclService;
@@ -52,14 +54,14 @@ public class HibernateUserGroupStore extends HibernateIdentifiableObjectStore<Us
     }
 
     @Override
-    public void save( UserGroup object, boolean clearSharing )
+    public void save( @Nonnull UserGroup object, boolean clearSharing )
     {
         super.save( object, clearSharing );
         object.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUid() ) );
     }
 
     @Override
-    public void update( UserGroup object, User user )
+    public void update( @Nonnull UserGroup object, User user )
     {
         super.update( object, user );
         object.getMembers().forEach( member -> currentUserService.invalidateUserGroupCache( member.getUid() ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/hibernate/HibernateUserStore.java
@@ -115,7 +115,7 @@ public class HibernateUserStore
     }
 
     @Override
-    public void save( User user, boolean clearSharing )
+    public void save( @Nonnull User user, boolean clearSharing )
     {
         super.save( user, clearSharing );
 

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/DefaultGeoJsonService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/geojson/DefaultGeoJsonService.java
@@ -41,6 +41,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -199,7 +201,8 @@ public class DefaultGeoJsonService implements GeoJsonService
         }
     }
 
-    private List<OrganisationUnit> fetchOrganisationUnits( GeoJsonImportParams params, Set<String> ouIdentifiers )
+    private List<OrganisationUnit> fetchOrganisationUnits( GeoJsonImportParams params,
+        @Nonnull Set<String> ouIdentifiers )
     {
         switch ( params.getIdType() )
         {

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/document/impl/DefaultDocumentService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/document/impl/DefaultDocumentService.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.document.impl;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.document.Document;
 import org.hisp.dhis.document.DocumentService;
 import org.hisp.dhis.document.DocumentStore;
@@ -116,7 +118,7 @@ public class DefaultDocumentService
     }
 
     @Override
-    public List<Document> getDocumentsByUid( List<String> uids )
+    public List<Document> getDocumentsByUid( @Nonnull List<String> uids )
     {
         return documentStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/DefaultValidationRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/DefaultValidationRuleService.java
@@ -35,6 +35,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObjectManager;
@@ -176,7 +178,7 @@ public class DefaultValidationRuleService
 
     @Transactional( readOnly = true )
     @Override
-    public List<ValidationRule> getValidationRulesByUid( Collection<String> uids )
+    public List<ValidationRule> getValidationRulesByUid( @Nonnull Collection<String> uids )
     {
         return validationRuleStore.getByUid( uids );
     }

--- a/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationRuleStore.java
+++ b/dhis-2/dhis-services/dhis-service-validation/src/main/java/org/hisp/dhis/validation/hibernate/HibernateValidationRuleStore.java
@@ -31,6 +31,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import javax.persistence.criteria.CriteriaBuilder;
 
 import org.hibernate.SessionFactory;
@@ -75,7 +76,7 @@ public class HibernateValidationRuleStore
     // -------------------------------------------------------------------------
 
     @Override
-    public void save( ValidationRule validationRule )
+    public void save( @Nonnull ValidationRule validationRule )
     {
         PeriodType periodType = periodService.reloadPeriodType( validationRule.getPeriodType() );
 
@@ -85,7 +86,7 @@ public class HibernateValidationRuleStore
     }
 
     @Override
-    public void update( ValidationRule validationRule )
+    public void update( @Nonnull ValidationRule validationRule )
     {
         PeriodType periodType = periodService.reloadPeriodType( validationRule.getPeriodType() );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -466,9 +466,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void getByUidWithNull()
+    void getByUidWithEmpty()
     {
-        assertIsEmpty( idObjectManager.getByUid( DataElement.class, null ) );
+        assertIsEmpty( idObjectManager.getByUid( DataElement.class, List.of() ) );
     }
 
     @Test
@@ -488,9 +488,9 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void loadByUidNullTest()
+    void loadByUidWithEmpty()
     {
-        assertIsEmpty( idObjectManager.loadByUid( DataElement.class, null ) );
+        assertIsEmpty( idObjectManager.loadByUid( DataElement.class, List.of() ) );
     }
 
     @Test


### PR DESCRIPTION
This PR propagates annotations from interface to the base implementation of the hibernate store.

As the store implementation would often handle `null` when collections of identifiers where passed as parameters but the annotation set is `@Nonnull` I also propagated that annotation upwards to the services so we better see and sonar checks that the caller would not call this with a `null` collection. I think this is not 100% safe change but long term this is what we want to have so should there be callers found that can pass null we have to fix that as we discover them. I mostly suspect that not all controllers always make sure input parameters used are non-null collections.