### PR TITLE
ci(deps): add dependabot updates to 2.39

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
     labels:
       - "dependencies"
       - "java"
-      - "run-api-tests"
     ignore:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
@@ -58,7 +57,6 @@ updates:
     labels:
       - "dependencies"
       - "java"
-      - "run-api-tests"
     ignore:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,6 @@
 version: 2
 updates:
+  # master
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,7 +18,6 @@ updates:
       interval: "daily"
       time: "02:17" # GitHub says 'High load times include the start of every hour'
       timezone: "Europe/Oslo"
-    open-pull-requests-limit: 8
     pull-request-branch-name:
       separator: "-"
     commit-message:
@@ -31,3 +31,36 @@ updates:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
           - ">= 11.0"
+  # 2.39
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "02:17" # GitHub says 'High load times include the start of every hour'
+      timezone: "Europe/Oslo"
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    target-branch: "2.39"
+  - package-ecosystem: "maven"
+    directory: "/dhis-2"
+    schedule:
+      interval: "daily"
+      time: "02:17" # GitHub says 'High load times include the start of every hour'
+      timezone: "Europe/Oslo"
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "java"
+      - "run-api-tests"
+    ignore:
+      - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
+        versions:
+          - ">= 11.0"
+    target-branch: "2.39"


### PR DESCRIPTION
as discussed in the backend team meeting

`target-branch` does not allow an array of branches

https://github.com/dependabot/dependabot-core/issues/2511

it seems that duplicating the config on the main branch itself per `target-branch` should configure dependabot to update other branches (security fixes and regular updates).

Trying it first on 2.39 before adding it to 2.38, 2.37.