### PR TITLE
fix: invalidation of tracker tree DHIS2-14213

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ overlays/
 ./.gitattributes
 ./.gitignore
 ./.travis.yml
+.attach_pid*
 .DS_Store
 dhis-2/projectFilesBackup
 coverage

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/AtomicModeTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/AtomicModeTests.java
@@ -67,8 +67,8 @@ public class AtomicModeTests
             .body( "stats.ignored", equalTo( 3 ) );
 
         response.validateErrorReport()
-            .body( "", hasSize( 3 ) )
-            .body( "errorCode", contains( "E1121", "E4014", "E4011" ) );
+            .body( "", hasSize( 2 ) )
+            .body( "errorCode", contains( "E1121", "E4014" ) );
     }
 
     @Test
@@ -84,8 +84,8 @@ public class AtomicModeTests
             .body( "stats.created", equalTo( 1 ) );
 
         response.validateErrorReport()
-            .body( "", hasSize( 3 ) )
-            .body( "errorCode", contains( "E1121", "E4014", "E4011" ) );
+            .body( "", hasSize( 2 ) )
+            .body( "errorCode", contains( "E1121", "E4014" ) );
     }
 
     private JsonObject createWrongPayload()

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/enrollments/EnrollmentsTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/importer/enrollments/EnrollmentsTests.java
@@ -169,8 +169,8 @@ public class EnrollmentsTests
         }
 
         response.validateErrorReport()
