### PR TITLE
refactor: Clean up module dependencies

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-administration/pom.xml
@@ -34,10 +34,6 @@
       <artifactId>dhis-service-schema</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hisp.dhis</groupId>    
-      <artifactId>dhis-service-validation</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-system</artifactId>
     </dependency>
@@ -147,16 +143,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-program-rule</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-audit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-analytics/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-analytics/pom.xml
@@ -38,10 +38,6 @@
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-administration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-commons</artifactId>
     </dependency>
     <dependency>
@@ -149,11 +145,6 @@
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-validation</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-dxf2/pom.xml
@@ -242,11 +242,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-validation</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/pom.xml
@@ -37,10 +37,6 @@
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-system</artifactId>
     </dependency>
     <dependency>

--- a/dhis-2/dhis-services/dhis-service-reporting/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-reporting/pom.xml
@@ -205,11 +205,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-service-validation</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -27,14 +27,6 @@
     </dependency>
     <dependency>
       <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-hibernate</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
-      <artifactId>dhis-support-db-migration</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hisp.dhis</groupId>
       <artifactId>dhis-support-external</artifactId>
     </dependency>
 

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -703,14 +703,9 @@
               <!-- Removing makes the startup with Jetty fail -->
               <ignoredUnusedDeclaredDependency>javax.media:jai_imageio</ignoredUnusedDeclaredDependency>
               <!-- Only exist at runtime -->
-              <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-support-hibernate</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-support-db-migration</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-support-audit</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-audit-consumer</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-validation</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-administration</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-program-rule</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-core</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-web-api</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-dxf2</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-service-reporting</ignoredUnusedDeclaredDependency>


### PR DESCRIPTION
After creating `dhis-test-integration` module a few dependencies that were needed before to run the tests in every module are now redundant and the analyzer was not complaining because we had a ignore rules on such modules.