### PR TITLE
fix: generated programIndicatorSQL is now wrapped by parenthesis [DHIS2-14210]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
@@ -53,9 +53,9 @@ import com.google.common.base.Strings;
 public class DefaultProgramIndicatorSubqueryBuilder
     implements ProgramIndicatorSubqueryBuilder
 {
-    private final static String ANALYTICS_TABLE_NAME = "analytics";
+    private static final String ANALYTICS_TABLE_NAME = "analytics";
 
-    private final static String SUBQUERY_TABLE_ALIAS = "subax";
+    private static final String SUBQUERY_TABLE_ALIAS = "subax";
 
     private final ProgramIndicatorService programIndicatorService;
 
@@ -113,8 +113,10 @@ public class DefaultProgramIndicatorSubqueryBuilder
         if ( !Strings.isNullOrEmpty( programIndicator.getFilter() ) )
         {
             aggregateSql += (where.isBlank() ? " WHERE " : " AND ")
+                + "("
                 + getProgramIndicatorSql( programIndicator.getFilter(), BOOLEAN, programIndicator, earliestStartDate,
-                    latestDate );
+                    latestDate )
+                + ")";
         }
 
         return "(SELECT " + function + " (" + aggregateSql + ")";
@@ -137,7 +139,7 @@ public class DefaultProgramIndicatorSubqueryBuilder
      * enrollment -> pi = ax.pi (enrollment operates on the same enrollment as
      * outer) 5) if RelationshipType, call the RelationshipTypeJoinGenerator
      *
-     * @param outerSqlEntity the outer {@link AnayticsType}.
+     * @param outerSqlEntity the outer {@link AnalyticsType}.
      * @param programIndicator the {@link ProgramIndicator}.
      * @param relationshipType the optional {@link RelationshipType}.
      * @return a SQL where clause.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -170,7 +170,7 @@ class ProgramIndicatorSubqueryBuilderTest
         String sql = subject.getAggregateClauseForProgramIndicator( pi, AnalyticsType.ENROLLMENT, startDate, endDate );
 
         assertThat( sql, is( "(SELECT avg (distinct psi) FROM analytics_event_" + program.getUid().toLowerCase()
-            + " as subax WHERE pi = ax.pi AND a = b)" ) );
+            + " as subax WHERE pi = ax.pi AND (a = b))" ) );
     }
 
 }


### PR DESCRIPTION
When we define a PI with an OR condition, like
`C1 OR C2`, the resulting SQL for analytics is wrong since it looks like:
`WHERE JOINCONDITION AND C1 OR C2`

Based on the boolean operator precedence, the above condition is true when C2 alone is true, ignoring JOINCONDITION which should be always verified as well.

The generated SQL, with this fix, should look like this:
`WHERE JOINCONDITION AND (C1 OR C2)`