### PR TITLE
fix: always sort notifications newest first on redis [DHIS2-9048]

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notification.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/Notification.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.system.notification;
 
 import java.util.Date;
 
+import javax.annotation.Nonnull;
+
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.scheduling.JobType;
@@ -41,7 +43,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
  * @author Lars Helge Overland
  */
 @JacksonXmlRootElement( localName = "notification", namespace = DxfNamespaces.DXF_2_0 )
-public class Notification
+public class Notification implements Comparable<Notification>
 {
     private String uid; // FIXME expose as "id" externally in next API version
                        // as "uid" is internal
@@ -196,5 +198,16 @@ public class Notification
     public String toString()
     {
         return "[Level: " + level + ", category: " + category + ", time: " + time + ", message: " + message + "]";
+    }
+
+    @Override
+    public int compareTo( @Nonnull Notification other )
+    {
+        if ( category != other.category )
+        {
+            return category.compareTo( other.category );
+        }
+        // flip this/other => newest first
+        return other.time.compareTo( time );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
@@ -150,11 +150,13 @@ public class RedisNotifier implements Notifier
     @Override
     public Deque<Notification> getNotificationsByJobId( JobType jobType, String jobId )
     {
-        Set<String> keys = redisTemplate.boundZSetOps( generateNotificationKey( jobType, jobId ) ).range( 0, -1 );
-        if ( keys == null )
+        Set<String> notifications = redisTemplate.boundZSetOps( generateNotificationKey( jobType, jobId ) ).range( 0,
+            -1 );
+        if ( notifications == null )
             return new LinkedList<>();
         Deque<Notification> res = new LinkedList<>();
-        keys.forEach( x -> executeLogErrors( () -> res.add( jsonMapper.readValue( x, Notification.class ) ) ) );
+        notifications.stream().sorted().forEach( notification -> executeLogErrors(
+            () -> res.add( jsonMapper.readValue( notification, Notification.class ) ) ) );
         return res;
     }
 
@@ -165,7 +167,7 @@ public class RedisNotifier implements Notifier
         if ( keys == null || keys.isEmpty() )
             return Map.of();
         LinkedHashMap<String, Deque<Notification>> res = new LinkedHashMap<>();
-        keys.forEach( j -> res.put( j, getNotificationsByJobId( jobType, j ) ) );
+        keys.forEach( jobId -> res.put( jobId, getNotificationsByJobId( jobType, jobId ) ) );
         return res;
     }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/notification/NotificationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.system.notification;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.hisp.dhis.scheduling.JobType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests properties of {@link Notification}s.
+ *
+ * @author Jan Bernitt
+ */
+class NotificationTest
+{
+    @Test
+    void testNotificationAreNaturallySortedNewestFirst()
+    {
+        Date now = new Date();
+
+        Notification a = createNotificationWithTime( now );
+        Notification b = createNotificationWithTime( new Date( now.getTime() - 1000L ) );
+        Notification c = createNotificationWithTime( new Date( now.getTime() + 1000L ) );
+
+        assertEquals( List.of( c, a, b ), Stream.of( a, b, c ).sorted().collect( toList() ) );
+    }
+
+    private Notification createNotificationWithTime( Date now )
+    {
+        Notification notification = new Notification();
+        notification.setCategory( JobType.ACCOUNT_EXPIRY_ALERT );
+        notification.setTime( now );
+        return notification;
+    }
+}


### PR DESCRIPTION
### Summary
The implementation of `RedisNotifier` changed between 2.35 and 2.36 when it comes to querying the notifications. 
This apparently caused the order of items to be reversed. 

However, as the spring redis API is poorly documented it is hard to say what exactly caused the change in ordering. Also it is unclear what order guarantee there is when the notifications are fetched from redis. Therefore it seems the most maintainable and stable fix to simply sort the notifications in the intended order before returning them. This should always keep them in the order expected by the app.

The only real change here is to use `.stream().sorted().forEach` instead if `.forEach` on the notifications fetched from redis. To make them naturally sort newest first `Notification` was made `Comparable`. 

### Automatic Testing
The "newest first" natural sort order of `Notification`s was tested in an added unit test.