### PR TITLE
fix: sonar warnings - Object#equals

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
@@ -228,23 +228,11 @@ public class Attribute
     @Override
     public boolean equals( Object obj )
     {
-        if ( this == obj )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof Attribute && super.equals( obj ) && objectEquals( (Attribute) obj );
+    }
 
-        if ( obj == null || getClass() != obj.getClass() )
-        {
-            return false;
-        }
-
-        if ( !super.equals( obj ) )
-        {
-            return false;
-        }
-
-        final Attribute other = (Attribute) obj;
-
+    private boolean objectEquals( Attribute other )
+    {
         return Objects.equals( this.valueType, other.valueType )
             && Objects.equals( this.objectTypes, other.objectTypes )
             && Objects.equals( this.mandatory, other.mandatory )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/category/CategoryOptionCombo.java
@@ -104,50 +104,15 @@ public class CategoryOptionCombo
     }
 
     @Override
-    public boolean equals( Object object )
+    public boolean equals( Object obj )
     {
-        if ( this == object )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof CategoryOptionCombo && objectEquals( (CategoryOptionCombo) obj );
+    }
 
-        if ( object == null )
-        {
-            return false;
-        }
-
-        if ( !(object instanceof CategoryOptionCombo) )
-        {
-            return false;
-        }
-
-        final CategoryOptionCombo other = (CategoryOptionCombo) object;
-
-        if ( categoryCombo == null )
-        {
-            if ( other.categoryCombo != null )
-            {
-                return false;
-            }
-        }
-        else if ( !categoryCombo.equals( other.categoryCombo ) )
-        {
-            return false;
-        }
-
-        if ( categoryOptions == null )
-        {
-            if ( other.categoryOptions != null )
-            {
-                return false;
-            }
-        }
-        else if ( !categoryOptions.equals( other.categoryOptions ) )
-        {
-            return false;
-        }
-
-        return true;
+    private boolean objectEquals( CategoryOptionCombo other )
+    {
+        return Objects.equals( categoryCombo, other.categoryCombo )
+            && Objects.equals( categoryOptions, other.categoryOptions );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -200,15 +200,13 @@ public class BaseDimensionalItemObject
     }
 
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( !super.equals( o ) )
-        {
-            return false;
-        }
+        return this == obj || super.equals( obj ) && objectEquals( (BaseDimensionalItemObject) obj );
+    }
 
