### PR TITLE
refactor: clean ValidationErrorReporter DHIS2-14213

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -35,6 +35,8 @@ import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Value;
 
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
@@ -59,6 +61,7 @@ public class ValidationErrorReporter
 
     TrackerIdSchemeParams idSchemes;
 
+    @Getter( AccessLevel.NONE )
     /*
      * Keeps track of all the invalid Tracker objects (i.e. objects with at
      * least one TrackerErrorReport in the ValidationErrorReporter) encountered

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -114,14 +114,20 @@ public class ValidationErrorReporter
         return reportList.stream().anyMatch( test );
     }
 
-    public boolean hasWarningReport( Predicate<TrackerWarningReport> test )
+    public void addErrorIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
     {
-        return warningsReportList.stream().anyMatch( test );
+        if ( expression.getAsBoolean() )
+        {
+            addError( dto, code, args );
+        }
     }
 
-    public boolean hasWarnings()
+    public void addErrorIfNull( Object object, TrackerDto dto, TrackerErrorCode code, Object... args )
     {
-        return !this.warningsReportList.isEmpty();
+        if ( object == null )
+        {
+            addError( dto, code, args );
+        }
     }
 
     public void addError( TrackerDto dto, TrackerErrorCode code, Object... args )
@@ -141,29 +147,14 @@ public class ValidationErrorReporter
         }
     }
 
-    public void addWarning( TrackerWarningReport warning )
+    public boolean hasWarnings()
     {
-        getWarningsReportList().add( warning );
+        return !this.warningsReportList.isEmpty();
     }
 
-    /**
-     * Checks if a TrackerDto with given type and uid is invalid (i.e. has at
-     * least one TrackerErrorReport in the ValidationErrorReporter).
-     */
-    public boolean isInvalid( TrackerType trackerType, String uid )
+    public boolean hasWarningReport( Predicate<TrackerWarningReport> test )
     {
-        return this.invalidDTOs.getOrDefault( trackerType, new HashSet<>() ).contains( uid );
-    }
-
-    public boolean isInvalid( TrackerDto dto )
-    {
-        return this.isInvalid( dto.getTrackerType(), dto.getUid() );
-    }
-
-    public void addWarning( TrackerDto dto, TrackerErrorCode code, Object... args )
-    {
-        addWarning( new TrackerWarningReport( MessageFormatter.format( idSchemes, code.getMessage(), args ),
-            code, dto.getTrackerType(), dto.getUid() ) );
+        return warningsReportList.stream().anyMatch( test );
     }
 
     public void addWarningIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
@@ -174,19 +165,32 @@ public class ValidationErrorReporter
         }
     }
 
-    public void addErrorIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
+    public void addWarning( TrackerDto dto, TrackerErrorCode code, Object... args )
     {
-        if ( expression.getAsBoolean() )
-        {
-            addError( dto, code, args );
-        }
+        addWarning( new TrackerWarningReport( MessageFormatter.format( idSchemes, code.getMessage(), args ),
+            code, dto.getTrackerType(), dto.getUid() ) );
     }
 
