### PR TITLE
fix: multiOrgUnit openingDate/closingDate/name [DHIS2-13088]

### DIFF
--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/javascript/form.js
@@ -1892,11 +1892,11 @@ function insertDataValues( json )
     	
     	$.each( organisationUnitList, function( idx, item )
         {    		
-    		orgUnitClosed = dhis2.de.validateOrgUnitOpening( organisationUnits[item.uid], period ) ;
+    		orgUnitClosed = dhis2.de.validateOrgUnitOpening( item, period ) ;
     		
     		if( orgUnitClosed )
     		{    			  	        
-    			return;
+    			return false;
     		}            
         } );
     	
@@ -2099,7 +2099,12 @@ function valueFocus( e )
 
     var dataElementName = getDataElementName( dataElementId );
     var optionComboName = getOptionComboName( optionComboId );
-    var organisationUnitName = organisationUnits[dhis2.de.getCurrentOrganisationUnit()].n;
+    var organisationUnitName;
+    if ( dhis2.de.multiOrganisationUnit ) {
+        organisationUnitName = organisationUnitList.filter( ou=>ou.uid === dhis2.de.getCurrentOrganisationUnit() )[0].n;
+    } else {
+        organisationUnitName = organisationUnits[dhis2.de.getCurrentOrganisationUnit()].n;
+    }
 
     $( '#currentOrganisationUnit' ).html( organisationUnitName );
     $( '#currentDataElement' ).html( dataElementName + ' ' + optionComboName );

--- a/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/multiOrgSectionForm.vm
+++ b/dhis-2/dhis-web/dhis-web-dataentry/src/main/webapp/dhis-web-dataentry/multiOrgSectionForm.vm
@@ -1,5 +1,8 @@
 <script type="text/javascript">
-var organisationUnitList = JSON.parse( '$organisationUnits' );
+var organisationUnitList = []
+#foreach( $unit in $organisationUnits )
+    organisationUnitList.push({"uid": "$unit.uid", "n": "$unit.name", #if( $unit.openingDate )"odate":"${unit.openingDate}",#end #if( $unit.closedDate )"cdate":"${unit.closedDate}"#end})
+#end
 </script>
 
 #set( $marker = 0 )


### PR DESCRIPTION
See [comment on DHIS2-13088](https://dhis2.atlassian.net/browse/DHIS2-13088?focusedCommentId=178868).

Some of the logic in form.js assumes that organisationUnits object will contain the organisationUnits needed when a multiOrganisationUnit form is loaded. However, ouwt.js does not seem to populate those organisationUnits until one has clicked on an organisation unit at that level. See for example this error in the console:
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/18490902/203544249-d0a3286a-9953-4c88-8078-ce96566451fd.png">


Because of errors, the data values will not necessarily populate in the multiOrgUnit forms.

I've added a fix to populate the relevant information (openingDate, closingDate, name) into the `organisationUnitList` variable (rather than relying on the standard string representation inherited from BaseNameableObject) and then use the orgUnit information from organistationUnitList rather than retrieving from organisationUnits[id].

I now do not notice any other issues when testing these multiOrgUnit forms, so hopefully the end of this ticket 😔