### PR TITLE
fix: Improve option codes handling in analytics events [DHIS2-13953]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -226,7 +226,7 @@ public class DataQueryParams
     protected Map<MeasureFilter, Double> preAggregateMeasureCriteria = new HashMap<>();
 
     /**
-     * Indicates if the meta data part of the query response should be omitted.
+     * Indicates if the metadata part of the query response should be omitted.
      */
     protected boolean skipMeta;
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
@@ -46,12 +45,16 @@ import static org.hisp.dhis.common.ValueType.COORDINATE;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.getParentGraphMap;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.getParentNameGraphMap;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.data.handler.SchemaIdResponseMapper;
@@ -59,7 +62,6 @@ import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.calendar.Calendar;
-import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.DimensionItemKeywords;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
@@ -67,6 +69,7 @@ import org.hisp.dhis.common.DisplayProperty;
 import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
+import org.hisp.dhis.common.IdentifiableObjectUtils;
 import org.hisp.dhis.common.MetadataItem;
 import org.hisp.dhis.common.Pager;
 import org.hisp.dhis.common.QueryItem;
@@ -83,25 +86,14 @@ import com.google.common.collect.Lists;
 /**
  * @author Luciano Fiandesio
  */
+@RequiredArgsConstructor
 public abstract class AbstractAnalyticsService
 {
-    final AnalyticsSecurityManager securityManager;
+    protected final AnalyticsSecurityManager securityManager;
 
-    final EventQueryValidator queryValidator;
+    protected final EventQueryValidator queryValidator;
 
-    final SchemaIdResponseMapper schemaIdResponseMapper;
-
-    public AbstractAnalyticsService( AnalyticsSecurityManager securityManager, EventQueryValidator queryValidator,
-        SchemaIdResponseMapper schemaIdResponseMapper )
-    {
-        checkNotNull( securityManager );
-        checkNotNull( queryValidator );
-        checkNotNull( schemaIdResponseMapper );
-
-        this.securityManager = securityManager;
-        this.queryValidator = queryValidator;
-        this.schemaIdResponseMapper = schemaIdResponseMapper;
-    }
+    protected final SchemaIdResponseMapper schemaIdResponseMapper;
 
     protected Grid getGrid( EventQueryParams params )
     {
@@ -115,10 +107,10 @@ public abstract class AbstractAnalyticsService
 
         queryValidator.validate( params );
 
-        // keywords as well as their periods are removed in the next step,
-        // params object is modified
-        List<DimensionItemKeywords.Keyword> periodKeywords = params.getDimensions().stream().map(
-            DimensionalObject::getDimensionItemKeywords )
+        // Keywords and periods are removed in the next step
+
+        List<DimensionItemKeywords.Keyword> periodKeywords = params.getDimensions().stream()
+            .map( DimensionalObject::getDimensionItemKeywords )
             .filter( dimensionItemKeywords -> dimensionItemKeywords != null && !dimensionItemKeywords.isEmpty() )
             .flatMap( dk -> dk.getKeywords().stream() ).collect( toList() );
 
@@ -141,9 +133,9 @@ public abstract class AbstractAnalyticsService
         for ( QueryItem item : params.getItems() )
         {
             /**
-             * Special case: If the request contains an item of Org Unit value
-             * type and the item UID is linked to coordinates (coordinateField),
-             * then create an Header of ValueType COORDINATE and type "Point"
+             * If the request contains an item of value type ORGANISATION_UNIT
+             * and the item UID is linked to coordinates (coordinateField), then
+             * create header of value type COORDINATE and type Point.
              */
             if ( item.getValueType() == ValueType.ORGANISATION_UNIT
                 && params.getCoordinateField().equals( item.getItem().getUid() ) )
@@ -154,7 +146,6 @@ public abstract class AbstractAnalyticsService
             }
             else if ( hasNonDefaultRepeatableProgramStageOffset( item ) )
             {
-
                 String column = item.getItem().getDisplayProperty( params.getDisplayProperty() );
 
                 RepeatableStageParams repeatableStageParams = item.getRepeatableStageParams();
@@ -189,7 +180,7 @@ public abstract class AbstractAnalyticsService
         }
 
         // ---------------------------------------------------------------------
-        // Meta-data
+        // Metadata
         // ---------------------------------------------------------------------
 
         addMetadata( params, periodKeywords, grid );
@@ -226,17 +217,14 @@ public abstract class AbstractAnalyticsService
      */
     void maybeApplyIdScheme( EventQueryParams params, Grid grid )
     {
-        if ( !params.isSkipMeta() )
+        if ( !params.isSkipMeta() && params.hasCustomIdSchemaSet() )
         {
-            if ( params.hasCustomIdSchemaSet() )
-            {
-                // Apply all schemas set/mapped to the grid.
-                grid.substituteMetaData( schemaIdResponseMapper.getSchemeIdResponseMap( params ) );
-            }
+            // Apply ID schemes mapped to the grid.
+            grid.substituteMetaData( schemaIdResponseMapper.getSchemeIdResponseMap( params ) );
         }
     }
 
-    private static void maybeApplyPaging( EventQueryParams params, long count, Grid grid )
+    private void maybeApplyPaging( EventQueryParams params, long count, Grid grid )
     {
         if ( params.isPaging() )
         {
@@ -249,13 +237,13 @@ public abstract class AbstractAnalyticsService
     }
 
     /**
-     * Based on the given item this method returns the correct uid based on
+     * Based on the given item this method returns the correct UID based on
      * internal rules/requirements.
      *
      * @param item the current QueryItem
      * @return the correct uid based on the item type
      */
-    private String getItemUid( final QueryItem item )
+    private String getItemUid( QueryItem item )
     {
         String uid = item.getItem().getUid();
 
@@ -271,12 +259,12 @@ public abstract class AbstractAnalyticsService
 
     protected abstract long addEventData( Grid grid, EventQueryParams params );
 
-    private void maybeApplyHeaders( final EventQueryParams params, final Grid grid )
+    private void maybeApplyHeaders( EventQueryParams params, Grid grid )
     {
         if ( params.hasHeaders() )
         {
             grid.keepOnlyThese( params.getHeaders() );
-            grid.repositionColumns( grid.repositionHeaders( params.getHeaders() ) );
+            grid.repositionColumns( grid.repositionHeaders( new HashSet<>( params.getHeaders() ) ) );
         }
     }
 
@@ -303,35 +291,56 @@ public abstract class AbstractAnalyticsService
     {
         if ( !params.isSkipMeta() )
         {
-            final Map<String, Object> metadata = new HashMap<>();
+            Map<String, Object> metadata = new HashMap<>();
+            Map<String, List<Option>> dimensionOptions = getItemOptions( grid, params );
+            Set<Option> responseOptions = new LinkedHashSet<>();
 
-            Map<String, List<Option>> options = getItemOptions( grid, params );
-
-            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, options.values().stream()
-                .flatMap( Collection::stream ).distinct().collect( toList() ) ) );
-
-            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, options ) );
-
-            if ( params.isHierarchyMeta() || params.isShowHierarchy() )
+            if ( !params.isSkipData() )
             {
-                User user = securityManager.getCurrentUser( params );
-                List<OrganisationUnit> organisationUnits = asTypedList(
-                    params.getDimensionOrFilterItems( ORGUNIT_DIM_ID ) );
-                Collection<OrganisationUnit> roots = user != null ? user.getOrganisationUnits() : null;
-
-                if ( params.isHierarchyMeta() )
-                {
-                    metadata.put( ORG_UNIT_HIERARCHY.getKey(), getParentGraphMap( organisationUnits, roots ) );
-                }
-
-                if ( params.isShowHierarchy() )
-                {
-                    metadata.put( ORG_UNIT_NAME_HIERARCHY.getKey(),
-                        getParentNameGraphMap( organisationUnits, roots, true ) );
-                }
+                responseOptions.addAll( dimensionOptions.values().stream()
+                    .flatMap( Collection::stream ).distinct().collect( toList() ) );
+            }
+            else
+            {
+                responseOptions.addAll( getItemOptions( params.getItemOptions(), params.getItems() ) );
             }
 
+            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, responseOptions ) );
+
+            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, dimensionOptions ) );
+
+            maybeAddOrgUnitHierarchyInfo( params, metadata );
+
             grid.setMetaData( metadata );
