### PR TITLE
fix: support ordering by simple types

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -484,7 +484,7 @@ public final class QueryUtils
 
     private static boolean validProperty( Property property )
     {
-        return property.isSimple();
+        return property.getPropertyType().isSimple();
     }
 
     private static boolean validDirection( String direction )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -484,7 +484,7 @@ public final class QueryUtils
 
     private static boolean validProperty( Property property )
     {
-        return property.isSimple() || property.getPropertyType().isSimple();
+        return property.isSimple() || (property.getPropertyType() != null && property.getPropertyType().isSimple());
     }
 
     private static boolean validDirection( String direction )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/query/QueryUtils.java
@@ -484,7 +484,7 @@ public final class QueryUtils
 
     private static boolean validProperty( Property property )
     {
-        return property.getPropertyType().isSimple();
+        return property.isSimple() || property.getPropertyType().isSimple();
     }
 
     private static boolean validDirection( String direction )


### PR DESCRIPTION
## Summary

Fix ordering by persisted properties that are of simple type (but is not marked with `property.simple`).

[DHIS2-13555](https://dhis2.atlassian.net/browse/DHIS2-13555)