### PR TITLE
chore: Cleanup tracker reporter

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -396,8 +396,7 @@ public class DefaultTrackerImportService
         else if ( originalValidationReport != null && TrackerBundleReportMode.FULL == reportMode )
         {
             validationReport
-                .addWarnings( originalValidationReport.getWarnings() )
-                .addTimings( originalValidationReport.getTimings() );
+                .addWarnings( originalValidationReport.getWarnings() );
             importReportBuilder.timingsStats( originalImportReport.getTimingsStats() );
         }
         importReportBuilder.validationReport( validationReport );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerObjectReport.java
@@ -28,9 +28,7 @@
 package org.hisp.dhis.tracker.report;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import lombok.Data;
 
@@ -63,7 +61,7 @@ public class TrackerObjectReport
     @JsonProperty
     private String uid;
 
-    private Map<TrackerErrorCode, List<TrackerErrorReport>> errorReportsByCode = new HashMap<>();
+    private List<TrackerErrorReport> errorReports = new ArrayList<>();
 
     public TrackerObjectReport( TrackerType trackerType )
     {
@@ -87,46 +85,13 @@ public class TrackerObjectReport
         this.index = index;
         if ( errorReports != null )
         {
-            List<TrackerErrorReport> errorCodeReportList;
-            for ( TrackerErrorReport errorReport : errorReports )
-            {
-                errorCodeReportList = this.errorReportsByCode.get( errorReport.getErrorCode() );
-
-                if ( errorCodeReportList == null )
-                {
-                    errorCodeReportList = new ArrayList<>();
-                }
-                errorCodeReportList.add( errorReport );
-                this.errorReportsByCode.put( errorReport.getErrorCode(), errorCodeReportList );
-            }
+            this.errorReports = errorReports;
         }
     }
 
     @JsonProperty
     public List<TrackerErrorReport> getErrorReports()
     {
-        List<TrackerErrorReport> errorReports = new ArrayList<>();
-        errorReportsByCode.values().forEach( errorReports::addAll );
-
-        return errorReports;
-    }
-
-    // -----------------------------------------------------------------------------------
-    // Utility Methods
-    // -----------------------------------------------------------------------------------
-
-    public boolean isEmpty()
-    {
-        return errorReportsByCode.isEmpty();
-    }
-
-    public int size()
-    {
-        return errorReportsByCode.size();
-    }
-
-    public List<TrackerErrorCode> getErrorCodes()
-    {
-        return new ArrayList<>( errorReportsByCode.keySet() );
+        return this.errorReports;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/report/TrackerValidationReport.java
@@ -69,7 +69,6 @@ public class TrackerValidationReport
     {
         addErrors( report.getErrors() );
         addWarnings( report.getWarnings() );
-        addTimings( report.getTimings() );
     }
 
     public List<TrackerErrorReport> getErrors()
@@ -80,11 +79,6 @@ public class TrackerValidationReport
     public List<TrackerWarningReport> getWarnings()
     {
         return Collections.unmodifiableList( warningReports );
-    }
-
-    public List<Timing> getTimings()
-    {
-        return Collections.unmodifiableList( timings );
     }
 
     public TrackerValidationReport addError( TrackerErrorReport error )
@@ -117,18 +111,6 @@ public class TrackerValidationReport
         return this;
     }
 
