### PR TITLE
ci(deps): add dependabot limits for older versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
       prefix: "chore"
       include: "scope"
     target-branch: "2.39"
+    open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   - package-ecosystem: "maven"
     directory: "/dhis-2"
     schedule:
@@ -56,6 +57,7 @@ updates:
         versions:
           - ">= 11.0"
     target-branch: "2.39"
+    open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.38
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -69,6 +71,7 @@ updates:
       prefix: "chore"
       include: "scope"
     target-branch: "2.38"
+    open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   - package-ecosystem: "maven"
     directory: "/dhis-2"
     schedule:
@@ -85,6 +88,7 @@ updates:
         versions:
           - ">= 11.0"
     target-branch: "2.38"
+    open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.37
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -98,6 +102,7 @@ updates:
       prefix: "chore"
       include: "scope"
     target-branch: "2.37"
+    open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   - package-ecosystem: "maven"
     directory: "/dhis-2"
     schedule:
@@ -114,3 +119,4 @@ updates:
         versions:
           - ">= 11.0"
     target-branch: "2.37"
+    open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources


### PR DESCRIPTION
just initially as we update dependencies on the older branches. Otherwise, dependabot will take away too many of our CI resources