### PR TITLE
chore: Clean up TrackerBundle methods [TECH-14298]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/bundle/TrackerBundle.java
@@ -42,11 +42,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
-import org.hisp.dhis.program.ProgramInstance;
-import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.rules.models.RuleEffect;
 import org.hisp.dhis.rules.models.RuleEffects;
-import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.AtomicMode;
 import org.hisp.dhis.tracker.FlushMode;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
@@ -188,22 +185,22 @@ public class TrackerBundle
     @JsonIgnore
     private Set<String> updatedTeis = new HashSet<>();
 
-    public Optional<TrackedEntity> getTrackedEntity( String uid )
+    public Optional<TrackedEntity> findTrackedEntityByUid( String uid )
     {
         return findById( this.trackedEntities, uid );
     }
 
-    public Optional<Event> getEvent( String uid )
-    {
-        return findById( this.events, uid );
-    }
-
-    public Optional<Enrollment> getEnrollment( String uid )
+    public Optional<Enrollment> findEnrollmentByUid( String uid )
     {
         return findById( this.enrollments, uid );
     }
 
-    public Optional<Relationship> getRelationship( String uid )
+    public Optional<Event> findEventByUid( String uid )
+    {
+        return findById( this.events, uid );
+    }
+
+    public Optional<Relationship> findRelationshipByUid( String uid )
     {
         return findById( this.relationships, uid );
     }
@@ -217,7 +214,7 @@ public class TrackerBundle
     {
         return ruleEffects.stream()
             .filter( RuleEffects::isEnrollment )
-            .filter( e -> getEnrollment( e.getTrackerObjectUid() ).isPresent() )
+            .filter( e -> findEnrollmentByUid( e.getTrackerObjectUid() ).isPresent() )
             .collect( Collectors.toMap( RuleEffects::getTrackerObjectUid, RuleEffects::getRuleEffects ) );
     }
 
@@ -225,7 +222,7 @@ public class TrackerBundle
     {
         return ruleEffects.stream()
             .filter( RuleEffects::isEvent )
-            .filter( e -> getEvent( e.getTrackerObjectUid() ).isPresent() )
+            .filter( e -> findEventByUid( e.getTrackerObjectUid() ).isPresent() )
             .collect( Collectors.toMap( RuleEffects::getTrackerObjectUid, RuleEffects::getRuleEffects ) );
     }
 