-    public void addErrorIfNull( Object object, TrackerDto dto, TrackerErrorCode code, Object... args )
+    public void addWarning( TrackerWarningReport warning )
     {
-        if ( object == null )
-        {
-            addError( dto, code, args );
-        }
+        getWarningsReportList().add( warning );
+    }
+
+    /**
+     * Checks if a TrackerDto is invalid (i.e. has at least one
+     * TrackerErrorReport in the ValidationErrorReporter).
+     */
+    public boolean isInvalid( TrackerDto dto )
+    {
+        return this.isInvalid( dto.getTrackerType(), dto.getUid() );
+    }
+
+    /**
+     * Checks if a TrackerDto with given type and uid is invalid (i.e. has at
+     * least one TrackerErrorReport in the ValidationErrorReporter).
+     */
+    public boolean isInvalid( TrackerType trackerType, String uid )
+    {
+        return this.invalidDTOs.getOrDefault( trackerType, new HashSet<>() ).contains( uid );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -53,9 +53,9 @@ import org.hisp.dhis.tracker.validation.ValidationFailFastException;
 @Value
 public class ValidationErrorReporter
 {
-    List<TrackerErrorReport> reportList;
+    List<TrackerErrorReport> errors;
 
-    List<TrackerWarningReport> warningsReportList;
+    List<TrackerWarningReport> warnings;
 
     boolean isFailFast;
 
@@ -80,8 +80,8 @@ public class ValidationErrorReporter
      */
     public ValidationErrorReporter( TrackerIdSchemeParams idSchemes, boolean failFast )
     {
-        this.reportList = new ArrayList<>();
-        this.warningsReportList = new ArrayList<>();
+        this.errors = new ArrayList<>();
+        this.warnings = new ArrayList<>();
         this.invalidDTOs = new EnumMap<>( TrackerType.class );
         this.idSchemes = idSchemes;
         this.isFailFast = failFast;
@@ -97,8 +97,8 @@ public class ValidationErrorReporter
      */
     public ValidationErrorReporter( TrackerIdSchemeParams idSchemes )
     {
-        this.reportList = new ArrayList<>();
-        this.warningsReportList = new ArrayList<>();
+        this.errors = new ArrayList<>();
+        this.warnings = new ArrayList<>();
         this.invalidDTOs = new EnumMap<>( TrackerType.class );
         this.idSchemes = idSchemes;
         this.isFailFast = false;
@@ -106,12 +106,12 @@ public class ValidationErrorReporter
 
     public boolean hasErrors()
     {
-        return !this.reportList.isEmpty();
+        return !this.errors.isEmpty();
     }
 
     public boolean hasErrorReport( Predicate<TrackerErrorReport> test )
     {
-        return reportList.stream().anyMatch( test );
+        return errors.stream().anyMatch( test );
     }
 
     public void addErrorIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
@@ -138,23 +138,23 @@ public class ValidationErrorReporter
 
     public void addError( TrackerErrorReport error )
     {
-        getReportList().add( error );
+        getErrors().add( error );
         this.invalidDTOs.computeIfAbsent( error.getTrackerType(), k -> new HashSet<>() ).add( error.getUid() );
 
         if ( isFailFast() )
         {
-            throw new ValidationFailFastException( getReportList() );
+            throw new ValidationFailFastException( getErrors() );
         }
     }
 
     public boolean hasWarnings()
     {
-        return !this.warningsReportList.isEmpty();
+        return !this.warnings.isEmpty();
     }
 
     public boolean hasWarningReport( Predicate<TrackerWarningReport> test )
     {
-        return warningsReportList.stream().anyMatch( test );
+        return warnings.stream().anyMatch( test );
     }
 
     public void addWarningIf( BooleanSupplier expression, TrackerDto dto, TrackerErrorCode code, Object... args )
@@ -173,7 +173,7 @@ public class ValidationErrorReporter
 
     public void addWarning( TrackerWarningReport warning )
     {
-        getWarningsReportList().add( warning );
+        getWarnings().add( warning );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -29,8 +29,10 @@ package org.hisp.dhis.tracker.report;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
 
@@ -62,7 +64,7 @@ public class ValidationErrorReporter
      * A map that keep tracks of all the invalid Tracker objects encountered
      * during the validation process
      */
-    Map<TrackerType, List<String>> invalidDTOs;
+    Map<TrackerType, Set<String>> invalidDTOs;
 
     /**
      * Create a {@link ValidationErrorReporter} reporting all errors and
@@ -128,7 +130,7 @@ public class ValidationErrorReporter
     public void addError( TrackerErrorReport error )
     {
         getReportList().add( error );
-        this.invalidDTOs.computeIfAbsent( error.getTrackerType(), k -> new ArrayList<>() ).add( error.getUid() );
+        this.invalidDTOs.computeIfAbsent( error.getTrackerType(), k -> new HashSet<>() ).add( error.getUid() );
 
         if ( isFailFast() )
         {
@@ -147,7 +149,7 @@ public class ValidationErrorReporter
      */
     public boolean isInvalid( TrackerType trackerType, String uid )
     {
-        return this.invalidDTOs.getOrDefault( trackerType, new ArrayList<>() ).contains( uid );
+        return this.invalidDTOs.getOrDefault( trackerType, new HashSet<>() ).contains( uid );
     }
 
     public boolean isInvalid( TrackerDto dto )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -97,11 +97,7 @@ public class ValidationErrorReporter
      */
     public ValidationErrorReporter( TrackerIdSchemeParams idSchemes )
     {
-        this.errors = new ArrayList<>();
-        this.warnings = new ArrayList<>();
-        this.invalidDTOs = new EnumMap<>( TrackerType.class );
-        this.idSchemes = idSchemes;
-        this.isFailFast = false;
+        this( idSchemes, false );
     }
 
     public boolean hasErrors()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -28,10 +28,9 @@
 package org.hisp.dhis.tracker.report;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -65,7 +64,7 @@ public class ValidationErrorReporter
      * least one TrackerErrorReport in the ValidationErrorReporter) encountered
      * during the validation process.
      */
-    Map<TrackerType, Set<String>> invalidDTOs;
+    EnumMap<TrackerType, Set<String>> invalidDTOs;
 
     /**
      * Create a {@link ValidationErrorReporter} reporting all errors and
@@ -74,13 +73,13 @@ public class ValidationErrorReporter
      * {@link ValidationFailFastException} if {@code failFast} true is given.
      *
      * @param idSchemes idSchemes in which to report errors and warnings
-     * @param failFast
+     * @param failFast reporter throws exception on first error added when true
      */
     public ValidationErrorReporter( TrackerIdSchemeParams idSchemes, boolean failFast )
     {
         this.reportList = new ArrayList<>();
         this.warningsReportList = new ArrayList<>();
-        this.invalidDTOs = new HashMap<>();
+        this.invalidDTOs = new EnumMap<>( TrackerType.class );
         this.idSchemes = idSchemes;
         this.isFailFast = failFast;
     }
@@ -97,7 +96,7 @@ public class ValidationErrorReporter
     {
         this.reportList = new ArrayList<>();
         this.warningsReportList = new ArrayList<>();
-        this.invalidDTOs = new HashMap<>();
+        this.invalidDTOs = new EnumMap<>( TrackerType.class );
         this.idSchemes = idSchemes;
         this.isFailFast = false;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -61,8 +61,9 @@ public class ValidationErrorReporter
     TrackerIdSchemeParams idSchemes;
 
     /*
-     * A map that keep tracks of all the invalid Tracker objects encountered
-     * during the validation process
+     * Keeps track of all the invalid Tracker objects (i.e. objects with at
+     * least one TrackerErrorReport in the ValidationErrorReporter) encountered
+     * during the validation process.
      */
     Map<TrackerType, Set<String>> invalidDTOs;
 
@@ -144,8 +145,8 @@ public class ValidationErrorReporter
     }
 
     /**
-     * Checks if the provided uid and Tracker Type is part of the invalid
-     * entities
+     * Checks if a TrackerDto with given type and uid is invalid (i.e. has at
+     * least one TrackerErrorReport in the ValidationErrorReporter).
      */
     public boolean isInvalid( TrackerType trackerType, String uid )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/ValidationErrorReporter.java
@@ -48,23 +48,21 @@ import org.hisp.dhis.tracker.validation.ValidationFailFastException;
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Value
-// TODO: should this be "ValidationReporter" since it does not only report
-// errors ?
 public class ValidationErrorReporter
 {
-    private final List<TrackerErrorReport> reportList;
+    List<TrackerErrorReport> reportList;
 
-    private final List<TrackerWarningReport> warningsReportList;
+    List<TrackerWarningReport> warningsReportList;
 
-    private final boolean isFailFast;
+    boolean isFailFast;
 
-    private final TrackerIdSchemeParams idSchemes;
+    TrackerIdSchemeParams idSchemes;
 
     /*
      * A map that keep tracks of all the invalid Tracker objects encountered
      * during the validation process
      */
-    private final Map<TrackerType, List<String>> invalidDTOs;
+    Map<TrackerType, List<String>> invalidDTOs;
 
     /**
      * Create a {@link ValidationErrorReporter} reporting all errors and

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -106,8 +106,8 @@ public class DefaultTrackerValidationService
             // exit early when in FAIL_FAST validation mode
         }
         validationReport
-            .addErrors( reporter.getReportList() )
-            .addWarnings( reporter.getWarningsReportList() );
+            .addErrors( reporter.getErrors() )
+            .addWarnings( reporter.getWarnings() );
 
         removeInvalidObjects( bundle, reporter );
 
@@ -251,6 +251,6 @@ public class DefaultTrackerValidationService
 
     private boolean didNotPassValidation( ValidationErrorReporter reporter, String uid )
     {
-        return reporter.getReportList().stream().anyMatch( r -> r.getUid().equals( uid ) );
+        return reporter.getErrors().stream().anyMatch( r -> r.getUid().equals( uid ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -135,7 +135,7 @@ public class RelationshipsValidationHook
             () -> getRelationshipType( relationshipsTypes, relationship.getRelationshipType() ).isEmpty(),
             relationship, E4009, relationship.getRelationshipType() );
 
-        return reporter.getReportList()
+        return reporter.getErrors()
             .stream()
             .noneMatch( r -> relationship.getRelationship().equals( r.getUid() ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertValidationErrorReporter.java
@@ -44,6 +44,6 @@ public class AssertValidationErrorReporter
             type == err.getTrackerType() &&
             uid.equals( err.getUid() ) ),
             String.format( "error with code %s, type %s, uid %s not found in reporter with %d error(s)", code, type,
-                uid, reporter.getReportList().size() ) );
+                uid, reporter.getErrors().size() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHookTest.java
@@ -176,7 +176,7 @@ class EnrollmentAttributeValidationHookTest
 
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
         hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
@@ -205,7 +205,7 @@ class EnrollmentAttributeValidationHookTest
 
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
-        assertThat( reporter.getReportList(), hasSize( 0 ) );
+        assertThat( reporter.getErrors(), hasSize( 0 ) );
     }
 
     @Test
@@ -233,7 +233,7 @@ class EnrollmentAttributeValidationHookTest
 
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
         hasTrackerError( reporter, TrackerErrorCode.E1085, TrackerType.ENROLLMENT, enrollment.getUid() );
     }
 
@@ -263,7 +263,7 @@ class EnrollmentAttributeValidationHookTest
 
         hasTrackerError( reporter, TrackerErrorCode.E1076, TrackerType.ENROLLMENT, enrollment.getUid() );
         hasTrackerError( reporter, TrackerErrorCode.E1018, TrackerType.ENROLLMENT, enrollment.getUid() );
-        assertThat( reporter.getReportList(), hasSize( 2 ) );
+        assertThat( reporter.getErrors(), hasSize( 2 ) );
     }
 
     @Test
@@ -286,7 +286,7 @@ class EnrollmentAttributeValidationHookTest
 
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
         hasTrackerError( reporter,
             TrackerErrorCode.E1006,
             TrackerType.ENROLLMENT,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -181,7 +181,7 @@ class EnrollmentInExistingValidationHookTest
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
 
         hasTrackerError( reporter, E1015, ENROLLMENT, enrollment.getUid() );
     }
@@ -199,7 +199,7 @@ class EnrollmentInExistingValidationHookTest
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
 
         hasTrackerError( reporter, E1016, ENROLLMENT, enrollment.getUid() );
     }
@@ -222,7 +222,7 @@ class EnrollmentInExistingValidationHookTest
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
 
         hasTrackerError( reporter, E1015, ENROLLMENT, enrollment.getUid() );
     }
@@ -240,7 +240,7 @@ class EnrollmentInExistingValidationHookTest
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         hasTrackerError( reporter, E1016, ENROLLMENT, enrollment.getUid() );
     }
 
@@ -268,7 +268,7 @@ class EnrollmentInExistingValidationHookTest
         hookToTest.validateEnrollment( reporter, bundle, enrollment );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         hasTrackerError( reporter, E1016, ENROLLMENT, enrollment.getUid() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidationHookTest.java
@@ -182,8 +182,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1304, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1304, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -215,8 +215,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1303, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1303, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -313,8 +313,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1305, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1305, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -367,8 +367,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1302, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -394,8 +394,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1084, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1084, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -441,8 +441,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1076, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -466,8 +466,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1076, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -491,8 +491,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1076, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -540,8 +540,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1076, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -637,8 +637,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1009, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
@@ -646,7 +646,7 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 0 ) );
+        assertThat( reporter.getErrors(), hasSize( 0 ) );
     }
 
     @Test
@@ -673,8 +673,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1009, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
         event.setEvent( "XYZ" );
         fileResource.setFileResourceOwner( "ABC" );
@@ -685,8 +685,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1009, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
         event.setEvent( "ABC" );
         fileResource.setFileResourceOwner( "ABC" );
@@ -697,7 +697,7 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 0 ) );
+        assertThat( reporter.getErrors(), hasSize( 0 ) );
     }
 
     @Test
@@ -782,8 +782,8 @@ class EventDataValuesValidationHookTest
         hook.validateEvent( reporter, bundle, event );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( 1, reporter.getReportList().stream()
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( 1, reporter.getErrors().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1125 ).count() );
     }
 
@@ -809,8 +809,8 @@ class EventDataValuesValidationHookTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1007, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1007, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -861,8 +861,8 @@ class EventDataValuesValidationHookTest
         reporter = new ValidationErrorReporter( idSchemes );
         hook.validateEvent( reporter, bundle, event );
 
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
-        assertEquals( TrackerErrorCode.E1302, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
+        assertEquals( TrackerErrorCode.E1302, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     private DataElement dataElement( ValueType type )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -339,7 +339,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1033 ) );
     }
 
@@ -375,7 +375,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1079 ) );
     }
 
@@ -412,7 +412,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1029 ) );
     }
 
@@ -428,7 +428,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1055 ) );
     }
 
@@ -449,7 +449,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
             r.getErrorMessage().contains( program.getCategoryCombo().getUid() ) &&
             r.getErrorMessage().contains( co.getUid() ) ) );
@@ -498,7 +498,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
             r.getErrorMessage().contains( program.getCategoryCombo().getUid() ) &&
             r.getErrorMessage().contains( co.getUid() ) ) );
@@ -521,7 +521,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
             r.getErrorMessage().contains( program.getCategoryCombo().getUid() ) &&
             r.getErrorMessage().contains( co.getUid() ) ) );
@@ -584,7 +584,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
     }
 
@@ -604,7 +604,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
     }
 
@@ -624,7 +624,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1054 &&
             r.getErrorMessage().contains( aoc.getUid() ) &&
             r.getErrorMessage().contains( program.getCategoryCombo().getUid() ) ) );
@@ -647,7 +647,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1055 ) );
     }
 
@@ -667,7 +667,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1054 &&
             r.getErrorMessage().contains( aoc.getUid() ) &&
             r.getErrorMessage().contains( program.getCategoryCombo().getUid() ) ) );
@@ -743,7 +743,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
     }
 
@@ -769,7 +769,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1055 ) );
     }
 
@@ -794,7 +794,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1116 ) );
     }
 
@@ -825,7 +825,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 3, reporter.getReportList().size() );
+        assertEquals( 3, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1115 ) );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1116
             && r.getErrorMessage().contains( UNKNOWN_CO_ID1 ) ) );
@@ -854,7 +854,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
             r.getErrorMessage().contains( eventCO.getUid() ) &&
             r.getErrorMessage().contains( aoc.getUid() ) ) );
@@ -882,7 +882,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
             r.getErrorMessage().contains( co1.getUid() ) &&
             r.getErrorMessage().contains( aoc2.getUid() ) ) );
@@ -908,7 +908,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         hook.validateEvent( reporter, bundle, event );
 
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E1117 &&
             r.getErrorMessage().contains( co1.getUid() ) &&
             r.getErrorMessage().contains( aoc.getUid() ) ) );
@@ -931,10 +931,10 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         assertTrue( reporter.hasErrors() );
         assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == TrackerErrorCode.E4012 ) );
         assertThat(
-            reporter.getReportList().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
+            reporter.getErrors().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
             hasItem( "Could not find `trackedEntity`: `validTrackedEntity`, linked to Relationship." ) );
         assertThat(
-            reporter.getReportList().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
+            reporter.getErrors().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
             hasItem( "Could not find `trackedEntity`: `anotherValidTrackedEntity`, linked to Relationship." ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -381,7 +381,7 @@ class PreCheckExistenceValidationHookTest
         validationHook.validateRelationship( reporter, bundle, rel );
 
         assertFalse( reporter.hasErrors() );
-        assertThat( reporter.getWarningsReportList(), empty() );
+        assertThat( reporter.getWarnings(), empty() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMandatoryFieldsValidationHookTest.java
@@ -243,7 +243,7 @@ class PreCheckMandatoryFieldsValidationHookTest
         validationHook.validateEvent( reporter, bundle, event );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
         hasTrackerError( reporter, E1008, EVENT, event.getUid() );
     }
 
@@ -372,9 +372,9 @@ class PreCheckMandatoryFieldsValidationHookTest
         TrackerErrorCode errorCode )
     {
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList(), hasSize( 1 ) );
+        assertThat( reporter.getErrors(), hasSize( 1 ) );
         hasTrackerError( reporter, errorCode, type, uid );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Missing required " + entity + " property: `" + property + "`." ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -165,7 +165,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         hasTrackerError( reporter, E1127, ENROLLMENT, enrollment.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "program" ) );
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), containsString( "program" ) );
     }
 
     @Test
@@ -180,7 +180,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         hasTrackerError( reporter, E1127, ENROLLMENT, enrollment.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "trackedEntity" ) );
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), containsString( "trackedEntity" ) );
     }
 
     @Test
@@ -208,7 +208,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         hasTrackerError( reporter, E1128, EVENT, event.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "programStage" ) );
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), containsString( "programStage" ) );
     }
 
     @Test
@@ -223,7 +223,7 @@ class PreCheckUpdatableFieldsValidationHookTest
 
         // then
         hasTrackerError( reporter, E1128, EVENT, event.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), containsString( "enrollment" ) );
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), containsString( "enrollment" ) );
     }
 
     private TrackedEntity validTei()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -145,8 +145,8 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         assertTrue( reporter.hasErrors() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4001 ) );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
+        assertThat( reporter.getErrors().get( 0 ).getErrorCode(), is( TrackerErrorCode.E4001 ) );
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), is(
             "Relationship Item `from` for Relationship `nBx6auGDUHG` is invalid: an Item can link only one Tracker entity." ) );
     }
 
@@ -174,7 +174,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4013, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), is(
             "Relationship Type `from` constraint is missing trackedEntity." ) );
     }
 
@@ -205,7 +205,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4001, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(), is(
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(), is(
             "Relationship Item `to` for Relationship `nBx6auGDUHG` is invalid: an Item can link only one Tracker entity." ) );
     }
 
@@ -227,7 +227,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a trackedEntity but a enrollment was found." ) );
     }
 
@@ -249,7 +249,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a event but a enrollment was found." ) );
     }
 
@@ -273,7 +273,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4010, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a enrollment but a event was found." ) );
     }
 
@@ -323,7 +323,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship Type `to` constraint requires a Tracked Entity having type `GREEN` but `RED` was found." ) );
     }
 
@@ -360,7 +360,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4014, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a Tracked Entity having type `"
                 + constraintTrackedEntityType.getUid() + "` but `" + trackedEntityType + "` was found." ) );
     }
@@ -385,7 +385,7 @@ class RelationshipsValidationHookTest
 
         hasTrackerError( reporter, TrackerErrorCode.E4011, RELATIONSHIP, relationship.getUid() );
         assertThat(
-            reporter.getReportList().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
+            reporter.getErrors().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
             hasItem( "Relationship: `" + relationship.getRelationship() +
                 "` cannot be persisted because trackedEntity notValidTrackedEntity referenced by this relationship is not valid." ) );
     }
@@ -410,7 +410,7 @@ class RelationshipsValidationHookTest
 
         assertTrue( reporter.hasErrors() );
         assertThat(
-            reporter.getReportList().stream().map( TrackerErrorReport::getErrorCode ).collect( Collectors.toList() ),
+            reporter.getErrors().stream().map( TrackerErrorReport::getErrorCode ).collect( Collectors.toList() ),
             not( hasItem( TrackerErrorCode.E4011 ) ) );
     }
 
@@ -432,7 +432,7 @@ class RelationshipsValidationHookTest
         validationHook.validateRelationship( reporter, bundle, relationship );
 
         hasTrackerError( reporter, E4000, RELATIONSHIP, relationship.getUid() );
-        assertThat( reporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship: `" + relationship.getRelationship() + "` cannot link to itself" ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -111,7 +111,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validate( errorReporter, bundle );
 
-        assertTrue( errorReporter.getReportList().isEmpty() );
+        assertTrue( errorReporter.getErrors().isEmpty() );
     }
 
     @Test
@@ -134,11 +134,11 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         validatorToTest.validate( errorReporter, bundle );
 
         // then
-        assertEquals( 1, errorReporter.getReportList().size() );
+        assertEquals( 1, errorReporter.getErrors().size() );
         assertTrue( errorReporter.hasErrorReport( err -> E1039.equals( err.getErrorCode() ) &&
             EVENT.equals( err.getTrackerType() ) &&
             event.getUid().equals( err.getUid() ) ) );
-        assertThat( errorReporter.getReportList().get( 0 ).getErrorMessage(),
+        assertThat( errorReporter.getErrors().get( 0 ).getErrorMessage(),
             is( "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
                 "`, is not repeatable and an event already exists." ) );
     }
@@ -154,17 +154,17 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validate( errorReporter, bundle );
 
-        assertEquals( 2, errorReporter.getReportList().size() );
-        assertThat( errorReporter.getReportList().get( 0 ).getErrorCode(), is( E1039 ) );
-        assertThat( errorReporter.getReportList().get( 0 ).getTrackerType(), is( EVENT ) );
-        assertThat( errorReporter.getReportList().get( 0 ).getUid(), is( events.get( 0 ).getUid() ) );
-        assertThat( errorReporter.getReportList().get( 0 ).getErrorMessage(),
+        assertEquals( 2, errorReporter.getErrors().size() );
+        assertThat( errorReporter.getErrors().get( 0 ).getErrorCode(), is( E1039 ) );
+        assertThat( errorReporter.getErrors().get( 0 ).getTrackerType(), is( EVENT ) );
+        assertThat( errorReporter.getErrors().get( 0 ).getUid(), is( events.get( 0 ).getUid() ) );
+        assertThat( errorReporter.getErrors().get( 0 ).getErrorMessage(),
             is( "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
                 "`, is not repeatable and an event already exists." ) );
-        assertThat( errorReporter.getReportList().get( 1 ).getErrorCode(), is( E1039 ) );
-        assertThat( errorReporter.getReportList().get( 1 ).getTrackerType(), is( EVENT ) );
-        assertThat( errorReporter.getReportList().get( 1 ).getUid(), is( events.get( 1 ).getUid() ) );
-        assertThat( errorReporter.getReportList().get( 1 ).getErrorMessage(),
+        assertThat( errorReporter.getErrors().get( 1 ).getErrorCode(), is( E1039 ) );
+        assertThat( errorReporter.getErrors().get( 1 ).getTrackerType(), is( EVENT ) );
+        assertThat( errorReporter.getErrors().get( 1 ).getUid(), is( events.get( 1 ).getUid() ) );
+        assertThat( errorReporter.getErrors().get( 1 ).getErrorMessage(),
             is( "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
                 "`, is not repeatable and an event already exists." ) );
     }
@@ -180,7 +180,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validate( errorReporter, bundle );
 
-        assertTrue( errorReporter.getReportList().isEmpty() );
+        assertTrue( errorReporter.getErrors().isEmpty() );
     }
 
     @Test
@@ -214,7 +214,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validate( errorReporter, bundle );
 
-        assertTrue( errorReporter.getReportList().isEmpty() );
+        assertTrue( errorReporter.getErrors().isEmpty() );
     }
 
     @Test
@@ -230,7 +230,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
 
         validatorToTest.validate( errorReporter, bundle );
 
-        assertTrue( errorReporter.getReportList().isEmpty() );
+        assertTrue( errorReporter.getErrors().isEmpty() );
     }
 
     private ProgramStage notRepeatebleProgramStageWithRegistration()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -31,7 +31,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hisp.dhis.tracker.TrackerType.EVENT;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E1039;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E9999;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +50,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -189,11 +192,12 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         List<Event> events = Lists.newArrayList( invalidEvent, notRepeatableEvent( "B" ) );
         bundle.setEvents( events );
         events.forEach( e -> bundle.setStrategy( e, TrackerImportStrategy.CREATE_AND_UPDATE ) );
-        errorReporter.getInvalidDTOs().put( EVENT, Lists.newArrayList( invalidEvent.getUid() ) );
+        errorReporter
+            .addError( new TrackerErrorReport( "", E9999, invalidEvent.getTrackerType(), invalidEvent.getUid() ) );
 
         validatorToTest.validate( errorReporter, bundle );
 
-        assertTrue( errorReporter.getReportList().isEmpty() );
+        assertFalse( errorReporter.hasErrorReport( e -> E1039 == e.getErrorCode() ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHookTest.java
@@ -125,7 +125,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
-        assertEquals( 0, reporter.getReportList().size() );
+        assertEquals( 0, reporter.getErrors().size() );
     }
 
     @Test
@@ -162,8 +162,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( 1, reporter.getReportList().stream()
+        assertEquals( 1, reporter.getErrors().size() );
+        assertEquals( 1, reporter.getErrors().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1090 ).count() );
     }
 
@@ -182,8 +182,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 2, reporter.getReportList().size() );
-        assertEquals( 2, reporter.getReportList().stream()
+        assertEquals( 2, reporter.getErrors().size() );
+        assertEquals( 2, reporter.getErrors().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1006 ).count() );
     }
 
@@ -217,8 +217,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( 1, reporter.getReportList().stream()
+        assertEquals( 1, reporter.getErrors().size() );
+        assertEquals( 1, reporter.getErrors().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1076 ).count() );
     }
 
@@ -240,7 +240,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntityAttribute, sbString.toString() );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1077.equals( err.getErrorCode() ) &&
             TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
             te.getTrackedEntity().equals( err.getUid() ) ) );
@@ -257,7 +257,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1085.equals( err.getErrorCode() ) &&
             TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
             te.getTrackedEntity().equals( err.getUid() ) ) );
@@ -281,7 +281,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
+        assertEquals( 1, reporter.getErrors().size() );
         assertTrue( reporter.hasErrorReport( err -> TrackerErrorCode.E1112.equals( err.getErrorCode() ) &&
             TrackerType.TRACKED_ENTITY.equals( err.getTrackerType() ) &&
             te.getTrackedEntity().equals( err.getUid() ) ) );
@@ -306,8 +306,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( 1, reporter.getReportList().stream()
+        assertEquals( 1, reporter.getErrors().size() );
+        assertEquals( 1, reporter.getErrors().stream()
             .filter( e -> e.getErrorCode() == TrackerErrorCode.E1125 ).count() );
     }
 
@@ -330,7 +330,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
-        assertEquals( 0, reporter.getReportList().size() );
+        assertEquals( 0, reporter.getErrors().size() );
     }
 
     @Test
@@ -361,7 +361,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
-        assertEquals( 0, reporter.getReportList().size() );
+        assertEquals( 0, reporter.getErrors().size() );
     }
 
     @Test
@@ -394,8 +394,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( TrackerErrorCode.E1076, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( 1, reporter.getErrors().size() );
+        assertEquals( TrackerErrorCode.E1076, reporter.getErrors().get( 0 ).getErrorCode() );
     }
 
     @Test
@@ -435,8 +435,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( TrackerErrorCode.E1009, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( 1, reporter.getErrors().size() );
+        assertEquals( TrackerErrorCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
         reporter = new ValidationErrorReporter( idSchemes );
 
@@ -449,8 +449,8 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertTrue( reporter.hasErrors() );
-        assertEquals( 1, reporter.getReportList().size() );
-        assertEquals( TrackerErrorCode.E1009, reporter.getReportList().get( 0 ).getErrorCode() );
+        assertEquals( 1, reporter.getErrors().size() );
+        assertEquals( TrackerErrorCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
         reporter = new ValidationErrorReporter( idSchemes );
 
@@ -463,7 +463,7 @@ class TrackedEntityAttributeValidationHookTest
             trackedEntity );
 
         assertFalse( reporter.hasErrors() );
-        assertEquals( 0, reporter.getReportList().size() );
+        assertEquals( 0, reporter.getErrors().size() );
     }
 
     private TrackedEntityAttribute getTrackedEntityAttributeWithOptionSet()


### PR DESCRIPTION
* fix linting issues (redundant access modifiers added by lombok, missing javadoc)
* collect invalid dtos in set. As we do not need to keep track of how many errors a dto has.
* tracker invalid dtos in enummap. As its more efficient since amount of keys is known beforehand
* don't allow direct access to invalid dtos. It's an internal structure the reporter keeps track of. Access is given via its `isInvalid` methods.
* group methods related to fields together in call order. So if one like `addErrorIf` calls another one addErrorIf should be above it. So we can read/navigate from top to bottom.
* name fields simply error and warning 
  * `reportList` makes it unclear that these are actually errors. warnings
  are also reports since both are TrackerError/WarningReports
  * no need to add suffixes like list as this is clear from its type