+        }
+    }
+
+    /**
+     * Depending on the params "hierarchy" metadata boolean flags, this method
+     * may append (or not) Org. Unit data into the given metadata map.
+     *
+     * @param params the {@link EventQueryParams}.
+     * @param metadata map.
+     */
+    private void maybeAddOrgUnitHierarchyInfo( EventQueryParams params, Map<String, Object> metadata )
+    {
+        if ( params.isHierarchyMeta() || params.isShowHierarchy() )
+        {
+            User user = securityManager.getCurrentUser( params );
+            List<OrganisationUnit> organisationUnits = asTypedList(
+                params.getDimensionOrFilterItems( ORGUNIT_DIM_ID ) );
+            Collection<OrganisationUnit> roots = user != null ? user.getOrganisationUnits() : null;
+
+            if ( params.isHierarchyMeta() )
+            {
+                metadata.put( ORG_UNIT_HIERARCHY.getKey(), getParentGraphMap( organisationUnits, roots ) );
+            }
+
+            if ( params.isShowHierarchy() )
+            {
+                metadata.put( ORG_UNIT_NAME_HIERARCHY.getKey(),
+                    getParentNameGraphMap( organisationUnits, roots, true ) );
+            }
         }
     }
 
@@ -342,7 +351,7 @@ public abstract class AbstractAnalyticsService
      * @return a map.
      */
     private Map<String, MetadataItem> getMetadataItems( EventQueryParams params,
-        List<DimensionItemKeywords.Keyword> periodKeywords, List<Option> itemOptions )
+        List<DimensionItemKeywords.Keyword> periodKeywords, Set<Option> itemOptions )
     {
         Map<String, MetadataItem> metadataItemMap = AnalyticsUtils.getDimensionMetadataItemMap( params );
 
@@ -366,8 +375,8 @@ public abstract class AbstractAnalyticsService
 
         params.getItemsAndItemFilters().stream()
             .filter( Objects::nonNull )
-            .forEach(
-                item -> addItemIntoMetadata( metadataItemMap, item, includeDetails, params.getDisplayProperty() ) );
+            .forEach( item -> addItemToMetadata(
+                metadataItemMap, item, includeDetails, params.getDisplayProperty() ) );
 
         if ( hasPeriodKeywords( periodKeywords ) )
         {
@@ -383,26 +392,25 @@ public abstract class AbstractAnalyticsService
         return metadataItemMap;
     }
 
-    private void addItemIntoMetadata( final Map<String, MetadataItem> metadataItemMap, final QueryItem item,
-        final boolean includeDetails, final DisplayProperty displayProperty )
+    private void addItemToMetadata( Map<String, MetadataItem> metadataItemMap, QueryItem item,
+        boolean includeDetails, DisplayProperty displayProperty )
     {
-        final MetadataItem metadataItem = new MetadataItem( item.getItem().getDisplayProperty( displayProperty ),
+        MetadataItem metadataItem = new MetadataItem( item.getItem().getDisplayProperty( displayProperty ),
             includeDetails ? item.getItem() : null );
 
-        metadataItemMap.put( getItemIdMaybeWithProgramStageIdPrefix( item ), metadataItem );
+        metadataItemMap.put( getItemIdWithProgramStageIdPrefix( item ), metadataItem );
 
-        // This is done for backward compatibility reason. It should remain here
-        // while the New Event Report is living along with its "classic"
-        // version.
+        // Done for backwards compatibility
+
         metadataItemMap.put( item.getItemId(), metadataItem );
     }
 
     /**
-     * Program Stage id prefix for meta items
+     * Returns the query item identifier, may have a program stage prefix.
      *
-     * @param item QueryItem.
+     * @param item {@link QueryItem}.
      */
-    private String getItemIdMaybeWithProgramStageIdPrefix( QueryItem item )
+    private String getItemIdWithProgramStageIdPrefix( QueryItem item )
     {
         if ( item.hasProgramStage() )
         {
@@ -413,54 +421,32 @@ public abstract class AbstractAnalyticsService
     }
 
     /**
-     * check the period dimension keywords
+     * Indicates whether any keywords exist.
      *
-     * @param periodKeywords PeriodKeywords.
+     * @param keywords the list of {@link Keyword}.
      */
-    private boolean hasPeriodKeywords( List<DimensionItemKeywords.Keyword> periodKeywords )
+    private boolean hasPeriodKeywords( List<DimensionItemKeywords.Keyword> keywords )
     {
-        return periodKeywords != null && !periodKeywords.isEmpty();
+        return keywords != null && !keywords.isEmpty();
     }
 
     /**
-     * Add into the MetadataItemMap itemOptions
+     * Adds the given metadata items.
      *
-     * @param metadataItemMap MetadataItemMap.
-     * @param params EventQueryParams.
-     * @param itemOptions itemOtion list.
+     * @param metadataItemMap the metadata item map.
+     * @param params the {@link EventQueryParams}.
+     * @param itemOptions the list of {@link Option}.
      */
-    private void addMetadataItems( final Map<String, MetadataItem> metadataItemMap, final EventQueryParams params,
-        final List<Option> itemOptions )
+    private void addMetadataItems( Map<String, MetadataItem> metadataItemMap,
+        EventQueryParams params, Set<Option> itemOptions )
     {
         boolean includeDetails = params.isIncludeMetadataDetails();
 
-        if ( !params.isSkipData() )
-        {
-            // filtering if the rows in grid are there (skipData = false)
-            itemOptions.forEach( option -> metadataItemMap.put( option.getUid(),
-                new MetadataItem( option.getDisplayProperty( params.getDisplayProperty() ),
-                    includeDetails ? option.getUid() : null, option.getCode() ) ) );
-        }
-        else
-        {
-            // filtering if the rows in grid are not there (skipData = true
-            // only)
-            // dimension=Zj7UnCAulEk.K6uUAvq500H:IN:A00;A60;A01 -> IN indicates
-            // there is a filter
-            // the stream contains all options if no filter or only options fit
-            // to the filter
-            // options can be divided by separator <<;>>
-            params.getItemOptions().stream()
-                .filter( option -> option != null &&
-                    (params.getItems().stream().noneMatch( QueryItem::hasFilter ) ||
-                        params.getItems().stream().filter( QueryItem::hasFilter )
-                            .anyMatch( qi -> qi.getFilters().stream()
-                                .anyMatch( f -> Arrays.stream( f.getFilter().split( ";" ) )
-                                    .anyMatch( ft -> ft.equalsIgnoreCase( option.getCode() ) ) ) )) )
-                .forEach( option -> metadataItemMap.put( option.getUid(),
-                    new MetadataItem( option.getDisplayProperty( params.getDisplayProperty() ),
-                        includeDetails ? option.getUid() : null, option.getCode() ) ) );
-        }
+        itemOptions.forEach( option -> metadataItemMap.put( option.getUid(),
+            new MetadataItem(
+                option.getDisplayProperty( params.getDisplayProperty() ),
+                includeDetails ? option.getUid() : null,
+                option.getCode() ) ) );
     }
 
     /**
@@ -468,6 +454,7 @@ public abstract class AbstractAnalyticsService
      * identifiers.
      *
      * @param params the data query parameters.
+     * @param itemOptions the data query parameters.
      * @return a map.
      */
     private Map<String, List<String>> getDimensionItems( EventQueryParams params,
@@ -533,10 +520,10 @@ public abstract class AbstractAnalyticsService
      * Return a list of dimension item uids. If itemOptions is null, it returns
      * an empty List, which means no options set and no legend set.
      *
-     * @param params EventQueryParams.
-     * @param item QueryItem
-     * @param itemOptions itemOtion list.
-     * @return a list of uids.
+     * @param params the {@link EventQueryParams}.
+     * @param item the {@link QueryItem}.
+     * @param itemOptions the list of item {@link Option}.
+     * @return a list of identifiers.
      */
     private List<String> getDimensionItemUidList( EventQueryParams params, QueryItem item, List<Option> itemOptions )
     {
@@ -546,9 +533,7 @@ public abstract class AbstractAnalyticsService
         }
         else if ( itemOptions != null )
         {
-            return itemOptions.stream()
-                .map( BaseIdentifiableObject::getUid )
-                .collect( toList() );
+            return IdentifiableObjectUtils.getUids( itemOptions );
         }
 
         return Lists.newArrayList();

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractAnalyticsService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.event.data;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.joinWith;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.DIMENSIONS;
 import static org.hisp.dhis.analytics.AnalyticsMetaDataKey.ITEMS;
@@ -45,9 +46,9 @@ import static org.hisp.dhis.common.ValueType.COORDINATE;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.getParentGraphMap;
 import static org.hisp.dhis.organisationunit.OrganisationUnit.getParentNameGraphMap;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -264,7 +265,7 @@ public abstract class AbstractAnalyticsService
         if ( params.hasHeaders() )
         {
             grid.keepOnlyThese( params.getHeaders() );
-            grid.repositionColumns( grid.repositionHeaders( new HashSet<>( params.getHeaders() ) ) );
+            grid.repositionColumns( grid.repositionHeaders( params.getHeaders() ) );
         }
     }
 
@@ -292,23 +293,22 @@ public abstract class AbstractAnalyticsService
         if ( !params.isSkipMeta() )
         {
             Map<String, Object> metadata = new HashMap<>();
-            Map<String, List<Option>> dimensionOptions = getItemOptions( grid, params );
-            Set<Option> responseOptions = new LinkedHashSet<>();
+            Map<String, List<Option>> optionsPresentInGrid = getItemOptions( grid, params );
+            Set<Option> optionItems = new LinkedHashSet<>();
+            boolean hasResults = isNotEmpty( grid.getRows() );
 
-            if ( !params.isSkipData() )
+            if ( hasResults )
             {
-                responseOptions.addAll( dimensionOptions.values().stream()
+                optionItems.addAll( optionsPresentInGrid.values().stream()
                     .flatMap( Collection::stream ).distinct().collect( toList() ) );
             }
             else
             {
-                responseOptions.addAll( getItemOptions( params.getItemOptions(), params.getItems() ) );
+                optionItems.addAll( getItemOptions( params.getItemOptions(), params.getItems() ) );
             }
 
-            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, responseOptions ) );
-
-            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, dimensionOptions ) );
-
+            metadata.put( ITEMS.getKey(), getMetadataItems( params, periodKeywords, optionItems ) );
+            metadata.put( DIMENSIONS.getKey(), getDimensionItems( params, optionsPresentInGrid ) );
             maybeAddOrgUnitHierarchyInfo( params, metadata );
 
             grid.setMetaData( metadata );
@@ -476,16 +476,15 @@ public abstract class AbstractAnalyticsService
 
         for ( QueryItem item : params.getItems() )
         {
-            final String itemUid = getItemUid( item );
+            String itemUid = getItemUid( item );
 
             if ( item.hasOptionSet() )
             {
-                // The call itemOptions.get( item.getItem().getUid() ) can
-                // return null.
+                // The call itemOptions.get( itemUid ) can return null.
                 // This should be ok, the query item can't have both legends and
                 // options.
                 dimensionItems.put( itemUid,
-                    getDimensionItemUidList( params, item, itemOptions.get( item.getItem().getUid() ) ) );
+                    getDimensionItemUidsFrom( itemOptions.get( itemUid ), item.getOptionSetFilterItemsOrAll() ) );
             }
             else if ( item.hasLegendSet() )
             {
@@ -517,26 +516,29 @@ public abstract class AbstractAnalyticsService
     }
 
     /**
-     * Return a list of dimension item uids. If itemOptions is null, it returns
-     * an empty List, which means no options set and no legend set.
+     * Based on the given arguments, this method will extract a list of uids of
+     * {@link Option}. If itemOptions is null, it returns the default list of
+     * uids (defaultOptionUids). Otherwise, it will return the list of uids from
+     * itemOptions.
      *
-     * @param params the {@link EventQueryParams}.
-     * @param item the {@link QueryItem}.
-     * @param itemOptions the list of item {@link Option}.
-     * @return a list of identifiers.
+     * @param itemOptions a list of {@link Option} objects
+     * @param defaultOptionUids a list of default {@link Option} uids
+     * @return a list of uids
      */
-    private List<String> getDimensionItemUidList( EventQueryParams params, QueryItem item, List<Option> itemOptions )
+    private List<String> getDimensionItemUidsFrom( List<Option> itemOptions, List<String> defaultOptionUids )
     {
-        if ( params.isSkipData() )
+        List<String> dimensionUids = new ArrayList<>();
+
+        if ( itemOptions == null )
         {
-            return item.getOptionSetFilterItemsOrAll();
+            dimensionUids.addAll( defaultOptionUids );
         }
-        else if ( itemOptions != null )
+        else
         {
-            return IdentifiableObjectUtils.getUids( itemOptions );
+            dimensionUids.addAll( IdentifiableObjectUtils.getUids( itemOptions ) );
         }
 
-        return Lists.newArrayList();
+        return dimensionUids;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
@@ -30,14 +30,18 @@ package org.hisp.dhis.analytics.event.data;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -174,6 +178,65 @@ public class QueryItemHelper
     }
 
     /**
+     * Based on the given options, it returns a set of {@link Option} objects
+     * which are referenced as filter by any one of the query items provided.
+     *
+     * @param options the set of {@link Option}.
+     * @param queryItems the list of {@link QueryItem}.
+     * @return the set of {@link Option} found.
+     */
+    public static Set<Option> getItemOptions( Set<Option> options, List<QueryItem> queryItems )
+    {
+        Set<Option> matchedOptions = new LinkedHashSet<>();
+
+        options.stream().filter( Objects::nonNull ).forEach(
+            option -> {
+                boolean queryItemsHaveNoFilter = queryItems.stream().noneMatch( QueryItem::hasFilter );
+
+                boolean queryItemsFilterMatchOptionCode = queryItems.stream().anyMatch(
+                    queryItem -> queryItem.hasFilter() && filtersContainOption( option, queryItem.getFilters() ) );
+
+                if ( queryItemsHaveNoFilter || queryItemsFilterMatchOptionCode )
+                {
+                    matchedOptions.add( option );
+                }
+            } );
+
+        return matchedOptions;
+    }
+
+    /**
+     * This method will check each filter in the given list of
+     * {@link QueryFilter} objects. For each filter, it will try to match the
+     * given option with any filter that contain an option or multiple options
+     * (split by ";"). If a match is found, it will return true.
+     *
+     * Example of a possible filter: Zj7UnCAulEk.K6uUAvq500H:IN:A03;B01, where
+     * "A03;B01" are the options codes.
+     *
+     * @param option the {@link Option}.
+     * @param queryFilters the list of {@link QueryFilter}.
+     * @return true if a match is found, false otherwise.
+     */
+    private static boolean filtersContainOption( Option option, List<QueryFilter> queryFilters )
+    {
+        for ( QueryFilter queryFilter : queryFilters )
+        {
+            String[] filterValues = defaultString( queryFilter.getFilter() ).split( ";" );
+
+            for ( String filterValue : filterValues )
+            {
+                if ( filterValue.equalsIgnoreCase( option.getCode() ) )
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * This method will extract the options (based on their codes) from the
      * element filter.
      *
@@ -239,8 +302,8 @@ public class QueryItemHelper
      * Zj7UnCAulEk.K6uUAvq500H:IN:A03;B01, where "A03;B01" are the options
      * codes.
      *
-     * The codes are split by the token ";" and the respective Option objects
-     * are returned.
+     * The codes are split by the token ";" and the respective {@link Option}
+     * objects are returned.
      *
      * @param item the QueryItem
      * @return the list of options found in the filter

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/QueryItemHelper.java
@@ -191,12 +191,10 @@ public class QueryItemHelper
 
         options.stream().filter( Objects::nonNull ).forEach(
             option -> {
-                boolean queryItemsHaveNoFilter = queryItems.stream().noneMatch( QueryItem::hasFilter );
-
                 boolean queryItemsFilterMatchOptionCode = queryItems.stream().anyMatch(
                     queryItem -> queryItem.hasFilter() && filtersContainOption( option, queryItem.getFilters() ) );
 
-                if ( queryItemsHaveNoFilter || queryItemsFilterMatchOptionCode )
+                if ( queryItemsFilterMatchOptionCode )
                 {
                     matchedOptions.add( option );
                 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
@@ -31,9 +31,11 @@ import static org.hisp.dhis.common.QueryOperator.IN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.DhisConvenienceTest;
@@ -47,13 +49,11 @@ import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.legend.Legend;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.system.grid.ListGrid;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -61,34 +61,93 @@ import org.junit.jupiter.api.Test;
  */
 class QueryItemHelperTest extends DhisConvenienceTest
 {
+    private String UID_A = CodeGenerator.generateUid();
 
-    private final String UID_A = CodeGenerator.generateUid();
+    private String UID_B = CodeGenerator.generateUid();
 
-    private final String UID_B = CodeGenerator.generateUid();
+    private String OPTION_NAME_A = "OptionA";
 
-    private final String OPTION_NAME_A = "OptionA";
+    private String OPTION_NAME_B = "OptionB";
 
-    private final String OPTION_NAME_B = "OptionB";
+    private String LEGEND_NAME_A = "LegendA";
 
-    private final String LEGEND_NAME_A = "LegendA";
+    private String LEGEND_NAME_B = "LegendB";
 
-    private final String LEGEND_NAME_B = "LegendB";
+    private String LEGEND_CODE_A = "LegendCodeA";
 
-    private final String LEGEND_CODE_A = "LegendCodeA";
+    private String LEGEND_CODE_B = "LegendCodeB";
 
-    private final String LEGEND_CODE_B = "LegendCodeB";
-
-    private QueryItem queryItem;
-
-    @BeforeEach
-    void setUp()
+    @Test
+    void testGeItemOptionValueWithIdSchemeNAME()
     {
-        DataElement deA = createDataElement( 'A' );
+        // arrange
         Option opA = createOption( 'A' );
         Option opB = createOption( 'B' );
         opA.setUid( UID_A );
         opB.setUid( UID_B );
         OptionSet os = createOptionSet( 'A', opA, opB );
+        QueryItem queryItem = new QueryItem( null, null, null, null, os );
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem )
+            .withOutputIdScheme( IdScheme.NAME ).build();
+
+        // act
+        String optionValueA = QueryItemHelper.getItemOptionValue( OPTION_NAME_A, params );
+        String optionValueB = QueryItemHelper.getItemOptionValue( OPTION_NAME_B, params );
+
+        // assert
+        assertEquals( OPTION_NAME_A, optionValueA );
+        assertEquals( OPTION_NAME_B, optionValueB );
+    }
+
+    @Test
+    void testGeItemOptionValueWithIdSchemeUID()
+    {
+        // arrange
+        Option opA = createOption( 'A' );
+        Option opB = createOption( 'B' );
+        opA.setUid( UID_A );
+        opB.setUid( UID_B );
+        OptionSet os = createOptionSet( 'A', opA, opB );
+        QueryItem queryItem = new QueryItem( null, null, null, null, os );
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).withOutputIdScheme( IdScheme.UID )
+            .build();
+
+        // act
+        String optionValueA = QueryItemHelper.getItemOptionValue( OPTION_NAME_A, params );
+        String optionValueB = QueryItemHelper.getItemOptionValue( OPTION_NAME_B, params );
+
+        // assert
+        assertEquals( UID_A, optionValueA );
+        assertEquals( UID_B, optionValueB );
+    }
+
+    @Test
+    void testGeItemOptionValueWithIdSchemeCODE()
+    {
+        // arrange
+        Option opA = createOption( 'A' );
+        Option opB = createOption( 'B' );
+        opA.setUid( UID_A );
+        opB.setUid( UID_B );
+        OptionSet os = createOptionSet( 'A', opA, opB );
+        QueryItem queryItem = new QueryItem( null, null, null, null, os );
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem )
+            .withOutputIdScheme( IdScheme.CODE )
+            .build();
+
+        // act
+        String optionValueA = QueryItemHelper.getItemOptionValue( OPTION_NAME_A, params );
+        String optionValueB = QueryItemHelper.getItemOptionValue( OPTION_NAME_B, params );
+
+        // assert
+        assertEquals( "OptionCodeA", optionValueA );
+        assertEquals( "OptionCodeB", optionValueB );
+    }
+
+    @Test
+    void testGeItemLegendValueWithIdSchemeNAME()
+    {
+        // arrange
         Legend lpA = createLegend( 'A', 0.0, 1.0 );
         lpA.setCode( LEGEND_CODE_A );
         Legend lpB = createLegend( 'B', 0.0, 1.0 );
@@ -96,80 +155,152 @@ class QueryItemHelperTest extends DhisConvenienceTest
         lpA.setUid( UID_A );
         lpB.setUid( UID_B );
         LegendSet ls = createLegendSet( 'A', lpA, lpB );
-        queryItem = new QueryItem( deA, ls, deA.getValueType(), deA.getAggregationType(), os );
-    }
 
-    @Test
-    void geItemOptionNameValueTest()
-    {
-        // / arrange
+        QueryItem queryItem = new QueryItem( null, ls, null, null, null );
         EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem )
             .withOutputIdScheme( IdScheme.NAME ).build();
+
         // act
-        String optionValueA = QueryItemHelper.getItemOptionValue( OPTION_NAME_A, params );
-        String optionValueB = QueryItemHelper.getItemOptionValue( OPTION_NAME_B, params );
         String legendValueA = QueryItemHelper.getItemLegendValue( LEGEND_NAME_A, params );
         String legendValueB = QueryItemHelper.getItemLegendValue( LEGEND_NAME_B, params );
+
         // assert
-        assertEquals( OPTION_NAME_A, optionValueA );
-        assertEquals( OPTION_NAME_B, optionValueB );
         assertEquals( LEGEND_NAME_A, legendValueA );
         assertEquals( LEGEND_NAME_B, legendValueB );
     }
 
     @Test
-    void geItemOptionCodeTest()
+    void testGeItemLegendValueWithIdSchemeUID()
     {
         // arrange
-        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem )
-            .withOutputIdScheme( IdScheme.CODE ).build();
+        Legend lpA = createLegend( 'A', 0.0, 1.0 );
+        lpA.setCode( LEGEND_CODE_A );
+        Legend lpB = createLegend( 'B', 0.0, 1.0 );
+        lpB.setCode( LEGEND_CODE_B );
+        lpA.setUid( UID_A );
+        lpB.setUid( UID_B );
+        LegendSet ls = createLegendSet( 'A', lpA, lpB );
+        QueryItem queryItem = new QueryItem( null, ls, null, null, null );
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).withOutputIdScheme( IdScheme.UID )
+            .build();
+
         // act
-        String optionValueA = QueryItemHelper.getItemOptionValue( OPTION_NAME_A, params );
-        String optionValueB = QueryItemHelper.getItemOptionValue( OPTION_NAME_B, params );
         String legendValueA = QueryItemHelper.getItemLegendValue( LEGEND_NAME_A, params );
         String legendValueB = QueryItemHelper.getItemLegendValue( LEGEND_NAME_B, params );
+
         // assert
-        assertEquals( "OptionCodeA", optionValueA );
-        assertEquals( "OptionCodeB", optionValueB );
+        assertEquals( UID_A, legendValueA );
+        assertEquals( UID_B, legendValueB );
+    }
+
+    @Test
+    void testGeItemLegendValueWithIdSchemeCODE()
+    {
+        // arrange
+        Legend lpA = createLegend( 'A', 0.0, 1.0 );
+        lpA.setCode( LEGEND_CODE_A );
+        Legend lpB = createLegend( 'B', 0.0, 1.0 );
+        lpB.setCode( LEGEND_CODE_B );
+        lpA.setUid( UID_A );
+        lpB.setUid( UID_B );
+        LegendSet ls = createLegendSet( 'A', lpA, lpB );
+
+        QueryItem queryItem = new QueryItem( null, ls, null, null, null );
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem )
+            .withOutputIdScheme( IdScheme.CODE ).build();
+
+        // act
+        String legendValueA = QueryItemHelper.getItemLegendValue( LEGEND_NAME_A, params );
+        String legendValueB = QueryItemHelper.getItemLegendValue( LEGEND_NAME_B, params );
+
+        // assert
         assertEquals( LEGEND_CODE_A, legendValueA );
         assertEquals( LEGEND_CODE_B, legendValueB );
     }
 
     @Test
-    void geItemOptionUidTest()
+    void testGetItemOptionsThatAreReferencedByQueryItems()
     {
-        // arrange
-        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).withOutputIdScheme( IdScheme.UID )
-            .build();
-        // act
-        String optionValueA = QueryItemHelper.getItemOptionValue( OPTION_NAME_A, params );
-        String optionValueB = QueryItemHelper.getItemOptionValue( OPTION_NAME_B, params );
-        String legendValueA = QueryItemHelper.getItemLegendValue( LEGEND_NAME_A, params );
-        String legendValueB = QueryItemHelper.getItemLegendValue( LEGEND_NAME_B, params );
-        // assert
-        assertEquals( UID_A, optionValueA );
-        assertEquals( UID_B, optionValueB );
-        assertEquals( UID_A, legendValueA );
-        assertEquals( UID_B, legendValueB );
+        // Given
+        Option option1 = new Option( "Opt-A", "Code-A" );
+        Option option2 = new Option( "Opt-B", "Code-B" );
+        Option option3 = new Option( "Opt-C", "Code-C" );
+        OptionSet optionSet = createOptionSet( 'A', option1, option2, option3 );
+
+        Set<Option> options = Set.of( option1, option2, option3 );
+        List<QueryItem> queryItems = new ArrayList<>();
+
+        QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        queryItem.addFilter( new QueryFilter( IN, "Code-A;Code-B" ) );
+        queryItems.add( queryItem );
+
+        // When
+        Set<Option> actualOptions = QueryItemHelper.getItemOptions( options, queryItems );
+
+        // Then
+        assertEquals( 2, actualOptions.size(), "Should have size of 2: actualOptions" );
+    }
+
+    @Test
+    void testGetItemOptionsThatAreReferencedByQueryItemsDifferentCases()
+    {
+        // Given
+        Option option1 = new Option( "Opt-A", "Code-A" );
+        Option option2 = new Option( "Opt-B", "Code-B" );
+        Option option3 = new Option( "Opt-C", "Code-C" );
+        OptionSet optionSet = createOptionSet( 'A', option1, option2, option3 );
+
+        Set<Option> options = Set.of( option1, option2, option3 );
+        List<QueryItem> queryItems = new ArrayList<>();
+
+        QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        queryItem.addFilter( new QueryFilter( IN, "CODE-A;CODE-C" ) );
+        queryItems.add( queryItem );
+
+        // When
+        Set<Option> actualOptions = QueryItemHelper.getItemOptions( options, queryItems );
+
+        // Then
+        assertEquals( 2, actualOptions.size(), "Should have size of 2: actualOptions" );
+    }
+
+    @Test
+    void testGetItemOptionsThatHaveNoFilters()
+    {
+        // Given
+        Option option1 = new Option( "Opt-A", "Code-A" );
+        Option option2 = new Option( "Opt-B", "Code-B" );
+        Option option3 = new Option( "Opt-C", "Code-C" );
+        OptionSet optionSet = createOptionSet( 'A', option1, option2, option3 );
+
+        Set<Option> options = Set.of( option1, option2, option3 );
+        QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        List<QueryItem> queryItems = new ArrayList<>();
+        queryItems.add( queryItem );
+
+        // When
+        Set<Option> actualOptions = QueryItemHelper.getItemOptions( options, queryItems );
+
+        // Then
+        assertEquals( 3, actualOptions.size(), "Should have size of 3: actualOptions" );
     }
 
     @Test
     void testGetItemOptionsWhenRowsArePresent()
     {
         // Given
-        final Option option = new Option( "Opt-A", "Code-A" );
-        final OptionSet optionSet = new OptionSet();
-        optionSet.addOption( option );
+        Option option = new Option( "Opt-A", "Code-A" );
+        OptionSet optionSet = createOptionSet( 'A', option );
 
-        final Grid grid = stubGridWithRowsAndOptionSet( optionSet );
-        final QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        Grid grid = stubGridWithRowsAndOptionSet( optionSet );
+        QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
         queryItem.addFilter( new QueryFilter( IN, "Code-A" ) );
 
-        final EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).build();
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).build();
         params.getItems().add( queryItem );
 
         // When
