### PR TITLE
chore: make tracker RelationshipItem API safer

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/converter/RelationshipTrackerConverterService.java
@@ -87,13 +87,20 @@ public class RelationshipTrackerConverterService
 
     private RelationshipItem convertRelationshipType( org.hisp.dhis.relationship.RelationshipItem from )
     {
-        RelationshipItem relationshipItem = new RelationshipItem();
-        relationshipItem.setEnrollment( from.getProgramInstance() != null ? from.getProgramInstance().getUid() : null );
-        relationshipItem
-            .setEvent( from.getProgramStageInstance() != null ? from.getProgramStageInstance().getUid() : null );
-        relationshipItem.setTrackedEntity(
-            from.getTrackedEntityInstance() != null ? from.getTrackedEntityInstance().getUid() : null );
-        return relationshipItem;
+        if ( from.getProgramInstance() != null )
+        {
+            return RelationshipItem.ofEnrollment( from.getProgramInstance().getUid() );
+        }
+        if ( from.getProgramStageInstance() != null )
+        {
+            return RelationshipItem.ofEvent( from.getProgramStageInstance().getUid() );
+        }
+        if ( from.getTrackedEntityInstance() != null )
+        {
+            return RelationshipItem.ofTrackedEntity( from.getTrackedEntityInstance().getUid() );
+        }
+        // TODO this should not happen; previously we returned a RelationshipItem without any field set
+        return null;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/RelationshipItem.java
@@ -29,21 +29,32 @@ package org.hisp.dhis.tracker.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
+import org.hisp.dhis.tracker.TrackerType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-@Data
+@EqualsAndHashCode
+@ToString
+@Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
 public class RelationshipItem
 {
 
+    // TODO each field should be final
+    // TODO can we make this a Value class?
+    // TODO I don't want to make this a TrackerDto as this might have unwanted side-effects. It would be nice to just call
+    // getUid() to get the id of the entity. We could still add this method without implementing TrackerDto
+    // the interface would just fit as we want/have uid and type
+    // TODO do we allow relationship items of type relationship?
     @JsonProperty
     private String trackedEntity;
 
@@ -52,4 +63,44 @@ public class RelationshipItem
 
     @JsonProperty
     private String event;
+
+    @JsonIgnore
+    private TrackerType type;
+
+    // did NOT use TrackerDto intentionally as we do not allow RelationshipItems of type Relationship
+    public RelationshipItem( TrackedEntity trackedEntity )
+    {
+        this.trackedEntity = trackedEntity.getUid();
+        this.type = TrackerType.TRACKED_ENTITY;
+    }
+
+    public RelationshipItem( Enrollment enrollment )
+    {
+        this.enrollment = enrollment.getUid();
+        this.type = TrackerType.ENROLLMENT;
+    }
+
+    public RelationshipItem( Event event )
+    {
+        this.event = event.getUid();
+        this.type = TrackerType.ENROLLMENT;
+    }
+
+    public static RelationshipItem ofTrackedEntity( String uid )
+    {
+        TrackedEntity trackedEntity = TrackedEntity.builder().trackedEntity( uid ).build();
+        return new RelationshipItem( trackedEntity );
+    }
+
+    public static RelationshipItem ofEnrollment( String uid )
+    {
+        Enrollment enrollment = Enrollment.builder().enrollment( uid ).build();
+        return new RelationshipItem( enrollment );
+    }
+
+    public static RelationshipItem ofEvent( String uid )
+    {
+        Event event = Event.builder().enrollment( uid ).build();
+        return new RelationshipItem( event );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/domain/RelationshipItemTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/domain/RelationshipItemTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.domain;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.hisp.dhis.tracker.TrackerType;
+import org.junit.jupiter.api.Test;
+
+class RelationshipItemTest
+{
+
+    @Test
+    void testRelationshipItemFromTrackedEntity()
+    {
+
+        TrackedEntity trackedEntity = TrackedEntity.builder().trackedEntity( "some" ).build();
+        RelationshipItem item = new RelationshipItem( trackedEntity );
+
+        assertEquals( item.getTrackedEntity(), "some" );
+        assertEquals( item.getType(), TrackerType.TRACKED_ENTITY );
+    }
+
+    // TODO setup a test to ensure JSON serialization/deserialization still works
+
+}


### PR DESCRIPTION
* `RelationshipItem` does not guard its state-space. Exactly one of the fields trackedEntity, enrollment, event must be set! So we should not use a builder since they are not all optional.

=> create constructors and factories that only allow creating a valid `RelationshipItem`

* Once you have an item you don't know which of the fields contains the UID. You also don't know what the item represents. This makes it hard to just answer a question like `does this entity exist in the DB?` without either trying all fields or actually figuring out what it is. The figuring out part is a lot of work 😅 Leading down a rabbit hole of classes back to the  [Relationship.relationshipType](https://github.com/dhis2/dhis2-core/blob/3b2d94a99479c414ca93272c1c1fa7660bfeeede/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/domain/Relationship.java#L57) -> [RelationshipType](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipType.java#L50-L52) -> [RelationshipConstraint](https://github.com/dhis2/dhis2-core/blob/3b2d94a99479c414ca93272c1c1fa7660bfeeede/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipConstraint.java#L51) -> [RelationshipEntity](https://github.com/dhis2/dhis2-core/blob/3b2d94a99479c414ca93272c1c1fa7660bfeeede/dhis-2/dhis-api/src/main/java/org/hisp/dhis/relationship/RelationshipEntity.java#L35-L39). The latter not being very useful as its just some String telling me I've got a TEI, enrollment or event. This entire flow means you need to leave our domain to recover information we actually had when the `RelationshipItem` was instantiated. 

=> Add type information so we can programmatically access the identifier that is set, without knowing exactly whether its a trackedEntity, enrollment or event.