@@ -237,21 +234,6 @@ public class TrackerBundle
     public TrackerImportStrategy getStrategy( TrackerDto dto )
     {
         return getResolvedStrategyMap().get( dto.getTrackerType() ).get( dto.getUid() );
-    }
-
-    public TrackedEntityInstance getTrackedEntityInstance( String id )
-    {
-        return getPreheat().getTrackedEntity( id );
-    }
-
-    public ProgramInstance getProgramInstance( String id )
-    {
-        return getPreheat().getEnrollment( id );
-    }
-
-    public ProgramStageInstance getProgramStageInstance( String event )
-    {
-        return getPreheat().getEvent( event );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -300,13 +282,13 @@ public class TrackerBundle
         switch ( type )
         {
         case TRACKED_ENTITY:
-            return getTrackedEntity( uid ).isPresent();
+            return findTrackedEntityByUid( uid ).isPresent();
         case ENROLLMENT:
-            return getEnrollment( uid ).isPresent();
+            return findEnrollmentByUid( uid ).isPresent();
         case EVENT:
-            return getEvent( uid ).isPresent();
+            return findEventByUid( uid ).isPresent();
         case RELATIONSHIP:
-            return getRelationship( uid ).isPresent();
+            return findRelationshipByUid( uid ).isPresent();
         default:
             // only reached if a new TrackerDto implementation is added
             throw new IllegalStateException( "TrackerType " + type.getName() + " not yet supported." );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/DefaultTrackerProgramRuleService.java
@@ -126,7 +126,7 @@ public class DefaultTrackerProgramRuleService
             .getTrackedEntity( enrollment.getTrackedEntity() );
 
         List<TrackedEntityAttributeValue> payloadAttributeValues = bundle
-            .getTrackedEntity( enrollment.getTrackedEntity() )
+            .findTrackedEntityByUid( enrollment.getTrackedEntity() )
             .map( tei -> attributeValueTrackerConverterService.from( bundle.getPreheat(), tei.getAttributes() ) )
             .orElse( Lists.newArrayList() );
         attributeValues.addAll( payloadAttributeValues );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/programrule/implementers/AssignValueImplementer.java
@@ -235,7 +235,7 @@ public class AssignValueImplementer
     private void addOrOverwriteAttribute( Enrollment enrollment, EnrollmentActionRule actionRule, TrackerBundle bundle )
     {
         TrackedEntityAttribute attribute = bundle.getPreheat().getTrackedEntityAttribute( actionRule.getField() );
-        Optional<TrackedEntity> trackedEntity = bundle.getTrackedEntity( enrollment.getTrackedEntity() );
+        Optional<TrackedEntity> trackedEntity = bundle.findTrackedEntityByUid( enrollment.getTrackedEntity() );
         List<Attribute> attributes;
 
         if ( trackedEntity.isPresent() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidationHook.java
@@ -85,7 +85,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         Program program = preheat.getProgram( enrollment.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );
 
-        TrackedEntityInstance tei = bundle.getTrackedEntityInstance( enrollment.getTrackedEntity() );
+        TrackedEntityInstance tei = bundle.getPreheat().getTrackedEntity( enrollment.getTrackedEntity() );
 
         OrganisationUnit orgUnit = preheat
             .getOrganisationUnit( getOrgUnitUidFromTei( bundle, enrollment.getTrackedEntity() ) );
@@ -209,7 +209,7 @@ public class EnrollmentAttributeValidationHook extends AttributeValidationHook
         final Optional<ReferenceTrackerEntity> reference = bundle.getPreheat().getReference( teiUid );
         if ( reference.isPresent() )
         {
-            final Optional<TrackedEntity> tei = bundle.getTrackedEntity( teiUid );
+            final Optional<TrackedEntity> tei = bundle.findTrackedEntityByUid( teiUid );
             if ( tei.isPresent() )
             {
                 return tei.get().getOrgUnit();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHook.java
@@ -145,7 +145,7 @@ public class EnrollmentInExistingValidationHook
 
     private TrackedEntityInstance getTrackedEntityInstance( TrackerBundle bundle, String uid )
     {
-        TrackedEntityInstance tei = bundle.getTrackedEntityInstance( uid );
+        TrackedEntityInstance tei = bundle.getPreheat().getTrackedEntity( uid );
 
         if ( tei == null && bundle.getPreheat().getReference( uid ).isPresent() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHook.java
@@ -387,7 +387,7 @@ public class PreCheckDataRelationsValidationHook
 
     private Program getEnrollmentProgramFromEvent( TrackerBundle bundle, Event event )
     {
-        ProgramInstance programInstance = bundle.getProgramInstance( event.getEnrollment() );
+        ProgramInstance programInstance = bundle.getPreheat().getEnrollment( event.getEnrollment() );
         if ( programInstance != null )
         {
             return programInstance.getProgram();
@@ -398,7 +398,7 @@ public class PreCheckDataRelationsValidationHook
                 .getReference( event.getEnrollment() );
             if ( reference.isPresent() )
             {
-                final Optional<Enrollment> enrollment = bundle.getEnrollment( event.getEnrollment() );
+                final Optional<Enrollment> enrollment = bundle.findEnrollmentByUid( event.getEnrollment() );
                 if ( enrollment.isPresent() )
                 {
                     return bundle.getPreheat().getProgram( enrollment.get().getProgram() );
@@ -427,7 +427,7 @@ public class PreCheckDataRelationsValidationHook
     private boolean trackedEntityTypesMatch( TrackerBundle bundle, Program program, Enrollment enrollment )
     {
         final TrackedEntityInstance trackedEntityInstance = bundle
-            .getTrackedEntityInstance( enrollment.getTrackedEntity() );
+            .getPreheat().getTrackedEntity( enrollment.getTrackedEntity() );
         if ( trackedEntityInstance != null )
         {
             return program.getTrackedEntityType().getUid()
@@ -438,7 +438,7 @@ public class PreCheckDataRelationsValidationHook
             .getReference( enrollment.getTrackedEntity() );
         if ( reference.isPresent() )
         {
-            final Optional<TrackedEntity> tei = bundle.getTrackedEntity( enrollment.getTrackedEntity() );
+            final Optional<TrackedEntity> tei = bundle.findTrackedEntityByUid( enrollment.getTrackedEntity() );
             if ( tei.isPresent() )
             {
                 return tei.get().getTrackedEntityType().isEqualTo( program.getTrackedEntityType() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHook.java
@@ -66,7 +66,7 @@ public class PreCheckExistenceValidationHook
     {
         TrackerImportStrategy importStrategy = bundle.getStrategy( trackedEntity );
 
-        TrackedEntityInstance existingTe = bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+        TrackedEntityInstance existingTe = bundle.getPreheat().getTrackedEntity( trackedEntity.getTrackedEntity() );
 
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingTe != null && existingTe.isDeleted() )
@@ -90,7 +90,7 @@ public class PreCheckExistenceValidationHook
     {
         TrackerImportStrategy importStrategy = bundle.getStrategy( enrollment );
 
-        ProgramInstance existingPi = bundle.getProgramInstance( enrollment.getEnrollment() );
+        ProgramInstance existingPi = bundle.getPreheat().getEnrollment( enrollment.getEnrollment() );
 
         // If the tracked entity is soft-deleted no operation is allowed
         if ( existingPi != null && existingPi.isDeleted() )
@@ -114,7 +114,7 @@ public class PreCheckExistenceValidationHook
     {
         TrackerImportStrategy importStrategy = bundle.getStrategy( event );
 
-        ProgramStageInstance existingPsi = bundle.getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance existingPsi = bundle.getPreheat().getEvent( event.getEvent() );
 
         // If the event is soft-deleted no operation is allowed
         if ( existingPsi != null && existingPsi.isDeleted() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHook.java
@@ -108,12 +108,12 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( trackedEntity, TRACKED_ENTITY_CANT_BE_NULL );
 
         TrackedEntityType trackedEntityType = strategy.isUpdateOrDelete()
-            ? bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() ).getTrackedEntityType()
+            ? bundle.getPreheat().getTrackedEntity( trackedEntity.getTrackedEntity() ).getTrackedEntityType()
             : bundle.getPreheat()
                 .getTrackedEntityType( trackedEntity.getTrackedEntityType() );
 
         OrganisationUnit organisationUnit = strategy.isUpdateOrDelete()
-            ? bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() ).getOrganisationUnit()
+            ? bundle.getPreheat().getTrackedEntity( trackedEntity.getTrackedEntity() ).getOrganisationUnit()
             : bundle.getPreheat().getOrganisationUnit( trackedEntity.getOrgUnit() );
 
         // If trackedEntity is newly created, or going to be deleted, capture
@@ -130,7 +130,7 @@ public class PreCheckSecurityOwnershipValidationHook
 
         if ( strategy.isDelete() )
         {
-            TrackedEntityInstance tei = bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+            TrackedEntityInstance tei = bundle.getPreheat().getTrackedEntity( trackedEntity.getTrackedEntity() );
 
             if ( tei.getProgramInstances().stream().anyMatch( pi -> !pi.isDeleted() )
                 && !user.isAuthorized( Authorities.F_TEI_CASCADE_DELETE.getAuthority() ) )
@@ -164,7 +164,7 @@ public class PreCheckSecurityOwnershipValidationHook
         TrackerPreheat preheat = bundle.getPreheat();
         User user = bundle.getUser();
         Program program = strategy.isUpdateOrDelete()
-            ? bundle.getProgramInstance( enrollment.getEnrollment() )
+            ? bundle.getPreheat().getEnrollment( enrollment.getEnrollment() )
                 .getProgram()
             : bundle.getPreheat().getProgram( enrollment.getProgram() );
         OrganisationUnit ownerOrgUnit = getOwnerOrganisationUnit( preheat, enrollment.getTrackedEntity(),
@@ -217,7 +217,7 @@ public class PreCheckSecurityOwnershipValidationHook
 
         if ( strategy.isUpdateOrDelete() )
         {
-            enrollmentOrgUnit = bundle.getProgramInstance( enrollment.getEnrollment() )
+            enrollmentOrgUnit = bundle.getPreheat().getEnrollment( enrollment.getEnrollment() )
                 .getOrganisationUnit();
 
             if ( enrollmentOrgUnit == null )
@@ -252,7 +252,7 @@ public class PreCheckSecurityOwnershipValidationHook
         checkNotNull( user, USER_CANT_BE_NULL );
         checkNotNull( event, EVENT_CANT_BE_NULL );
 
-        ProgramStageInstance programStageInstance = bundle.getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance programStageInstance = bundle.getPreheat().getEvent( event.getEvent() );
 
         ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         Program program = strategy.isUpdateOrDelete() ? programStageInstance.getProgramStage()
@@ -362,12 +362,12 @@ public class PreCheckSecurityOwnershipValidationHook
             return null;
         }
 
-        ProgramInstance programInstance = bundle.getProgramInstance( event.getEnrollment() );
+        ProgramInstance programInstance = bundle.getPreheat().getEnrollment( event.getEnrollment() );
 
         if ( programInstance == null )
         {
             return bundle
-                .getEnrollment( event.getEnrollment() )
+                .findEnrollmentByUid( event.getEnrollment() )
                 .map( Enrollment::getTrackedEntity )
                 .orElse( null );
         }
@@ -455,7 +455,7 @@ public class PreCheckSecurityOwnershipValidationHook
         if ( program.isRegistration() )
         {
             String trackedEntity = bundle.getStrategy( enrollment ).isDelete()
-                ? bundle.getProgramInstance( enrollment.getEnrollment() ).getEntityInstance().getUid()
+                ? bundle.getPreheat().getEnrollment( enrollment.getEnrollment() ).getEntityInstance().getUid()
                 : enrollment.getTrackedEntity();
 
             checkNotNull( program.getTrackedEntityType(), TRACKED_ENTITY_TYPE_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHook.java
@@ -60,7 +60,7 @@ public class PreCheckUpdatableFieldsValidationHook
         TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         TrackedEntityInstance trackedEntityInstance = bundle
-            .getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+            .getPreheat().getTrackedEntity( trackedEntity.getTrackedEntity() );
 
         reporter.addErrorIf(
             () -> !trackedEntity.getTrackedEntityType().isEqualTo( trackedEntityInstance.getTrackedEntityType() ),
@@ -70,7 +70,7 @@ public class PreCheckUpdatableFieldsValidationHook
     @Override
     public void validateEnrollment( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
-        ProgramInstance pi = bundle.getProgramInstance( enrollment.getEnrollment() );
+        ProgramInstance pi = bundle.getPreheat().getEnrollment( enrollment.getEnrollment() );
         Program program = pi.getProgram();
         TrackedEntityInstance trackedEntityInstance = pi.getEntityInstance();
 
@@ -83,7 +83,7 @@ public class PreCheckUpdatableFieldsValidationHook
     @Override
     public void validateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        ProgramStageInstance programStageInstance = bundle.getProgramStageInstance( event.getEvent() );
+        ProgramStageInstance programStageInstance = bundle.getPreheat().getEvent( event.getEvent() );
         ProgramStage programStage = programStageInstance.getProgramStage();
         ProgramInstance programInstance = programStageInstance.getProgramInstance();
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHook.java
@@ -224,7 +224,7 @@ public class RelationshipsValidationHook
 
     private Optional<MetadataIdentifier> getTrackedEntityTypeFromTrackedEntity( TrackerBundle bundle, String uid )
     {
-        final TrackedEntityInstance trackedEntity = bundle.getTrackedEntityInstance( uid );
+        final TrackedEntityInstance trackedEntity = bundle.getPreheat().getTrackedEntity( uid );
 
         return trackedEntity != null
             ? Optional

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -85,7 +85,7 @@ public class RepeatedEventsValidationHook
 
     private void validateNotMultipleEvents( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
     {
-        ProgramInstance programInstance = bundle.getProgramInstance( event.getEnrollment() );
+        ProgramInstance programInstance = bundle.getPreheat().getEnrollment( event.getEnrollment() );
         ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
 
         TrackerImportStrategy strategy = bundle.getStrategy( event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidationHook.java
@@ -81,7 +81,7 @@ public class TrackedEntityAttributeValidationHook extends AttributeValidationHoo
         TrackedEntityType trackedEntityType = bundle.getPreheat()
             .getTrackedEntityType( trackedEntity.getTrackedEntityType() );
 
-        TrackedEntityInstance tei = bundle.getTrackedEntityInstance( trackedEntity.getTrackedEntity() );
+        TrackedEntityInstance tei = bundle.getPreheat().getTrackedEntity( trackedEntity.getTrackedEntity() );
         OrganisationUnit organisationUnit = bundle.getPreheat()
             .getOrganisationUnit( trackedEntity.getOrgUnit() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -180,19 +180,19 @@ public class ValidationUtils
 
     public static boolean trackedEntityInstanceExist( TrackerBundle bundle, String teiUid )
     {
-        return bundle.getTrackedEntityInstance( teiUid ) != null
+        return bundle.getPreheat().getTrackedEntity( teiUid ) != null
             || bundle.getPreheat().getReference( teiUid ).isPresent();
     }
 
     public static boolean enrollmentExist( TrackerBundle bundle, String enrollmentUid )
     {
-        return bundle.getProgramInstance( enrollmentUid ) != null
+        return bundle.getPreheat().getEnrollment( enrollmentUid ) != null
             || bundle.getPreheat().getReference( enrollmentUid ).isPresent();
     }
 
     public static boolean eventExist( TrackerBundle bundle, String eventUid )
     {
-        return bundle.getProgramStageInstance( eventUid ) != null
+        return bundle.getPreheat().getEvent( eventUid ) != null
             || bundle.getPreheat().getReference( eventUid ).isPresent();
     }
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerBundleTest.java
@@ -88,7 +88,7 @@ class TrackerBundleTest
             .trackedEntities( List.of( TrackedEntity.builder().trackedEntity( "uid" ).build() ) )
             .build();
 
-        assertTrue( bundle.getTrackedEntity( null ).isEmpty() );
+        assertTrue( bundle.findTrackedEntityByUid( null ).isEmpty() );
     }
 
     @Test
@@ -109,7 +109,7 @@ class TrackerBundleTest
             .enrollments( List.of( Enrollment.builder().enrollment( "uid" ).build() ) )
             .build();
 
-        assertTrue( bundle.getEnrollment( null ).isEmpty() );
+        assertTrue( bundle.findEnrollmentByUid( null ).isEmpty() );
     }
 
     @Test
@@ -130,7 +130,7 @@ class TrackerBundleTest
             .events( List.of( Event.builder().event( "uid" ).build() ) )
             .build();
 
-        assertTrue( bundle.getEvent( null ).isEmpty() );
+        assertTrue( bundle.findEventByUid( null ).isEmpty() );
     }
 
     @Test
@@ -151,7 +151,7 @@ class TrackerBundleTest
             .relationships( List.of( Relationship.builder().relationship( "uid" ).build() ) )
             .build();
 
-        assertTrue( bundle.getRelationship( null ).isEmpty() );
+        assertTrue( bundle.findRelationshipByUid( null ).isEmpty() );
     }
 
     @Test
@@ -161,7 +161,7 @@ class TrackerBundleTest
             .relationships( List.of( Relationship.builder().build() ) )
             .build();
 
-        assertTrue( bundle.getRelationship( "uid" ).isEmpty() );
+        assertTrue( bundle.findRelationshipByUid( "uid" ).isEmpty() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidationHookTest.java
@@ -102,7 +102,7 @@ class EnrollmentInExistingValidationHookTest
         when( enrollment.getUid() ).thenReturn( enrollmentUid );
         when( enrollment.getTrackerType() ).thenCallRealMethod();
 
-        when( bundle.getTrackedEntityInstance( trackedEntity ) ).thenReturn( trackedEntityInstance );
+        when( preheat.getTrackedEntity( trackedEntity ) ).thenReturn( trackedEntityInstance );
         when( trackedEntityInstance.getUid() ).thenReturn( trackedEntity );
 
         Program program = new Program();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckDataRelationsValidationHookTest.java
@@ -128,7 +128,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( programWithRegistration( PROGRAM_UID, orgUnit, teiType ) );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) )
+        when( preheat.getTrackedEntity( TEI_ID ) )
             .thenReturn( trackedEntityInstance( TEI_TYPE_ID, teiType, orgUnit ) );
 
         Enrollment enrollment = Enrollment.builder()
@@ -200,7 +200,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
         TrackedEntityType anotherTrackedEntityType = trackedEntityType( TEI_ID, 'B' );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) )
+        when( preheat.getTrackedEntity( TEI_ID ) )
             .thenReturn( trackedEntityInstance( TEI_ID, anotherTrackedEntityType, orgUnit ) );
 
         Enrollment enrollment = Enrollment.builder()
@@ -225,7 +225,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( programWithRegistration( PROGRAM_UID, orgUnit, trackedEntityType( TEI_TYPE_ID ) ) );
         when( preheat.getProgramWithOrgUnitsMap() )
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( null );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( null );
 
         TrackedEntity trackedEntity = TrackedEntity.builder()
             .trackedEntity( TEI_ID )
@@ -257,7 +257,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
-        when( bundle.getProgramInstance( ENROLLMENT_ID ) )
+        when( preheat.getEnrollment( ENROLLMENT_ID ) )
             .thenReturn( programInstance( ENROLLMENT_ID, program ) );
 
         CategoryCombo defaultCC = defaultCategoryCombo();
@@ -355,7 +355,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
-        when( bundle.getProgramInstance( ENROLLMENT_ID ) )
+        when( preheat.getEnrollment( ENROLLMENT_ID ) )
             .thenReturn(
                 programInstance( ENROLLMENT_ID, programWithRegistration( CodeGenerator.generateUid(), orgUnit ) ) );
 
@@ -393,7 +393,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
                 Collections.singletonMap( PROGRAM_UID, Collections.singletonList( anotherOrgUnit.getUid() ) ) );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
-        when( bundle.getProgramInstance( ENROLLMENT_ID ) )
+        when( preheat.getEnrollment( ENROLLMENT_ID ) )
             .thenReturn( programInstance( ENROLLMENT_ID, program ) );
 
         CategoryCombo defaultCC = defaultCategoryCombo();
@@ -944,7 +944,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
 
         TrackedEntityInstance validTrackedEntity = new TrackedEntityInstance();
         validTrackedEntity.setUid( "validTrackedEntity" );
-        when( bundle.getTrackedEntityInstance( "validTrackedEntity" ) ).thenReturn( validTrackedEntity );
+        when( preheat.getTrackedEntity( "validTrackedEntity" ) ).thenReturn( validTrackedEntity );
 
         ReferenceTrackerEntity anotherValidTrackedEntity = new ReferenceTrackerEntity( "anotherValidTrackedEntity",
             null );
@@ -1049,7 +1049,7 @@ class PreCheckDataRelationsValidationHookTest extends DhisConvenienceTest
             .thenReturn( Collections.singletonMap( PROGRAM_UID, Collections.singletonList( ORG_UNIT_ID ) ) );
         when( preheat.getProgramStage( MetadataIdentifier.ofUid( PROGRAM_STAGE_ID ) ) )
             .thenReturn( programStage( PROGRAM_STAGE_ID, program ) );
-        when( bundle.getProgramInstance( ENROLLMENT_ID ) )
+        when( preheat.getEnrollment( ENROLLMENT_ID ) )
             .thenReturn( programInstance( ENROLLMENT_ID, program ) );
         return program;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckExistenceValidationHookTest.java
@@ -113,6 +113,8 @@ class PreCheckExistenceValidationHookTest
     @BeforeEach
     void setUp()
     {
+        when( bundle.getPreheat() ).thenReturn( preheat );
+
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         reporter = new ValidationErrorReporter( idSchemes );
     }
@@ -151,7 +153,7 @@ class PreCheckExistenceValidationHookTest
             .trackedEntity( TEI_UID )
             .build();
 
-        when( bundle.getTrackedEntityInstance( TEI_UID ) ).thenReturn( getTei() );
+        when( preheat.getTrackedEntity( TEI_UID ) ).thenReturn( getTei() );
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -165,7 +167,7 @@ class PreCheckExistenceValidationHookTest
             .trackedEntity( SOFT_DELETED_TEI_UID )
             .build();
 
-        when( bundle.getTrackedEntityInstance( SOFT_DELETED_TEI_UID ) ).thenReturn( getSoftDeletedTei() );
+        when( preheat.getTrackedEntity( SOFT_DELETED_TEI_UID ) ).thenReturn( getSoftDeletedTei() );
         when( bundle.getStrategy( any( TrackedEntity.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
 
@@ -179,7 +181,7 @@ class PreCheckExistenceValidationHookTest
             .trackedEntity( TEI_UID )
             .build();
 
-        when( bundle.getTrackedEntityInstance( TEI_UID ) ).thenReturn( getTei() );
+        when( preheat.getTrackedEntity( TEI_UID ) ).thenReturn( getTei() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         validationHook.validateTrackedEntity( reporter, bundle, trackedEntity );
@@ -235,7 +237,7 @@ class PreCheckExistenceValidationHookTest
             .enrollment( ENROLLMENT_UID )
             .build();
 
-        when( bundle.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
+        when( preheat.getEnrollment( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
@@ -249,7 +251,7 @@ class PreCheckExistenceValidationHookTest
             .enrollment( SOFT_DELETED_ENROLLMENT_UID )
             .build();
 
-        when( bundle.getProgramInstance( SOFT_DELETED_ENROLLMENT_UID ) ).thenReturn( getSoftDeletedEnrollment() );
+        when( preheat.getEnrollment( SOFT_DELETED_ENROLLMENT_UID ) ).thenReturn( getSoftDeletedEnrollment() );
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         validationHook.validateEnrollment( reporter, bundle, enrollment );
 
@@ -263,7 +265,7 @@ class PreCheckExistenceValidationHookTest
             .enrollment( ENROLLMENT_UID )
             .build();
 
-        when( bundle.getProgramInstance( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
+        when( preheat.getEnrollment( ENROLLMENT_UID ) ).thenReturn( getEnrollment() );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         validationHook.validateEnrollment( reporter, bundle, enrollment );
@@ -319,7 +321,7 @@ class PreCheckExistenceValidationHookTest
             .event( EVENT_UID )
             .build();
 
-        when( bundle.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
+        when( preheat.getEvent( EVENT_UID ) ).thenReturn( getEvent() );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         validationHook.validateEvent( reporter, bundle, event );
 
@@ -333,7 +335,7 @@ class PreCheckExistenceValidationHookTest
             .event( SOFT_DELETED_EVENT_UID )
             .build();
 
-        when( bundle.getProgramStageInstance( SOFT_DELETED_EVENT_UID ) ).thenReturn( getSoftDeletedEvent() );
+        when( preheat.getEvent( SOFT_DELETED_EVENT_UID ) ).thenReturn( getSoftDeletedEvent() );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         validationHook.validateEvent( reporter, bundle, event );
 
@@ -347,7 +349,7 @@ class PreCheckExistenceValidationHookTest
             .event( EVENT_UID )
             .build();
 
-        when( bundle.getProgramStageInstance( EVENT_UID ) ).thenReturn( getEvent() );
+        when( preheat.getEvent( EVENT_UID ) ).thenReturn( getEvent() );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
 
         validationHook.validateEvent( reporter, bundle, event );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckMetaValidationHookTest.java
@@ -169,7 +169,7 @@ class PreCheckMetaValidationHookTest
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
-        when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
+        when( preheat.getTrackedEntity( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
@@ -205,7 +205,7 @@ class PreCheckMetaValidationHookTest
 
         // when
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_UID ) ) ).thenReturn( new Program() );
-        when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
+        when( preheat.getTrackedEntity( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 
@@ -239,7 +239,7 @@ class PreCheckMetaValidationHookTest
         // when
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_UID ) ) )
             .thenReturn( new OrganisationUnit() );
-        when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
+        when( preheat.getTrackedEntity( TRACKED_ENTITY_UID ) ).thenReturn( new TrackedEntityInstance() );
 
         validatorToTest.validateEnrollment( reporter, bundle, enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckSecurityOwnershipValidationHookTest.java
@@ -133,6 +133,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
     @BeforeEach
     public void setUp()
     {
+        when( bundle.getPreheat() ).thenReturn( preheat );
+
         user = makeUser( "A" );
         when( bundle.getUser() ).thenReturn( user );
 
@@ -188,7 +190,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -253,7 +255,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithNoProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -274,7 +276,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithDeleteProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithDeleteProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -296,7 +298,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getUser() ).thenReturn( deleteTeiAuthorisedUser() );
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -317,7 +319,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
             .build();
 
         when( bundle.getStrategy( trackedEntity ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getTrackedEntityInstance( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
+        when( preheat.getTrackedEntity( TEI_ID ) ).thenReturn( getTEIWithProgramInstances() );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
         when( aclService.canDataWrite( user, trackedEntityType ) ).thenReturn( true );
@@ -409,7 +411,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramInstance programInstance = getEnrollment( enrollment.getEnrollment() );
         programInstance.setOrganisationUnit( null );
 
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( programInstance );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -485,7 +487,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -535,7 +537,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() ).thenReturn( Collections.emptyList() );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -562,7 +564,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getUser() ).thenReturn( deleteEnrollmentAuthorisedUser() );
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() )
             .thenReturn( Collections.singletonList( enrollment.getEnrollment() ) );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -587,7 +589,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() ).thenReturn( Collections.emptyList() );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( false );
@@ -613,7 +615,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
         when( preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent() )
             .thenReturn( Collections.singletonList( enrollment.getEnrollment() ) );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -638,7 +640,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( false );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
@@ -663,7 +665,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( enrollment ) ).thenReturn( TrackerImportStrategy.DELETE );
-        when( bundle.getProgramInstance( enrollment.getEnrollment() ) )
+        when( preheat.getEnrollment( enrollment.getEnrollment() ) )
             .thenReturn( getEnrollment( enrollment.getEnrollment() ) );
         when( aclService.canDataWrite( user, program ) ).thenReturn( true );
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( false );
@@ -692,8 +694,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
 
-        when( bundle.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( programStageInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
 
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
             .thenReturn( true );
@@ -748,7 +750,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -775,7 +777,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE_AND_UPDATE );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -807,8 +809,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( bundle.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( programStageInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
 
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
@@ -839,8 +841,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( bundle.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( programStageInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
         when( preheat.getProgramOwner() )
             .thenReturn( Collections.singletonMap( TEI_ID, Collections.singletonMap( PROGRAM_ID,
                 new TrackedEntityProgramOwnerOrgUnit( TEI_ID, PROGRAM_ID, organisationUnit ) ) ) );
@@ -880,8 +882,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
 
-        when( bundle.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( programStageInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
 
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
@@ -906,7 +908,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserHierarchyCached( user, organisationUnit ) )
@@ -935,7 +937,7 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.CREATE );
         when( preheat.getProgramStage( event.getProgramStage() ) ).thenReturn( programStage );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( getEnrollment( null ) );
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM_ID ) ) ).thenReturn( program );
         when( preheat.getOrganisationUnit( MetadataIdentifier.ofUid( ORG_UNIT_ID ) ) ).thenReturn( organisationUnit );
         when( organisationUnitService.isInUserSearchHierarchyCached( user, organisationUnit ) )
@@ -966,8 +968,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         ProgramInstance programInstance = getEnrollment( enrollmentUid );
         ProgramStageInstance programStageInstance = getEvent();
         programStageInstance.setProgramInstance( programInstance );
-        when( bundle.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( programStageInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
 
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );
@@ -999,8 +1001,8 @@ class PreCheckSecurityOwnershipValidationHookTest extends DhisConvenienceTest
         programStageInstance.setProgramInstance( programInstance );
         programStageInstance.setOrganisationUnit( null );
 
-        when( bundle.getProgramStageInstance( event.getEvent() ) ).thenReturn( programStageInstance );
-        when( bundle.getProgramInstance( event.getEnrollment() ) ).thenReturn( programInstance );
+        when( preheat.getEvent( event.getEvent() ) ).thenReturn( programStageInstance );
+        when( preheat.getEnrollment( event.getEnrollment() ) ).thenReturn( programInstance );
 
         when( aclService.canDataRead( user, program.getTrackedEntityType() ) ).thenReturn( true );
         when( aclService.canDataRead( user, program ) ).thenReturn( true );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/PreCheckUpdatableFieldsValidationHookTest.java
@@ -88,6 +88,7 @@ class PreCheckUpdatableFieldsValidationHookTest
     @Mock
     private TrackerBundle bundle;
 
+    @Mock
     private TrackerPreheat preheat;
 
     private ValidationErrorReporter reporter;
@@ -103,15 +104,13 @@ class PreCheckUpdatableFieldsValidationHookTest
         when( bundle.getStrategy( any( Enrollment.class ) ) ).thenReturn( TrackerImportStrategy.UPDATE );
         when( bundle.getStrategy( any( Event.class ) ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        when( bundle.getTrackedEntityInstance( TRACKED_ENTITY_ID ) ).thenReturn( trackedEntityInstance() );
-        when( bundle.getProgramInstance( ENROLLMENT_ID ) ).thenReturn( programInstance() );
-        when( bundle.getProgramStageInstance( EVENT_ID ) ).thenReturn( programStageInstance() );
+        when( preheat.getTrackedEntity( TRACKED_ENTITY_ID ) ).thenReturn( trackedEntityInstance() );
+        when( preheat.getEnrollment( ENROLLMENT_ID ) ).thenReturn( programInstance() );
+        when( preheat.getEvent( EVENT_ID ) ).thenReturn( programStageInstance() );
 
-        preheat = new TrackerPreheat();
-        TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        preheat.setIdSchemes( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
         when( bundle.getPreheat() ).thenReturn( preheat );
+
+        reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidationHookTest.java
@@ -313,7 +313,7 @@ class RelationshipsValidationHookTest
         trackedEntityInstance.setUid( trackedEntityUid );
         trackedEntityInstance.setTrackedEntityType( teiTrackedEntityType );
 
-        when( bundle.getTrackedEntityInstance( trackedEntityUid ) ).thenReturn( trackedEntityInstance );
+        when( preheat.getTrackedEntity( trackedEntityUid ) ).thenReturn( trackedEntityInstance );
 
         validationHook.validateRelationship( reporter, bundle, relationship );
 


### PR DESCRIPTION
Clean up in `TrackerBundle`
- Rename get entities from bundle methods to findBy convention as they return and Optional in case nothing was found
- Move get entities from DB methods to preheat