### PR TITLE
fix: getSystemSetting causes performance issue

### DIFF
--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/DefaultSystemSettingManager.java
@@ -48,6 +48,7 @@ import org.jasypt.encryption.pbe.PBEStringEncryptor;
 import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -82,11 +83,13 @@ public class DefaultSystemSettingManager
 
     private final PBEStringEncryptor pbeStringEncryptor;
 
+    private final TransactionTemplate transactionTemplate;
+
     private final List<String> flags;
 
     public DefaultSystemSettingManager( SystemSettingStore systemSettingStore,
         @Qualifier( "tripleDesStringEncryptor" ) PBEStringEncryptor pbeStringEncryptor,
-        CacheProvider cacheProvider, List<String> flags )
+        CacheProvider cacheProvider, List<String> flags, TransactionTemplate transactionTemplate )
     {
         checkNotNull( systemSettingStore );
         checkNotNull( pbeStringEncryptor );
@@ -97,6 +100,7 @@ public class DefaultSystemSettingManager
         this.pbeStringEncryptor = pbeStringEncryptor;
         this.flags = flags;
         this.settingCache = cacheProvider.createSystemSettingCache();
+        this.transactionTemplate = transactionTemplate;
     }
 
     // -------------------------------------------------------------------------
@@ -179,8 +183,6 @@ public class DefaultSystemSettingManager
      * cache hits.
      */
     @Override
-    @SuppressWarnings( "unchecked" )
-    @Transactional( readOnly = true )
     public <T extends Serializable> T getSystemSetting( SettingKey key, T defaultValue )
     {
         SerializableOptional value = settingCache.get( key.getName(),
@@ -223,7 +225,7 @@ public class DefaultSystemSettingManager
 
     private Serializable getSettingDisplayValue( String name )
     {
-        SystemSetting setting = systemSettingStore.getByName( name );
+        SystemSetting setting = transactionTemplate.execute( status -> systemSettingStore.getByName( name ) );
 
         if ( setting != null && setting.hasValue() )
         {

--- a/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-setting/src/main/java/org/hisp/dhis/setting/config/ServiceConfig.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * @author Luciano Fiandesio
@@ -53,7 +54,8 @@ public class ServiceConfig
     private PBEStringEncryptor pbeStringEncryptor;
 
     @Bean( "org.hisp.dhis.setting.SystemSettingManager" )
-    public DefaultSystemSettingManager defaultSystemSettingManager( CacheProvider cacheProvider )
+    public DefaultSystemSettingManager defaultSystemSettingManager( CacheProvider cacheProvider,
+        TransactionTemplate transactionTemplate )
     {
 
         List<String> flags = new ArrayList<>();
@@ -356,6 +358,7 @@ public class ServiceConfig
         flags.add( "zimbabwe" );
         flags.add( "who" );
 
-        return new DefaultSystemSettingManager( systemSettingStore, pbeStringEncryptor, cacheProvider, flags );
+        return new DefaultSystemSettingManager( systemSettingStore, pbeStringEncryptor, cacheProvider, flags,
+            transactionTemplate );
     }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14114

### Issue: 
- `SystemSettingManager.getSystemSetting()` use `settingCache`. Currently `@Transaction( readOnly = true )` commit the transaction for every function call even with cache hits, which is causing performance issue when we call this method in a for loop.
- We want to initiate the transaction only when cache miss.

### Fix:
- Use `TransactionTemplate.execute()` to manually initiate transaction when cache misses in `SystemSettingManager.getSystemSettingOptional()`

### Test:
- The affected function of this issue is in Aggregate Data Entry app. Just need to test if the forms can be loaded successfully.