### PR TITLE
fix: Internal server error in /trackedEntityInstances/query when there are no filterable attributes [ DHIS2-13076 ]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/teis/TrackedEntityInstanceQueryTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/teis/TrackedEntityInstanceQueryTests.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.teis;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hisp.dhis.helpers.matchers.CustomMatchers.hasToStringContaining;
@@ -46,6 +47,7 @@ import org.hisp.dhis.tracker.importer.databuilder.EnrollmentDataBuilder;
 import org.hisp.dhis.tracker.importer.databuilder.TeiDataBuilder;
 import org.hisp.dhis.utils.DataGenerator;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -120,6 +122,17 @@ class TrackedEntityInstanceQueryTests
             .body( "rows", hasItem(
                 hasToStringContaining(
                     Arrays.asList( teiId, lastNameAttribute.getValue(), firstNameAttribute.getValue() ) ) ) );
+    }
+
+    @Test
+    public void shouldReturnBadRequestProgramWithNoFilterableAttributes()
+    {
+        trackedEntityInstanceQueryActions
+            .get( "?ouMode=ACCESSIBLE&query=LIKE:value&program=jDnjGYZFkA2" )
+            .validate()
+            .statusCode( 400 )
+            .body( "status", equalTo( "ERROR" ) )
+            .body( "httpStatusCode", equalTo( 400 ) );
     }
 
     private String createTei()

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/hibernate/HibernateTrackedEntityInstanceStore.java
@@ -392,6 +392,12 @@ public class HibernateTrackedEntityInstanceStore
      */
     private String getQuery( TrackedEntityInstanceQueryParams params, boolean isGridQuery )
     {
+        if ( params.isOrQuery() && params.getAttributesAndFilters().isEmpty() )
+        {
+            throw new IllegalArgumentException(
+                "A query parameter is used in the request but there aren't filterable attributes" );
+        }
+
         return new StringBuilder()
             .append( getQuerySelect( params, isGridQuery ) )
             .append( "FROM " )
@@ -487,7 +493,7 @@ public class HibernateTrackedEntityInstanceStore
             .append( " FROM trackedentityinstance TEI " )
 
             // INNER JOIN on constraints
-            .append( getFromSubQueryJoinAttributeConditions( whereAnd, params ) )
+            .append( getFromSubQueryJoinAttributeConditions( params ) )
             .append( getFromSubQueryJoinProgramOwnerConditions( params ) )
             .append( getFromSubQueryJoinOrgUnitConditions( params ) )
 
@@ -639,27 +645,17 @@ public class HibernateTrackedEntityInstanceStore
      * @return a series of 1 or more SQL INNER JOINs, or empty string if no
      *         query or attribute filters exists.
      */
-    private String getFromSubQueryJoinAttributeConditions( SqlHelper whereAnd, TrackedEntityInstanceQueryParams params )
+    private String getFromSubQueryJoinAttributeConditions( TrackedEntityInstanceQueryParams params )
     {
-        StringBuilder attributes = new StringBuilder();
-
-        List<QueryItem> filterItems = params.getAttributesAndFilters().stream()
-            .filter( QueryItem::hasFilter )
-            .collect( Collectors.toList() );
-
-        if ( !filterItems.isEmpty() || params.isOrQuery() )
+        if ( !params.isOrQuery() )
         {
-            if ( !params.isOrQuery() )
-            {
-                joinAttributeValueWithoutQueryParameter( attributes, filterItems );
-            }
-            else
-            {
-                joinAttributeValueWithQueryParameter( params, attributes );
-            }
+            return joinAttributeValueWithoutQueryParameter( params );
         }
+        else
+        {
+            return joinAttributeValueWithQueryParameter( params );
 
-        return attributes.toString();
+        }
     }
 
     /**
@@ -671,11 +667,11 @@ public class HibernateTrackedEntityInstanceStore
      * search, allowing both exact match and with wildcards (EQ or LIKE).
      *
      * @param params
-     * @param attributes
      */
-    private void joinAttributeValueWithQueryParameter( TrackedEntityInstanceQueryParams params,
-        StringBuilder attributes )
+    private String joinAttributeValueWithQueryParameter( TrackedEntityInstanceQueryParams params )
     {
+        StringBuilder attributes = new StringBuilder();
+
         final String regexp = statementBuilder.getRegexpMatch();
         final String wordStart = statementBuilder.getRegexpWordStart();
         final String wordEnd = statementBuilder.getRegexpWordEnd();
@@ -711,7 +707,7 @@ public class HibernateTrackedEntityInstanceStore
                 .append( SINGLE_QUOTE );
         }
 
-        attributes.append( ")" );
+        return attributes.append( ")" ).toString();
     }
 
     /**
@@ -719,11 +715,16 @@ public class HibernateTrackedEntityInstanceStore
      * can search by a range of operators. All searching is using lower() since
      * attribute values are case insensitive.
      *
-     * @param attributes
-     * @param filterItems
+     * @param params
      */