-            .body( "errorCode", hasSize( 1 ) )
-            .body( "errorCode", hasItems( "E1020" ) )
+            .body( "errorCode", hasSize( 2 ) )
+            .body( "errorCode", hasItems( "E1020", "E5000" ) )
             .body( "message", hasItems( containsString( enrollmentDate ) ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerType.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerType.java
@@ -35,6 +35,11 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
@@ -42,14 +47,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TrackerType
 {
-    TRACKED_ENTITY( "trackedEntity", 1 ),
-    ENROLLMENT( "enrollment", 2 ),
-    EVENT( "event", 3 ),
-    RELATIONSHIP( "relationship", 4 );
+    TRACKED_ENTITY( "trackedEntity", 1, TrackedEntity.class ),
+    ENROLLMENT( "enrollment", 2, Enrollment.class ),
+    EVENT( "event", 3, Event.class ),
+    RELATIONSHIP( "relationship", 4, Relationship.class );
 
     private final String name;
 
     private final Integer priority;
+
+    private final Class klass;
 
     public static List<TrackerType> getOrderedByPriority()
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerType.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/TrackerType.java
@@ -35,11 +35,6 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
-
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
@@ -47,16 +42,14 @@ import org.hisp.dhis.tracker.domain.TrackedEntity;
 @RequiredArgsConstructor
 public enum TrackerType
 {
-    TRACKED_ENTITY( "trackedEntity", 1, TrackedEntity.class ),
-    ENROLLMENT( "enrollment", 2, Enrollment.class ),
-    EVENT( "event", 3, Event.class ),
-    RELATIONSHIP( "relationship", 4, Relationship.class );
+    TRACKED_ENTITY( "trackedEntity", 1 ),
+    ENROLLMENT( "enrollment", 2 ),
+    EVENT( "event", 3 ),
+    RELATIONSHIP( "relationship", 4 );
 
     private final String name;
 
     private final Integer priority;
-
-    private final Class klass;
 
     public static List<TrackerType> getOrderedByPriority()
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -189,6 +189,7 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
+    // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
     public Optional<TrackedEntity> getTrackedEntity( String id )
     {
         return this.trackedEntities.stream().filter( t -> t.getTrackedEntity().equals( id ) ).findFirst();
@@ -250,7 +251,7 @@ public class TrackerBundle
         return getPreheat().getRelationship( relationship );
     }
 
-    // TODO test
+    // TODO(DHIS2-14213) test
     @SuppressWarnings( "unchecked" )
     public <T extends TrackerDto> List<T> get( Class<T> type )
     {
@@ -305,7 +306,7 @@ public class TrackerBundle
             return false; // TODO(DHIS2-14213) will this ever be needed? Even if not, I guess it should be implemented or an exception thrown as this is surprising
         default:
             // only reached if a new TrackerDto implementation is added
-            return false;
+            return false; // TODO(DHIS2-14213) better to throw than to hide this
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -189,26 +189,30 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
-    // TODO(DHIS2-14213) not safe if bundle contains a TEI with no id
     // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
-    public Optional<TrackedEntity> getTrackedEntity( String id )
+    public Optional<TrackedEntity> getTrackedEntity( String uid )
     {
-        return this.trackedEntities.stream().filter( t -> t.getTrackedEntity().equals( id ) ).findFirst();
+        return findById( this.trackedEntities, uid );
     }
 
-    public Optional<Event> getEvent( String id )
+    public Optional<Event> getEvent( String uid )
     {
-        return this.events.stream().filter( t -> t.getEvent().equals( id ) ).findFirst();
+        return findById( this.events, uid );
     }
 
-    public Optional<Enrollment> getEnrollment( String id )
+    public Optional<Enrollment> getEnrollment( String uid )
     {
-        return this.enrollments.stream().filter( t -> t.getEnrollment().equals( id ) ).findFirst();
+        return findById( this.enrollments, uid );
     }
 
-    public Optional<Relationship> getRelationship( String id )
+    public Optional<Relationship> getRelationship( String uid )
     {
-        return this.relationships.stream().filter( t -> t.getRelationship().equals( id ) ).findFirst();
+        return findById( this.relationships, uid );
+    }
+
+    private static <T extends TrackerDto> Optional<T> findById( List<T> entities, String uid )
+    {
+        return entities.stream().filter( e -> Objects.equals( e.getUid(), uid ) ).findFirst();
     }
 
     public Map<String, List<RuleEffect>> getEnrollmentRuleEffects()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -189,6 +189,7 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
+    // TODO(DHIS2-14213) rename to findBy as per our convention?
     // TODO(DHIS2-14213) not safe if bundle contains a TEI with no id
     // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
     public Optional<TrackedEntity> getTrackedEntity( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -125,8 +125,7 @@ public class TrackerBundle
     private ValidationMode validationMode = ValidationMode.FULL;
 
     /**
-     * Preheat bundle for all attached objects (or null if preheater not run
-     * yet).
+     * Preheat bundle for all attached objects (or null if preheat not run yet).
      */
     private TrackerPreheat preheat;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -188,7 +188,6 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
-    // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
     public Optional<TrackedEntity> getTrackedEntity( String uid )
     {
         return findById( this.trackedEntities, uid );
@@ -276,7 +275,7 @@ public class TrackerBundle
             return (List<T>) relationships;
         }
         // only reached if a new TrackerDto implementation is added
-        throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
+        throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
     }
 
     /**
@@ -310,7 +309,7 @@ public class TrackerBundle
             return getRelationship( uid ).isPresent();
         default:
             // only reached if a new TrackerDto implementation is added
-            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return false?
+            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -189,7 +189,7 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
-    // TODO(DHIS2-14213) not safe; what if arg is null or there is a null in our bundle
+    // TODO(DHIS2-14213) not safe if bundle contains a TEI with no id
     // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
     public Optional<TrackedEntity> getTrackedEntity( String id )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -189,6 +189,7 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
+    // TODO(DHIS2-14213) not safe; what if arg is null or there is a null in our bundle
     // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
     public Optional<TrackedEntity> getTrackedEntity( String id )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -189,7 +189,6 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
-    // TODO(DHIS2-14213) rename to findBy as per our convention?
     // TODO(DHIS2-14213) not safe if bundle contains a TEI with no id
     // TODO(DHIS2-14213) not very efficient; does it matter? should we adapt this?
     public Optional<TrackedEntity> getTrackedEntity( String id )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -106,7 +107,7 @@ public class TrackerBundle
     private boolean skipRuleEngine;
 
     /**
-     * Should import be treated as a atomic import (all or nothing).
+     * Should import be treated as an atomic import (all or nothing).
      */
     @Builder.Default
     private AtomicMode atomicMode = AtomicMode.ALL;
@@ -247,5 +248,64 @@ public class TrackerBundle
     public org.hisp.dhis.relationship.Relationship getRelationship( String relationship )
     {
         return getPreheat().getRelationship( relationship );
+    }
+
+    // TODO test
+    @SuppressWarnings( "unchecked" )
+    public <T extends TrackerDto> List<T> get( Class<T> type )
+    {
+        Objects.requireNonNull( type );
+        if ( type == TrackedEntity.class )
+        {
+            return (List<T>) trackedEntities;
+        }
+        else if ( type == Enrollment.class )
+        {
+            return (List<T>) enrollments;
+        }
+        else if ( type == Event.class )
+        {
+            return (List<T>) events;
+        }
+        else if ( type == Relationship.class )
+        {
+            return (List<T>) relationships;
+        }
+        return null;
+    }
+
+    /**
+     * Checks if an entity exists in the payload.
+     */
+    public <T extends TrackerDto> boolean exists( T entity )
+    {
+        return exists( entity.getTrackerType(), entity.getUid() );
+    }
+
+    /**
+     * Checks if an entity of given type and UID exists in the payload.
+     *
+     * @param type tracker type
+     * @param uid uid of entity to check
+     * @return true if an entity of given type and UID exists in the payload
+     */
+    public boolean exists( TrackerType type, String uid )
+    {
+        Objects.requireNonNull( type );
+
+        switch ( type )
+        {
+        case TRACKED_ENTITY:
+            return getTrackedEntity( uid ).isPresent();
+        case ENROLLMENT:
+            return getEnrollment( uid ).isPresent();
+        case EVENT:
+            return getEvent( uid ).isPresent();
+        case RELATIONSHIP:
+            return false; // TODO(DHIS2-14213) will this ever be needed? Even if not, I guess it should be implemented or an exception thrown as this is surprising
+        default:
+            // only reached if a new TrackerDto implementation is added
+            return false;
+        }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -205,6 +205,11 @@ public class TrackerBundle
         return this.enrollments.stream().filter( t -> t.getEnrollment().equals( id ) ).findFirst();
     }
 
+    public Optional<Relationship> getRelationship( String id )
+    {
+        return this.relationships.stream().filter( t -> t.getRelationship().equals( id ) ).findFirst();
+    }
+
     public Map<String, List<RuleEffect>> getEnrollmentRuleEffects()
     {
         return ruleEffects.stream()
@@ -246,12 +251,6 @@ public class TrackerBundle
         return getPreheat().getEvent( event );
     }
 
-    public org.hisp.dhis.relationship.Relationship getRelationship( String relationship )
-    {
-        return getPreheat().getRelationship( relationship );
-    }
-
-    // TODO(DHIS2-14213) test
     @SuppressWarnings( "unchecked" )
     public <T extends TrackerDto> List<T> get( Class<T> type )
     {
@@ -272,7 +271,8 @@ public class TrackerBundle
         {
             return (List<T>) relationships;
         }
-        return null;
+        // only reached if a new TrackerDto implementation is added
+        throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
     }
 
     /**
@@ -303,10 +303,10 @@ public class TrackerBundle
         case EVENT:
             return getEvent( uid ).isPresent();
         case RELATIONSHIP:
-            return false; // TODO(DHIS2-14213) will this ever be needed? Even if not, I guess it should be implemented or an exception thrown as this is surprising
+            return getRelationship( uid ).isPresent();
         default:
             // only reached if a new TrackerDto implementation is added
-            return false; // TODO(DHIS2-14213) better to throw than to hide this
+            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return false?
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -78,6 +78,7 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.user.User;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -859,6 +860,41 @@ public class TrackerPreheat
         ProgramStage ps = this.getProgramStage( programStage );
         ProgramInstance pi = this.getEnrollment( enrollmentUid );
         return this.programStageWithEvents.contains( Pair.of( ps.getUid(), pi.getUid() ) );
+    }
+
+    /**
+     * Checks if an entity exists in the DB.
+     */
+    public <T extends TrackerDto> boolean exists( T entity )
+    {
+        return exists( entity.getTrackerType(), entity.getUid() );
+    }
+
+    /**
+     * Checks if an entity of given type and UID exists in the DB.
+     *
+     * @param type tracker type
+     * @param uid uid of entity to check
+     * @return true if an entity of given type and UID exists in the DB
+     */
+    public boolean exists( TrackerType type, String uid )
+    {
+        Objects.requireNonNull( type );
+
+        switch ( type )
+        {
+        case TRACKED_ENTITY:
+            return getTrackedEntity( uid ) != null;
+        case ENROLLMENT:
+            return getEnrollment( uid ) != null;
+        case EVENT:
+            return getEvent( uid ) != null;
+        case RELATIONSHIP:
+            return getRelationship( uid ) != null;
+        default:
+            // only reached if a new TrackerDto implementation is added
+            return false;
+        }
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -893,7 +893,7 @@ public class TrackerPreheat
             return getRelationship( uid ) != null;
         default:
             // only reached if a new TrackerDto implementation is added
-            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
+            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/preheat/TrackerPreheat.java
@@ -893,7 +893,7 @@ public class TrackerPreheat
             return getRelationship( uid ) != null;
         default:
             // only reached if a new TrackerDto implementation is added
-            return false;
+            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerErrorCode.java
@@ -155,7 +155,6 @@ public enum TrackerErrorCode
     E4008( "Missing required relationship property: 'to'." ),
     E4009( "Relationship Type `{0}` is not valid." ),
     E4010( "Relationship Type `{0}` constraint requires a {1} but a {2} was found." ),
-    E4011( "Relationship: `{0}` cannot be persisted because {1} {2} referenced by this relationship is not valid." ),
     E4012( "Could not find `{0}`: `{1}`, linked to Relationship." ),
     E4013( "Relationship Type `{0}` constraint is missing {1}." ),
     E4014( "Relationship Type `{0}` constraint requires a Tracked Entity having type `{1}` but `{2}` was found." ),
@@ -163,6 +162,8 @@ public enum TrackerErrorCode
     E4016( "Relationship: `{0}`, do not exist." ),
     E4017( "Relationship: `{0}`, is already deleted and cannot be modified." ),
     E4018( "Relationship: `{0}`, linking {1}: `{2}` to {3}: `{4}` already exists." ),
+    E5000( "\"{0}\" `{1}` cannot be persisted because \"{2}\" `{3}` referenced by it cannot be persisted." ),
+    E5001( "\"{0}\" `{1}` cannot be deleted because \"{2}\" `{3}` referenced by it cannot be deleted." ),
     E9999( "N/A" );
 
     private final String message;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.tracker.validation;
 
+import static org.hisp.dhis.tracker.validation.PersistablesFilter.filter;
+
 import java.util.List;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -108,7 +109,15 @@ public class DefaultTrackerValidationService
             .addErrors( reporter.getErrors() )
             .addWarnings( reporter.getWarnings() );
 
-        removeInvalidObjects( bundle, reporter );
+        PersistablesFilter.Result persistables = filter( bundle, reporter.getInvalidDTOs(),
+            bundle.getImportStrategy() );
+
+        bundle.setTrackedEntities( persistables.getTrackedEntities() );
+        bundle.setEnrollments( persistables.getEnrollments() );
+        bundle.setEvents( persistables.getEvents() );
+        bundle.setRelationships( persistables.getRelationships() );
+
+        validationReport.addErrors( persistables.getErrors() );
 
         return validationReport;
     }
@@ -230,22 +239,6 @@ public class DefaultTrackerValidationService
                 hook.getClass().getName(),
                 hookTimer.toString() ) );
         }
-    }
-
-    private void removeInvalidObjects( TrackerBundle bundle, ValidationErrorReporter reporter )
-    {
-        bundle.setEvents( bundle.getEvents().stream().filter(
-            e -> !reporter.isInvalid( e ) )
-            .collect( Collectors.toList() ) );
-        bundle.setEnrollments( bundle.getEnrollments().stream().filter(
-            e -> !reporter.isInvalid( e ) )
-            .collect( Collectors.toList() ) );
-        bundle.setTrackedEntities( bundle.getTrackedEntities().stream().filter(
-            e -> !reporter.isInvalid( e ) )
-            .collect( Collectors.toList() ) );
-        bundle.setRelationships( bundle.getRelationships().stream().filter(
-            e -> !reporter.isInvalid( e ) )
-            .collect( Collectors.toList() ) );
     }
 
     private boolean didNotPassValidation( ValidationErrorReporter reporter, String uid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -362,7 +362,8 @@ class PersistablesFilter
         {
             return Event.builder().event( item.getEvent() ).build();
         }
-        return null; // TODO(DHIS2-14213) isn't throwing better? if none of the above is set its not a valid item
+        // only reached if a new TrackerDto implementation is added
+        throw new IllegalStateException( "TrackerType for relationship item not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
     }
 
     /**
@@ -410,7 +411,8 @@ class PersistablesFilter
             {
                 return (List<T>) relationships;
             }
-            return Collections.emptyList();
+            // only reached if a new TrackerDto implementation is added
+            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -68,7 +68,7 @@ import org.hisp.dhis.tracker.report.TrackerErrorReport;
  * {@link TrackerImportStrategy#CREATE} no valid child of an invalid parent can
  * be created (i.e. enrollment of trackedEntity or event of enrollment). During
  * {@link TrackerImportStrategy#UPDATE} a valid child of an invalid parent can
- * be updated if the parent exists.
+ * be updated.
  * <p>
  * The {@link Result} returned from
  * {@link #filter(TrackerBundle, EnumMap, TrackerImportStrategy)} can be trusted

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 
 // TODO(DHIS2-14213) reword all javadocs
+// TODO(DHIS2-14213) get rid of compiler warnings
 /**
  * Determines whether entities can be persisted (created, updated, deleted)
  * taking into account the {@link TrackerImportStrategy} and the links between

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.RelationshipItem;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.domain.TrackerDto;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
+
+/**
+ * Determines whether entities can be persisted (created, updated, deleted)
+ * taking into account the {@link TrackerImportStrategy} and the links between
+ * entities. For example during {@link TrackerImportStrategy#CREATE} no valid
+ * child of an invalid parent can be created (i.e. enrollment of trackedEntity
+ * or event of enrollment). During {@link TrackerImportStrategy#UPDATE} a valid
+ * child of an invalid parent can be updated if the parent exists.
+ * <p>
+ * Filtering is only concerned with
+ * {@link org.hisp.dhis.tracker.AtomicMode#OBJECT} as only then do we need to
+ * determine what is persistable despite errors in the payload. With
+ * {@link org.hisp.dhis.tracker.AtomicMode#ALL} only one error suffices to
+ * reject the entire payload.
+ * </p>
+ * <p>
+ * This filter relies on validations having run beforehand. The following are
+ * some assumptions the filtering relies on:
+ * </p>
+ * <ul>
+ * <li>This does not validate whether the {@link TrackerImportStrategy} matches
+ * the state of a given entity. This is expected to be validated by the
+ * {@link org.hisp.dhis.tracker.validation.TrackerValidationHook}s. Currently,
+ * it's done by
+ * {@link org.hisp.dhis.tracker.validation.hooks.PreCheckExistenceValidationHook}
+ * So for example a TEI can only be {@link TrackerImportStrategy#UPDATE}d if it
+ * exists. Existence is only checked in relation to a parent or child. During
+ * {@link TrackerImportStrategy#UPDATE} a valid enrollment can be updated if its
+ * parent the TEI is invalid but exists. Same applies to
+ * {@link TrackerImportStrategy#DELETE} as you cannot delete an entity that does
+ * not yet exist.</li>
+ * <li>An {@link Event} in an event program does not have an
+ * {@link Event#getEnrollment()} (parent) set. {@link PersistablesFilter} relies
+ * on validations having marked entities as invalid that should have a parent.
+ * It does so by only checking the parent if it is set.</li>
+ * </ul>
+ */
+// TODO naming. commit or persist? CommittablesFilter, PersistablesFilter?
+// variations in logic to consider when refactoring
+// != DELETE
+//  direction: is top-down (TEI -> EN -> EV -> REL)
+//  conditions: current is valid && includes parents and if parent exists or is persistable
+// DELETE
+//  direction: is bottom up (REL -> EV -> EN -> TEI)
+//  conditions: current is valid && includes children and if children are persistable
+// CASCADE
+//  direction: does not matter
+//  conditions: current is valid
+
+// PATTERNS
+// links are always comprised of TrackerType and UID; so what I am doing for RelationshipItem
+// could be done for the other links as well; pack these into a TrackerDto only containing type and UID
+// then pass that around
+
+// != DELETE
+// filter
+//   current == valid &&
+//   for each link (type and uid): persistable or exists
+// collect in persistables
+
+// == DELETE
+// filter
+//   current == invalid
+//   for each link (type and uid)
+// collect in nonPersistables
+
+// filter
+//   current == valid &&
+//   current == persistable (not in nonPersistable)
+// collect in persistables
+// the difference to the != DELETE is that we also collect a nonPersistable structure with all the invalid parents
+
+class PersistablesFilter
+{
+    private PersistablesFilter()
+    {
+        // should not be instantiated
+    }
+
+    public static Result filter( TrackerBundle bundle,
+        EnumMap<TrackerType, Set<String>> invalidEntities, TrackerImportStrategy importStrategy )
+    {
+        // TODO think about the design. This does not feel right.
+        return new Checks( bundle, invalidEntities, importStrategy ).apply();
+    }
+
+    /**
+     * Result of {@link #filter(TrackerBundle, EnumMap, TrackerImportStrategy)}
+     * operation indicating all entities that can be persisted. The meaning of
+     * persisted comes from the context which includes the
+     * {@link TrackerImportStrategy} and whether the entity existed or not (for
+     * {@link TrackerImportStrategy#CREATE_AND_UPDATE}).
+     */
+    @Getter
+    public static class Result
+    {
+        private final List<TrackedEntity> trackedEntities = new ArrayList<>();
+
+        private final List<Enrollment> enrollments = new ArrayList<>();
+
+        private final List<Event> events = new ArrayList<>();
+
+        private final List<Relationship> relationships = new ArrayList<>();
+
+        private final List<TrackerErrorReport> errors = new ArrayList<>();
+
+        private <T extends TrackerDto> void put( Class<T> type, T instance )
+        {
+            get( Objects.requireNonNull( type ) ).add( instance );
+        }
+
+        @SuppressWarnings( "unchecked" )
+        public <T extends TrackerDto> List<T> get( Class<T> type )
+        {
+            Objects.requireNonNull( type );
+            if ( type == TrackedEntity.class )
+            {
+                return (List<T>) trackedEntities;
+            }
+            else if ( type == Enrollment.class )
+            {
+                return (List<T>) enrollments;
+            }
+            else if ( type == Event.class )
+            {
+                return (List<T>) events;
+            }
+            else if ( type == Relationship.class )
+            {
+                return (List<T>) relationships;
+            }
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * <p>
+     * Using {@link TrackerDto} in functions to parents {@link Check#parents} as
+     * a tuple of UID and {@link TrackerType}. This makes working with the
+     * different types (trackedEntity, enrollment, ...) easier.
+     * </p>
+     */
+    @RequiredArgsConstructor
+    private static class Checks
+    {
+        private static final Check<TrackedEntity> TRACKED_ENTITY_CHECK = new Check<>();
+
+        private static final Check<Enrollment> ENROLLMENT_CHECK = new Check<>(
+            List.of(
+                en -> TrackedEntity.builder().trackedEntity( en.getTrackedEntity() ).build() // parent
+            ) );
+
+        private static final Check<Event> EVENT_CHECK = new Check<>(
+            List.of(
+                ev -> Enrollment.builder().enrollment( ev.getEnrollment() ).build() // parent
+            ),
+            parent -> StringUtils.isBlank( parent.getUid() ) // events in event programs have no enrollment
+        );
+
+        private static final Check<Relationship> RELATIONSHIP_CHECK = new Check<>(
+            List.of(
+                rel -> toTrackerDto( rel.getFrom() ), // parents
+                rel -> toTrackerDto( rel.getTo() ) ) );
+
+        /**
+         * Collects non-deletable parent entities on DELETE and persistable
+         * entities otherwise. Checking each non-root "layer" depends on the
+         * knowledge (marked entities) we gain from the previous layers. For
+         * example on DELETE event, enrollment, trackedEntity entities cannot be
+         * deleted if an invalid relationship points to them.
+         */
+        private final EnumMap<TrackerType, Set<String>> markedEntities = new EnumMap<>( Map.of(
+            TRACKED_ENTITY, new HashSet<>(),
+            ENROLLMENT, new HashSet<>(),
+            EVENT, new HashSet<>(),
+            RELATIONSHIP, new HashSet<>() ) );
+
+        private final TrackerBundle bundle;
+
+        private final EnumMap<TrackerType, Set<String>> invalidEntities;
+
+        private final TrackerImportStrategy importStrategy;
+
+        private final Result result = new Result();
+
+        private Result apply()
+        {
+            if ( isDelete() )
+            {
+                // bottom-up
+                collectPersistables( Relationship.class, RELATIONSHIP_CHECK, bundle.getRelationships(),
+                    bundle.getPreheat(), bundle );
+                collectPersistables( Event.class, EVENT_CHECK, bundle.getEvents(), bundle.getPreheat(), bundle );
+                collectPersistables( Enrollment.class, ENROLLMENT_CHECK, bundle.getEnrollments(),
+                    bundle.getPreheat(), bundle );
+                collectPersistables( TrackedEntity.class, TRACKED_ENTITY_CHECK, bundle.getTrackedEntities(),
+                    bundle.getPreheat(), bundle );
+            }
+            else
+            {
+                // top-down
+                collectPersistables( TrackedEntity.class, TRACKED_ENTITY_CHECK, bundle.getTrackedEntities(),
+                    bundle.getPreheat(), bundle );
+                collectPersistables( Enrollment.class, ENROLLMENT_CHECK, bundle.getEnrollments(),
+                    bundle.getPreheat(), bundle );
+                collectPersistables( Event.class, EVENT_CHECK, bundle.getEvents(), bundle.getPreheat(), bundle );
+                collectPersistables( Relationship.class, RELATIONSHIP_CHECK, bundle.getRelationships(),
+                    bundle.getPreheat(), bundle );
+            }
+            return this.result;
+        }
+
+        private <T extends TrackerDto> void collectPersistables( Class<T> type, Check<T> check, List<T> entities,
+            TrackerPreheat preheat, TrackerBundle bundle )
+        {
+            for ( T entity : entities )
+            {
+                if ( isNotValid( entity ) )
+                {
+                    if ( isDelete() )
+                    {
+                        // add error for parents with entity as reason (only to valid parents in the payload)
+                        List<TrackerErrorReport> errors = check.parents.stream()
+                            .map( p -> p.apply( entity ) )
+                            .filter( this::isValid ) // remove invalid parents
+                            .filter( bundle::exists ) // remove parents not in payload
+                            .map( p -> error( TrackerErrorCode.E5001, p, entity ) )
+                            .collect( Collectors.toList() );
+                        this.result.errors.addAll( errors );
+                        errors.forEach( this::mark ); // mark parents as non-deletable
+                    }
+                    continue;
+                }
+
+                if ( isDelete() )
+                {
+                    if ( isMarked( entity ) ) // parents of invalid children cannot be deleted
+                    {
+                        // add error for its parents with itself as reason (only to valid parents in the payload)
+                        List<TrackerErrorReport> errors = check.parents.stream()
+                            .map( p -> p.apply( entity ) )
+                            .filter( this::isValid ) // remove invalid parents
+                            .map( p -> error( TrackerErrorCode.E5001, p, entity ) )
+                            .collect( Collectors.toList() );
+                        this.result.errors.addAll( errors );
+                        errors.forEach( this::mark ); // mark parents as non-deletable
+                        continue;
+                    }
+                }
+                else
+                {
+                    if ( hasInvalidParents( check, preheat, entity ) )
+                    {
+                        // add error for entity with parent as a reason
+                        List<TrackerErrorReport> errors = check.parents.stream()
+                            .map( p -> p.apply( entity ) )
+                            .filter( this::isNotValid ) // remove valid parents
+                            .map( p -> error( TrackerErrorCode.E5000, entity, p ) )
+                            .collect( Collectors.toList() );
+                        this.result.errors.addAll( errors );
+                        continue;
+                    }
+                    mark( entity ); // mark as persistable for later children
+                }
+
+                this.result.put( type, entity );
+            }
+        }
+
+        private boolean isNotValid( TrackerDto entity )
+        {
+            return !isValid( entity );
+        }
+
+        private boolean isValid( TrackerDto entity )
+        {
+            return !isContained( this.invalidEntities, entity );
+        }
+
+        private boolean isContained( EnumMap<TrackerType, Set<String>> map, TrackerDto entity )
+        {
+            return map.get( entity.getTrackerType() ).contains( entity.getUid() );
+        }
+
+        private boolean isDelete()
+        {
+            return this.importStrategy == TrackerImportStrategy.DELETE;
+        }
+
+        private <T extends TrackerDto> void mark( T entity )
+        {
+            this.markedEntities.get( entity.getTrackerType() ).add( entity.getUid() );
+        }
+
+        private void mark( TrackerErrorReport error )
+        {
+            this.markedEntities.get( error.getTrackerType() ).add( error.getUid() );
+        }
+
+        private <T extends TrackerDto> boolean isMarked( T entity )
+        {
+            return isContained( this.markedEntities, entity );
+        }
+
+        private <T extends TrackerDto> boolean hasInvalidParents( Check<T> check, TrackerPreheat preheat, T entity )
+        {
+            return !parentConditions( check, preheat ).test( entity );
+        }
+
+        private <T extends TrackerDto> Predicate<T> parentConditions( Check<T> check, TrackerPreheat preheat )
+        {
+            final Predicate<TrackerDto> baseParentCondition = parent -> isContained( this.markedEntities, parent )
+                || preheat.exists( parent.getTrackerType(), parent.getUid() );
+            final Predicate<TrackerDto> parentCondition = check.parentCondition.map( baseParentCondition::or )
+                .orElse( baseParentCondition );
+
+            return check.parents.stream()
+                .map( p -> (Predicate<T>) t -> parentCondition.test( p.apply( t ) ) ) // children of invalid parents can only be persisted under certain conditions
+                .reduce( Predicate::and )
+                .orElse( t -> true ); // predicate always returning true for entities without parents
+        }
+
+        private static TrackerErrorReport error( TrackerErrorCode code, TrackerDto notPersistable, TrackerDto reason )
+        {
+            String message = MessageFormat.format(
+                code.getMessage(),
+                notPersistable.getTrackerType().getName(),
+                notPersistable.getUid(),
+                reason.getTrackerType().getName(),
+                reason.getUid() );
+
+            return new TrackerErrorReport(
+                message,
+                code,
+                notPersistable.getTrackerType(),
+                notPersistable.getUid() );
+        }
+
+        /**
+         * Captures UID and {@link TrackerType} information in a
+         * {@link TrackerDto}. Valid {@link RelationshipItem} only has one of
+         * its 3 identifier fields set. The RelationshipItem API does not
+         * enforce it since it needs to capture invalid user input. Transform it
+         * to a shallow TrackerDto, so it is easier to work with.
+         *
+         * @param item relationship item
+         * @return a tracker dto only capturing the uid and type
+         */
+        private static TrackerDto toTrackerDto( RelationshipItem item )
+        {
+            if ( StringUtils.isNotEmpty( item.getTrackedEntity() ) )
+            {
+                return TrackedEntity.builder().trackedEntity( item.getTrackedEntity() ).build();
+            }
+            else if ( StringUtils.isNotEmpty( item.getEnrollment() ) )
+            {
+                return Enrollment.builder().enrollment( item.getEnrollment() ).build();
+            }
+            else if ( StringUtils.isNotEmpty( item.getEvent() ) )
+            {
+                return Event.builder().event( item.getEvent() ).build();
+            }
+            return null; // TODO(DHIS2-14213) isn't throwing better? if none of the above is set its not a valid item
+        }
+    }
+
+    private static class Check<T extends TrackerDto>
+    {
+        private final List<Function<T, TrackerDto>> parents;
+
+        private final Optional<Predicate<TrackerDto>> parentCondition;
+
+        public Check()
+        {
+            this( Collections.emptyList() );
+        }
+
+        public Check( List<Function<T, TrackerDto>> parents )
+        {
+            this.parents = parents;
+            this.parentCondition = Optional.empty();
+        }
+
+        public Check( List<Function<T, TrackerDto>> parents, Predicate<TrackerDto> parentCondition )
+        {
+            this.parents = parents;
+            this.parentCondition = Optional.of( parentCondition );
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -108,7 +108,6 @@ import org.hisp.dhis.tracker.report.TrackerErrorReport;
  * children that cannot be deleted by that user.</li>
  * </ul>
  */
-// TODO(DHIS2-14213) naming. commit or persist? CommittablesFilter, PersistablesFilter?
 class PersistablesFilter
 {
     private static final List<Function<TrackedEntity, TrackerDto>> TRACKED_ENTITY_PARENTS = Collections.emptyList();
@@ -128,8 +127,6 @@ class PersistablesFilter
         rel -> toTrackerDto( rel.getFrom() ),
         rel -> toTrackerDto( rel.getTo() ) );
 
-    // TODO(DHIS2-14213) in theory we could rely on result and errors we collect to figure out whether something
-    // is persistable or deletable. These structures are just not designed for fast lookups.
     /**
      * Collects non-deletable parent entities on DELETE and persistable entities
      * otherwise. Checking each "layer" depends on the knowledge (marked
@@ -360,7 +357,7 @@ class PersistablesFilter
             return Event.builder().event( item.getEvent() ).build();
         }
         // only reached if a new TrackerDto implementation is added
-        throw new IllegalStateException( "TrackerType for relationship item not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
+        throw new IllegalStateException( "TrackerType for relationship item not yet supported." );
     }
 
     /**
@@ -409,7 +406,7 @@ class PersistablesFilter
                 return (List<T>) relationships;
             }
             // only reached if a new TrackerDto implementation is added
-            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." ); // TODO(DHIS2-14213) do you agree its better to throw than just return
+            throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );
         }
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -195,7 +195,7 @@ class PersistablesFilter
                 {
                     mark( entity ); // mark as persistable for later children
                 }
-                this.result.put( type, entity ); // persistable
+                this.result.put( type, entity );
                 continue;
             }
 
@@ -279,6 +279,10 @@ class PersistablesFilter
             .orElse( t -> true ); // predicate always returning true for entities without parents
     }
 
+    /**
+     * Add error for valid parents with invalid child as the reason. So users
+     * know why a valid entity could not be deleted.
+     */
     private <T extends TrackerDto> List<TrackerErrorReport> addErrorsForParents( Check<T> check, T entity )
     {
         // add error for parents with entity as reason (only to valid parents in the payload)
@@ -292,9 +296,18 @@ class PersistablesFilter
         return errors;
     }
 
+    /**
+     * Add error for valid child entity with invalid parent as a reason. If a
+     * child is invalid that is enough information for a user to know why it
+     * could not be persisted.
+     */
     private <T extends TrackerDto> void addErrorsForChildren( Check<T> check, T entity )
     {
-        // add error for entity with parent as a reason
+        if ( isNotValid( entity ) )
+        {
+            return;
+        }
+
         List<TrackerErrorReport> errors = check.parents.stream()
             .map( p -> p.apply( entity ) )
             .filter( this::isNotValid ) // remove valid parents

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -64,6 +64,7 @@ import org.hisp.dhis.tracker.report.TrackerErrorReport;
 
 // TODO(DHIS2-14213) reword all javadocs
 // TODO(DHIS2-14213) get rid of compiler warnings
+// TODO(DHIS2-14213) can we remove its reliance on the preheat? now that we also need to check whether something is in the payload for error reporting?
 /**
  * Determines whether entities can be persisted (created, updated, deleted)
  * taking into account the {@link TrackerImportStrategy} and the links between

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -270,7 +270,7 @@ class PersistablesFilter
     private <T extends TrackerDto> Predicate<T> parentConditions( Check<T> check )
     {
         final Predicate<TrackerDto> baseParentCondition = parent -> isMarked( parent )
-            || this.preheat.exists( parent.getTrackerType(), parent.getUid() );
+            || this.preheat.exists( parent );
         final Predicate<TrackerDto> parentCondition = check.parentCondition.map( baseParentCondition::or )
             .orElse( baseParentCondition );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 
-// TODO(DHIS2-14213) get rid of compiler warnings
 // TODO(DHIS2-14213) can we remove its reliance on the preheat? now that we also need to check whether something is in the payload for error reporting?
 /**
  * Determines whether entities can be persisted (created, updated, deleted)

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -396,11 +396,9 @@ class PersistablesFilter
     }
 
     /**
-     * <p>
      * Using {@link TrackerDto} in functions to parents {@link Check#parents} as
      * a tuple of UID and {@link TrackerType}. This makes working with the
      * different types (trackedEntity, enrollment, ...) easier.
-     * </p>
      */
     private static class Check<T extends TrackerDto>
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 
-// TODO(DHIS2-14213) can we remove its reliance on the preheat? now that we also need to check whether something is in the payload for error reporting?
 /**
  * Determines whether entities can be persisted (created, updated, deleted)
  * taking into account the {@link TrackerImportStrategy} and the parent/child

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/PersistablesFilter.java
@@ -283,13 +283,12 @@ class PersistablesFilter
     }
 
     /**
-     * Add error for valid parents with invalid child as the reason. So users
-     * know why a valid entity could not be deleted.
+     * Add error for valid parents in the payload with invalid child as the
+     * reason. So users know why a valid entity could not be deleted.
      */
     private <T extends TrackerDto> List<TrackerErrorReport> addErrorsForParents( List<Function<T, TrackerDto>> parents,
         T entity )
     {
-        // add error for parents with entity as reason (only to valid parents in the payload)
         List<TrackerErrorReport> errors = parents.stream()
             .map( p -> p.apply( entity ) )
             .filter( this::isValid ) // remove invalid parents

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationErrorReporter.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BooleanSupplier;
 import java.util.function.Predicate;
@@ -89,7 +90,11 @@ public class ValidationErrorReporter
     {
         this.errors = new ArrayList<>();
         this.warnings = new ArrayList<>();
-        this.invalidDTOs = new EnumMap<>( TrackerType.class );
+        this.invalidDTOs = new EnumMap<>( Map.of(
+            TrackerType.TRACKED_ENTITY, new HashSet<>(),
+            TrackerType.ENROLLMENT, new HashSet<>(),
+            TrackerType.EVENT, new HashSet<>(),
+            TrackerType.RELATIONSHIP, new HashSet<>() ) );
         this.idSchemes = idSchemes;
         this.isFailFast = failFast;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationFailFastException.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationFailFastException.java
@@ -34,7 +34,7 @@ import org.hisp.dhis.tracker.report.TrackerErrorReport;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-public class ValidationFailFastException
+class ValidationFailFastException
     extends RuntimeException
 {
     private final transient List<TrackerErrorReport> errorReportRef;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -138,7 +138,7 @@ public class PreCheckExistenceValidationHook
         Relationship relationship )
     {
 
-        org.hisp.dhis.relationship.Relationship existingRelationship = bundle
+        org.hisp.dhis.relationship.Relationship existingRelationship = bundle.getPreheat()
             .getRelationship( relationship.getRelationship() );
         TrackerImportStrategy importStrategy = bundle.getStrategy( relationship );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -33,7 +33,6 @@ import static org.hisp.dhis.relationship.RelationshipEntity.TRACKED_ENTITY_INSTA
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4000;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4001;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4009;
-import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4011;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4018;
 import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils.getUidFromRelationshipItem;
 import static org.hisp.dhis.tracker.validation.hooks.RelationshipValidationUtils.relationshipItemValueType;
@@ -84,11 +83,7 @@ public class RelationshipsValidationHook
             validateAutoRelationship( reporter, relationship );
 
             validateDuplication( reporter, relationship, bundle );
-
-            validateReferences( reporter, relationship, relationship.getFrom() );
-            validateReferences( reporter, relationship, relationship.getTo() );
         }
-
     }
 
     private void validateDuplication( ValidationErrorReporter reporter, Relationship relationship,
@@ -219,18 +214,6 @@ public class RelationshipsValidationHook
         return Stream.of( item.getTrackedEntity(), item.getEnrollment(), item.getEvent() )
             .filter( StringUtils::isNotBlank )
             .count() > 1;
-    }
-
-    private void validateReferences( ValidationErrorReporter reporter, Relationship relationship,
-        RelationshipItem item )
-
-    {
-        TrackerType trackerType = relationshipItemValueType( item );
-        Optional<String> itemUid = getUidFromRelationshipItem( item );
-
-        itemUid.ifPresent( s -> reporter.addErrorIf( () -> reporter.isInvalid( trackerType, s ),
-            relationship, E4011, relationship.getRelationship(),
-            trackerType.getName(), s ) );
     }
 
     private Optional<MetadataIdentifier> getRelationshipTypeUidFromTrackedEntity( TrackerBundle bundle, String uid )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/package-info.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Package validation takes a potentially invalid user payload
+ * ({@link org.hisp.dhis.tracker.bundle.TrackerBundle} in and runs all our
+ * {@link org.hisp.dhis.tracker.validation.TrackerValidationHook}s attributing
+ * errors and warnings to entities in the payload. The
+ * {@link org.hisp.dhis.tracker.bundle.TrackerBundle} leaving this package can
+ * be persisted (created, updated, deleted) and thus trusted to be in a valid
+ * state. {@link org.hisp.dhis.tracker.validation.TrackerValidationService} is
+ * the main entry point into this package.
+ */
+package org.hisp.dhis.tracker.validation;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
@@ -30,14 +30,19 @@ package org.hisp.dhis.tracker.bundle;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.hisp.dhis.tracker.AtomicMode;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.junit.jupiter.api.Test;
 
@@ -74,5 +79,57 @@ class TrackerBundleTest
         assertEquals( 2, trackerBundle.getTrackedEntities().size() );
         assertEquals( 2, trackerBundle.getEnrollments().size() );
         assertEquals( 2, trackerBundle.getEvents().size() );
+    }
+
+    @Test
+    void testExistsTrackedEntity()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .trackedEntities( List.of( TrackedEntity.builder().trackedEntity( "uid" ).build() ) )
+            .build();
+
+        assertFalse( bundle.exists( TrackerType.TRACKED_ENTITY, "missing" ) );
+        assertTrue( bundle.exists( TrackedEntity.builder().trackedEntity( "uid" ).build() ) );
+    }
+
+    @Test
+    void testExistsEnrollment()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .enrollments( List.of( Enrollment.builder().enrollment( "uid" ).build() ) )
+            .build();
+
+        assertFalse( bundle.exists( TrackerType.ENROLLMENT, "missing" ) );
+        assertTrue( bundle.exists( Enrollment.builder().enrollment( "uid" ).build() ) );
+    }
+
+    @Test
+    void testExistsEvent()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .events( List.of( Event.builder().event( "uid" ).build() ) )
+            .build();
+
+        assertFalse( bundle.exists( TrackerType.EVENT, "missing" ) );
+        assertTrue( bundle.exists( Event.builder().event( "uid" ).build() ) );
+    }
+
+    @Test
+    void testExistsRelationship()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .relationships( List.of( Relationship.builder().relationship( "uid" ).build() ) )
+            .build();
+
+        assertFalse( bundle.exists( TrackerType.RELATIONSHIP, "missing" ) );
+        assertTrue( bundle.exists( Relationship.builder().relationship( "uid" ).build() ) );
+    }
+
+    @Test
+    void testExistsFailsOnNullType()
+    {
+        TrackerBundle bundle = TrackerBundle.builder().build();
+
+        assertThrows( NullPointerException.class, () -> bundle.exists( null, "uid" ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
@@ -155,6 +155,16 @@ class TrackerBundleTest
     }
 
     @Test
+    void testGetRelationshipInBundleContainingNullUids()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .relationships( List.of( Relationship.builder().build() ) )
+            .build();
+
+        assertTrue( bundle.getRelationship( "uid" ).isEmpty() );
+    }
+
+    @Test
     void testExistsRelationship()
     {
         TrackerBundle bundle = TrackerBundle.builder()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
@@ -82,6 +82,16 @@ class TrackerBundleTest
     }
 
     @Test
+    void testGetTrackedEntityGivenNull()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .trackedEntities( List.of( TrackedEntity.builder().trackedEntity( "uid" ).build() ) )
+            .build();
+
+        assertTrue( bundle.getTrackedEntity( null ).isEmpty() );
+    }
+
+    @Test
     void testExistsTrackedEntity()
     {
         TrackerBundle bundle = TrackerBundle.builder()
@@ -90,6 +100,16 @@ class TrackerBundleTest
 
         assertFalse( bundle.exists( TrackerType.TRACKED_ENTITY, "missing" ) );
         assertTrue( bundle.exists( TrackedEntity.builder().trackedEntity( "uid" ).build() ) );
+    }
+
+    @Test
+    void testGetEnrollmentGivenNull()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .enrollments( List.of( Enrollment.builder().enrollment( "uid" ).build() ) )
+            .build();
+
+        assertTrue( bundle.getEnrollment( null ).isEmpty() );
     }
 
     @Test
@@ -104,6 +124,16 @@ class TrackerBundleTest
     }
 
     @Test
+    void testGetEventGivenNull()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .events( List.of( Event.builder().event( "uid" ).build() ) )
+            .build();
+
+        assertTrue( bundle.getEvent( null ).isEmpty() );
+    }
+
+    @Test
     void testExistsEvent()
     {
         TrackerBundle bundle = TrackerBundle.builder()
@@ -112,6 +142,16 @@ class TrackerBundleTest
 
         assertFalse( bundle.exists( TrackerType.EVENT, "missing" ) );
         assertTrue( bundle.exists( Event.builder().event( "uid" ).build() ) );
+    }
+
+    @Test
+    void testGetRelationshipGivenNull()
+    {
+        TrackerBundle bundle = TrackerBundle.builder()
+            .relationships( List.of( Relationship.builder().relationship( "uid" ).build() ) )
+            .build();
+
+        assertTrue( bundle.getRelationship( null ).isEmpty() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/preheat/TrackerPreheatTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -60,9 +61,12 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
+import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.Lists;
@@ -74,10 +78,17 @@ import com.google.common.collect.Sets;
 class TrackerPreheatTest extends DhisConvenienceTest
 {
 
+    private TrackerPreheat preheat;
+
+    @BeforeEach
+    void setUp()
+    {
+        preheat = new TrackerPreheat();
+    }
+
     @Test
     void testAllEmpty()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         assertTrue( preheat.isEmpty() );
         assertTrue( preheat.getAll( Program.class ).isEmpty() );
     }
@@ -94,7 +105,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
         TrackerIdSchemeParams identifierParams = TrackerIdSchemeParams.builder()
             .categoryOptionComboIdScheme( TrackerIdSchemeParam.CODE )
             .build();
-        TrackerPreheat preheat = new TrackerPreheat();
         preheat.setIdSchemes( identifierParams );
 
         assertFalse( preheat.containsCategoryOptionCombo( categoryCombo, options ) );
@@ -122,7 +132,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
         CategoryOptionCombo aoc = firstCategoryOptionCombo( categoryCombo );
         Set<CategoryOption> options = aoc.getCategoryOptions();
 
-        TrackerPreheat preheat = new TrackerPreheat();
         TrackerIdSchemeParams identifiers = new TrackerIdSchemeParams();
         preheat.setIdSchemes( identifiers );
 
@@ -140,7 +149,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetByUid()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         assertTrue( preheat.getAll( Program.class ).isEmpty() );
         assertTrue( preheat.isEmpty() );
 
@@ -158,7 +166,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetByCode()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         DataElement de1 = new DataElement( "dataElementA" );
         de1.setCode( "CODE1" );
         DataElement de2 = new DataElement( "dataElementB" );
@@ -175,7 +182,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetByName()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         DataElement de1 = new DataElement( "dataElementA" );
         de1.setName( "DATA_ELEM1" );
         DataElement de2 = new DataElement( "dataElementB" );
@@ -192,7 +198,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetByAttribute()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         Attribute attribute = new Attribute();
         attribute.setAutoFields();
         AttributeValue attributeValue = new AttributeValue( "value1" );
@@ -212,7 +217,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetDataElementByCode()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         preheat.setIdSchemes( TrackerIdSchemeParams.builder()
             .idScheme( TrackerIdSchemeParam.UID )
             .dataElementIdScheme( TrackerIdSchemeParam.CODE )
@@ -233,7 +237,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetDataElementByName()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         preheat.setIdSchemes( TrackerIdSchemeParams.builder()
             .idScheme( TrackerIdSchemeParam.CODE )
             .dataElementIdScheme( TrackerIdSchemeParam.NAME )
@@ -252,7 +255,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetProgramByCode()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         preheat.setIdSchemes( TrackerIdSchemeParams.builder()
             .idScheme( TrackerIdSchemeParam.UID )
             .programIdScheme( TrackerIdSchemeParam.CODE )
@@ -273,7 +275,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutAndGetProgramByName()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         preheat.setIdSchemes( TrackerIdSchemeParams.builder()
             .idScheme( TrackerIdSchemeParam.CODE )
             .programIdScheme( TrackerIdSchemeParam.NAME )
@@ -292,8 +293,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testGetByMetadataIdentifier()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
-
         Attribute attribute = new Attribute();
         attribute.setAutoFields();
         attribute.setName( "best" );
@@ -316,15 +315,12 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testGetByMetadataIdentifierGivenNull()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
-
         assertNull( preheat.get( Attribute.class, (MetadataIdentifier) null ) );
     }
 
     @Test
     void testPutUid()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         DataElement de1 = new DataElement( "dataElementA" );
         DataElement de2 = new DataElement( "dataElementB" );
         DataElement de3 = new DataElement( "dataElementC" );
@@ -343,7 +339,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutCode()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         DataElement de1 = new DataElement( "dataElementA" );
         DataElement de2 = new DataElement( "dataElementB" );
         DataElement de3 = new DataElement( "dataElementC" );
@@ -365,7 +360,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testPutCollectionUid()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         DataElement de1 = new DataElement( "dataElementA" );
         DataElement de2 = new DataElement( "dataElementB" );
         DataElement de3 = new DataElement( "dataElementC" );
@@ -382,7 +376,6 @@ class TrackerPreheatTest extends DhisConvenienceTest
     @Test
     void testReferenceInvalidation()
     {
-        TrackerPreheat preheat = new TrackerPreheat();
         // Create root TEI
         TrackedEntityInstance tei = new TrackedEntityInstance();
         tei.setUid( CodeGenerator.generateUid() );
@@ -472,6 +465,61 @@ class TrackerPreheatTest extends DhisConvenienceTest
         Optional<ReferenceTrackerEntity> reference4 = preheat.getReference( allEvents.get( 3 ).getUid() );
         assertThat( reference4.get().getUid(), is( allEvents.get( 3 ).getUid() ) );
         assertThat( reference4.get().getParentUid(), is( allPs.get( 1 ).getUid() ) );
+    }
+
+    @Test
+    void testExistsTrackedEntity()
+    {
+        assertFalse( preheat.exists( TrackerType.TRACKED_ENTITY, "uid" ) );
+
+        TrackedEntityInstance tei = new TrackedEntityInstance();
+        tei.setUid( "uid" );
+        preheat.putTrackedEntities( List.of( tei ) );
+
+        assertTrue( preheat.exists( TrackerType.TRACKED_ENTITY, "uid" ) );
+        assertTrue( preheat.exists( TrackedEntity.builder().trackedEntity( "uid" ).build() ) );
+    }
+
+    @Test
+    void testExistsEnrollment()
+    {
+        assertFalse( preheat.exists( TrackerType.ENROLLMENT, "uid" ) );
+
+        ProgramInstance pi = new ProgramInstance();
+        pi.setUid( "uid" );
+        preheat.putEnrollments( List.of( pi ) );
+
+        assertTrue( preheat.exists( TrackerType.ENROLLMENT, "uid" ) );
+    }
+
+    @Test
+    void testExistsEvent()
+    {
+        assertFalse( preheat.exists( TrackerType.EVENT, "uid" ) );
+
+        ProgramStageInstance psi = new ProgramStageInstance();
+        psi.setUid( "uid" );
+        preheat.putEvents( List.of( psi ) );
+
+        assertTrue( preheat.exists( TrackerType.EVENT, "uid" ) );
+    }
+
+    @Test
+    void testExistsRelationship()
+    {
+        assertFalse( preheat.exists( TrackerType.RELATIONSHIP, "uid" ) );
+
+        org.hisp.dhis.relationship.Relationship relationship = new org.hisp.dhis.relationship.Relationship();
+        relationship.setUid( "uid" );
+        preheat.putRelationship( relationship );
+
+        assertTrue( preheat.exists( TrackerType.RELATIONSHIP, "uid" ) );
+    }
+
+    @Test
+    void testExistsFailsOnNullType()
+    {
+        assertThrows( NullPointerException.class, () -> preheat.exists( null, "uid" ) );
     }
 
     private Set<MetadataIdentifier> categoryOptionIds( TrackerIdSchemeParams params, Set<CategoryOption> options )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -63,7 +63,6 @@ import org.junit.jupiter.api.Test;
 class DefaultTrackerValidationServiceTest
 {
 
-    // TODO(DHIS2-14213) ensure we have a test that shows an invalid entity will be removed and the error end in the report
     private DefaultTrackerValidationService service;
 
     @Test
@@ -213,7 +212,7 @@ class DefaultTrackerValidationServiceTest
         TrackerValidationReport report = service.validate( bundle );
 
         assertTrue( report.hasErrors() );
-        assertEquals( 1, report.getErrors().size(), "only remove on error hook should add 1 error" );
+        assertEquals( 1, report.getErrors().size(), "only skip on error hook should add 1 error" );
         assertHasError( report, TrackerErrorCode.E1032, invalidEvent );
 
         assertFalse( bundle.getEvents().contains( invalidEvent ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -63,6 +63,7 @@ import org.junit.jupiter.api.Test;
 class DefaultTrackerValidationServiceTest
 {
 
+    // TODO(DHIS2-14213) ensure we have a test that shows an invalid entity will be removed and the error end in the report
     private DefaultTrackerValidationService service;
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -38,6 +38,7 @@ import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationRepo
 import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasNoErrorWithCode;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -796,7 +797,7 @@ class PersistablesFilterTest
              */
             Builder eventWithoutRegistration( String uid )
             {
-                Entity<Event> entity = event( uid, currentEnrollment );
+                Entity<Event> entity = event( uid, null );
                 this.events.add(entity);
                 current = entity;
                 // unset enrollment cursor. Otherwise, it might be confusing when calling .enrollment().eventWithoutRegistration().event()
@@ -887,16 +888,10 @@ class PersistablesFilterTest
             }
 
             private <T extends TrackerDto> void inDB(TrackerPreheat preheat, List<Entity<T>> entities) {
-                // TODO(DHIS2-14213) mocking of preheat.exists( dto) does not work if the dto is not of the same instance
-                // makes sense but is annoying; so I have to write preheat.exists( parent.getTrackerType(), parent.getUid())
-                // for now
                 entities.stream()
                     .filter(e -> e.isInDB)
                     .map(e -> e.entity)
-                    .forEach(e -> {
-                        when( preheat.exists( e.getTrackerType(), e.getUid() ) ).thenReturn( true);
-                        when( preheat.exists( e) ).thenReturn( true);
-                    });
+                    .forEach(e -> when( preheat.exists( argThat(t -> t != null && e.getTrackerType() == t.getTrackerType() && e.getUid().equals(t.getUid()))) ).thenReturn( true));
             }
 
             /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -96,7 +96,6 @@ class PersistablesFilterTest
         );
     }
 
-    // TODO(DHIS2-14213) also test relationship
     @Test
     void testCreateAndUpdateValidEntitiesReferencingParentsNotInPayload()
     {
@@ -106,11 +105,10 @@ class PersistablesFilterTest
                     .enrollment( "t1zaUjKgT3p")
                 .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
                     .event( "Ox1qBWsnVwE" )
+                .relationship("Te3IC6TpnBB",
+                        trackedEntity("xK7H53f4Hc2"),
+                        enrollment("Ok4Fe5moc3N") )
                 .build();
-//                .relationship("Te3IC6TpnBB",
-//                        trackedEntity("xK7H53f4Hc2"),
-//                        trackedEntity("QxGbKYwChDM")
-//                );
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
                 TrackerImportStrategy.CREATE_AND_UPDATE );
@@ -119,63 +117,8 @@ class PersistablesFilterTest
                 () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
                 () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p"),
                 () -> assertContainsOnly( persistable, Event.class,  "Ox1qBWsnVwE"),
-//                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
                 () -> assertIsEmpty( persistable.getErrors())
-        );
-    }
-
-    // TODO(DHIS2-14213) move to delete tests
-    @Test
-    void testDeleteValidEntitiesReferencingParentsNotInPayload()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
-                    .enrollment( "t1zaUjKgT3p")
-                .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
-                    .event( "Ox1qBWsnVwE" )
-                .build();
-//                .relationship("Te3IC6TpnBB",
-//                        trackedEntity("xK7H53f4Hc2"),
-//                        trackedEntity("QxGbKYwChDM")
-//                );
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-                TrackerImportStrategy.DELETE );
-
-        assertAll(
-                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
-                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p"),
-                () -> assertContainsOnly( persistable, Event.class,  "Ox1qBWsnVwE"),
-//                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
-                () -> assertIsEmpty( persistable.getErrors())
-        );
-    }
-
-    @Test
-    void testDeleteInvalidEntitiesReferencingParentsNotInPayload()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
-                    .enrollment( "t1zaUjKgT3p").isNotValid()
-                .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload() // TODO(DHIS2-14213) could there be a case where a parent of a parent has a reference? second if
-                    .event( "Ox1qBWsnVwE" ).isNotValid()
-                .build();
-//                .relationship("Te3IC6TpnBB",
-//                        trackedEntity("xK7H53f4Hc2"),
-//                        trackedEntity("QxGbKYwChDM")
-//                );
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-                TrackerImportStrategy.DELETE );
-
-        assertAll(
-                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
-                () -> assertIsEmpty(persistable.get(Enrollment.class)),
-                () -> assertIsEmpty(persistable.get(Event.class)),
-                () -> assertIsEmpty(persistable.get(Relationship.class)),
-                () -> assertNoErrorWithCode( persistable, E5001)
         );
     }
 
@@ -550,6 +493,9 @@ class PersistablesFilterTest
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
                     .enrollment( "t1zaUjKgT3p" ).isNotValid()
+                .relationship("Te3IC6TpnBB",
+                        trackedEntity("xK7H53f4Hc2"),
+                        enrollment("t1zaUjKgT3p") ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -658,6 +604,32 @@ class PersistablesFilterTest
                 () -> assertIsEmpty(persistable.get(Enrollment.class)),
                 () -> assertContainsOnly( persistable, Event.class, "QxGbKYwChDM"),
                 () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB")
+        );
+    }
+
+    @Test
+    void testDeleteValidEntitiesReferencingParentsNotInPayload()
+    {
+        // @formatter:off
+        Setup setup = new Setup.Builder()
+                .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
+                .enrollment( "t1zaUjKgT3p")
+                .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
+                .event( "Ox1qBWsnVwE" )
+                .relationship("Te3IC6TpnBB",
+                        trackedEntity("xK7H53f4Hc2"),
+                        enrollment("Ok4Fe5moc3N") )
+                .build();
+
+        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p"),
+                () -> assertContainsOnly( persistable, Event.class,  "Ox1qBWsnVwE"),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
         );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -144,23 +144,6 @@ class PersistablesFilterTest
     }
 
     @Test
-    void testCreateAndUpdateInvalidTeiCannotBePersisted()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
-            .build();
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-            TrackerImportStrategy.CREATE_AND_UPDATE );
-
-        assertAll(
-                () -> assertIsEmpty( persistable.get( TrackedEntity.class ) ),
-                () -> assertIsEmpty( persistable.getErrors())
-        );
-    }
-
-    @Test
     void testCreateAndUpdateValidEnrollmentOfInvalidTeiCanBeUpdatedIfTeiExists()
     {
         // @formatter:off
@@ -195,25 +178,6 @@ class PersistablesFilterTest
                 () -> assertIsEmpty( persistable.get( TrackedEntity.class ) ),
                 () -> assertIsEmpty( persistable.get( Enrollment.class ) ),
                 () -> assertError(persistable, E5000, ENROLLMENT, "t1zaUjKgT3p", "because \"trackedEntity\" `xK7H53f4Hc2`")
-        );
-    }
-
-    @Test
-    void testCreateAndUpdateInvalidEnrollmentOfValidTeiCannotBePersisted()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" ).isNotValid()
-            .build();
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-            TrackerImportStrategy.CREATE_AND_UPDATE );
-
-        assertAll(
-                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2" ),
-                () -> assertIsEmpty( persistable.get( Enrollment.class ) ),
-                () -> assertIsEmpty( persistable.getErrors())
         );
     }
 
