### PR TITLE
fix: #{deGroup:deGroupUid} bug DHIS2-13456

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/dataitem/DimItemDataElementAndOperand.java
@@ -60,7 +60,8 @@ public class DimItemDataElementAndOperand
         else
         {
             return new DimensionalItemId( DATA_ELEMENT,
-                ctx.uid0.getText(), visitor.getState().getQueryMods() );
+                ctx.uid0.getText(), null, null,
+                ctx.getText(), visitor.getState().getQueryMods() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/expression/ExpressionService2Test.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
 import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
+import static org.hisp.dhis.common.DimensionItemType.DATA_ELEMENT;
 import static org.hisp.dhis.expression.Expression.SEPARATOR;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_DAYS;
 import static org.hisp.dhis.expression.ExpressionService.SYMBOL_WILDCARD;
@@ -379,7 +380,7 @@ class ExpressionService2Test extends DhisConvenienceTest
         switch ( type )
         {
         case DATA_ELEMENT:
-            return new DimensionalItemId( type, o.getUid() );
+            return new DimensionalItemId( type, o.getUid(), null, null, o.getDimensionItem() );
 
         case DATA_ELEMENT_OPERAND:
             DataElementOperand deo = (DataElementOperand) o;
@@ -483,6 +484,22 @@ class ExpressionService2Test extends DhisConvenienceTest
         assertTrue( itemIds.contains( getId( pdeA ) ) );
         assertTrue( itemIds.contains( getId( pteaA ) ) );
         assertTrue( itemIds.contains( getId( piA ) ) );
+    }
+
+    @Test
+    void testGetExpressionDimensionalItemIdsWithDeGroup()
+    {
+        mockConstantService();
+
+        String deGroupUid = "deGroupUidA";
+        String expr = "#{deGroup:" + deGroupUid + "}";
+
+        DimensionalItemId itemId = new DimensionalItemId( DATA_ELEMENT, "deGroup:" + deGroupUid, null, null, expr );
+
+        Set<DimensionalItemId> itemIds = target.getExpressionDimensionalItemIds( expr, INDICATOR_EXPRESSION );
+
+        assertEquals( 1, itemIds.size() );
+        assertTrue( itemIds.contains( itemId ) );
     }
 
     @Test


### PR DESCRIPTION
See [DHIS2-13456](https://dhis2.atlassian.net/browse/DHIS2-13456). Previously, ticket [DHIS2-716](https://dhis2.atlassian.net/browse/DHIS2-716) implemented the `deGroup:` tag so that an entire data element group can be specified in an indicator expression item instead of a single data element. This worked correctly for data element operands such as:
> #{deGroup:deGroupUid.cocUid}

To support this, the method `DimItemDataElementAndOperand.getDimensionalItemId` added the entire text of the item to the `item` field when creating a new `DimensionalItemId` for a `DATA_ELEMENT_OPERAND` item.

However it did not work for a data element of the form:
> #{deGroup:deGroupUid}

The problem was that in the entire text of the item was not also added to the `item` field by the same method when creating a new `DimensionalItemId` for a `DATA_ELEMENT` item.

This fix adds the item text for data elements, and adds the test `ExpressionService2Test.testGetExpressionDimensionalItemIdsWithDeGroup` to verify the fix. It has also been manually tested by running the backend.