### PR TITLE
fix: Improve option codes handling in analytics events [DHIS2-13953]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
@@ -292,23 +293,22 @@ public abstract class AbstractAnalyticsService
         if ( !params.isSkipMeta() )
         {
             Map<String, Object> metadata = new HashMap<>();
-            Map<String, List<Option>> dimensionOptions = getItemOptions( grid, params );
-            Set<Option> responseOptions = new LinkedHashSet<>();
+            Map<String, List<Option>> optionsPresentInGrid = getItemOptions( grid, params );
+            Set<Option> optionItems = new LinkedHashSet<>();
+            boolean hasResults = isNotEmpty( grid.getRows() );
 
-            if ( !params.isSkipData() )
+            if ( hasResults )
             {
-                responseOptions.addAll( dimensionOptions.values().stream()
+                optionItems.addAll( optionsPresentInGrid.values().stream()
                     .flatMap( Collection::stream ).distinct().collect( toList() ) );
             }
             else
             {
-                responseOptions.addAll( getItemOptions( params.getItemOptions(), params.getItems() ) );
+                optionItems.addAll( getItemOptions( params.getItemOptions(), params.getItems() ) );
             }
 
-            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, responseOptions ) );
-
-            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, dimensionOptions ) );
-
+            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, optionItems ) );
+            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, optionsPresentInGrid ) );
             maybeAddOrgUnitHierarchyInfo( params, metadata );
 
             grid.setMetaData( metadata );
@@ -480,12 +480,11 @@ public abstract class AbstractAnalyticsService
 
             if ( item.hasOptionSet() )
             {
-                // The call itemOptions.get( item.getItem().getUid() ) can
-                // return null.
+                // The call itemOptions.get( itemUid ) can return null.
                 // This should be ok, the query item can't have both legends and
                 // options.
                 dimensionItems.put( itemUid,
-                    getDimensionItemUidList( params, item, itemOptions.get( item.getItem().getUid() ) ) );
+                    getDimensionItemUidsFrom( itemOptions.get( itemUid ), item.getOptionSetFilterItemsOrAll() ) );
             }
             else if ( item.hasLegendSet() )
             {
@@ -517,26 +516,29 @@ public abstract class AbstractAnalyticsService
     }
 
     /**
-     * Return a list of dimension item uids. If itemOptions is null, it returns
-     * an empty List, which means no options set and no legend set.
+     * Based on the given arguments, this method will extract a list of uids of
+     * {@link Option}. If itemOptions is null, it returns the default list of
+     * uids (defaultOptionUids). Otherwise, it will return the list of uids from
+     * itemOptions.
      *
-     * @param params EventQueryParams.
-     * @param item QueryItem
-     * @param itemOptions itemOtion list.
-     * @return a list of uids.
+     * @param itemOptions a list of {@link Option} objects
+     * @param defaultOptionUids a list of default {@link Option} uids
+     * @return a list of uids
      */
-    private List<String> getDimensionItemUidList( EventQueryParams params, QueryItem item, List<Option> itemOptions )
+    private List<String> getDimensionItemUidsFrom( List<Option> itemOptions, List<String> defaultOptionUids )
     {
-        if ( params.isSkipData() )
+        List<String> dimensionUids = new ArrayList<>();
+
+        if ( itemOptions == null )
         {
-            return item.getOptionSetFilterItemsOrAll();
+            dimensionUids.addAll( defaultOptionUids );
         }
-        else if ( itemOptions != null )
+        else
         {
-            return IdentifiableObjectUtils.getUids( itemOptions );
+            dimensionUids.addAll( IdentifiableObjectUtils.getUids( itemOptions ) );
         }
 
-        return Lists.newArrayList();
+        return dimensionUids;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
@@ -192,12 +192,10 @@ public class QueryItemHelper
 
         options.stream().filter( Objects::nonNull ).forEach(
             option -> {
-                boolean queryItemsHaveNoFilter = queryItems.stream().noneMatch( QueryItem::hasFilter );
-
                 boolean queryItemsFilterMatchOptionCode = queryItems.stream().anyMatch(
                     queryItem -> queryItem.hasFilter() && filtersContainOption( option, queryItem.getFilters() ) );
 
-                if ( queryItemsHaveNoFilter || queryItemsFilterMatchOptionCode )
+                if ( queryItemsFilterMatchOptionCode )
                 {
                     matchedOptions.add( option );
                 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
@@ -282,7 +282,7 @@ class QueryItemHelperTest extends DhisConvenienceTest
         Set<Option> actualOptions = QueryItemHelper.getItemOptions( options, queryItems );
 
         // Then
-        assertEquals( 3, actualOptions.size(), "Should have size of 3: actualOptions" );
+        assertEquals( 0, actualOptions.size(), "Should have size of 0: actualOptions" );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.common.QueryFilter.OPTION_SEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -236,7 +237,9 @@ class EventAnalyticsServiceMetadataTest extends SingleSetupIntegrationTestBase
         }
         for ( Option option : deE.getOptionSet().getOptions() )
         {
-            assertNotNull( itemMap.get( option.getUid() ) );
+            // Because skipData is set to "true" and no option code is specified
+            // as filter.
+            assertNull( itemMap.get( option.getUid() ) );
         }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );


### PR DESCRIPTION
**_[Backport from master/2.40]_**

**Approved by the RCB team.**

These changes will improve the handling of option codes in the `analytics/events/query` endpoint.
Currently, the logic is based on the flag `skipData`. We should actually consider the returned `rows` instead. Based on that, the following scenarios are now being covered.

1) If `rows` is empty and an option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk:IN:MODTRANS` -> the response returns the filtered option code in `metaData/dimensions` and `metaData/items`.

2) If `rows` is not empty and an option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk:IN:MODTRANS` -> the response returns the filtered option code in `metaDate/dimensions` and `metaData/items`.

3) If `rows` is empty and no option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk` -> the response returns only the optionset name. Nothing is returning in `metaData/dimensions` and `metaData/items`.

4) If `rows` is not empty and no option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk` -> the response returns, in `metaData/dimensions` and `metaData/items`, only the option codes that are present in `rows`.