@@ -319,28 +283,6 @@ class PersistablesFilterTest
 
         assertAll(
                 () -> assertContainsOnly( persistable, TrackedEntity.class,  "QxGbKYwChDM" ),
-                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
-                () -> assertIsEmpty( persistable.getErrors())
-        );
-    }
-
-    @Test
-    void testCreateAndUpdateValidRelationshipWithInvalidButExistingTo()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" )
-                .trackedEntity( "QxGbKYwChDM" ).isNotValid().isInDB()
-                .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    trackedEntity("QxGbKYwChDM") )
-                .build();
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-                TrackerImportStrategy.CREATE_AND_UPDATE );
-
-        assertAll(
-                () -> assertContainsOnly( persistable, TrackedEntity.class,  "xK7H53f4Hc2" ),
                 () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
                 () -> assertIsEmpty( persistable.getErrors())
         );
@@ -470,27 +412,6 @@ class PersistablesFilterTest
     }
 
     @Test
-    void testDeleteValidTrackedEntityOfInvalidEnrollmentCannotBeDeleted()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" )
-                    .enrollment( "t1zaUjKgT3p" ).isNotValid()
-                        .event( "Qck4PQ7TMun" )
-                .build();
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-                TrackerImportStrategy.DELETE );
-
-        assertAll(
-                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
-                () -> assertIsEmpty(persistable.get(Enrollment.class)),
-                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun"),
-                () -> assertError(persistable, E5001, TRACKED_ENTITY, "xK7H53f4Hc2", "because \"enrollment\" `t1zaUjKgT3p`")
-        );
-    }
-
-    @Test
     void testDeleteOnlyReportErrorsIfItAddsNewInformation()
     {
         // If entities are found to be invalid during the validation an error for the entity will already be in the
@@ -517,52 +438,31 @@ class PersistablesFilterTest
     }
 
     @Test