-        final BaseDimensionalItemObject that = (BaseDimensionalItemObject) o;
-
+    private boolean objectEquals( BaseDimensionalItemObject that )
+    {
         return Objects.equals( this.queryMods, that.queryMods );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseDimensionalItemObject.java
@@ -207,7 +207,7 @@ public class BaseDimensionalItemObject
 
     private boolean objectEquals( BaseDimensionalItemObject that )
     {
-        return Objects.equals( this.queryMods, that.queryMods );
+        return Objects.equals( queryMods, that.queryMods );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -632,7 +632,7 @@ public class BaseIdentifiableObject
     public boolean equals( Object obj )
     {
         return this == obj || obj instanceof BaseIdentifiableObject
-            && getRealClass( this ) != getRealClass( obj )
+            && getRealClass( this ) == getRealClass( obj )
             && typedEquals( (IdentifiableObject) obj );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -27,11 +27,14 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
+
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -626,41 +629,11 @@ public class BaseIdentifiableObject
      * objects.
      */
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-        {
-            return true;
-        }
-
-        if ( o == null )
-        {
-            return false;
-        }
-
-        if ( !getClass().isAssignableFrom( o.getClass() ) )
-        {
-            return false;
-        }
-
-        final BaseIdentifiableObject other = (BaseIdentifiableObject) o;
-
-        if ( getUid() != null ? !getUid().equals( other.getUid() ) : other.getUid() != null )
-        {
-            return false;
-        }
-
-        if ( getCode() != null ? !getCode().equals( other.getCode() ) : other.getCode() != null )
-        {
-            return false;
-        }
-
-        if ( getName() != null ? !getName().equals( other.getName() ) : other.getName() != null )
-        {
-            return false;
-        }
-
-        return true;
+        return this == obj || obj instanceof BaseIdentifiableObject
+            && getRealClass( this ) != getRealClass( obj )
+            && typedEquals( (IdentifiableObject) obj );
     }
 
     /**
@@ -671,29 +644,15 @@ public class BaseIdentifiableObject
      * @param other the identifiable object to compare this object against.
      * @return true if equal.
      */
-    public boolean typedEquals( IdentifiableObject other )
+    public final boolean typedEquals( IdentifiableObject other )
     {
         if ( other == null )
         {
             return false;
         }
-
-        if ( getUid() != null ? !getUid().equals( other.getUid() ) : other.getUid() != null )
-        {
-            return false;
-        }
-
-        if ( getCode() != null ? !getCode().equals( other.getCode() ) : other.getCode() != null )
-        {
-            return false;
-        }
-
-        if ( getName() != null ? !getName().equals( other.getName() ) : other.getName() != null )
-        {
-            return false;
-        }
-
-        return true;
+        return Objects.equals( getUid(), other.getUid() )
+            && Objects.equals( getCode(), other.getCode() )
+            && Objects.equals( getName(), other.getName() );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseNameableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseNameableObject.java
@@ -27,6 +27,10 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
+
+import java.util.Objects;
+
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.translation.Translatable;
 
@@ -129,42 +133,18 @@ public class BaseNameableObject
      * objects.
      */
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof BaseNameableObject
+            && getRealClass( this ) == getRealClass( obj )
+            && super.equals( obj )
+            && objectEquals( (BaseNameableObject) obj );
+    }
 
-        if ( o == null )
-        {
-            return false;
-        }
-
-        if ( !getClass().isAssignableFrom( o.getClass() ) )
-        {
-            return false;
-        }
-
-        if ( !super.equals( o ) )
-        {
-            return false;
-        }
-
-        final BaseNameableObject other = (BaseNameableObject) o;
-
-        if ( getShortName() != null ? !getShortName().equals( other.getShortName() ) : other.getShortName() != null )
-        {
-            return false;
-        }
-
-        if ( getDescription() != null ? !getDescription().equals( other.getDescription() )
-            : other.getDescription() != null )
-        {
-            return false;
-        }
-
-        return true;
+    private boolean objectEquals( BaseNameableObject other )
+    {
+        return Objects.equals( getShortName(), other.getShortName() )
+            && Objects.equals( getDescription(), other.getDescription() );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SoftDeletableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/SoftDeletableObject.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.hibernate.HibernateProxyUtils.getRealClass;
+
 import java.util.Objects;
 
 import org.hisp.dhis.audit.AuditAttribute;
@@ -77,21 +79,16 @@ public class SoftDeletableObject extends BaseIdentifiableObject
     }
 
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-        if ( !super.equals( o ) )
-        {
-            return false;
-        }
-        SoftDeletableObject that = (SoftDeletableObject) o;
+        return this == obj || obj instanceof SoftDeletableObject &&
+            getRealClass( this ) == getRealClass( obj )
+            && super.equals( obj )
+            && objectEquals( (SoftDeletableObject) obj );
+    }
+
+    private boolean objectEquals( SoftDeletableObject that )
+    {
         return deleted == that.deleted;
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperand.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataelement/DataElementOperand.java
@@ -401,18 +401,17 @@ public class DataElementOperand
     // -------------------------------------------------------------------------
 
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-            return true;
-        if ( o == null || getClass() != o.getClass() )
-            return false;
-        if ( !super.equals( o ) )
-            return false;
-        DataElementOperand that = (DataElementOperand) o;
-        return Objects.equals( dataElement, that.dataElement ) &&
-            Objects.equals( categoryOptionCombo, that.categoryOptionCombo ) &&
-            Objects.equals( attributeOptionCombo, that.attributeOptionCombo );
+        return this == obj
+            || obj instanceof DataElementOperand && super.equals( obj ) && objectEquals( (DataElementOperand) obj );
+    }
+
+    private boolean objectEquals( DataElementOperand other )
+    {
+        return Objects.equals( dataElement, other.dataElement )
+            && Objects.equals( categoryOptionCombo, other.categoryOptionCombo )
+            && Objects.equals( attributeOptionCombo, other.attributeOptionCombo );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataentryform/DataEntryForm.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataentryform/DataEntryForm.java
@@ -119,23 +119,16 @@ public class DataEntryForm
     @Override
     public boolean equals( Object obj )
     {
-        if ( this == obj )
-        {
-            return true;
-        }
-        if ( obj == null || getClass() != obj.getClass() )
-        {
-            return false;
-        }
-        if ( !super.equals( obj ) )
-        {
-            return false;
-        }
-        final DataEntryForm other = (DataEntryForm) obj;
-        return Objects.equals( this.name, other.name )
-            && Objects.equals( this.style, other.style )
-            && Objects.equals( this.htmlCode, other.htmlCode )
-            && Objects.equals( this.format, other.format );
+        return this == obj
+            || obj instanceof DataEntryForm && super.equals( obj ) && objectEquals( (DataEntryForm) obj );
+    }
+
+    private boolean objectEquals( DataEntryForm other )
+    {
+        return Objects.equals( name, other.name )
+            && Objects.equals( style, other.style )
+            && Objects.equals( htmlCode, other.htmlCode )
+            && Objects.equals( format, other.format );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSetElement.java
@@ -120,26 +120,9 @@ public class DataSetElement implements EmbeddedObject, Serializable
     }
 
     @Override
-    public boolean equals( Object object )
+    public boolean equals( Object obj )
     {
-        if ( this == object )
-        {
-            return true;
-        }
-
-        if ( object == null )
-        {
-            return false;
-        }
-
-        if ( !getClass().isAssignableFrom( object.getClass() ) )
-        {
-            return false;
-        }
-
-        DataSetElement other = (DataSetElement) object;
-
-        return objectEquals( other );
+        return this == obj || obj instanceof DataSetElement && objectEquals( (DataSetElement) obj );
     }
 
     public boolean objectEquals( DataSetElement other )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/ConfigurablePeriod.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/ConfigurablePeriod.java
@@ -28,14 +28,14 @@
 package org.hisp.dhis.period;
 
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * @author Lars Helge Overland
  */
-public class ConfigurablePeriod
-    extends Period
+public class ConfigurablePeriod extends Period
 {
-    private String value;
+    private final String value;
 
     public ConfigurablePeriod( String value )
     {
@@ -63,26 +63,14 @@ public class ConfigurablePeriod
     }
 
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof ConfigurablePeriod && objectEquals( (ConfigurablePeriod) obj );
+    }
 
-        if ( o == null )
-        {
-            return false;
-        }
-
-        if ( !(o instanceof Period) )
-        {
-            return false;
-        }
-
-        final Period other = (Period) o;
-
-        return value.equals( other.getIsoDate() );
+    private boolean objectEquals( ConfigurablePeriod other )
+    {
+        return Objects.equals( value, other.value );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/ConfigurablePeriod.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/ConfigurablePeriod.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.period;
 
 import java.util.Date;
-import java.util.Objects;
 
 /**
  * @author Lars Helge Overland
@@ -65,12 +64,12 @@ public class ConfigurablePeriod extends Period
     @Override
     public boolean equals( Object obj )
     {
-        return this == obj || obj instanceof ConfigurablePeriod && objectEquals( (ConfigurablePeriod) obj );
+        return this == obj || obj instanceof Period && objectEquals( (Period) obj );
     }
 
-    private boolean objectEquals( ConfigurablePeriod other )
+    private boolean objectEquals( Period other )
     {
-        return Objects.equals( value, other.value );
+        return value.equals( other.getIsoDate() );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -344,25 +344,13 @@ public class Period
     }
 
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof Period && objectEquals( (Period) obj );
+    }
 
-        if ( o == null )
-        {
-            return false;
-        }
-
-        if ( !(o instanceof Period) )
-        {
-            return false;
-        }
-
-        final Period other = (Period) o;
-
+    private boolean objectEquals( Period other )
+    {
         return startDate.equals( other.getStartDate() ) &&
             endDate.equals( other.getEndDate() ) &&
             periodType.equals( other.getPeriodType() ) &&

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/AnalyticsPeriodBoundary.java
@@ -228,17 +228,11 @@ public class AnalyticsPeriodBoundary extends BaseIdentifiableObject implements E
     @Override
     public boolean equals( Object obj )
     {
-        if ( this == obj )
-        {
-            return true;
-        }
-        if ( obj == null || getClass() != obj.getClass() )
-        {
-            return false;
-        }
+        return this == obj || obj instanceof AnalyticsPeriodBoundary && objectEquals( (AnalyticsPeriodBoundary) obj );
+    }
 
-        final AnalyticsPeriodBoundary other = (AnalyticsPeriodBoundary) obj;
-
+    private boolean objectEquals( AnalyticsPeriodBoundary other )
+    {
         return Objects.equals( this.boundaryTarget, other.boundaryTarget )
             && Objects.equals( this.analyticsPeriodBoundaryType, other.analyticsPeriodBoundaryType )
             && Objects.equals( this.offsetPeriodType, other.offsetPeriodType )

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstance.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramInstance.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.hisp.dhis.audit.AuditAttribute;
@@ -240,74 +241,17 @@ public class ProgramInstance
     }
 
     @Override
-    public boolean equals( Object object )
+    public boolean equals( Object obj )
     {
-        if ( this == object )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof ProgramInstance && objectEquals( (ProgramInstance) obj );
+    }
 
-        if ( object == null )
-        {
-            return false;
-        }
-
-        if ( !getClass().isAssignableFrom( object.getClass() ) )
-        {
-            return false;
-        }
-
-        final ProgramInstance other = (ProgramInstance) object;
-
-        if ( incidentDate == null )
-        {
-            if ( other.incidentDate != null )
-            {
-                return false;
-            }
-        }
-        else if ( !incidentDate.equals( other.incidentDate ) )
-        {
-            return false;
-        }
-
-        if ( enrollmentDate == null )
-        {
-            if ( other.enrollmentDate != null )
-            {
-                return false;
-            }
-        }
-        else if ( !enrollmentDate.equals( other.enrollmentDate ) )
-        {
-            return false;
-        }
-
-        if ( entityInstance == null )
-        {
-            if ( other.entityInstance != null )
-            {
-                return false;
-            }
-        }
-        else if ( !entityInstance.equals( other.entityInstance ) )
-        {
-            return false;
-        }
-
-        if ( program == null )
-        {
-            if ( other.program != null )
-            {
-                return false;
-            }
-        }
-        else if ( !program.equals( other.program ) )
-        {
-            return false;
-        }
-
-        return true;
+    private boolean objectEquals( ProgramInstance other )
+    {
+        return Objects.equals( incidentDate, other.incidentDate )
+            && Objects.equals( enrollmentDate, other.enrollmentDate )
+            && Objects.equals( entityInstance, other.entityInstance )
+            && Objects.equals( program, other.program );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElement.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramStageDataElement.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.program;
 
+import java.util.Objects;
+
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.EmbeddedObject;
@@ -256,21 +258,15 @@ public class ProgramStageDataElement
     // -------------------------------------------------------------------------
 
     @Override
-    public boolean equals( Object o )
+    public boolean equals( Object obj )
     {
-        if ( this == o )
-            return true;
-        if ( o == null || getClass() != o.getClass() )
-            return false;
+        return this == obj || obj instanceof ProgramStageDataElement && objectEquals( (ProgramStageDataElement) obj );
+    }
 
-        ProgramStageDataElement that = (ProgramStageDataElement) o;
-
-        if ( dataElement != null ? !dataElement.equals( that.dataElement ) : that.dataElement != null )
-            return false;
-        if ( programStage != null ? !programStage.equals( that.programStage ) : that.programStage != null )
-            return false;
-
-        return true;
+    private boolean objectEquals( ProgramStageDataElement other )
+    {
+        return Objects.equals( dataElement, other.dataElement )
+            && Objects.equals( programStage, other.programStage );
     }
 
     @Override

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttributeDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramTrackedEntityAttributeDimensionItem.java
@@ -124,26 +124,16 @@ public class ProgramTrackedEntityAttributeDimensionItem
     }
 
     @Override
-    public boolean equals( Object object )
+    public boolean equals( Object obj )
     {
-        if ( this == object )
-        {
-            return true;
-        }
+        return this == obj || obj instanceof ProgramTrackedEntityAttributeDimensionItem && objectEquals(
+            (ProgramTrackedEntityAttributeDimensionItem) obj );
+    }
 
-        if ( object == null )
-        {
-            return false;
-        }
-
-        if ( !getClass().isAssignableFrom( object.getClass() ) )
-        {
-            return false;
-        }
-
-        ProgramTrackedEntityAttributeDimensionItem other = (ProgramTrackedEntityAttributeDimensionItem) object;
-
-        return Objects.equal( attribute, other.attribute ) && Objects.equal( program, other.program );
+    private boolean objectEquals( ProgramTrackedEntityAttributeDimensionItem other )
+    {
+        return Objects.equal( attribute, other.attribute )
+            && Objects.equal( program, other.program );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Client.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/oauth2/OAuth2Client.java
@@ -136,24 +136,14 @@ public class OAuth2Client
     @Override
     public boolean equals( Object obj )
     {
-        if ( this == obj )
-        {
-            return true;
-        }
-        if ( obj == null || getClass() != obj.getClass() )
-        {
-            return false;
-        }
-        if ( !super.equals( obj ) )
-        {
-            return false;
-        }
+        return this == obj || obj instanceof OAuth2Client && super.equals( obj ) && objectEquals( (OAuth2Client) obj );
+    }
 
-        final OAuth2Client other = (OAuth2Client) obj;
-
-        return Objects.equals( this.cid, other.cid )
-            && Objects.equals( this.secret, other.secret )
-            && Objects.equals( this.redirectUris, other.redirectUris )
-            && Objects.equals( this.grantTypes, other.grantTypes );
+    private boolean objectEquals( OAuth2Client other )
+    {
+        return Objects.equals( cid, other.cid )
+            && Objects.equals( secret, other.secret )
+            && Objects.equals( redirectUris, other.redirectUris )
+            && Objects.equals( grantTypes, other.grantTypes );
     }
 }


### PR DESCRIPTION
Had a look at sonar issues of type [_Bug_](https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=dhis2_dhis2-core).

Sonar correctly found that `BaseIdentifiableObject#equals` was not making a class check and therefore is very likely to violate
```java
a.equals(b)
// must imply:
b.equals(a)
```
I figured that the reason a `isAssignableFrom` check was done was to handle hibernate proxies so I did a exact match compare after getting the actual class
```java
getRealClass(a) == getRealClass(b)
```

`BaseIdentifiableObject#equals` was also overridden so I had a look at all the overrides and addressed similar issues found there.

I also made the implementations more consistent by 
* always comparing specific class field within a extra method called `objectEquals` (found in one of them so I continued the pattern).
* use `Objects.equals` to do null-safe value `equals`
* always call parameter of `equals` `obj` and `other` after the cast
* use `this == obj || obj instanceof X && objectEquals( (X) ob)` instead of a sequence of if-return-true/false.

Please note that some types call the `super.equals( obj )` while others don't. I would assume this is wrong but I kept it "as is" for now.

**Edit:**
Reverted the semantic change to `ConfigurablePeriod`. 
This means a `ConfigurablePeriod` can be equal to a `Period` but the the other way around a `Period` is very unlikely to be equal to a `ConfigurablePeriod` (which is obviously not how `equals` is supposed to work but we don't want to break whatever issue the `ConfigurablePeriod` is working around).