-    private void joinAttributeValueWithoutQueryParameter( StringBuilder attributes, List<QueryItem> filterItems )
+    private String joinAttributeValueWithoutQueryParameter( TrackedEntityInstanceQueryParams params )
     {
+        StringBuilder attributes = new StringBuilder();
+
+        List<QueryItem> filterItems = params.getAttributesAndFilters().stream()
+            .filter( QueryItem::hasFilter )
+            .collect( Collectors.toList() );
+
         for ( QueryItem queryItem : filterItems )
         {
             String col = statementBuilder.columnQuote( queryItem.getItemId() );
@@ -756,6 +757,8 @@ public class HibernateTrackedEntityInstanceStore
                         .lowerCase( filter.getSqlFilter( encodedFilter ) ) );
             }
         }
+
+        return attributes.toString();
     }
 
     /**

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -30,6 +30,7 @@ package org.hisp.dhis.trackedentity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -308,5 +309,37 @@ class TrackedEntityInstanceServiceTest
         Grid grid = entityInstanceService.getTrackedEntityInstancesGrid( params );
 
         assertEquals( 1, grid.getHeight() );
+    }
+
+    @Test
+    void testTrackedEntityInstanceGridWithNoFilterableAttributes()
+    {
+        injectSecurityContext( superUser );
+
+        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
+        params.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
+        params.setTrackedEntityType( trackedEntityTypeA );
+
+        params.setQuery( new QueryFilter( QueryOperator.LIKE, ATTRIBUTE_VALUE ) );
+
+        assertThrows( IllegalArgumentException.class,
+            () -> entityInstanceService.getTrackedEntityInstancesGrid( params ) );
+    }
+
+    @Test
+    void testTrackedEntityInstanceGridWithNoDisplayAttributes()
+    {
+        injectSecurityContext( superUser );
+        filtH.setDisplayInListNoProgram( false );
+        attributeService.addTrackedEntityAttribute( filtH );
+
+        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
+        params.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
+        params.setTrackedEntityType( trackedEntityTypeA );
+
+        params.setQuery( new QueryFilter( QueryOperator.LIKE, ATTRIBUTE_VALUE ) );
+
+        assertThrows( IllegalArgumentException.class,
+            () -> entityInstanceService.getTrackedEntityInstancesGrid( params ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
@@ -118,8 +118,6 @@ public class TrackedEntityInstanceCriteriaMapper
             possibleSearchOrgUnits = user.getTeiSearchOrganisationUnitsWithFallback();
         }
 
-        QueryFilter queryFilter = getQueryFilter( criteria.getQuery() );
-
         Map<String, TrackedEntityAttribute> attributes = attributeService.getAllTrackedEntityAttributes()
             .stream().collect( Collectors.toMap( TrackedEntityAttribute::getUid, att -> att ) );
 
@@ -174,7 +172,7 @@ public class TrackedEntityInstanceCriteriaMapper
 
         validateOrderParams( program, orderParams, attributes );
 
-        params.setQuery( queryFilter )
+        params.setQuery( getQueryFilter( criteria.getQuery() ) )
             .setProgram( program )
             .setProgramStage( validateProgramStage( criteria, program ) )
             .setProgramStatus( criteria.getProgramStatus() )


### PR DESCRIPTION
For /trackedEntityInstances/query endpoint, we now throw an illegal argument exception when there are no filterable attributes.
This happens when :
- there are no tracked entity attributes (also related to a type ) or with no display property
- if the request has a program parameter, the program has no tracked entity attributes