-    void testDeleteValidTrackedEntityAndEnrollmentWithInvalidEventCannotBeDeleted()
-    {
-        // @formatter:off
-        Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" )
-                    .enrollment( "t1zaUjKgT3p" )
-                        .event( "Qck4PQ7TMun" ).isNotValid()
-                        .event( "Ox1qBWsnVwE" )
-                .build();
-
-        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
-                TrackerImportStrategy.DELETE );
-
-        assertAll(
-                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
-                () -> assertIsEmpty(persistable.get(Enrollment.class)),
-                () -> assertContainsOnly( persistable, Event.class, "Ox1qBWsnVwE"),
-                () -> assertError(persistable, E5001, TRACKED_ENTITY, "xK7H53f4Hc2", "because \"enrollment\" `t1zaUjKgT3p`"),
-                () -> assertError(persistable, E5001, ENROLLMENT, "t1zaUjKgT3p", "because \"event\" `Qck4PQ7TMun`")
-        );
-    }
-
-    @Test
     void testDeleteInvalidRelationshipPreventsDeletionOfTrackedEntityAndEvent()
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
                     .enrollment( "t1zaUjKgT3p" )
-                        .event( "QxGbKYwChDM" )
+                        .event( "Qck4PQ7TMun" )
+                .trackedEntity( "QxGbKYwChDM" )
+                    .enrollment( "Ok4Fe5moc3N" )
                 .relationship("Te3IC6TpnBB",
                         trackedEntity("xK7H53f4Hc2"),
-                        event("QxGbKYwChDM") ).isNotValid()
+                        event("Qck4PQ7TMun") ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
                 TrackerImportStrategy.DELETE );
 
         assertAll(
-                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
-                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "QxGbKYwChDM"),
+                () -> assertContainsOnly( persistable, Enrollment.class, "Ok4Fe5moc3N"),
                 () -> assertIsEmpty(persistable.get(Event.class)),
                 () -> assertIsEmpty(persistable.get(Relationship.class)),
                 () -> assertError(persistable, E5001, TRACKED_ENTITY, "xK7H53f4Hc2", "because \"relationship\" `Te3IC6TpnBB`"),
