### PR TITLE
fix: multi-orgunit forms html [DHIS2-13088]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/multiOrgSectionForm.vm
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/multiOrgSectionForm.vm
@@ -13,9 +13,10 @@ var organisationUnitList = JSON.parse( '$organisationUnits' );
         #set( $categoryComboIds = "null" )
     #set( $categoryComboIds = $sectionCombos.get( $section.id ) )
 
-    #foreach( $categoryComboId in $categoryComboIds )
-        #set( $seCbId = "${section.id}-${categoryComboId}" )
+    #foreach( $catComboId in $categoryComboIds )
+        #set( $seCbId = "${section.id}-${catComboId}" )
         #set( $dataElements = $sectionCategoryComboDataElements.get( $seCbId ) )
+        #set( $categoryComboId = $orderedSectionCategoryCombos.get( $catComboId ) )
     
         #if( $marker == 1 )
           #set( $marker = 0 )


### PR DESCRIPTION
Fixes issue with multi-orgUnit forms html (categoryOptionCombos were not loading / inputs were not being created) because of categoryComboId used for retrieval.

**Current DHIS2**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/18490902/199762481-256cb768-a203-4d68-975b-51459fc78506.png">


**After this change**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/18490902/199762676-5545bc28-cde1-47f2-9a39-d77b4c5f080e.png">