-    public TrackerValidationReport addTiming( Timing timing )
-    {
-        timings.add( timing );
-        return this;
-    }
-
-    public TrackerValidationReport addTimings( List<Timing> timings )
-    {
-        this.timings.addAll( timings );
-        return this;
-    }
-
     public boolean hasErrors()
     {
         return !errorReports.isEmpty();
@@ -147,11 +129,6 @@ public class TrackerValidationReport
     public boolean hasWarning( Predicate<TrackerWarningReport> test )
     {
         return warningReports.stream().anyMatch( test );
-    }
-
-    public boolean hasTimings()
-    {
-        return !timings.isEmpty();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -94,11 +94,11 @@ public class DefaultTrackerValidationService
 
         try
         {
-            validateTrackedEntities( bundle, hooks, validationReport, reporter );
-            validateEnrollments( bundle, hooks, validationReport, reporter );
-            validateEvents( bundle, hooks, validationReport, reporter );
-            validateRelationships( bundle, hooks, validationReport, reporter );
-            validateBundle( bundle, hooks, validationReport, reporter );
+            validateTrackedEntities( bundle, hooks, reporter );
+            validateEnrollments( bundle, hooks, reporter );
+            validateEvents( bundle, hooks, reporter );
+            validateRelationships( bundle, hooks, reporter );
+            validateBundle( bundle, hooks, reporter );
         }
         catch ( ValidationFailFastException e )
         {
@@ -114,7 +114,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateTrackedEntities( TrackerBundle bundle, List<TrackerValidationHook> hooks,
-        TrackerValidationReport validationReport, ValidationErrorReporter reporter )
+        ValidationErrorReporter reporter )
     {
         for ( TrackedEntity tei : bundle.getTrackedEntities() )
         {
@@ -126,7 +126,7 @@ public class DefaultTrackerValidationService
 
                     hook.validateTrackedEntity( reporter, bundle, tei );
 
-                    validationReport.addTiming( new Timing(
+                    reporter.addTiming( new Timing(
                         hook.getClass().getName(),
                         hookTimer.toString() ) );
 
@@ -140,7 +140,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateEnrollments( TrackerBundle bundle, List<TrackerValidationHook> hooks,
-        TrackerValidationReport validationReport, ValidationErrorReporter reporter )
+        ValidationErrorReporter reporter )
     {
         for ( Enrollment enrollment : bundle.getEnrollments() )
         {
@@ -152,7 +152,7 @@ public class DefaultTrackerValidationService
 
                     hook.validateEnrollment( reporter, bundle, enrollment );
 
-                    validationReport.addTiming( new Timing(
+                    reporter.addTiming( new Timing(
                         hook.getClass().getName(),
                         hookTimer.toString() ) );
 
@@ -166,7 +166,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateEvents( TrackerBundle bundle, List<TrackerValidationHook> hooks,
-        TrackerValidationReport validationReport, ValidationErrorReporter reporter )
+        ValidationErrorReporter reporter )
     {
         for ( Event event : bundle.getEvents() )
         {
@@ -178,7 +178,7 @@ public class DefaultTrackerValidationService
 
                     hook.validateEvent( reporter, bundle, event );
 
-                    validationReport.addTiming( new Timing(
+                    reporter.addTiming( new Timing(
                         hook.getClass().getName(),
                         hookTimer.toString() ) );
 
@@ -192,7 +192,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateRelationships( TrackerBundle bundle, List<TrackerValidationHook> hooks,
-        TrackerValidationReport validationReport, ValidationErrorReporter reporter )
+        ValidationErrorReporter reporter )
     {
         for ( Relationship relationship : bundle.getRelationships() )
         {
@@ -204,7 +204,7 @@ public class DefaultTrackerValidationService
 
                     hook.validateRelationship( reporter, bundle, relationship );
 
-                    validationReport.addTiming( new Timing(
+                    reporter.addTiming( new Timing(
                         hook.getClass().getName(),
                         hookTimer.toString() ) );
 
@@ -218,7 +218,7 @@ public class DefaultTrackerValidationService
     }
 
     private static void validateBundle( TrackerBundle bundle, List<TrackerValidationHook> hooks,
-        TrackerValidationReport validationReport, ValidationErrorReporter reporter )
+        ValidationErrorReporter reporter )
     {
         for ( TrackerValidationHook hook : hooks )
         {
@@ -226,7 +226,7 @@ public class DefaultTrackerValidationService
 
             hook.validate( reporter, bundle );
 
-            validationReport.addTiming( new Timing(
+            reporter.addTiming( new Timing(
                 hook.getClass().getName(),
                 hookTimer.toString() ) );
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationErrorReporter.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.tracker.validation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,6 +43,7 @@ import lombok.Value;
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.domain.TrackerDto;
+import org.hisp.dhis.tracker.report.Timing;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerWarningReport;
@@ -68,6 +70,8 @@ public class ValidationErrorReporter
 
     TrackerIdSchemeParams idSchemes;
 
+    List<Timing> timings;
+
     @Getter( AccessLevel.PACKAGE )
     /*
      * Keeps track of all the invalid Tracker objects (i.e. objects with at
@@ -92,6 +96,7 @@ public class ValidationErrorReporter
         this.invalidDTOs = new EnumMap<>( TrackerType.class );
         this.idSchemes = idSchemes;
         this.isFailFast = failFast;
+        this.timings = new ArrayList<>();
     }
 
     /**
@@ -195,5 +200,27 @@ public class ValidationErrorReporter
     public boolean isInvalid( TrackerType trackerType, String uid )
     {
         return this.invalidDTOs.getOrDefault( trackerType, new HashSet<>() ).contains( uid );
+    }
+
+    public ValidationErrorReporter addTiming( Timing timing )
+    {
+        timings.add( timing );
+        return this;
+    }
+
+    public ValidationErrorReporter addTimings( List<Timing> timings )
+    {
+        this.timings.addAll( timings );
+        return this;
+    }
+
+    public List<Timing> getTimings()
+    {
+        return Collections.unmodifiableList( timings );
+    }
+
+    public boolean hasTimings()
+    {
+        return !timings.isEmpty();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -46,7 +46,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.commons.jackson.config.JacksonObjectMapperConfig;
 import org.hisp.dhis.system.notification.Notifier;
 import org.hisp.dhis.tracker.DefaultTrackerImportService;
@@ -102,7 +101,6 @@ class TrackerBundleImportReportTest
         assertNotNull( report.getValidationReport() );
         assertTrue( report.getValidationReport().hasErrors() );
         assertFalse( report.getValidationReport().hasWarnings() );
-        assertFalse( report.getValidationReport().hasTimings() );
         assertNull( report.getTimingsStats() );
     }
 
@@ -117,7 +115,6 @@ class TrackerBundleImportReportTest
         assertNotNull( report.getValidationReport() );
         assertTrue( report.getValidationReport().hasErrors() );
         assertTrue( report.getValidationReport().hasWarnings() );
-        assertFalse( report.getValidationReport().hasTimings() );
         assertNull( report.getTimingsStats() );
     }
 
@@ -132,7 +129,6 @@ class TrackerBundleImportReportTest
         assertNotNull( report.getValidationReport() );
         assertTrue( report.getValidationReport().hasErrors() );
         assertTrue( report.getValidationReport().hasWarnings() );
-        assertTrue( report.getValidationReport().hasTimings() );
         assertNotNull( report.getTimingsStats() );
         assertEquals( "1 sec.", report.getTimingsStats().getProgramRule() );
         assertEquals( "2 sec.", report.getTimingsStats().getCommit() );
@@ -289,11 +285,10 @@ class TrackerBundleImportReportTest
     private TrackerValidationReport createValidationReport()
     {
         return new TrackerValidationReport()
-            .addError(
-                new TrackerErrorReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) )
-            .addWarning(
-                new TrackerWarningReport( "", TrackerErrorCode.E9999, TrackerType.EVENT, CodeGenerator.generateUid() ) )
-            .addTiming( new Timing( "1min", "validation" ) );
+            .addError( new TrackerErrorReport( "Could not find OrganisationUnit: ``, linked to Tracked Entity.",
+                TrackerErrorCode.E1049, TRACKED_ENTITY, "BltTZV9HvEZ" ) )
+            .addWarning( new TrackerWarningReport( "ProgramStage `l8oDIfJJhtg` does not allow user assignment",
+                TrackerErrorCode.E1120, TrackerType.EVENT, "BltTZV9HvEZ" ) );
     }
 
     private TrackerBundleReport createBundleReport()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerValidationReportTest.java
@@ -154,26 +154,6 @@ class TrackerValidationReportTest
     }
 
     @Test
-    void hasPerfsReturnsFalse()
-    {
-
-        TrackerValidationReport report = new TrackerValidationReport();
-
-        assertFalse( report.hasTimings() );
-    }
-
-    @Test
-    void hasPerfsReturnsTrue()
-    {
-
-        TrackerValidationReport report = new TrackerValidationReport();
-
-        report.addTiming( new Timing( "1min", "validation" ) );
-
-        assertTrue( report.hasTimings() );
-    }
-
-    @Test
     void hasErrorReportFound()
     {
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ValidationErrorReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ValidationErrorReporterTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.report.Timing;
 import org.hisp.dhis.tracker.report.TrackerErrorCode;
 import org.hisp.dhis.tracker.report.TrackerErrorReport;
 import org.hisp.dhis.tracker.report.TrackerWarningReport;
@@ -78,6 +79,25 @@ class ValidationErrorReporterTest
         reporter.addWarning( eventWarning() );
 
         assertFalse( reporter.hasWarningReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
+    }
+
+    @Test
+    void hasPerfsReturnsFalse()
+    {
+
+        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+
+        assertFalse( reporter.hasTimings() );
+    }
+
+    @Test
+    void hasPerfsReturnsTrue()
+    {
+        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+
+        reporter.addTiming( new Timing( "1min", "validation" ) );
+
+        assertTrue( reporter.hasTimings() );
     }
 
     private TrackerErrorReport eventError()


### PR DESCRIPTION
Make some cleanup in `TrackerValidationReport`
- errorReportsByCode can be changed to a list as is never actually used as a map
- timings is moved to `ValidationErrorReporter` as they are never really exposed to the API, they are @JsonIgnore annotated. We could think of remove them once for all