-                () -> assertError(persistable, E5001, ENROLLMENT, "t1zaUjKgT3p", "because \"event\" `QxGbKYwChDM`"),
-                () -> assertError(persistable, E5001, EVENT, "QxGbKYwChDM", "because \"relationship\" `Te3IC6TpnBB`")
+                () -> assertError(persistable, E5001, ENROLLMENT, "t1zaUjKgT3p", "because \"event\" `Qck4PQ7TMun`"),
+                () -> assertError(persistable, E5001, EVENT, "Qck4PQ7TMun", "because \"relationship\" `Te3IC6TpnBB`")
         );
     }
 
@@ -574,6 +474,8 @@ class PersistablesFilterTest
                 .trackedEntity( "xK7H53f4Hc2" )
                     .enrollment( "t1zaUjKgT3p" )
                         .event( "QxGbKYwChDM" )
+                        .event( "Ox1qBWsnVwE" )
+                    .enrollment( "Ok4Fe5moc3N" )
                 .relationship("Te3IC6TpnBB",
                         event("QxGbKYwChDM"),
                         enrollment("t1zaUjKgT3p") ).isNotValid()
@@ -584,8 +486,8 @@ class PersistablesFilterTest
 
         assertAll(
                 () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
-                () -> assertIsEmpty(persistable.get(Enrollment.class)),
-                () -> assertIsEmpty(persistable.get(Event.class)),
+                () -> assertContainsOnly( persistable, Enrollment.class, "Ok4Fe5moc3N"),
+                () -> assertContainsOnly( persistable, Event.class, "Ox1qBWsnVwE"),
                 () -> assertIsEmpty(persistable.get(Relationship.class)),
                 () -> assertError(persistable, E5001, ENROLLMENT, "t1zaUjKgT3p", "because \"relationship\" `Te3IC6TpnBB`"),
                 () -> assertError(persistable, E5001, EVENT, "QxGbKYwChDM", "because \"relationship\" `Te3IC6TpnBB`")

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -64,11 +64,8 @@ import org.junit.jupiter.api.Test;
 
 class PersistablesFilterTest
 {
-    // TODO get rid of compiler warnings
-
-    // TODO run all tests with everything wired up
-
-    // TODO mocking of preheat.exists( dto) does not work if the dto is not of the same instance
+    // TODO(DHIS2-14213) get rid of compiler warnings
+    // TODO(DHIS2-14213) mocking of preheat.exists( dto) does not work if the dto is not of the same instance
     // makes sense but is annoying; so I have to write preheat.exists( parent.getTrackerType(), parent.getUid())
     // for now
 
@@ -101,8 +98,8 @@ class PersistablesFilterTest
         );
     }
 
-    // TODO find an alternative to the boolean flag
-    // TODO also test relationship
+    // TODO(DHIS2-14213) find an alternative to the boolean flag
+    // TODO(DHIS2-14213) also test relationship
     @Test
     void testCreateAndUpdateValidEntitiesReferencingParentsNotInPayload()
     {
@@ -129,7 +126,7 @@ class PersistablesFilterTest
         );
     }
 
