### PR TITLE
fix: incorrect content-type for events/query.csv

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventController.java
@@ -430,7 +430,7 @@ public class EventController
 
     }
 
-    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_CSV )
+    @GetMapping( value = "/query", produces = ContextUtils.CONTENT_TYPE_TEXT_CSV )
     public void queryEventsCsv(
         @RequestParam( required = false ) String program,
         @RequestParam( required = false ) String programStage,
@@ -498,7 +498,7 @@ public class EventController
             totalPages, skipPaging, getOrderParams( null ), getGridOrderParams( order ), false, eventIds, false,
             assignedUserMode, assignedUserIds, filter, dataElement, includeAllDataElements, includeDeleted );
 
-        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_CSV, CacheStrategy.NO_CACHE );
+        contextUtils.configureResponse( response, ContextUtils.CONTENT_TYPE_TEXT_CSV, CacheStrategy.NO_CACHE );
         Grid grid = eventService.getEventsGrid( params );
         GridUtils.toCsv( grid, response.getWriter() );
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13471

- For CSV, the produces content-type should be `text/csv` not `application/csv`

- The app sends below request to server 
```
http://localhost:8080/api/events/query.csv?fields=dataValues%2CoccurredAt%2Cevent%2Cstatus%2CorgUnit%2Cprogram%2CprogramType%2CupdatedAt%2CcreatedAt%2CassignedUser%2C&program=q04UBOqq3rp&orgUnit=DiszpKrYNg8&programStage=pSllsjpfLH2&ouMode=SELECTED&order=occurredAt%3Adesc&skipPaging=true
```
Screenshot result in postman
<img width="1283" alt="Screen Shot 2022-10-18 at 17 20 37" src="https://user-images.githubusercontent.com/766102/196404751-53be3cd2-28ed-43b5-8b7c-0403a28d94b5.png">

