### PR TITLE
fix: Dashboad items query for EventReport [DHIS2-14146]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
@@ -118,7 +118,6 @@ public interface EventVisualizationStore extends
 
     /**
      * Counts the number of EventVisualization created since the given date.
-     * Only the non-legacy ones should be considered.
      *
      * @param startingAt
      * @return the total of EventVisualization found.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
@@ -115,4 +115,13 @@ public interface EventVisualizationStore extends
      * @return the total of Chart found.
      */
     int countChartsCreated( Date startingAt );
+
+    /**
+     * Counts the number of EventVisualization created since the given date.
+     * Only the non-legacy ones should be considered.
+     *
+     * @param startingAt
+     * @return the total of EventVisualization found.
+     */
+    int countEventVisualizationsCreated( Date startingAt );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
@@ -83,46 +83,53 @@ public class HibernateEventVisualizationStore extends
     @Override
     public List<EventVisualization> getCharts( int first, int max )
     {
-        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_CHART );
+        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_CHART, true );
     }
 
     @Override
     public List<EventVisualization> getChartsLikeName( Set<String> words, int first, int max )
     {
-        return getEventVisualizationsLikeName( words, first, max, EventVisualizationSet.EVENT_CHART );
+        return getEventVisualizationsLikeName( words, first, max, EventVisualizationSet.EVENT_CHART, true );
     }
 
     @Override
     public List<EventVisualization> getReports( int first, int max )
     {
-        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_REPORT );
+        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_REPORT, true );
     }
 
     @Override
     public List<EventVisualization> getReportsLikeName( Set<String> words, int first, int max )
     {
-        return getEventVisualizationsLikeName( words, first, max, EventVisualizationSet.EVENT_REPORT );
+        return getEventVisualizationsLikeName( words, first, max, EventVisualizationSet.EVENT_REPORT, true );
     }
 
     @Override
     public int countReportsCreated( Date startingAt )
     {
-        return countEventVisualizationCreated( startingAt, EventVisualizationSet.EVENT_REPORT );
+        return countEventVisualizationCreated( startingAt, EventVisualizationSet.EVENT_REPORT, true );
     }
 
     @Override
     public int countChartsCreated( Date startingAt )
     {
-        return countEventVisualizationCreated( startingAt, EventVisualizationSet.EVENT_CHART );
+        return countEventVisualizationCreated( startingAt, EventVisualizationSet.EVENT_CHART, true );
+    }
+
+    @Override
+    public int countEventVisualizationsCreated( Date startingAt )
+    {
+        return countEventVisualizationCreated( startingAt, EventVisualizationSet.EVENT_LINE_LIST, false );
     }
 
     @Override
     public List<EventVisualization> getLineLists( int first, int max )
     {
-        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_LINE_LIST );
+        return getEventVisualizations( first, max, EventVisualizationSet.EVENT_LINE_LIST, false );
     }
 
-    private int countEventVisualizationCreated( Date startingAt, EventVisualizationSet eventVisualizationSet )
+    private int countEventVisualizationCreated( Date startingAt, EventVisualizationSet eventVisualizationSet,
+        boolean legacy )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -131,13 +138,13 @@ public class HibernateEventVisualizationStore extends
             .addPredicate( root -> builder.greaterThanOrEqualTo( root.get( "created" ), startingAt ) )
             .count( root -> builder.countDistinct( root.get( "id" ) ) );
 
-        setCorrectPredicates( eventVisualizationSet, builder, params );
+        setCorrectPredicates( eventVisualizationSet, builder, params, legacy );
 
         return getCount( builder, params ).intValue();
     }
 
     private List<EventVisualization> getEventVisualizations( int first, int max,
-        EventVisualizationSet eventVisualizationSet )
+        EventVisualizationSet eventVisualizationSet, boolean legacy )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -145,13 +152,13 @@ public class HibernateEventVisualizationStore extends
             .addPredicates( getSharingPredicates( builder ) ).addOrder( root -> builder.asc( root.get( "name" ) ) )
             .setFirstResult( first ).setMaxResults( max );
 
-        setCorrectPredicates( eventVisualizationSet, builder, params );
+        setCorrectPredicates( eventVisualizationSet, builder, params, legacy );
 
         return getList( builder, params );
     }
 
     private List<EventVisualization> getEventVisualizationsLikeName( Set<String> words, int first, int max,
-        EventVisualizationSet eventVisualizationSet )
+        EventVisualizationSet eventVisualizationSet, boolean legacy )
     {
         CriteriaBuilder builder = getCriteriaBuilder();
 
@@ -175,13 +182,13 @@ public class HibernateEventVisualizationStore extends
         params.addPredicate( root -> builder.and( conjunction.stream().map( p -> p.apply( root ) )
             .collect( Collectors.toList() ).toArray( new Predicate[0] ) ) );
 
-        setCorrectPredicates( eventVisualizationSet, builder, params );
+        setCorrectPredicates( eventVisualizationSet, builder, params, legacy );
 
         return getList( builder, params );
     }
 
     private void setCorrectPredicates( EventVisualizationSet eventVisualizationSet, CriteriaBuilder builder,
-        JpaQueryParameters<EventVisualization> params )
+        JpaQueryParameters<EventVisualization> params, boolean legacy )
     {
         if ( eventVisualizationSet == EventVisualizationSet.EVENT_CHART )
         {
@@ -193,9 +200,7 @@ public class HibernateEventVisualizationStore extends
             params.addPredicate( root -> builder.or( builder.equal( root.get( "type" ), PIVOT_TABLE ),
                 builder.equal( root.get( "type" ), LINE_LIST ) ) );
         }
-        else
-        {
-            params.addPredicate( root -> builder.equal( root.get( "type" ), LINE_LIST ) );
-        }
+
+        params.addPredicate( root -> builder.equal( root.get( "legacy" ), legacy ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/hibernate/HibernateEventVisualizationStore.java
@@ -200,6 +200,10 @@ public class HibernateEventVisualizationStore extends
             params.addPredicate( root -> builder.or( builder.equal( root.get( "type" ), PIVOT_TABLE ),
                 builder.equal( root.get( "type" ), LINE_LIST ) ) );
         }
+        else
+        {
+            params.addPredicate( root -> builder.equal( root.get( "type" ), LINE_LIST ) );
+        }
 
         params.addPredicate( root -> builder.equal( root.get( "legacy" ), legacy ) );
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
-import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationStore;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.program.ProgramStageInstanceService;
@@ -152,7 +151,7 @@ public class DefaultDataStatisticsService
             () -> eventVisualizationStore.countChartsCreated( startDate ) );
         progress.startingStage( "Counting event visualisations", SKIP_STAGE );
         Integer savedEventVisualizations = progress.runStage( errorValue,
-            () -> idObjectManager.getCountByCreated( EventVisualization.class, startDate ) );
+            () -> eventVisualizationStore.countEventVisualizationsCreated( startDate ) );
         progress.startingStage( "Counting dashboards", SKIP_STAGE );
         Integer savedDashboards = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( Dashboard.class, startDate ) );


### PR DESCRIPTION
The dashboard item search endpoint `/dashboards/q` is returning both `EventReports` and `EventVisualizations` as `EventReports`. The expected behaviour is to only return `EventReports` as `EventReports`. 