-    // TODO move to delete tests
+    // TODO(DHIS2-14213) move to delete tests
     @Test
     void testDeleteValidEntitiesReferencingParentsNotInPayload()
     {
@@ -163,7 +160,7 @@ class PersistablesFilterTest
         Setup setup = new Setup()
                 .trackedEntity( "xK7H53f4Hc2", true ).isExisting()
                     .enrollment( "t1zaUjKgT3p").isInvalid()
-                .enrollment( "Ok4Fe5moc3N", true).isExisting() // TODO could there be a case where a parent of a parent has a reference? second if
+                .enrollment( "Ok4Fe5moc3N", true).isExisting() // TODO(DHIS2-14213) could there be a case where a parent of a parent has a reference? second if
                     .event( "Ox1qBWsnVwE" ).isInvalid();
 //                .relationship("Te3IC6TpnBB",
 //                        trackedEntity("xK7H53f4Hc2"),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -102,9 +102,9 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" ).isExisting().isNotInPayload()
+                .trackedEntity( "xK7H53f4Hc2" ).isInDB().isNotInPayload()
                     .enrollment( "t1zaUjKgT3p")
-                .enrollment( "Ok4Fe5moc3N").isExisting().isNotInPayload()
+                .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
                     .event( "Ox1qBWsnVwE" )
                 .build();
 //                .relationship("Te3IC6TpnBB",
@@ -130,9 +130,9 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2").isExisting().isNotInPayload()
+                .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
                     .enrollment( "t1zaUjKgT3p")
-                .enrollment( "Ok4Fe5moc3N").isExisting().isNotInPayload()
+                .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload()
                     .event( "Ox1qBWsnVwE" )
                 .build();
 //                .relationship("Te3IC6TpnBB",
@@ -157,10 +157,10 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2").isExisting().isNotInPayload()
-                    .enrollment( "t1zaUjKgT3p").isInvalid()
-                .enrollment( "Ok4Fe5moc3N").isExisting().isNotInPayload() // TODO(DHIS2-14213) could there be a case where a parent of a parent has a reference? second if
-                    .event( "Ox1qBWsnVwE" ).isInvalid()
+                .trackedEntity( "xK7H53f4Hc2").isInDB().isNotInPayload()
+                    .enrollment( "t1zaUjKgT3p").isNotValid()
+                .enrollment( "Ok4Fe5moc3N").isInDB().isNotInPayload() // TODO(DHIS2-14213) could there be a case where a parent of a parent has a reference? second if
+                    .event( "Ox1qBWsnVwE" ).isNotValid()
                 .build();
 //                .relationship("Te3IC6TpnBB",
 //                        trackedEntity("xK7H53f4Hc2"),
@@ -184,9 +184,9 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isExisting()
-                .enrollment( "t1zaUjKgT3p" ).isExisting()
-                    .event( "Qck4PQ7TMun" ).isExisting()
+            .trackedEntity( "xK7H53f4Hc2" ).isInDB()
+                .enrollment( "t1zaUjKgT3p" ).isInDB()
+                    .event( "Qck4PQ7TMun" ).isInDB()
             .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -205,7 +205,7 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
+            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
             .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -222,7 +222,7 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isInvalid().isExisting()
+            .trackedEntity( "xK7H53f4Hc2" ).isNotValid().isInDB()
                 .enrollment( "t1zaUjKgT3p" )
             .build();
 
@@ -241,7 +241,7 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-            .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
+            .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
                 .enrollment( "t1zaUjKgT3p" )
             .build();
 
@@ -261,7 +261,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
             .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                .enrollment( "t1zaUjKgT3p" ).isNotValid()
             .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -280,7 +280,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
             .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" ).isInvalid().isExisting()
+                .enrollment( "t1zaUjKgT3p" ).isNotValid().isInDB()
                     .event( "Qck4PQ7TMun" )
             .build();
 
@@ -301,7 +301,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
             .trackedEntity( "xK7H53f4Hc2" )
-                .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                .enrollment( "t1zaUjKgT3p" ).isNotValid()
                     .event( "Qck4PQ7TMun" )
             .build();
 
@@ -323,7 +323,7 @@ class PersistablesFilterTest
         Setup setup = new Setup.Builder()
             .trackedEntity( "xK7H53f4Hc2" )
                 .enrollment( "t1zaUjKgT3p" )
-                    .event( "Qck4PQ7TMun" ).isInvalid()
+                    .event( "Qck4PQ7TMun" ).isNotValid()
             .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -343,9 +343,9 @@ class PersistablesFilterTest
         // @formatter:off
         // an event in an event program does not have an enrollment set (even though technically its enrolled in a default program)
         Setup setup = new Setup.Builder()
-            .eventWithoutRegistration( "Qck4PQ7TMun" ).isInvalid()
-            .eventWithoutRegistration( "Ok4Fe5moc3N" ).isExisting()
-            .eventWithoutRegistration( "nVjkL7qHYvL" ).isExisting().isInvalid()
+            .eventWithoutRegistration( "Qck4PQ7TMun" ).isNotValid()
+            .eventWithoutRegistration( "Ok4Fe5moc3N" ).isInDB()
+            .eventWithoutRegistration( "nVjkL7qHYvL" ).isInDB().isNotValid()
             .eventWithoutRegistration( "MeC1UpOX4Wu" )
             .build();
 
@@ -367,7 +367,7 @@ class PersistablesFilterTest
                 .trackedEntity( "QxGbKYwChDM" )
                 .relationship("Te3IC6TpnBB",
                     trackedEntity("xK7H53f4Hc2"),
-                    trackedEntity("QxGbKYwChDM")).isInvalid()
+                    trackedEntity("QxGbKYwChDM")).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -385,7 +385,7 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" ).isInvalid().isExisting()
+                .trackedEntity( "xK7H53f4Hc2" ).isNotValid().isInDB()
                 .trackedEntity( "QxGbKYwChDM" )
                 .relationship("Te3IC6TpnBB",
                     trackedEntity("xK7H53f4Hc2"),
@@ -408,7 +408,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
-                .trackedEntity( "QxGbKYwChDM" ).isInvalid().isExisting()
+                .trackedEntity( "QxGbKYwChDM" ).isNotValid().isInDB()
                 .relationship("Te3IC6TpnBB",
                     trackedEntity("xK7H53f4Hc2"),
                     trackedEntity("QxGbKYwChDM") )
@@ -430,7 +430,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
-                    .enrollment( "QxGbKYwChDM" ).isInvalid()
+                    .enrollment( "QxGbKYwChDM" ).isNotValid()
                 .relationship("Te3IC6TpnBB",
                     enrollment("QxGbKYwChDM"),
                     trackedEntity("xK7H53f4Hc2") )
@@ -452,7 +452,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
-                .eventWithoutRegistration( "QxGbKYwChDM" ).isInvalid()
+                .eventWithoutRegistration( "QxGbKYwChDM" ).isNotValid()
                 .relationship("Te3IC6TpnBB",
                     trackedEntity("xK7H53f4Hc2"),
                     event("QxGbKYwChDM") )
@@ -502,7 +502,7 @@ class PersistablesFilterTest
     {
         // @formatter:off
         Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
+                .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
                     .enrollment( "t1zaUjKgT3p" )
                         .event( "Qck4PQ7TMun" )
                         .event( "Ox1qBWsnVwE" )
@@ -525,7 +525,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
-                    .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                    .enrollment( "t1zaUjKgT3p" ).isNotValid()
                         .event( "Qck4PQ7TMun" )
                 .build();
 
@@ -548,8 +548,8 @@ class PersistablesFilterTest
 
         // @formatter:off
         Setup setup = new Setup.Builder()
-                .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
-                    .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
+                    .enrollment( "t1zaUjKgT3p" ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -569,7 +569,7 @@ class PersistablesFilterTest
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
                     .enrollment( "t1zaUjKgT3p" )
-                        .event( "Qck4PQ7TMun" ).isInvalid()
+                        .event( "Qck4PQ7TMun" ).isNotValid()
                         .event( "Ox1qBWsnVwE" )
                 .eventWithoutRegistration("G9cH8AVvguf")
                 .build();
@@ -595,7 +595,7 @@ class PersistablesFilterTest
                 .eventWithoutRegistration( "QxGbKYwChDM" )
                 .relationship("Te3IC6TpnBB",
                         trackedEntity("xK7H53f4Hc2"),
-                        event("QxGbKYwChDM") ).isInvalid()
+                        event("QxGbKYwChDM") ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -621,7 +621,7 @@ class PersistablesFilterTest
                         .event( "QxGbKYwChDM" )
                 .relationship("Te3IC6TpnBB",
                         event("QxGbKYwChDM"),
-                        enrollment("t1zaUjKgT3p") ).isInvalid()
+                        enrollment("t1zaUjKgT3p") ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -643,7 +643,7 @@ class PersistablesFilterTest
         // @formatter:off
         Setup setup = new Setup.Builder()
                 .trackedEntity( "xK7H53f4Hc2" )
-                    .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                    .enrollment( "t1zaUjKgT3p" ).isNotValid()
                 .eventWithoutRegistration( "QxGbKYwChDM" )
                 .relationship("Te3IC6TpnBB",
                         enrollment("t1zaUjKgT3p"),
@@ -684,7 +684,7 @@ class PersistablesFilterTest
          * Adding an entity with methods like {@link #trackedEntity(String)} always assumes the
          * entity is valid and does not yet exist.
          * <p>
-         * Call {@link #isInvalid()} or {@link #isExisting()} to mark the current
+         * Call {@link #isNotValid()} or {@link #isInDB()} to mark the current
          * entity as invalid or existing. You need to make sure to add entities in
          * the right order (hierarchy) otherwise you'll get NPE. This means that you
          * cannot add an {@link #enrollment(String)} without first adding a
@@ -702,7 +702,7 @@ class PersistablesFilterTest
 
             /**
              * Keeps track of the current entity that can be set to
-             * {@link #isInvalid()} or {@link #isExisting()}.
+             * {@link #isNotValid()}, {@link #isNotInPayload()} or {@link #isInDB()}.
              */
             private Entity<? extends TrackerDto> current;
 
@@ -718,6 +718,16 @@ class PersistablesFilterTest
              */
             private Entity<Enrollment> currentEnrollment;
 
+            /**
+             * Build a tracked entity.
+             * <p>
+             * Configure it using calls to {@link #isInDB()}, {@link #isNotValid()} or {@link #isNotInPayload()}.
+             * Attach enrollments by calling {@link #enrollment(String)}.
+             * </p>
+             *
+             * @param uid uid of tracked entity
+             * @return builder
+             */
             Builder trackedEntity(String uid) {
                 Entity<TrackedEntity> entity = new Entity<>(TrackedEntity.builder().trackedEntity(uid).build());
                 this.trackedEntities.add(entity);
@@ -727,13 +737,17 @@ class PersistablesFilterTest
             }
 
             /**
-             * Add an enrollment to the payload with the {@link #currentTrackedEntity} as its parent which is also in the payload.
+             * Build an enrollment with the {@link #currentTrackedEntity} as its parent.
              * <p>
              * <b>Requires call</b> to {@link #trackedEntity(String)} first.
              * </p>
+             * <p>
+             * Configure it using calls to {@link #isInDB()}, {@link #isNotValid()} or {@link #isNotInPayload()}.
+             * Attach events by calling {@link #event(String)}.
+             * </p>
              *
              * @param uid uid of enrollment
-             * @return setup
+             * @return builder
              */
             Builder enrollment( String uid )
             {
@@ -752,6 +766,18 @@ class PersistablesFilterTest
                 return new Entity<>(enrollment);
             }
 
+            /**
+             * Build an event with the {@link #currentEnrollment} as its parent.
+             * <p>
+             * <b>Requires call</b> to {@link #enrollment(String)} first.
+             * </p>
+             * <p>
+             * Configure it using calls to {@link #isInDB()}, {@link #isNotValid()} or {@link #isNotInPayload()}.
+             * </p>
+             *
+             * @param uid uid of event
+             * @return builder
+             */
             Builder event( String uid )
             {
                 Entity<Event> entity = event( uid, currentEnrollment );
@@ -760,6 +786,15 @@ class PersistablesFilterTest
                 return this;
             }
 
+            /**
+             * Build an event without an enrollment as parent.
+             * <p>
+             * Configure it using calls to {@link #isInDB()}, {@link #isNotValid()} or {@link #isNotInPayload()}.
+             * </p>
+             *
+             * @param uid uid of event
+             * @return builder
+             */
             Builder eventWithoutRegistration( String uid )
             {
                 Entity<Event> entity = event( uid, currentEnrollment );
@@ -790,6 +825,19 @@ class PersistablesFilterTest
                 return new Entity<>(event);
             }
 
+            /**
+             * Build a relationship.
+             * <p>
+             * Configure it using calls to {@link #isInDB()}, {@link #isNotValid()} or {@link #isNotInPayload()}.
+             * Set {@code from} and {@code to} via {@link PersistablesFilterTest#trackedEntity(String)}, {@link PersistablesFilterTest#enrollment(String)} or {@link PersistablesFilterTest#event(String)}.
+             * Note: the entities you reference by UID in the from and to need to be setup using {@link #trackedEntity(String)}, {@link #enrollment(String)} or {@link #event(String)}.
+             * </p>
+             *
+             * @param uid uid of relationship
+             * @param from relationship item from
+             * @param to relationship item to
+             * @return builder
+             */
             Builder relationship(String uid, RelationshipItem from, RelationshipItem to) {
                 Relationship relationship = Relationship.builder()
                         .relationship(uid)
@@ -798,22 +846,20 @@ class PersistablesFilterTest
                         .build();
                 Entity<Relationship> entity = new Entity<>(relationship);
                 this.relationships.add(entity);
-                // set cursors
                 current = entity;
                 return this;
             }
 
-            // TODO(DHIS2-14213) return something? Maybe I need a setup builder and on build I return the setup with the args and mocks and so on
             private Setup build() {
                 TrackerPreheat preheat = mock( TrackerPreheat.class );
                 TrackerBundle bundle = TrackerBundle.builder().preheat(preheat).build();
-                EnumMap<TrackerType, Set<String>> invalidEntities = PersistablesFilterTest.invalidEntities();
 
                 bundle.setTrackedEntities( toEntitiesInPayload(trackedEntities));
                 bundle.setEnrollments( toEntitiesInPayload(enrollments));
                 bundle.setEvents( toEntitiesInPayload(events));
                 bundle.setRelationships( toEntitiesInPayload(relationships));
 
+                EnumMap<TrackerType, Set<String>> invalidEntities = PersistablesFilterTest.invalidEntities();
                 invalidEntities.get(TRACKED_ENTITY).addAll(invalid(trackedEntities));
                 invalidEntities.get(ENROLLMENT).addAll(invalid(enrollments));
                 invalidEntities.get(EVENT).addAll(invalid(events));
@@ -859,7 +905,7 @@ class PersistablesFilterTest
              *
              * @return this setup
              */
-            Builder isInvalid()
+            Builder isNotValid()
             {
                 this.current.valid = false;
                 return this;
@@ -871,14 +917,14 @@ class PersistablesFilterTest
              *
              * @return this setup
              */
-            Builder isExisting()
+            Builder isInDB()
             {
                 this.current.isInDB = true;
                 return this;
             }
 
             /**
-             * Exlude {@link #current} {@link TrackerDto} from the {@link #bundle}.
+             * Exclude {@link #current} {@link TrackerDto} from the {@link #bundle}.
              *
              * @return this setup
              */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -252,8 +252,9 @@ class PersistablesFilterTest
                 .trackedEntity( "xK7H53f4Hc2" )
                 .trackedEntity( "QxGbKYwChDM" )
                 .relationship("Te3IC6TpnBB",
-                    trackedEntity("xK7H53f4Hc2"),
-                    trackedEntity("QxGbKYwChDM")).isNotValid()
+                        trackedEntity("xK7H53f4Hc2"),
+                        trackedEntity("QxGbKYwChDM")
+                    ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -346,7 +347,8 @@ class PersistablesFilterTest
                 .enrollment( "t1zaUjKgT3p" ).isNotValid()
                 .relationship("Te3IC6TpnBB",
                         trackedEntity("xK7H53f4Hc2"),
-                        enrollment("t1zaUjKgT3p") ).isNotValid()
+                        enrollment("t1zaUjKgT3p")
+                    ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -423,7 +425,8 @@ class PersistablesFilterTest
                     .enrollment( "t1zaUjKgT3p" ).isNotValid()
                 .relationship("Te3IC6TpnBB",
                         trackedEntity("xK7H53f4Hc2"),
-                        enrollment("t1zaUjKgT3p") ).isNotValid()
+                        enrollment("t1zaUjKgT3p")
+                    ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -449,7 +452,8 @@ class PersistablesFilterTest
                     .enrollment( "Ok4Fe5moc3N" )
                 .relationship("Te3IC6TpnBB",
                         trackedEntity("xK7H53f4Hc2"),
-                        event("Qck4PQ7TMun") ).isNotValid()
+                        event("Qck4PQ7TMun")
+                    ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
@@ -478,7 +482,8 @@ class PersistablesFilterTest
                     .enrollment( "Ok4Fe5moc3N" )
                 .relationship("Te3IC6TpnBB",
                         event("QxGbKYwChDM"),
-                        enrollment("t1zaUjKgT3p") ).isNotValid()
+                        enrollment("t1zaUjKgT3p")
+                    ).isNotValid()
                 .build();
 
         PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -1,0 +1,886 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import static org.hisp.dhis.tracker.TrackerType.ENROLLMENT;
+import static org.hisp.dhis.tracker.TrackerType.EVENT;
+import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
+import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E5000;
+import static org.hisp.dhis.tracker.report.TrackerErrorCode.E5001;
+import static org.hisp.dhis.tracker.validation.PersistablesFilter.filter;
+import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasError;
+import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasNoErrorWithCode;
+import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.RelationshipItem;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.domain.TrackerDto;
+import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.utils.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PersistablesFilterTest
+{
+    // TODO get rid of compiler warnings
+
+    // TODO run all tests with everything wired up
+
+    // TODO mocking of preheat.exists( dto) does not work if the dto is not of the same instance
+    // makes sense but is annoying; so I have to write preheat.exists( parent.getTrackerType(), parent.getUid())
+    // for now
+
+    @Test
+    void testCreateAndUpdateValidEntitiesCanBePersisted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" )
+                    .event( "Qck4PQ7TMun" )
+            .trackedEntity( "QxGbKYwChDM" )
+                .enrollment( "Ok4Fe5moc3N" )
+                    .event( "Ox1qBWsnVwE" )
+                    .event( "jNyGqnwryNi" )
+            .relationship("Te3IC6TpnBB",
+                trackedEntity("xK7H53f4Hc2"),
+                trackedEntity("QxGbKYwChDM")
+            );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2", "QxGbKYwChDM" ),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p", "Ok4Fe5moc3N" ),
+                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun", "Ox1qBWsnVwE", "jNyGqnwryNi" ),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    // TODO find an alternative to the boolean flag
+    // TODO also test relationship
+    @Test
+    void testCreateAndUpdateValidEntitiesReferencingParentsNotInPayload()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2", true ).isExisting()
+                    .enrollment( "t1zaUjKgT3p")
+                .enrollment( "Ok4Fe5moc3N", true).isExisting()
+                    .event( "Ox1qBWsnVwE" );
+//                .relationship("Te3IC6TpnBB",
+//                        trackedEntity("xK7H53f4Hc2"),
+//                        trackedEntity("QxGbKYwChDM")
+//                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p"),
+                () -> assertContainsOnly( persistable, Event.class,  "Ox1qBWsnVwE"),
+//                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    // TODO move to delete tests
+    @Test
+    void testDeleteValidEntitiesReferencingParentsNotInPayload()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2", true ).isExisting()
+                    .enrollment( "t1zaUjKgT3p")
+                .enrollment( "Ok4Fe5moc3N", true).isExisting()
+                    .event( "Ox1qBWsnVwE" );
+//                .relationship("Te3IC6TpnBB",
+//                        trackedEntity("xK7H53f4Hc2"),
+//                        trackedEntity("QxGbKYwChDM")
+//                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p"),
+                () -> assertContainsOnly( persistable, Event.class,  "Ox1qBWsnVwE"),
+//                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testDeleteInvalidEntitiesReferencingParentsNotInPayload()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2", true ).isExisting()
+                    .enrollment( "t1zaUjKgT3p").isInvalid()
+                .enrollment( "Ok4Fe5moc3N", true).isExisting() // TODO could there be a case where a parent of a parent has a reference? second if
+                    .event( "Ox1qBWsnVwE" ).isInvalid();
+//                .relationship("Te3IC6TpnBB",
+//                        trackedEntity("xK7H53f4Hc2"),
+//                        trackedEntity("QxGbKYwChDM")
+//                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertIsEmpty(persistable.get(Event.class)),
+                () -> assertIsEmpty(persistable.get(Relationship.class)),
+                () -> assertNoErrorWithCode( persistable, E5001)
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidEntitiesCanBePersistedIfTheyExist()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" ).isExisting()
+                .enrollment( "t1zaUjKgT3p" ).isExisting()
+                    .event( "Qck4PQ7TMun" ).isExisting();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2" ),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p" ),
+                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun" ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateInvalidTeiCannotBePersisted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertIsEmpty( persistable.get( TrackedEntity.class ) ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidEnrollmentOfInvalidTeiCanBeUpdatedIfTeiExists()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" ).isInvalid().isExisting()
+                .enrollment( "t1zaUjKgT3p" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertIsEmpty( persistable.get( TrackedEntity.class ) ),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p" ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidEnrollmentOfInvalidTeiCannotBeUpdatedIfTeiDoesNotExist()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
+                .enrollment( "t1zaUjKgT3p" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertIsEmpty( persistable.get( TrackedEntity.class ) ),
+                () -> assertIsEmpty( persistable.get( Enrollment.class ) ),
+                () -> assertError(persistable, E5000, ENROLLMENT, "t1zaUjKgT3p", "because \"trackedEntity\" `xK7H53f4Hc2`")
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateInvalidEnrollmentOfValidTeiCannotBePersisted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2" ),
+                () -> assertIsEmpty( persistable.get( Enrollment.class ) ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidEventOfInvalidEnrollmentCanBeUpdatedIfEnrollmentExists()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" ).isInvalid().isExisting()
+                    .event( "Qck4PQ7TMun" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2" ),
+                () -> assertIsEmpty( persistable.get( Enrollment.class ) ),
+                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun" ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidEventOfInvalidEnrollmentCannotBeCreatedIfEnrollmentDoesNotExist()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                    .event( "Qck4PQ7TMun" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2" ),
+                () -> assertIsEmpty( persistable.get( Enrollment.class ) ),
+                () -> assertIsEmpty( persistable.get( Event.class ) ),
+                () -> assertError(persistable, E5000, EVENT, "Qck4PQ7TMun", "because \"enrollment\" `t1zaUjKgT3p`")
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateInvalidEventOfValidEnrollmentCannotBePersisted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+            .trackedEntity( "xK7H53f4Hc2" )
+                .enrollment( "t1zaUjKgT3p" )
+                    .event( "Qck4PQ7TMun" ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2" ),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p" ),
+                () -> assertIsEmpty( persistable.get( Event.class ) ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidEventWithoutEnrollment()
+    {
+        // @formatter:off
+        // an event in an event program does not have an enrollment set (even though technically its enrolled in a default program)
+        Setup setup = new Setup()
+            .eventWithoutRegistration( "Qck4PQ7TMun" ).isInvalid()
+            .eventWithoutRegistration( "Ok4Fe5moc3N" ).isExisting()
+            .eventWithoutRegistration( "nVjkL7qHYvL" ).isExisting().isInvalid()
+            .eventWithoutRegistration( "MeC1UpOX4Wu" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+            TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, Event.class, "Ok4Fe5moc3N", "MeC1UpOX4Wu" ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateInvalidRelationshipCannotBePersisted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                .trackedEntity( "QxGbKYwChDM" )
+                .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    trackedEntity("QxGbKYwChDM")
+                ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2", "QxGbKYwChDM" ),
+                () -> assertIsEmpty( persistable.get( Relationship.class ) ),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidRelationshipWithInvalidButExistingFrom()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" ).isInvalid().isExisting()
+                .trackedEntity( "QxGbKYwChDM" )
+                .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    trackedEntity("QxGbKYwChDM")
+                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class,  "QxGbKYwChDM" ),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidRelationshipWithInvalidButExistingTo()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                .trackedEntity( "QxGbKYwChDM" ).isInvalid().isExisting()
+                .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    trackedEntity("QxGbKYwChDM")
+                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class,  "xK7H53f4Hc2" ),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidRelationshipWithInvalidFromCannotBeCreated()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                    .enrollment( "QxGbKYwChDM" ).isInvalid()
+                .relationship("Te3IC6TpnBB",
+                    enrollment("QxGbKYwChDM"),
+                    trackedEntity("xK7H53f4Hc2")
+                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class,  "xK7H53f4Hc2" ),
+                () -> assertIsEmpty( persistable.get( Relationship.class ) ),
+                () -> assertError(persistable, E5000, RELATIONSHIP, "Te3IC6TpnBB", "because \"enrollment\" `QxGbKYwChDM`")
+        );
+    }
+
+    @Test
+    void testCreateAndUpdateValidRelationshipWithInvalidToCannotBeCreated()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                .eventWithoutRegistration( "QxGbKYwChDM" ).isInvalid()
+                .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    event("QxGbKYwChDM")
+                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class,  "xK7H53f4Hc2" ),
+                () -> assertIsEmpty( persistable.get( Relationship.class ) ),
+                () -> assertError(persistable, E5000, RELATIONSHIP, "Te3IC6TpnBB", "because \"event\" `QxGbKYwChDM`")
+        );
+    }
+
+    @Test
+    void testDeleteValidEntitiesCanBeDeleted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                    .enrollment( "t1zaUjKgT3p" )
+                        .event( "Qck4PQ7TMun" )
+                .trackedEntity( "QxGbKYwChDM" )
+                    .enrollment( "Ok4Fe5moc3N" )
+                        .event( "Ox1qBWsnVwE" )
+                        .event( "jNyGqnwryNi" )
+                .relationship("Te3IC6TpnBB",
+                    trackedEntity("xK7H53f4Hc2"),
+                    trackedEntity("QxGbKYwChDM")
+                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertContainsOnly( persistable, TrackedEntity.class, "xK7H53f4Hc2", "QxGbKYwChDM" ),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p", "Ok4Fe5moc3N" ),
+                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun", "Ox1qBWsnVwE", "jNyGqnwryNi" ),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testDeleteInvalidTrackedEntityCannotBeDeletedButItsChildrenCan()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
+                    .enrollment( "t1zaUjKgT3p" )
+                        .event( "Qck4PQ7TMun" )
+                        .event( "Ox1qBWsnVwE" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertContainsOnly( persistable, Enrollment.class, "t1zaUjKgT3p"),
+                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun", "Ox1qBWsnVwE"),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testDeleteValidTrackedEntityOfInvalidEnrollmentCannotBeDeleted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                    .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                        .event( "Qck4PQ7TMun" );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertContainsOnly( persistable, Event.class, "Qck4PQ7TMun"),
+                () -> assertError(persistable, E5001, TRACKED_ENTITY, "xK7H53f4Hc2", "because \"enrollment\" `t1zaUjKgT3p`")
+        );
+    }
+
+    @Test
+    void testDeleteOnlyReportErrorsIfItAddsNewInformation()
+    {
+        // If entities are found to be invalid during the validation an error for the entity will already be in the
+        // validation report. Only add errors if it would not be clear why an entity cannot be persisted.
+
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
+                    .enrollment( "t1zaUjKgT3p" ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
+    void testDeleteValidTrackedEntityAndEnrollmentWithInvalidEventCannotBeDeleted()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                    .enrollment( "t1zaUjKgT3p" )
+                        .event( "Qck4PQ7TMun" ).isInvalid()
+                        .event( "Ox1qBWsnVwE" )
+                .eventWithoutRegistration("G9cH8AVvguf");
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertContainsOnly( persistable, Event.class, "Ox1qBWsnVwE", "G9cH8AVvguf"),
+                () -> assertError(persistable, E5001, TRACKED_ENTITY, "xK7H53f4Hc2", "because \"enrollment\" `t1zaUjKgT3p`"),
+                () -> assertError(persistable, E5001, ENROLLMENT, "t1zaUjKgT3p", "because \"event\" `Qck4PQ7TMun`")
+        );
+    }
+
+    @Test
+    void testDeleteInvalidRelationshipPreventsDeletionOfTrackedEntityAndEvent()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                .eventWithoutRegistration( "QxGbKYwChDM" )
+                .relationship("Te3IC6TpnBB",
+                        trackedEntity("xK7H53f4Hc2"),
+                        event("QxGbKYwChDM")
+                ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertIsEmpty(persistable.get(Event.class)),
+                () -> assertIsEmpty(persistable.get(Relationship.class)),
+                () -> assertError(persistable, E5001, TRACKED_ENTITY, "xK7H53f4Hc2", "because \"relationship\" `Te3IC6TpnBB`"),
+                () -> assertError(persistable, E5001, EVENT, "QxGbKYwChDM", "because \"relationship\" `Te3IC6TpnBB`")
+        );
+    }
+
+    @Test
+    void testDeleteInvalidRelationshipPreventsDeletionOfEnrollmentAndEvent()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                    .enrollment( "t1zaUjKgT3p" )
+                        .event( "QxGbKYwChDM" )
+                .relationship("Te3IC6TpnBB",
+                        event("QxGbKYwChDM"),
+                        enrollment("t1zaUjKgT3p")
+                ).isInvalid();
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertIsEmpty(persistable.get(Event.class)),
+                () -> assertIsEmpty(persistable.get(Relationship.class)),
+                () -> assertError(persistable, E5001, ENROLLMENT, "t1zaUjKgT3p", "because \"relationship\" `Te3IC6TpnBB`"),
+                () -> assertError(persistable, E5001, EVENT, "QxGbKYwChDM", "because \"relationship\" `Te3IC6TpnBB`")
+        );
+    }
+
+    @Test
+    void testDeleteValidRelationshipWithInvalidFrom()
+    {
+        // @formatter:off
+        Setup setup = new Setup()
+                .trackedEntity( "xK7H53f4Hc2" )
+                    .enrollment( "t1zaUjKgT3p" ).isInvalid()
+                .eventWithoutRegistration( "QxGbKYwChDM" )
+                .relationship("Te3IC6TpnBB",
+                        enrollment("t1zaUjKgT3p"),
+                        event("QxGbKYwChDM")
+                );
+
+        PersistablesFilter.Result persistable = filter( setup.entities(), setup.invalidEntities(),
+                TrackerImportStrategy.DELETE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertContainsOnly( persistable, Event.class, "QxGbKYwChDM"),
+                () -> assertContainsOnly( persistable, Relationship.class, "Te3IC6TpnBB")
+        );
+    }
+
+    /**
+     * Setup builds the arguments for calling
+     * {@link PersistablesFilter#filter(TrackerBundle, EnumMap, TrackerImportStrategy)}
+     * Adding an entity with methods like {@link #trackedEntity(String)} always assumes the
+     * entity is valid and does not yet exist.
+     * <p>
+     * Call {@link #isInvalid()} or {@link #isExisting()} to mark the current
+     * entity as invalid or existing. You need to make sure to add entities in
+     * the right order (hierarchy) otherwise you'll get NPE. This means that you
+     * cannot add an {@link #enrollment(String)} without first adding a
+     * {@link #trackedEntity(String)}.
+     * </p>
+     */
+    private static class Setup
+    {
+
+        private final TrackerBundle bundle;
+
+        private final EnumMap<TrackerType, Set<String>> invalidEntities = PersistablesFilterTest.invalidEntities();
+
+        private final TrackerPreheat preheat;
+
+        /**
+         * Keeps track of the current entity that can be set to
+         * {@link #isInvalid()} or {@link #isExisting()}.
+         */
+        private TrackerDto current;
+
+        /**
+         * Keeps track of the current trackedEntity to which enrollments and
+         * events will be added on calls to {@link #enrollment(String)} or
+         * {@link #event(String)}.
+         */
+        private TrackedEntity currentTrackedEntity;
+
+        private Enrollment currentEnrollment;
+
+        Setup()
+        {
+            this.preheat = mock( TrackerPreheat.class );
+            this.bundle = TrackerBundle.builder().preheat(this.preheat).build();
+        }
+
+        Setup trackedEntity( String uid )
+        {
+            TrackedEntity trackedEntity = TrackedEntity.builder().trackedEntity(uid).build();
+            bundle.getTrackedEntities().add(trackedEntity);
+            // set cursors
+            current = trackedEntity;
+            currentTrackedEntity = trackedEntity;
+            return this;
+        }
+
+        Setup trackedEntity( String uid, boolean notInPayload )
+        {
+            TrackedEntity trackedEntity = TrackedEntity.builder().trackedEntity(uid).build();
+            if (!notInPayload) {
+                bundle.getTrackedEntities().add(trackedEntity);
+            }
+            // set cursors
+            current = trackedEntity;
+            currentTrackedEntity = trackedEntity;
+            return this;
+        }
+
+        /**
+         * Add an enrollment to the payload with the {@link #currentTrackedEntity} as its parent which is also in the payload.
+         * <p>
+         * <b>Requires call</b> to {@link #trackedEntity(String)} first.
+         * </p>
+         *
+         * @param uid uid of enrollment
+         * @return setup
+         */
+        Setup enrollment( String uid )
+        {
+            Enrollment enrollment = enrollment( uid, currentTrackedEntity );
+            bundle.getEnrollments().add(enrollment);
+            // set cursors
+            current = enrollment;
+            currentEnrollment = enrollment;
+            return this;
+        }
+
+        Setup enrollment( String uid, boolean notInPayload )
+        {
+            Enrollment enrollment = enrollment( uid, currentTrackedEntity );
+            if (!notInPayload) {
+                bundle.getEnrollments().add(enrollment);
+            }
+            // set cursors
+            current = enrollment;
+            currentEnrollment = enrollment;
+            return this;
+        }
+
+        private static Enrollment enrollment( String uid, TrackedEntity parent )
+        {
+            // set child/parent links
+            Enrollment enrollment = Enrollment.builder().enrollment( uid ).trackedEntity( parent.getUid() ).build();
+            parent.getEnrollments().add( enrollment );
+            return enrollment;
+        }
+
+        Setup event( String uid )
+        {
+            Event event = event( uid, currentEnrollment );
+            bundle.getEvents().add(event);
+            // set cursors
+            current = event;
+            return this;
+        }
+
+        Setup eventWithoutRegistration( String uid )
+        {
+            Event event = event( uid, null );
+            bundle.getEvents().add(event);
+            // set cursors
+            current = event;
+            // unset enrollment cursor. it might be confusing otherwise when calling .enrollment().eventWithoutRegistration().event()
+            currentEnrollment = null;
+            return this;
+        }
+
+        private static Event event( String uid, Enrollment parent )
+        {
+            Event event;
+            Event.EventBuilder eventBuilder = Event.builder().event( uid );
+
+            if ( parent != null )
+            {
+                // set child/parent links only if the event has a parent. Events in an event program have no enrollment.
+                // They do have a "fake" enrollment (a default program) but it's not set on the event DTO.
+                event = eventBuilder.enrollment( parent.getUid() ).build();
+                parent.getEvents().add( event );
+            }
+            else
+            {
+                event = eventBuilder.build();
+            }
+
+            return event;
+        }
+
+        Setup relationship(String uid, RelationshipItem from, RelationshipItem to) {
+            Relationship relationship = Relationship.builder()
+                    .relationship(uid)
+                    .from(from)
+                    .to(to)
+                    .build();
+            bundle.getRelationships().add(relationship);
+            // set cursors
+            current = relationship;
+            return this;
+        }
+
+        /**
+         * Marks {@link #current} {@link TrackerDto} as invalid.
+         *
+         * @return this setup
+         */
+        Setup isInvalid()
+        {
+            this.invalidEntities.get( current.getTrackerType() ).add( current.getUid() );
+            return this;
+        }
+
+        /**
+         * Marks {@link #current} {@link TrackerDto} as existing in
+         * {@link #preheat}.
+         *
+         * @return this setup
+         */
+        Setup isExisting()
+        {
+            when( this.preheat.exists( current.getTrackerType(), current.getUid() ) )
+                .thenReturn( true);
+            when( this.preheat.exists( current ) ).thenReturn( true);
+            return this;
+        }
+
+        TrackerBundle entities()
+        {
+            return bundle;
+        }
+
+        EnumMap<TrackerType, Set<String>> invalidEntities()
+        {
+            return invalidEntities;
+        }
+    }
+
+    private static RelationshipItem trackedEntity(String uid) {
+        return RelationshipItem.builder().trackedEntity(uid).build();
+    }
+
+    private static RelationshipItem enrollment(String uid) {
+        return RelationshipItem.builder().enrollment(uid).build();
+    }
+
+    private static RelationshipItem event(String uid) {
+        return RelationshipItem.builder().event(uid).build();
+    }
+
+    private static EnumMap<TrackerType, Set<String>> invalidEntities()
+    {
+        return new EnumMap<>( Map.of(
+            TRACKED_ENTITY, new HashSet<>(),
+            ENROLLMENT, new HashSet<>(),
+            EVENT, new HashSet<>(),
+            RELATIONSHIP, new HashSet<>() ) );
+    }
+
+    private static <T extends TrackerDto> void assertContainsOnly(PersistablesFilter.Result persistable,
+                                                                  Class<T> type, String... uid )
+    {
+        Assertions.assertContainsOnly( List.of( uid ), persistableUids( persistable, type ) );
+    }
+
+    private static <T extends TrackerDto> List<String> persistableUids( PersistablesFilter.Result persistable,
+        Class<T> type )
+    {
+        return persistable.get( type ).stream().map( TrackerDto::getUid ).collect( Collectors.toList() );
+    }
+
+    private static void assertError(PersistablesFilter.Result result, TrackerErrorCode code, TrackerType type, String uid, String messageContains ) {
+        assertHasError(result.getErrors(), code, type, uid, messageContains);
+    }
+
+    private static void assertNoErrorWithCode(PersistablesFilter.Result result, TrackerErrorCode code) {
+        assertHasNoErrorWithCode(result.getErrors(), code);
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -35,7 +35,6 @@ import static org.hisp.dhis.tracker.report.TrackerErrorCode.E5000;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E5001;
 import static org.hisp.dhis.tracker.validation.PersistablesFilter.filter;
 import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasError;
-import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasNoErrorWithCode;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -965,9 +964,5 @@ class PersistablesFilterTest
 
     private static void assertError(PersistablesFilter.Result result, TrackerErrorCode code, TrackerType type, String uid, String messageContains ) {
         assertHasError(result.getErrors(), code, type, uid, messageContains);
-    }
-
-    private static void assertNoErrorWithCode(PersistablesFilter.Result result, TrackerErrorCode code) {
-        assertHasNoErrorWithCode(result.getErrors(), code);
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -412,6 +412,32 @@ class PersistablesFilterTest
     }
 
     @Test
+    void testCreateAndUpdateOnlyReportErrorsIfItAddsNewInformation()
+    {
+        // If entities are found to be invalid during the validation an error for the entity will already be in the
+        // validation report. Only add errors if it would not be clear why an entity cannot be persisted.
+
+        // @formatter:off
+        Setup setup = new Setup.Builder()
+                .trackedEntity( "xK7H53f4Hc2" ).isNotValid()
+                .enrollment( "t1zaUjKgT3p" ).isNotValid()
+                .relationship("Te3IC6TpnBB",
+                        trackedEntity("xK7H53f4Hc2"),
+                        enrollment("t1zaUjKgT3p") ).isNotValid()
+                .build();
+
+        PersistablesFilter.Result persistable = filter( setup.bundle, setup.invalidEntities,
+                TrackerImportStrategy.CREATE_AND_UPDATE );
+
+        assertAll(
+                () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
+                () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertIsEmpty(persistable.get(Relationship.class)),
+                () -> assertIsEmpty( persistable.getErrors())
+        );
+    }
+
+    @Test
     void testDeleteValidEntitiesCanBeDeleted()
     {
         // @formatter:off
@@ -504,6 +530,7 @@ class PersistablesFilterTest
         assertAll(
                 () -> assertIsEmpty(persistable.get(TrackedEntity.class)),
                 () -> assertIsEmpty(persistable.get(Enrollment.class)),
+                () -> assertIsEmpty(persistable.get(Relationship.class)),
                 () -> assertIsEmpty( persistable.getErrors())
         );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/PersistablesFilterTest.java
@@ -670,21 +670,10 @@ class PersistablesFilterTest
 
             private static Entity<Event> event( String uid, Entity<Enrollment> parent )
             {
-                Event event;
-                Event.EventBuilder eventBuilder = Event.builder().event( uid );
-
-                if ( parent != null )
-                {
-                    // set child/parent links only if the event has a parent. Events in an event program have no enrollment.
-                    // They do have a "fake" enrollment (a default program) but it's not set on the event DTO.
-                    event = eventBuilder.enrollment( parent.entity.getUid() ).build();
-                    parent.entity.getEvents().add( event );
-                }
-                else
-                {
-                    event = eventBuilder.build();
-                }
-
+                // set child/parent links only if the event has a parent. Events in an event program have no enrollment.
+                // They do have a "fake" enrollment (a default program) but it's not set on the event DTO.
+                Event event = Event.builder().event( uid ).enrollment( parent.entity.getUid() ).build();
+                parent.entity.getEvents().add( event );
                 return new Entity<>(event);
             }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
@@ -27,11 +27,15 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
+import static org.hisp.dhis.utils.Assertions.assertNotEmpty;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
 
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
+import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerValidationReport;
 
 public class AssertTrackerValidationReport
@@ -51,6 +55,36 @@ public class AssertTrackerValidationReport
             uid.equals( err.getUid() ) ),
             String.format( "error with code %s, type %s, uid %s not found in report with error(s) %s", code,
                 type, uid, report.getErrors() ) );
+    }
+
+    public static void assertHasError( List<TrackerErrorReport> errors, TrackerErrorCode code, TrackerType type,
+        String uid )
+    {
+        assertNotEmpty( errors );
+        assertTrue( errors.stream().anyMatch( err -> code == err.getErrorCode() &&
+            type == err.getTrackerType() &&
+            uid.equals( err.getUid() ) ),
+            String.format( "error with code %s, type %s, uid %s not found in report with error(s) %s", code,
+                type, uid, errors ) );
+    }
+
+    public static void assertHasError( List<TrackerErrorReport> errors, TrackerErrorCode code, TrackerType type,
+        String uid, String messageContains )
+    {
+        assertNotEmpty( errors );
+        assertTrue( errors.stream().anyMatch( err -> code == err.getErrorCode() &&
+            type == err.getTrackerType() &&
+            uid.equals( err.getUid() ) &&
+            err.getMessage().contains( messageContains ) ),
+            String.format( "error with code %s, type %s, uid %s and partial message '%s' not found in error(s) %s",
+                code,
+                type, uid, messageContains, errors ) );
+    }
+
+    public static void assertHasNoErrorWithCode( List<TrackerErrorReport> errors, TrackerErrorCode code )
+    {
+        assertTrue( errors.stream().noneMatch( err -> code == err.getErrorCode() ),
+            String.format( "error with code %s not expected to be in error(s) %s", code, errors ) );
     }
 
     public static void assertHasWarning( TrackerValidationReport report, TrackerErrorCode code, TrackerDto dto )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
@@ -46,6 +46,7 @@ public class AssertTrackerValidationReport
         assertHasError( report, code, dto.getTrackerType(), dto.getUid() );
     }
 
+    // TODO(DHIS2-14213) reduce duplication?
     public static void assertHasError( TrackerValidationReport report, TrackerErrorCode code, TrackerType type,
         String uid )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
@@ -46,16 +46,10 @@ public class AssertTrackerValidationReport
         assertHasError( report, code, dto.getTrackerType(), dto.getUid() );
     }
 
