### PR TITLE
fix: speed up data import delete mode DHIS2-14293

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/datavalueset/DefaultDataValueSetService.java
@@ -895,12 +895,16 @@ public class DefaultDataValueSetService
 
         if ( !context.isDryRun() )
         {
-            DataValue actualDataValue = valueContext.getActualDataValue( dataValueService );
-            if ( valueContext.getDataElement().isFileType() && actualDataValue != null )
+            if ( valueContext.getDataElement().isFileType() )
             {
-                FileResource fr = fileResourceService.getFileResource( actualDataValue.getValue() );
+                DataValue actualDataValue = valueContext.getActualDataValue( dataValueService );
 
-                fileResourceService.updateFileResource( fr );
+                if ( actualDataValue != null )
+                {
+                    FileResource fr = fileResourceService.getFileResource( actualDataValue.getValue() );
+
+                    fileResourceService.updateFileResource( fr );
+                }
             }
 
             context.getDataValueBatchHandler().updateObject( internalValue );


### PR DESCRIPTION
See [DHIS2-14293](https://dhis2.atlassian.net/browse/DHIS2-14293). Data import in delete mode (for non file type data elements) is much slower from 2.37 onwards, as discovered recently by PEPFAR after upgrading from 2.36 to 2.38.

The cause was in the code refactor done for [DHIS2-6163](https://dhis2.atlassian.net/browse/DHIS2-6163). During delete mode, if the data element is of type file and the data value (fetched the slow way through Hibernate) is present, then the file resource specified by the data value is updated. Before the refactor the data value was fetched through Hibernate only for data elements of type file. After the refactor the data value was fetched for all data values before the check for type file was done. As a result, the profiler showed most of the time spent in delete mode (for non-file data elements) was spent fetching the data values.

The fix is to test the data element type first again, and only fetch the data value via Hibernate for files.