### PR TITLE
fix: NPE when updating programRuleActions

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/ProgramRuleActionValidationContextLoader.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/action/validation/ProgramRuleActionValidationContextLoader.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionGroup;
@@ -57,10 +58,13 @@ public class ProgramRuleActionValidationContextLoader
     @Nonnull
     private final ProgramRuleActionValidationService validationService;
 
+    private final IdentifiableObjectManager objectManager;
+
     public ProgramRuleActionValidationContextLoader(
-        @Nonnull ProgramRuleActionValidationService actionValidationService )
+        @Nonnull ProgramRuleActionValidationService actionValidationService, IdentifiableObjectManager manager )
     {
         this.validationService = actionValidationService;
+        this.objectManager = manager;
     }
 
     @Transactional( readOnly = true )
@@ -71,6 +75,12 @@ public class ProgramRuleActionValidationContextLoader
             ruleAction.getProgramRule() );
 
         Program program = preheat.get( preheatIdentifier, Program.class, rule.getProgram() );
+
+        if ( program == null )
+        {
+            program = objectManager.get( Program.class, rule.getProgram().getUid() );
+            preheat.put( preheatIdentifier, program );
+        }
 
         List<ProgramStage> stages = preheat.getAll( preheatIdentifier, new ArrayList<>( program.getProgramStages() ) );
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14105

### Issue:
- Program is not provided in payload, so Preheat doesn't have  it.


Error log

```
java.lang.NullPointerException
	at org.hisp.dhis.programrule.action.validation.ProgramRuleActionValidationContextLoader.load(ProgramRuleActionValidationContextLoader.java:85)
	at org.hisp.dhis.programrule.action.validation.ProgramRuleActionValidationContextLoader$$FastClassBySpringCGLIB$$23bc3578.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218)
```


Sample payload : 

```
{
  "programRuleActions":
  [
    {
      "lastUpdated": "2017-05-23T00:29:24.454",
      "id": "UUwZWS8uirn",
      "href": "https://play.dhis2.org/2.37.8/api/29/programRuleActions/UUwZWS8uirn",
      "created": "2016-04-12T15:58:55.041",
      "content": "The hemoglobin value cannot be above 99",
      "externalAccess": false,
      "displayContent": "The hemoglobin value cannot be above 99",
      "programRuleActionType": "SHOWERROR",
      "evaluationTime": "ALWAYS",
      "favorite": false,
      "access":
      {
        "read": true,
        "update": true,
        "externalize": false,
        "delete": true,
        "write": true,
        "manage": true
      },
      "programRule":
      {
        "id": "dahuKlP7jR2"
      },
      "lastUpdatedBy":
      {
        "displayName": "John Traore",
        "name": "John Traore",
        "id": "xE7jOejl9FI",
        "username": "admin"
      },
      "dataElement":
      {
        "id": "vANAXwtLwcT"
      },
      "sharing":
      {
        "external": false
      },
      "favorites":
      [],
      "evaluationEnvironments":
      [
        "WEB",
        "ANDROID"
      ],
      "translations":
      [],
      "userGroupAccesses":
      [],
      "attributeValues":
      [],
      "userAccesses":
      []
    }
  ]
}
```
