### PR TITLE
fix: [2.37] generated programIndicatorSQL is now wrapped by parenthesis [DHIS2-14210]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/programindicator/DefaultProgramIndicatorSubqueryBuilder.java
@@ -122,8 +122,10 @@ public class DefaultProgramIndicatorSubqueryBuilder
         if ( !Strings.isNullOrEmpty( programIndicator.getFilter() ) )
         {
             aggregateSql += " AND "
+                + "("
                 + getPrgIndSql( programIndicator.getFilter(), BOOLEAN, programIndicator, earliestStartDate,
-                    latestDate );
+                    latestDate )
+                + ")";
         }
 
         return "(SELECT " + function + " (" + aggregateSql + ")";

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/programindicator/ProgramIndicatorSubqueryBuilderTest.java
@@ -172,7 +172,7 @@ public class ProgramIndicatorSubqueryBuilderTest
         String sql = subject.getAggregateClauseForProgramIndicator( pi, AnalyticsType.ENROLLMENT, startDate, endDate );
 
         assertThat( sql, is( "(SELECT avg (distinct psi) FROM analytics_event_" + program.getUid().toLowerCase()
-            + " as subax WHERE pi = ax.pi AND a = b)" ) );
+            + " as subax WHERE pi = ax.pi AND (a = b))" ) );
     }
 
 }


### PR DESCRIPTION
When we define a PI with an OR condition, like
`C1 OR C2`, the resulting SQL for analytics is wrong since it looks like:
`WHERE JOINCONDITION AND C1 OR C2`

Based on the boolean operator precedence, the above condition is true when C2 alone is true, ignoring JOINCONDITION which should be always verified as well.

The generated SQL, with this fix, should look like this:
`WHERE JOINCONDITION AND (C1 OR C2)`