### PR TITLE
fix: NPE in Interpretations API [DHIS2-14010]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseAnalyticalObject.java
@@ -54,6 +54,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.annotation.CheckForNull;
+
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryDimension;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -1424,8 +1426,14 @@ public abstract class BaseAnalyticalObject
         return subscribers;
     }
 
+    @CheckForNull
     public void setSubscribers( Set<String> subscribers )
     {
+        if ( subscribers == null )
+        {
+            subscribers = new HashSet<>();
+        }
+
         this.subscribers = subscribers;
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.interpretation;
 
+import static java.util.Collections.emptySet;
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -118,8 +121,6 @@ public class DefaultInterpretationService
     {
         User user = currentUserService.getCurrentUser();
 
-        Set<User> users = new HashSet<>();
-
         if ( user != null )
         {
             interpretation.setCreatedBy( user );
@@ -130,7 +131,7 @@ public class DefaultInterpretationService
             interpretation.setPeriod( periodService.reloadPeriod( interpretation.getPeriod() ) );
         }
 
-        users = MentionUtils.getMentionedUsers( interpretation.getText(), userService );
+        Set<User> users = MentionUtils.getMentionedUsers( interpretation.getText(), userService );
         interpretation.setMentionsFromUsers( users );
         updateSharingForMentions( interpretation, users );
 
@@ -287,7 +288,8 @@ public class DefaultInterpretationService
         if ( interpretableObjectSchema.isSubscribable() )
         {
             SubscribableObject object = (SubscribableObject) interpretableObject;
-            Set<User> subscribers = new HashSet<>( userService.getUsers( object.getSubscribers() ) );
+            Set<User> subscribers = new HashSet<>(
+                userService.getUsers( firstNonNull( object.getSubscribers(), emptySet() ) ) );
             subscribers.remove( currentUserService.getCurrentUser() );
 
             if ( !subscribers.isEmpty() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.interpretation;
 
-import static java.util.Collections.emptySet;
-import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
-
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
@@ -288,8 +285,7 @@ public class DefaultInterpretationService
         if ( interpretableObjectSchema.isSubscribable() )
         {
             SubscribableObject object = (SubscribableObject) interpretableObject;
-            Set<User> subscribers = new HashSet<>(
-                userService.getUsers( firstNonNull( object.getSubscribers(), emptySet() ) ) );
+            Set<User> subscribers = new HashSet<>( userService.getUsers( object.getSubscribers() ) );
             subscribers.remove( currentUserService.getCurrentUser() );
 
             if ( !subscribers.isEmpty() )


### PR DESCRIPTION
This fix will prevent an NPE that was recently introduced as part of one of the non-null clean-ups (https://github.com/dhis2/dhis2-core/commit/add6ee3fa78ffe2c7e6864a611b92913ca636a2a)

As now there is no null check anymore for this particular case, we have to ensure we do not pass null objects down the flow.
Basically, we pass a default empty set instead of null, if we do not have any subscribers.