### PR TITLE
ci(deps): fix jboss-logging 3.5 needing JDK 11 as minimum

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,9 +23,9 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Test core
-        run: mvn --threads 2C clean install -Pdefault -Pjdk11 --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+        run: mvn --threads 2C clean install -Pdefault -Pjdk8 --update-snapshots -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
       - name: Test dhis-web
-        run: mvn --threads 2C clean install -Pdefault -Pjdk11 --update-snapshots -f ./dhis-2/dhis-web/pom.xml
+        run: mvn --threads 2C clean install -Pdefault -Pjdk8 --update-snapshots -f ./dhis-2/dhis-web/pom.xml
       - name: Generate surefire aggregate report
         run: mvn surefire-report:report-only -Daggregate=true --batch-mode --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
       # tar due to https://github.com/actions/upload-artifact/blob/3cea5372237819ed00197afe530f5a7ea3e805c8/README.md?plain=1#L254
@@ -55,7 +55,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Run integration tests
-        run: mvn --threads 2C clean install -Pintegration -Pjdk11 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+        run: mvn --threads 2C clean install -Pintegration -Pjdk8 -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
       - name: Generate surefire aggregate report
         run: mvn surefire-report:report-only -Daggregate=true --batch-mode --no-transfer-progress -f ./dhis-2/pom.xml -pl -dhis-web-embedded-jetty
       # tar due to https://github.com/actions/upload-artifact/blob/3cea5372237819ed00197afe530f5a7ea3e805c8/README.md?plain=1#L254

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -155,7 +155,7 @@
     <rxtx.version>2.1.7</rxtx.version>
     <json-path.version>2.4.0</json-path.version>
     <jsmpp-X.version>2.1.0-RELEASE</jsmpp-X.version>
-    <jboss-logging.version>3.5.0.Final</jboss-logging.version>
+    <jboss-logging.version>3.4.1.Final</jboss-logging.version>
     <jsoup.version>1.14.2</jsoup.version>
 
     <!-- Embedded Jetty -->


### PR DESCRIPTION
* reverts commit 98a19d4cbca845c8c32b0af38e64899c5b9a5025.

jboss-logging 3.5 requires Java 11 minimum while DHIS2 2.37 needs to run on Java 8 as well. Ignore future updates of jboss logging >= 3.5 https://github.com/dhis2/dhis2-core/pull/12360

* run tests on GitHub using JDK 8 like on Jenkins

so we catch errors in automatic updates like the jboss-logging one where a dependency needs JDK 11 as minimum after an update