### PR TITLE
chore: use AssignedUserQueryParam in EventSearchParams DHIS2-13765

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -1221,12 +1221,12 @@ public class TrackedEntityInstanceQueryParams
      * the query. Non-empty assigned users are only allowed with mode PROVIDED
      * (or null).
      *
-     * @param current current user with which query is made
      * @param mode assigned user mode
+     * @param current current user with which query is made
      * @param assignedUsers assigned user uids
      * @return this
      */
-    public TrackedEntityInstanceQueryParams setUserWithAssignedUsers( User current, AssignedUserSelectionMode mode,
+    public TrackedEntityInstanceQueryParams setUserWithAssignedUsers( AssignedUserSelectionMode mode, User current,
         Set<String> assignedUsers )
     {
         this.assignedUserQueryParam = new AssignedUserQueryParam( mode, current, assignedUsers );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParams.java
@@ -183,9 +183,6 @@ public class TrackedEntityInstanceQueryParams
      */
     private OrganisationUnitSelectionMode organisationUnitMode = OrganisationUnitSelectionMode.DESCENDANTS;
 
-    /**
-     * Selection mode for user assignment of events.
-     */
     @Getter
     private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParamsTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceQueryParamsTest.java
@@ -56,7 +56,7 @@ class TrackedEntityInstanceQueryParamsTest
     void testUserWithAssignedUsersGivenCurrentUserAndModeProvidedWithUsers()
     {
 
-        params.setUserWithAssignedUsers( current, PROVIDED, Set.of( "f1AyMswryyX" ) );
+        params.setUserWithAssignedUsers( PROVIDED, current, Set.of( "f1AyMswryyX" ) );
 
         assertEquals( current, params.getUser() );
         assertEquals( PROVIDED, params.getAssignedUserQueryParam().getMode() );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -290,8 +290,6 @@ public abstract class AbstractEventService implements EventService
 
         List<OrganisationUnit> organisationUnits = getOrganisationUnits( params, user );
 
-        params.handleCurrentUserSelectionMode( user );
-
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
             params.setDefaultPaging();
@@ -379,8 +377,6 @@ public abstract class AbstractEventService implements EventService
         }
 
         List<OrganisationUnit> organisationUnits = getOrganisationUnits( params, user );
-
-        params.handleCurrentUserSelectionMode( user );
 
         // ---------------------------------------------------------------------
         // If includeAllDataElements is set to true, return all data elements.

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -34,7 +34,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import lombok.Getter;
+
 import org.hisp.dhis.category.CategoryOptionCombo;
+import org.hisp.dhis.common.AssignedUserQueryParam;
 import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.IdSchemes;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
@@ -115,10 +118,6 @@ public class EventSearchParams
     private OrganisationUnit orgUnit;
 
     private OrganisationUnitSelectionMode orgUnitSelectionMode;
-
-    private AssignedUserSelectionMode assignedUserSelectionMode;
-
-    private Set<String> assignedUsers = new HashSet<>();
 
     private TrackedEntityInstance trackedEntityInstance;
 
@@ -205,6 +204,9 @@ public class EventSearchParams
     private Date skipChangedBefore;
 
     private Set<String> programInstances;
+
+    @Getter
+    private AssignedUserQueryParam assignedUserQueryParam = AssignedUserQueryParam.ALL;
 
     // -------------------------------------------------------------------------
     // Constructors
@@ -404,25 +406,20 @@ public class EventSearchParams
         return this;
     }
 
-    public AssignedUserSelectionMode getAssignedUserSelectionMode()
+    /**
+     * Set assigned user selection mode, assigned users and the current user for
+     * the query. Non-empty assigned users are only allowed with mode PROVIDED
+     * (or null).
+     *
+     * @param current current user with which query is made
+     * @param mode assigned user mode
+     * @param assignedUsers assigned user uids
+     * @return this
+     */
+    public EventSearchParams setUserWithAssignedUsers( User current, AssignedUserSelectionMode mode,
+        Set<String> assignedUsers )
     {
-        return assignedUserSelectionMode;
-    }
-
-    public EventSearchParams setAssignedUserSelectionMode( AssignedUserSelectionMode assignedUserSelectionMode )
-    {
-        this.assignedUserSelectionMode = assignedUserSelectionMode;
-        return this;
-    }
-
-    public Set<String> getAssignedUsers()
-    {
-        return assignedUsers;
-    }
-
-    public EventSearchParams setAssignedUsers( Set<String> assignedUsers )
-    {
-        this.assignedUsers = assignedUsers;
+        this.assignedUserQueryParam = new AssignedUserQueryParam( mode, current, assignedUsers );
         return this;
     }
 
@@ -826,30 +823,6 @@ public class EventSearchParams
     {
         this.programInstances = programInstances;
         return this;
-    }
-
-    public void handleCurrentUserSelectionMode( User currentUser )
-    {
-        if ( AssignedUserSelectionMode.CURRENT.equals( this.assignedUserSelectionMode ) && currentUser != null )
-        {
-            this.assignedUsers = Collections.singleton( currentUser.getUid() );
-            this.assignedUserSelectionMode = AssignedUserSelectionMode.PROVIDED;
-        }
-    }
-
-    public boolean hasAssignedUsers()
-    {
-        return this.assignedUsers != null && !this.assignedUsers.isEmpty();
-    }
-
-    public boolean isIncludeOnlyUnassignedEvents()
-    {
-        return AssignedUserSelectionMode.NONE.equals( this.assignedUserSelectionMode );
-    }
-
-    public boolean isIncludeOnlyAssignedEvents()
-    {
-        return AssignedUserSelectionMode.ANY.equals( this.assignedUserSelectionMode );
     }
 
     public boolean isIncludeRelationships()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/EventSearchParams.java
@@ -411,12 +411,12 @@ public class EventSearchParams
      * the query. Non-empty assigned users are only allowed with mode PROVIDED
      * (or null).
      *
-     * @param current current user with which query is made
      * @param mode assigned user mode
+     * @param current current user with which query is made
      * @param assignedUsers assigned user uids
      * @return this
      */
-    public EventSearchParams setUserWithAssignedUsers( User current, AssignedUserSelectionMode mode,
+    public EventSearchParams setUserWithAssignedUsers( AssignedUserSelectionMode mode, User current,
         Set<String> assignedUsers )
     {
         this.assignedUserQueryParam = new AssignedUserQueryParam( mode, current, assignedUsers );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -96,6 +96,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.BaseIdentifiableObject;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdSchemes;
@@ -1345,9 +1346,9 @@ public class JdbcEventStore implements EventStore
                 .append( ")) " );
         }
 
-        if ( params.hasAssignedUsers() )
+        if ( params.getAssignedUserQueryParam().hasAssignedUsers() )
         {
-            mapSqlParameterSource.addValue( "au_uid", params.getAssignedUsers() );
+            mapSqlParameterSource.addValue( "au_uid", params.getAssignedUserQueryParam().getAssignedUsers() );
 
             fromBuilder.append( hlp.whereAnd() )
                 .append( " (au.uid in (" )
@@ -1355,13 +1356,13 @@ public class JdbcEventStore implements EventStore
                 .append( ")) " );
         }
 
-        if ( params.isIncludeOnlyUnassignedEvents() )
+        if ( AssignedUserSelectionMode.NONE == params.getAssignedUserQueryParam().getMode() )
         {
             fromBuilder.append( hlp.whereAnd() )
                 .append( " (au.uid is null) " );
         }
 
-        if ( params.isIncludeOnlyAssignedEvents() )
+        if ( AssignedUserSelectionMode.ANY == params.getAssignedUserQueryParam().getMode() )
         {
             fromBuilder.append( hlp.whereAnd() )
                 .append( " (au.uid is not null) " );
@@ -1693,9 +1694,9 @@ public class JdbcEventStore implements EventStore
                 .append( ")) " );
         }
 
-        if ( params.hasAssignedUsers() )
+        if ( params.getAssignedUserQueryParam().hasAssignedUsers() )
         {
-            mapSqlParameterSource.addValue( "au_uid", params.getAssignedUsers() );
+            mapSqlParameterSource.addValue( "au_uid", params.getAssignedUserQueryParam().getAssignedUsers() );
 
             sqlBuilder.append( hlp.whereAnd() )
                 .append( " (au.uid in (" )
@@ -1703,13 +1704,13 @@ public class JdbcEventStore implements EventStore
                 .append( ")) " );
         }
 
-        if ( params.isIncludeOnlyUnassignedEvents() )
+        if ( AssignedUserSelectionMode.NONE == params.getAssignedUserQueryParam().getMode() )
         {
             sqlBuilder.append( hlp.whereAnd() )
                 .append( " (au.uid is null) " );
         }
 
-        if ( params.isIncludeOnlyAssignedEvents() )
+        if ( AssignedUserSelectionMode.ANY == params.getAssignedUserQueryParam().getMode() )
         {
             sqlBuilder.append( hlp.whereAnd() )
                 .append( " (au.uid is not null) " );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -236,7 +236,7 @@ class TrackedEntityInstanceAggregateTest extends TrackerTest
             hibernateService.flushSession();
         } );
         TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
-        queryParams.setUserWithAssignedUsers( superUser, null, null );
+        queryParams.setUserWithAssignedUsers( null, superUser, null );
         queryParams.setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
         queryParams.setProgram( programA );
         queryParams.setEventStatus( EventStatus.COMPLETED );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/trackedentityinstance/TrackedEntityInstanceQueryLimitTest.java
@@ -164,7 +164,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         params.setProgram( program );
         params.setOrganisationUnits( Set.of( orgUnitA ) );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );
