### PR TITLE
ci(deps): ignore Spring(security) framework 6 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,21 @@ updates:
       - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
         versions:
           - ">= 6.0"
+      - dependency-name: "org.springframework.security:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
       - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
         versions:
           - ">= 2.0"
+      - dependency-name: "org.springframework.session:spring-session-data-redis" # Spring redis 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.restdocs:*" # Spring restdocs 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
   # 2.39
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -62,13 +74,25 @@ updates:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
           - ">= 11.0"
+      - dependency-name: "org.antlr:antlr4-runtime" # Automatically upgrade ANTLR version can cause issues in rule-engine and antlr-parser libraries
       - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
+      - dependency-name: "org.springframework.security:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
         versions:
           - ">= 6.0"
       - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
         versions:
           - ">= 2.0"
-      - dependency-name: "org.antlr:antlr4-runtime" # Automatically upgrade ANTLR version can cause issues in rule-engine and antlr-parser libraries
+      - dependency-name: "org.springframework.session:spring-session-data-redis" # Spring redis 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.restdocs:*" # Spring restdocs 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
     target-branch: "2.39"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.38
@@ -100,13 +124,25 @@ updates:
       - dependency-name: "org.eclipse.jetty:*" # Jetty 11 moved some code to a different package, updated the Servlet version which requires more work
         versions:
           - ">= 11.0"
+      - dependency-name: "org.antlr:antlr4-runtime" # Automatically upgrade ANTLR version can cause issues in rule-engine and antlr-parser libraries
       - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
+      - dependency-name: "org.springframework.security:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
         versions:
           - ">= 6.0"
       - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
         versions:
           - ">= 2.0"
-      - dependency-name: "org.antlr:antlr4-runtime" # Automatically upgrade ANTLR version can cause issues in rule-engine and antlr-parser libraries
+      - dependency-name: "org.springframework.session:spring-session-data-redis" # Spring redis 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.restdocs:*" # Spring restdocs 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
     target-branch: "2.38"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.37
@@ -145,8 +181,20 @@ updates:
       - dependency-name: "org.springframework:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
         versions:
           - ">= 6.0"
+      - dependency-name: "org.springframework.security:*" # Spring framework 6 requires minimum JDK 17 so it will require more effort/time until we update it
+        versions:
+          - ">= 6.0"
       - dependency-name: "org.springframework.retry:spring-retry" # Spring retry 2.x requires Spring 6 (see above)
         versions:
           - ">= 2.0"
+      - dependency-name: "org.springframework.session:spring-session-data-redis" # Spring redis 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.restdocs:*" # Spring restdocs 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
+      - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
+        versions:
+          - ">= 3.0"
     target-branch: "2.37"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources


### PR DESCRIPTION
as Spring 6 requires minimum JDK 17 so it will require more effort/time until we update it.

For Spring and Spring security both need to be on the same major version
but are released independently.

Other libraries released by Spring follow a different release schedule
where the major version number differs.