-        final Map<String, List<Option>> options = QueryItemHelper.getItemOptions( grid, params );
+        Map<String, List<Option>> options = QueryItemHelper.getItemOptions( grid, params );
 
         // Then
         assertTrue(
@@ -180,31 +311,30 @@ class QueryItemHelperTest extends DhisConvenienceTest
     void testGetItemOptionsWhenRowsAreEmpty()
     {
         // Given
-        final Option option = new Option( "Opt-A", "Code-A" );
-        final OptionSet optionSet = new OptionSet();
-        optionSet.addOption( option );
+        Option option = new Option( "Opt-A", "Code-A" );
+        OptionSet optionSet = createOptionSet( 'A', option );
 
-        final Grid grid = stubGridWithEmptyRowsAndOptionSet( optionSet );
-        final QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
+        Grid grid = stubGridWithEmptyRowsAndOptionSet( optionSet );
+        QueryItem queryItem = new QueryItem( null, null, null, null, optionSet );
         queryItem.addFilter( new QueryFilter( IN, "Code-A" ) );
 
-        final EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).build();
+        EventQueryParams params = new EventQueryParams.Builder().addItem( queryItem ).build();
         params.getItems().add( queryItem );
 
         // When
-        final Map<String, List<Option>> options = QueryItemHelper.getItemOptions( grid, params );
+        Map<String, List<Option>> options = QueryItemHelper.getItemOptions( grid, params );
 
         // Then
         assertTrue(
             options.values().stream().flatMap( Collection::stream ).collect( Collectors.toList() ).contains( option ) );
     }
 