-        params.setUserWithAssignedUsers( user, null, null );
+        params.setUserWithAssignedUsers( null, user, null );
         params.setSkipPaging( true );
 
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
@@ -183,7 +183,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         params.setProgram( program );
         params.setOrganisationUnits( Set.of( orgUnitA ) );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );
-        params.setUserWithAssignedUsers( user, null, null );
+        params.setUserWithAssignedUsers( null, user, null );
         params.setSkipPaging( true );
 
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
@@ -199,7 +199,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         params.setProgram( program );
         params.setOrganisationUnits( Set.of( orgUnitA ) );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );
-        params.setUserWithAssignedUsers( user, null, null );
+        params.setUserWithAssignedUsers( null, user, null );
         params.setSkipPaging( true );
 
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,
@@ -217,7 +217,7 @@ class TrackedEntityInstanceQueryLimitTest extends SingleSetupIntegrationTestBase
         params.setProgram( program );
         params.setOrganisationUnits( Set.of( orgUnitA ) );
         params.setOrganisationUnitMode( OrganisationUnitSelectionMode.ALL );
-        params.setUserWithAssignedUsers( user, null, null );
+        params.setUserWithAssignedUsers( null, user, null );
         params.setSkipPaging( true );
 
         List<Long> teis = trackedEntityInstanceService.getTrackedEntityInstanceIds( params,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -230,13 +230,6 @@ class EventRequestToSearchParamsMapper
             }
         }
 
