### PR TITLE
fix: fix: Dashboad items query for EventReport [DHIS2-14146]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationStore.java
@@ -115,4 +115,12 @@ public interface EventVisualizationStore extends
      * @return the total of Chart found.
      */
     int countChartsCreated( Date startingAt );
+
+    /**
+     * Counts the number of EventVisualization created since the given date.
+     *
+     * @param startingAt
+     * @return the total of EventVisualization found.
+     */
+    int countEventVisualizationsCreated( Date startingAt );
 }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/datastatistics/DefaultDataStatisticsService.java
@@ -42,7 +42,6 @@ import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dashboard.Dashboard;
 import org.hisp.dhis.datasummary.DataSummary;
 import org.hisp.dhis.datavalue.DataValueService;
-import org.hisp.dhis.eventvisualization.EventVisualization;
 import org.hisp.dhis.eventvisualization.EventVisualizationStore;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.program.ProgramStageInstanceService;
@@ -152,7 +151,7 @@ public class DefaultDataStatisticsService
             () -> eventVisualizationStore.countChartsCreated( startDate ) );
         progress.startingStage( "Counting event visualisations", SKIP_STAGE );
         Integer savedEventVisualizations = progress.runStage( errorValue,
-            () -> idObjectManager.getCountByCreated( EventVisualization.class, startDate ) );
+            () -> eventVisualizationStore.countEventVisualizationsCreated( startDate ) );
         progress.startingStage( "Counting dashboards", SKIP_STAGE );
         Integer savedDashboards = progress.runStage( errorValue,
             () -> idObjectManager.getCountByCreated( Dashboard.class, startDate ) );


### PR DESCRIPTION
**_[Backport from master/2.40]_**

The dashboard item search endpoint `/dashboards/q` is returning both `EventReports` and `EventVisualizations` as `EventReports`. The expected behaviour is to only return `EventReports` as `EventReports`. 
