### PR TITLE
chore: add default AssignedUserSelectionMode.ALL

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserQueryParam.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserQueryParam.java
@@ -42,7 +42,8 @@ import org.hisp.dhis.user.User;
 public class AssignedUserQueryParam
 {
 
-    public static final AssignedUserQueryParam ALL = new AssignedUserQueryParam( null, null, null );
+    public static final AssignedUserQueryParam ALL = new AssignedUserQueryParam( AssignedUserSelectionMode.ALL, null,
+        Collections.emptySet() );
 
     private final AssignedUserSelectionMode mode;
 
@@ -87,6 +88,11 @@ public class AssignedUserQueryParam
         {
             this.mode = AssignedUserSelectionMode.PROVIDED;
             this.assignedUsers = assignedUsers;
+        }
+        else if ( mode == null )
+        {
+            this.mode = AssignedUserSelectionMode.ALL;
+            this.assignedUsers = Collections.emptySet();
         }
         else
         {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserSelectionMode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/AssignedUserSelectionMode.java
@@ -35,6 +35,7 @@ package org.hisp.dhis.common;
  * <li>PROVIDED: The user provided in the param/payload.</li>
  * <li>NONE: Unassigned.</li>
  * <li>ANY: Assigned to anyone.</li>
+ * <li>ALL: all events irrespective of whether a user is assigned.</li>
  * </ul>
  *
  * @author Ameen Mohamed
@@ -44,5 +45,6 @@ public enum AssignedUserSelectionMode
     CURRENT,
     PROVIDED,
     NONE,
-    ANY;
+    ANY,
+    ALL;
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -403,9 +403,7 @@ public class TrackedEntityInstanceQueryParams
 
     public boolean hasFilterForEvents()
     {
-        return this.getAssignedUserQueryParam().hasAssignedUsers()
-            || AssignedUserSelectionMode.ANY == this.getAssignedUserQueryParam().getMode()
-            || AssignedUserSelectionMode.NONE == this.getAssignedUserQueryParam().getMode()
+        return this.getAssignedUserQueryParam().getMode() != AssignedUserSelectionMode.ALL
             || hasEventStatus();
     }
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/AssignedUserQueryParamTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/common/AssignedUserQueryParamTest.java
@@ -27,12 +27,12 @@
  */
 package org.hisp.dhis.common;
 
+import static org.hisp.dhis.common.AssignedUserSelectionMode.ALL;
 import static org.hisp.dhis.common.AssignedUserSelectionMode.CURRENT;
 import static org.hisp.dhis.common.AssignedUserSelectionMode.PROVIDED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -94,7 +94,7 @@ class AssignedUserQueryParamTest
 
         AssignedUserQueryParam param = new AssignedUserQueryParam( null, current, users );
 
-        assertNull( param.getMode() );
+        assertEquals( ALL, param.getMode() );
         assertIsEmpty( param.getAssignedUsers() );
         assertFalse( param.hasAssignedUsers() );
     }


### PR DESCRIPTION
follow up after https://github.com/dhis2/dhis2-core/pull/12430

Add default AssignedUserSelectionMode.ALL in place of null indicating that all events should be returned irrespective of whether a user is assigned or not. This makes using the params safer and is analogous to OrganisationUnitSelectionMode which already has mode ALL.