-        if ( assignedUserSelectionMode != null && assignedUsers != null && !assignedUsers.isEmpty()
-            && !assignedUserSelectionMode.equals( AssignedUserSelectionMode.PROVIDED ) )
-        {
-            throw new IllegalQueryException(
-                "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
-        }
-
         if ( assignedUsers != null )
         {
             assignedUsers = assignedUsers.stream()
@@ -253,7 +246,7 @@ class EventRequestToSearchParamsMapper
 
         return params.setProgram( pr ).setProgramStage( ps ).setOrgUnit( ou ).setTrackedEntityInstance( tei )
             .setProgramStatus( programStatus ).setFollowUp( followUp ).setOrgUnitSelectionMode( orgUnitSelectionMode )
-            .setAssignedUserSelectionMode( assignedUserSelectionMode ).setAssignedUsers( assignedUsers )
+            .setUserWithAssignedUsers( user, assignedUserSelectionMode, assignedUsers )
             .setStartDate( startDate ).setEndDate( endDate ).setDueDateStart( dueDateStart ).setDueDateEnd( dueDateEnd )
             .setLastUpdatedStartDate( lastUpdatedStartDate ).setLastUpdatedEndDate( lastUpdatedEndDate )
             .setLastUpdatedDuration( lastUpdatedDuration ).setEventStatus( status )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -246,7 +246,7 @@ class EventRequestToSearchParamsMapper
 
         return params.setProgram( pr ).setProgramStage( ps ).setOrgUnit( ou ).setTrackedEntityInstance( tei )
             .setProgramStatus( programStatus ).setFollowUp( followUp ).setOrgUnitSelectionMode( orgUnitSelectionMode )
-            .setUserWithAssignedUsers( user, assignedUserSelectionMode, assignedUsers )
+            .setUserWithAssignedUsers( assignedUserSelectionMode, user, assignedUsers )
             .setStartDate( startDate ).setEndDate( endDate ).setDueDateStart( dueDateStart ).setDueDateEnd( dueDateEnd )
             .setLastUpdatedStartDate( lastUpdatedStartDate ).setLastUpdatedEndDate( lastUpdatedEndDate )
             .setLastUpdatedDuration( lastUpdatedDuration ).setEventStatus( status )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceCriteriaMapper.java
@@ -186,7 +186,7 @@ public class TrackedEntityInstanceCriteriaMapper
             .setEventStatus( criteria.getEventStatus() )
             .setEventStartDate( criteria.getEventStartDate() )
             .setEventEndDate( criteria.getEventEndDate() )
-            .setUserWithAssignedUsers( user, criteria.getAssignedUserMode(), criteria.getAssignedUsers() )
+            .setUserWithAssignedUsers( criteria.getAssignedUserMode(), user, criteria.getAssignedUsers() )
             .setTrackedEntityInstanceUids( criteria.getTrackedEntityInstances() )
             .setSkipMeta( criteria.isSkipMeta() )
             .setPage( criteria.getPage() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -48,7 +48,6 @@ import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.category.CategoryOptionCombo;
-import org.hisp.dhis.common.AssignedUserSelectionMode;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryItem;
@@ -162,7 +161,6 @@ class TrackerEventCriteriaMapper
         validateFilter( criteria.getFilter(), eventIds, criteria.getProgramStage(), programStage );
 
         Set<String> assignedUserIds = parseAndFilterUids( criteria.getAssignedUser() );
-        validateAssignedUsers( criteria.getAssignedUserMode(), assignedUserIds );
 
         Map<String, SortDirection> dataElementOrders = getDataElementsFromOrder( criteria.getOrder() );
         List<QueryItem> dataElements = dataElementOrders.keySet()
@@ -193,8 +191,7 @@ class TrackerEventCriteriaMapper
             .setTrackedEntityInstance( trackedEntityInstance )
             .setProgramStatus( criteria.getProgramStatus() ).setFollowUp( criteria.getFollowUp() )
             .setOrgUnitSelectionMode( criteria.getOuMode() )
-            .setAssignedUserSelectionMode( criteria.getAssignedUserMode() )
-            .setAssignedUsers( assignedUserIds )
+            .setUserWithAssignedUsers( user, criteria.getAssignedUserMode(), assignedUserIds )
             .setStartDate( criteria.getOccurredAfter() ).setEndDate( criteria.getOccurredBefore() )
             .setDueDateStart( criteria.getScheduledAfter() ).setDueDateEnd( criteria.getScheduledBefore() )
             .setLastUpdatedStartDate( criteria.getUpdatedAfter() )
@@ -285,20 +282,6 @@ class TrackerEventCriteriaMapper
         if ( !CollectionUtils.isEmpty( filters ) && !StringUtils.isEmpty( programStage ) && ps == null )
         {
             throw new IllegalQueryException( "ProgramStage needs to be specified for event filtering to work" );
-        }
-    }
-
-    private static void validateAssignedUsers( AssignedUserSelectionMode mode, Set<String> assignedUserIds )
-    {
-        if ( mode == null )
-        {
-            return;
-        }
-
-        if ( !assignedUserIds.isEmpty() && AssignedUserSelectionMode.PROVIDED != mode )
-        {
-            throw new IllegalQueryException(
-                "Assigned User uid(s) cannot be specified if selectionMode is not PROVIDED" );
         }
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -191,7 +191,7 @@ class TrackerEventCriteriaMapper
             .setTrackedEntityInstance( trackedEntityInstance )
             .setProgramStatus( criteria.getProgramStatus() ).setFollowUp( criteria.getFollowUp() )
             .setOrgUnitSelectionMode( criteria.getOuMode() )
-            .setUserWithAssignedUsers( user, criteria.getAssignedUserMode(), assignedUserIds )
+            .setUserWithAssignedUsers( criteria.getAssignedUserMode(), user, assignedUserIds )
             .setStartDate( criteria.getOccurredAfter() ).setEndDate( criteria.getOccurredBefore() )
             .setDueDateStart( criteria.getScheduledAfter() ).setDueDateEnd( criteria.getScheduledBefore() )
             .setLastUpdatedStartDate( criteria.getUpdatedAfter() )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntityCriteriaMapper.java
@@ -148,7 +148,7 @@ public class TrackerTrackedEntityCriteriaMapper
             .setEventStatus( criteria.getEventStatus() )
             .setEventStartDate( criteria.getEventOccurredAfter() )
             .setEventEndDate( criteria.getEventOccurredBefore() )
-            .setUserWithAssignedUsers( user, criteria.getAssignedUserMode(), assignedUserIds )
+            .setUserWithAssignedUsers( criteria.getAssignedUserMode(), user, assignedUserIds )
             .setTrackedEntityInstanceUids( trackedEntities )
             .setAttributes( attributeItems )
             .setFilters( filters )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
@@ -407,17 +407,6 @@ class TrackerEventCriteriaMapperTest
     }
 
     @Test
-    void testMappingAssignedUser()
-    {
-        TrackerEventCriteria criteria = new TrackerEventCriteria();
-        criteria.setAssignedUser( "XKrcfuM4Hcw;M4pNmLabtXl" );
-
-        EventSearchParams params = mapper.map( criteria );
-
-        assertContainsOnly( Set.of( "XKrcfuM4Hcw", "M4pNmLabtXl" ), params.getAssignedUsers() );
-    }
-
-    @Test
     void testMappingAssignedUserStripsInvalidUid()
     {
         TrackerEventCriteria criteria = new TrackerEventCriteria();
@@ -425,17 +414,7 @@ class TrackerEventCriteriaMapperTest
 
         EventSearchParams params = mapper.map( criteria );
 
-        assertEquals( Set.of( "M4pNmLabtXl" ), params.getAssignedUsers() );
-    }
-
-    @Test
-    void testMappingAssignedUserIsNull()
-    {
-        TrackerEventCriteria criteria = new TrackerEventCriteria();
-
-        EventSearchParams params = mapper.map( criteria );
-
-        assertIsEmpty( params.getAssignedUsers() );
+        assertEquals( Set.of( "M4pNmLabtXl" ), params.getAssignedUserQueryParam().getAssignedUsers() );
     }
 
     @Test
@@ -446,7 +425,7 @@ class TrackerEventCriteriaMapperTest
 
         EventSearchParams params = mapper.map( criteria );
 
-        assertIsEmpty( params.getAssignedUsers() );
+        assertIsEmpty( params.getAssignedUserQueryParam().getAssignedUsers() );
     }
 
     @Test


### PR DESCRIPTION
follow up to https://github.com/dhis2/dhis2-core/pull/12324

Reuse AssignedUserQueryParam in EventSearchParams as the same logic is used in EventSearchParams as in TrackedEntityInstanceQueryParams.