### PR TITLE
ci(deps): ignore auto update of Spring 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
           - ">= 11.0"
+      - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
+      - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
+        versions:
+          - ">= 2.0"
   # 2.39
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -56,6 +62,12 @@ updates:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
           - ">= 11.0"
+      - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
+      - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
+        versions:
+          - ">= 2.0"
     target-branch: "2.39"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.38
@@ -87,6 +99,12 @@ updates:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
           - ">= 11.0"
+      - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
+      - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
+        versions:
+          - ">= 2.0"
     target-branch: "2.38"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.37
@@ -121,5 +139,11 @@ updates:
       - dependency-name: "org.jboss.logging:jboss-logging"
         versions:
           - ">= 3.5" # Requires Java 11 as a minimum for the runtime while 2.37 still supports Java 8
+      - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
+      - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
+        versions:
+          - ">= 2.0"
     target-branch: "2.37"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources


### PR DESCRIPTION
as it requires JDK 17 as minimum

Other Spring related dependencies that are not released together like `org.springframework.security:spring-security-core` have a different `groupId`. So such auto updates PRs should still be created.