### PR TITLE
fix: Events for an org unit fail to import through Import/Export App unless there is at least one event in that program and org unit [ DHIS2-13484 ]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoader.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/context/WorkContextLoader.java
@@ -112,6 +112,8 @@ public class WorkContextLoader
     public WorkContext load( ImportOptions importOptions, List<Event> events )
     {
 
+        sessionFactory.getCurrentSession().flush();
+
         ImportOptions localImportOptions = importOptions;
         // API allows a null Import Options
         if ( localImportOptions == null )
@@ -120,8 +122,6 @@ public class WorkContextLoader
         }
 
         initializeUser( localImportOptions );
-
-        sessionFactory.getCurrentSession().flush();
 
         // Make sure all events have the 'uid' field populated
         events = uidGen.assignUidToEvents( events );


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13484
In WorkContextLoader, the Hibernate _unproxy_ is used to load all user lazy collections but it is not working 100% of the time probably due to Hibernate session propagation issues.
With the issue, we fix using _initialize_ to load relevant collections that are used later to check permissions.

Note that this could be fixed in a few different ways:
- @Transactional in _EventImporter_ but the persistence part is only in inner services
- With a UserMapper like in the new tracker but it would take time and more testing
- Fetch the user object in other parts of the flow but it would take a larger refactor
