### PR TITLE
fix: Date object conversion [DHIS2-14305]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/TimeToLive.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/cache/TimeToLive.java
@@ -46,7 +46,6 @@ public class TimeToLive
     implements
     Computable
 {
-
     static final long DEFAULT_MULTIPLIER = 1;
 
     private final Date dateBeforeToday;
@@ -58,7 +57,9 @@ public class TimeToLive
         notNull( dateBeforeToday, "Param dateBeforeToday must not be null" );
         isTrue( ttlFactor > 0, "Param ttlFactor must be greater than zero" );
 
-        this.dateBeforeToday = dateBeforeToday;
+        // This ensures we always work with java.util.Date type, avoiding issues
+        // with java.sql.Date.
+        this.dateBeforeToday = new Date( dateBeforeToday.getTime() );
         this.ttlFactor = ttlFactor;
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/cache/TimeToLiveTest.java
@@ -51,7 +51,6 @@ import org.mockito.quality.Strictness;
 @ExtendWith( MockitoExtension.class )
 class TimeToLiveTest
 {
-
     @Mock
     private DefaultSystemSettingManager systemSettingManager;
 
@@ -111,6 +110,23 @@ class TimeToLiveTest
 
         // When
         final long actualTtl = new TimeToLive( endingDate, aPositiveCachingFactor ).compute();
+
+        // Then
+        assertThat( actualTtl, is( equalTo( expectedTtl ) ) );
+    }
+
+    @Test
+    void testComputeWhenDateObjectIsOfTypeSqlDate()
+    {
+        // Given
+        int oneDayDiff = 1;
+        int aPositiveCachingFactor = 2;
+        java.sql.Date endingDate = new java.sql.Date(
+            calculateDateFrom( new Date(), minus( oneDayDiff ), DATE ).getTime() );
+        long expectedTtl = aPositiveCachingFactor * oneDayDiff;
+
+        // When
+        long actualTtl = new TimeToLive( endingDate, aPositiveCachingFactor ).compute();
 
         // Then
         assertThat( actualTtl, is( equalTo( expectedTtl ) ) );


### PR DESCRIPTION
**_Backport from master/2.40_**

Adds support to runtime usage of `java.sql.Date`. Ensures that, internally, we are always working with `java.util.Date`.