-    private Grid stubGridWithRowsAndOptionSet( final OptionSet optionSet )
+    private Grid stubGridWithRowsAndOptionSet( OptionSet optionSet )
     {
-        final Grid grid = new ListGrid();
-        final GridHeader headerA = new GridHeader( "ColA", "colA", ValueType.TEXT, false, true,
+        Grid grid = new ListGrid();
+        GridHeader headerA = new GridHeader( "ColA", "colA", ValueType.TEXT, false, true,
             optionSet, null, "programStage", new RepeatableStageParams() );
-        final GridHeader headerB = new GridHeader( "ColB", "colB", ValueType.TEXT, false, true );
+        GridHeader headerB = new GridHeader( "ColB", "colB", ValueType.TEXT, false, true );
 
         grid.addHeader( headerA );
         grid.addHeader( headerB );
@@ -224,12 +354,12 @@ class QueryItemHelperTest extends DhisConvenienceTest
         return grid;
     }
 
-    private Grid stubGridWithEmptyRowsAndOptionSet( final OptionSet optionSet )
+    private Grid stubGridWithEmptyRowsAndOptionSet( OptionSet optionSet )
     {
-        final Grid grid = new ListGrid();
-        final GridHeader headerA = new GridHeader( "ColA", "colA", ValueType.TEXT, false, true,
+        Grid grid = new ListGrid();
+        GridHeader headerA = new GridHeader( "ColA", "colA", ValueType.TEXT, false, true,
             optionSet, null, "programStage", new RepeatableStageParams() );
-        final GridHeader headerB = new GridHeader( "ColB", "colB", ValueType.TEXT, false, true );
+        GridHeader headerB = new GridHeader( "ColB", "colB", ValueType.TEXT, false, true );
 
         grid.addHeader( headerA );
         grid.addHeader( headerB );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/QueryItemHelperTest.java
@@ -282,7 +282,7 @@ class QueryItemHelperTest extends DhisConvenienceTest
         Set<Option> actualOptions = QueryItemHelper.getItemOptions( options, queryItems );
 
         // Then
-        assertEquals( 3, actualOptions.size(), "Should have size of 3: actualOptions" );
+        assertEquals( 0, actualOptions.size(), "Should have size of 0: actualOptions" );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EventAnalyticsServiceMetadataTest.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.common.QueryFilter.OPTION_SEP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -233,7 +234,9 @@ class EventAnalyticsServiceMetadataTest extends DhisSpringTest
         }
         for ( Option option : deE.getOptionSet().getOptions() )
         {
-            assertNotNull( itemMap.get( option.getUid() ) );
+            // Because skipData is set to "true" and no option code is specified
+            // as filter.
+            assertNull( itemMap.get( option.getUid() ) );
         }
         assertNotNull( itemMap.get( deA.getUid() ) );
         assertNotNull( itemMap.get( deE.getUid() ) );


### PR DESCRIPTION
**_[Backport from master/2.40]_**

These changes will improve the handling of option codes in the `analytics/events/query` endpoint.
Currently, the logic is based on the flag `skipData`. We should actually consider the returned `rows` instead. Based on that, the following scenarios are now being covered.

1) If `rows` is empty and an option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk:IN:MODTRANS` -> the response returns the filtered option code in `metaData/dimensions` and `metaData/items`.

2) If `rows` is not empty and an option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk:IN:MODTRANS` -> the response returns the filtered option code in `metaDate/dimensions` and `metaData/items`.

3) If `rows` is empty and no option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk` -> the response returns only the optionset name. Nothing is returning in `metaData/dimensions` and `metaData/items`.

4) If `rows` is not empty and no option code is specified as a filter, ie: `Zj7UnCAulEk.fWIAEtYVEGk` -> the response returns, in `metaData/dimensions` and `metaData/items`, only the option codes that are present in `rows`.