-    // TODO(DHIS2-14213) reduce duplication?
     public static void assertHasError( TrackerValidationReport report, TrackerErrorCode code, TrackerType type,
         String uid )
     {
-        assertTrue( report.hasErrors(), "error not found since report has no errors" );
-        assertTrue( report.hasError( err -> code == err.getErrorCode() &&
-            type == err.getTrackerType() &&
-            uid.equals( err.getUid() ) ),
-            String.format( "error with code %s, type %s, uid %s not found in report with error(s) %s", code,
-                type, uid, report.getErrors() ) );
+        assertHasError( report.getErrors(), code, type, uid );
     }
 
     public static void assertHasError( List<TrackerErrorReport> errors, TrackerErrorCode code, TrackerType type,
@@ -65,7 +59,7 @@ public class AssertTrackerValidationReport
         assertTrue( errors.stream().anyMatch( err -> code == err.getErrorCode() &&
             type == err.getTrackerType() &&
             uid.equals( err.getUid() ) ),
-            String.format( "error with code %s, type %s, uid %s not found in report with error(s) %s", code,
+            String.format( "error with code %s, type %s, uid %s not found in error(s) %s", code,
                 type, uid, errors ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertTrackerValidationReport.java
@@ -81,12 +81,6 @@ public class AssertTrackerValidationReport
                 type, uid, messageContains, errors ) );
     }
 
-    public static void assertHasNoErrorWithCode( List<TrackerErrorReport> errors, TrackerErrorCode code )
-    {
-        assertTrue( errors.stream().noneMatch( err -> code == err.getErrorCode() ),
-            String.format( "error with code %s not expected to be in error(s) %s", code, errors ) );
-    }
-
     public static void assertHasWarning( TrackerValidationReport report, TrackerErrorCode code, TrackerDto dto )
     {
         assertHasWarning( report, code, dto.getTrackerType(), dto.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -376,6 +376,7 @@ class PreCheckExistenceValidationHookTest
             .relationship( NOT_PRESENT_RELATIONSHIP_UID )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         validationHook.validateRelationship( reporter, bundle, rel );
@@ -390,7 +391,8 @@ class PreCheckExistenceValidationHookTest
         Relationship rel = getPayloadRelationship();
 
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.UPDATE );
-        when( bundle.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
+        when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
 
         validationHook.validateRelationship( reporter, bundle, rel );
 
@@ -406,7 +408,8 @@ class PreCheckExistenceValidationHookTest
         Relationship rel = getPayloadRelationship();
 
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.CREATE );
-        when( bundle.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
+        when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getRelationship( RELATIONSHIP_UID ) ).thenReturn( getRelationship() );
 
         validationHook.validateRelationship( reporter, bundle, rel );
 
@@ -420,6 +423,7 @@ class PreCheckExistenceValidationHookTest
             .relationship( NOT_PRESENT_RELATIONSHIP_UID )
             .build();
 
+        when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( rel ) ).thenReturn( TrackerImportStrategy.DELETE );
 
         validationHook.validateRelationship( reporter, bundle, rel );
@@ -434,7 +438,9 @@ class PreCheckExistenceValidationHookTest
             .relationship( SOFT_DELETED_RELATIONSHIP_UID )
             .build();
 
-        when( bundle.getRelationship( SOFT_DELETED_RELATIONSHIP_UID ) ).thenReturn( softDeletedRelationship() );
+        when( bundle.getPreheat() ).thenReturn( preheat );
+        when( preheat.getRelationship( SOFT_DELETED_RELATIONSHIP_UID ) )
+            .thenReturn( softDeletedRelationship() );
         validationHook.validateRelationship( reporter, bundle, rel );
 
         hasTrackerError( reporter, E4017, RELATIONSHIP, rel.getUid() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -28,14 +28,11 @@
 package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.PROGRAM_STAGE_INSTANCE;
 import static org.hisp.dhis.relationship.RelationshipEntity.TRACKED_ENTITY_INSTANCE;
 import static org.hisp.dhis.tracker.TrackerType.RELATIONSHIP;
-import static org.hisp.dhis.tracker.TrackerType.TRACKED_ENTITY;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4000;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4001;
 import static org.hisp.dhis.tracker.report.TrackerErrorCode.E4009;
@@ -50,7 +47,6 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.relationship.RelationshipConstraint;
@@ -67,7 +63,6 @@ import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
-import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -363,55 +358,6 @@ class RelationshipsValidationHookTest
         assertThat( reporter.getErrors().get( 0 ).getErrorMessage(),
             is( "Relationship Type `from` constraint requires a Tracked Entity having type `"
                 + constraintTrackedEntityType.getUid() + "` but `" + trackedEntityType + "` was found." ) );
-    }
-
-    @Test
-    void verifyValidationFailsWhenParentObjectFailed()
-    {
-        RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
-        when( preheat.getAll( RelationshipType.class ) )
-            .thenReturn( Collections.singletonList( relType ) );
-
-        Relationship relationship = Relationship.builder()
-            .relationship( CodeGenerator.generateUid() )
-            .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
-            .to( trackedEntityRelationshipItem( "notValidTrackedEntity" ) )
-            .relationshipType( MetadataIdentifier.ofUid( relType.getUid() ) )
-            .build();
-        reporter.addError( new TrackerErrorReport( "some error", TrackerErrorCode.E9999, TRACKED_ENTITY,
-            relationship.getTo().getTrackedEntity() ) );
-
-        validationHook.validateRelationship( reporter, bundle, relationship );
-
-        hasTrackerError( reporter, TrackerErrorCode.E4011, RELATIONSHIP, relationship.getUid() );
-        assertThat(
-            reporter.getErrors().stream().map( TrackerErrorReport::getErrorMessage ).collect( Collectors.toList() ),
-            hasItem( "Relationship: `" + relationship.getRelationship() +
-                "` cannot be persisted because trackedEntity notValidTrackedEntity referenced by this relationship is not valid." ) );
-    }
-
-    @Test
-    void verifyValidationSuccessWhenSomeObjectsFailButNoParentObject()
-    {
-        RelationshipType relType = createRelTypeConstraint( TRACKED_ENTITY_INSTANCE, TRACKED_ENTITY_INSTANCE );
-        when( preheat.getAll( RelationshipType.class ) )
-            .thenReturn( Collections.singletonList( relType ) );
-
-        Relationship relationship = Relationship.builder()
-            .relationship( CodeGenerator.generateUid() )
-            .from( trackedEntityRelationshipItem( "validTrackedEntity" ) )
-            .to( trackedEntityRelationshipItem( "anotherValidTrackedEntity" ) )
-            .relationshipType( MetadataIdentifier.ofUid( relType.getUid() ) )
-            .build();
-        reporter.addError(
-            new TrackerErrorReport( "some error", TrackerErrorCode.E9999, TRACKED_ENTITY, "notValidTrackedEntity" ) );
-
-        validationHook.validateRelationship( reporter, bundle, relationship );
-
-        assertTrue( reporter.hasErrors() );
-        assertThat(
-            reporter.getErrors().stream().map( TrackerErrorReport::getErrorCode ).collect( Collectors.toList() ),
-            not( hasItem( TrackerErrorCode.E4011 ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/validation/EventImportValidationTest.java
@@ -96,23 +96,13 @@ class EventImportValidationTest extends TrackerTest
     }
 
     @Test
-    void testEnrollmentAndEventFailIndependently()
+    void testInvalidEnrollmentPreventsValidEventFromBeingCreated()
         throws IOException
     {
-        // tests that a child like an event can be valid while its parent is
-        // invalid
-        // previously invalid entities like an enrollment were removed from the
-        // bundle during the validation process
-        // this affected subsequent validations like the
-        // PreCheckDataRelationsValidationHook. E1079 was raised because
-        // the enrollment was not in the bundle anymore. Even though enrollment
-        // and event program in the payload
-        // were identical.
-
         TrackerImportReport trackerImportReport = trackerImportService
             .importTracker( fromJson( "tracker/validations/invalid_enrollment_with_valid_event.json" ) );
 
-        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1070 );
+        assertHasOnlyErrors( trackerImportReport, TrackerErrorCode.E1070, TrackerErrorCode.E5000 );
     }
 
     @Test
@@ -161,13 +151,10 @@ class EventImportValidationTest extends TrackerTest
     {
         TrackerImportParams trackerBundleParams = fromJson(
             "tracker/validations/program_and_tracker_events.json" );
-
-        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
-
-        assertNoErrors( trackerImportReport );
+        assertNoErrors( trackerImportService.importTracker( trackerBundleParams ) );
 
         trackerBundleParams.setImportStrategy( UPDATE );
-        trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
+        TrackerImportReport trackerImportReport = trackerImportService.importTracker( trackerBundleParams );
 
         assertNoErrors( trackerImportReport );
     }


### PR DESCRIPTION
## Invalidating Entities

This adds `PersistablesFilter` which collects valid entities (trackedEntities, enrollments, events, relationships) and errors explaining why other entities are invalid. It relies on the validation hooks that run before it doing the bulk of the work. It is only concerned with collecting

* entities which are valid i.e. have no validation errors found by previous hooks
* and entities which have valid parents (on CREATE/UPDATE) or valid children (DELETE)

All entities passing this filter should be persistable (CREATE/UPDATE/DELETE).

Previously, some of this work at least for relationships was done in the `RelationshipsValidationHook`. Its now moved into a single place the `PersistablesFilter`.

## Reporting errors

The persistables filter will return errors for entities which it considers invalid only if its not already clear from the previous validation (hooks).

For example in case

```java
        Setup setup = new Setup()
                .trackedEntity( "xK7H53f4Hc2" ).isInvalid()
                    .enrollment( "t1zaUjKgT3p" ).isInvalid();
```

Since the TEI is invalid due to some validation hook it will already have an error in the report. So its clear to a user why it cannot be deleted. If the TEI were valid 

```java
        Setup setup = new Setup()
                .trackedEntity( "xK7H53f4Hc2" )
                    .enrollment( "t1zaUjKgT3p" ).isInvalid();
```

error `E5001( "trackedEntity" xK7H53f4Hc2 cannot be deleted because "enrollment" t1zaUjKgT3p referenced by it cannot be deleted."`  will be added. This makes it clear why a valid TEI in the payload cannot be deleted.

The same behavior is implemented for CREATE/UPDATE/CREATE_UPDATE where a child can only be created if its parent exists.

2 new generic error codes `E5000` and `E5001` for describing the above error for any entity and its parent/child are added.