### PR TITLE
chore: add smaller Validator interface DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/config/TrackerValidationConfig.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/config/TrackerValidationConfig.java
@@ -56,7 +56,6 @@ import org.hisp.dhis.tracker.validation.hooks.PreCheckUidValidationHook;
 import org.hisp.dhis.tracker.validation.hooks.PreCheckUpdatableFieldsValidationHook;
 import org.hisp.dhis.tracker.validation.hooks.RelationshipsValidationHook;
 import org.hisp.dhis.tracker.validation.hooks.RepeatedEventsValidationHook;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityAttributeValidationHook;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -93,7 +92,6 @@ public class TrackerValidationConfig
     {
         return getHookByClass( ImmutableList.of( EnrollmentRuleValidationHook.class,
             EventRuleValidationHook.class,
-            TrackedEntityAttributeValidationHook.class,
             EnrollmentAttributeValidationHook.class,
             EventDataValuesValidationHook.class ) );
     }
@@ -108,8 +106,6 @@ public class TrackerValidationConfig
             PreCheckUpdatableFieldsValidationHook.class,
             PreCheckDataRelationsValidationHook.class,
             PreCheckSecurityOwnershipValidationHook.class,
-
-            TrackedEntityAttributeValidationHook.class,
 
             EnrollmentNoteValidationHook.class,
             EnrollmentInExistingValidationHook.class,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -63,19 +63,26 @@ public class DefaultTrackerValidationService
     @Qualifier( "ruleEngineValidationHooks" )
     private final List<TrackerValidationHook> ruleEngineValidationHooks;
 
+    @Qualifier( "org.hisp.dhis.tracker.validation.DefaultValidators" )
+    private final Validators validators;
+
+    @Qualifier( "org.hisp.dhis.tracker.validation.RuleEngineValidators" )
+    private final Validators ruleEngineValidators;
+
     @Override
     public TrackerValidationReport validate( TrackerBundle bundle )
     {
-        return validate( bundle, validationHooks );
+        return validate( bundle, validationHooks, validators );
     }
 
     @Override
     public TrackerValidationReport validateRuleEngine( TrackerBundle bundle )
     {
-        return validate( bundle, ruleEngineValidationHooks );
+        return validate( bundle, ruleEngineValidationHooks, ruleEngineValidators );
     }
 
-    private TrackerValidationReport validate( TrackerBundle bundle, List<TrackerValidationHook> hooks )
+    private TrackerValidationReport validate( TrackerBundle bundle, List<TrackerValidationHook> hooks,
+        Validators validators )
     {
         TrackerValidationReport validationReport = new TrackerValidationReport();
 
@@ -95,7 +102,7 @@ public class DefaultTrackerValidationService
 
         try
         {
-            validateTrackedEntities( bundle, hooks, reporter );
+            validateTrackedEntities( bundle, hooks, validators, reporter );
             validateEnrollments( bundle, hooks, reporter );
             validateEvents( bundle, hooks, reporter );
             validateRelationships( bundle, hooks, reporter );
@@ -122,12 +129,13 @@ public class DefaultTrackerValidationService
         return validationReport;
     }
 
-    private void validateTrackedEntities( TrackerBundle bundle, List<TrackerValidationHook> hooks,
-        ValidationErrorReporter reporter )
+    private void validateTrackedEntities( TrackerBundle bundle, List<TrackerValidationHook> preCheckHooks,
+        Validators validators, ValidationErrorReporter reporter )
     {
         for ( TrackedEntity tei : bundle.getTrackedEntities() )
         {
-            for ( TrackerValidationHook hook : hooks )
+            boolean failed = false;
+            for ( TrackerValidationHook hook : preCheckHooks )
             {
                 if ( hook.needsToRun( bundle.getStrategy( tei ) ) )
                 {
@@ -141,8 +149,28 @@ public class DefaultTrackerValidationService
 
                     if ( hook.skipOnError() && didNotPassValidation( reporter, tei.getUid() ) )
                     {
-                        break; // skip subsequent validation hooks for this invalid entity
+                        failed = true;
+                        break; // skip subsequent validation for this invalid entity
                     }
+                }
+            }
+
+            if ( failed )
+            {
+                continue;
+            }
+
+            for ( Validator<TrackedEntity> validator : validators.getTrackedEntityValidators() )
+            {
+                if ( validator.needsToRun( bundle.getStrategy( tei ) ) )
+                {
+                    Timer hookTimer = Timer.startTimer();
+
+                    validator.validate( reporter, bundle, tei );
+
+                    reporter.addTiming( new Timing(
+                        validator.getClass().getName(),
+                        hookTimer.toString() ) );
                 }
             }
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -157,7 +157,7 @@ public class DefaultTrackerValidationService
 
             if ( failed )
             {
-                continue;
+                continue; // skip specific validations for this invalid entity
             }
 
             for ( Validator<TrackedEntity> validator : validators.getTrackedEntityValidators() )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidators.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.validation.hooks.TrackedEntityAttributeValidator;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link Validators} used in
+ * {@link TrackerValidationService#validate(TrackerBundle)}.
+ */
+@RequiredArgsConstructor
+@Component( "org.hisp.dhis.tracker.validation.DefaultValidators" )
+public class DefaultValidators implements Validators
+{
+
+    private final TrackedEntityAttributeValidator attributeValidator;
+
+    @Override
+    public List<Validator<TrackedEntity>> getTrackedEntityValidators()
+    {
+        return List.of(
+            attributeValidator );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/RuleEngineValidators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/RuleEngineValidators.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.validation.hooks.TrackedEntityAttributeValidator;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link Validators} used in
+ * {@link TrackerValidationService#validateRuleEngine(TrackerBundle)}.
+ */
+@RequiredArgsConstructor
+@Component( "org.hisp.dhis.tracker.validation.RuleEngineValidators" )
+public class RuleEngineValidators implements Validators
+{
+
+    private final TrackedEntityAttributeValidator attributeValidator;
+
+    @Override
+    public List<Validator<TrackedEntity>> getTrackedEntityValidators()
+    {
+        return List.of(
+            attributeValidator );
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.TrackerDto;
+
+@FunctionalInterface
+public interface Validator<T extends TrackerDto>
+{
+    /**
+     * Validates given input and adds errors and warnings to {@code reporter}.
+     *
+     * @param reporter aggregates errors and warnings
+     * @param bundle tracker bundle
+     * @param input input to validate
+     */
+    void validate( ValidationErrorReporter reporter, TrackerBundle bundle, T input );
+
+    default boolean needsToRun( TrackerImportStrategy strategy )
+    {
+        return strategy != TrackerImportStrategy.DELETE;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validators.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation;
+
+import java.util.List;
+
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+
+public interface Validators
+{
+
+    List<Validator<TrackedEntity>> getTrackedEntityValidators();
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidator.java
@@ -56,8 +56,8 @@ import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.TrackerValidationHook;
 import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 import org.springframework.stereotype.Component;
 
@@ -65,18 +65,17 @@ import org.springframework.stereotype.Component;
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Component
-public class TrackedEntityAttributeValidationHook extends AttributeValidationHook
-    implements TrackerValidationHook
+public class TrackedEntityAttributeValidator extends AttributeValidationHook
+    implements Validator<TrackedEntity>
 {
-    public TrackedEntityAttributeValidationHook( TrackedAttributeValidationService teAttrService,
+    public TrackedEntityAttributeValidator( TrackedAttributeValidationService teAttrService,
         DhisConfigurationProvider dhisConfigurationProvider )
     {
         super( teAttrService, dhisConfigurationProvider );
     }
 
     @Override
-    public void validateTrackedEntity( ValidationErrorReporter reporter, TrackerBundle bundle,
-        TrackedEntity trackedEntity )
+    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         TrackedEntityType trackedEntityType = bundle.getPreheat()
             .getTrackedEntityType( trackedEntity.getTrackedEntityType() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.tracker.validation;
 
+import static java.util.Collections.emptyList;
 import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasError;
 import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationReport.assertHasWarning;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,13 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.BiConsumer;
@@ -79,6 +80,10 @@ class DefaultTrackerValidationServiceTest
 
     private TrackerValidationHook hook2;
 
+    private Validators validators;
+
+    private Validators ruleEngineValidators;
+
     @BeforeEach
     void setUp()
     {
@@ -87,6 +92,9 @@ class DefaultTrackerValidationServiceTest
 
         hook1 = mock( TrackerValidationHook.class );
         hook2 = mock( TrackerValidationHook.class );
+
+        validators = mock( Validators.class );
+        ruleEngineValidators = mock( Validators.class );
 
         bundleBuilder = newBundle();
     }
@@ -98,7 +106,8 @@ class DefaultTrackerValidationServiceTest
             .validationMode( ValidationMode.SKIP )
             .user( null )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1 ), emptyList(), validators,
+            ruleEngineValidators );
 
         service.validate( bundle );
 
@@ -112,7 +121,8 @@ class DefaultTrackerValidationServiceTest
             .validationMode( ValidationMode.SKIP )
             .user( superUser() )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1 ), emptyList(), validators,
+            ruleEngineValidators );
 
         service.validate( bundle );
 
@@ -126,7 +136,8 @@ class DefaultTrackerValidationServiceTest
             .validationMode( ValidationMode.FULL )
             .user( superUser() )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), emptyList(), validators,
+            ruleEngineValidators );
 
         service.validate( bundle );
 
@@ -158,7 +169,7 @@ class DefaultTrackerValidationServiceTest
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E9999 ) )
             .build();
         service = new DefaultTrackerValidationService( List.of( skipOnError, doNotSkipOnError ),
-            Collections.emptyList() );
+            emptyList(), validators, ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -194,7 +205,8 @@ class DefaultTrackerValidationServiceTest
             .skipOnError( false )
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E9999 ) )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), emptyList(), validators,
+            ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -224,7 +236,8 @@ class DefaultTrackerValidationServiceTest
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E1032 ) )
             .build();
         TrackerValidationHook hook2 = mock( TrackerValidationHook.class );
-        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1, hook2 ), emptyList(), validators,
+            ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -253,7 +266,8 @@ class DefaultTrackerValidationServiceTest
         ValidationHook hook1 = ValidationHook.builder()
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E1032 ) )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1 ), emptyList(), validators,
+            ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -273,7 +287,8 @@ class DefaultTrackerValidationServiceTest
             .needsToRun( false )
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E1032 ) )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1 ), emptyList(), validators,
+            ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -293,7 +308,8 @@ class DefaultTrackerValidationServiceTest
             .needsToRun( true )
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E1032 ) )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook1 ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook1 ), emptyList(), validators,
+            ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -319,7 +335,7 @@ class DefaultTrackerValidationServiceTest
                 }
             } )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook ), emptyList(), validators, ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -357,7 +373,7 @@ class DefaultTrackerValidationServiceTest
             .validateEnrollment( addErrorIfMatches( invalidEnrollment, TrackerErrorCode.E1069 ) )
             .validateEvent( addErrorIfMatches( invalidEvent, TrackerErrorCode.E1032 ) )
             .build();
-        service = new DefaultTrackerValidationService( List.of( hook ), Collections.emptyList() );
+        service = new DefaultTrackerValidationService( List.of( hook ), emptyList(), validators, ruleEngineValidators );
 
         TrackerValidationReport report = service.validate( bundle );
 
@@ -370,6 +386,51 @@ class DefaultTrackerValidationServiceTest
         assertTrue( bundle.getTrackedEntities().isEmpty() );
         assertTrue( bundle.getEnrollments().isEmpty() );
         assertTrue( bundle.getEvents().isEmpty() );
+    }
+
+    @Test
+    void shouldNotCallValidatorIfPreCheckHookWithSkipOnErrorFail()
+    {
+        TrackedEntity invalidTrackedEntity = trackedEntity();
+        bundle = bundleBuilder
+            .trackedEntities( trackedEntities( invalidTrackedEntity ) )
+            .build();
+
+        Validator<TrackedEntity> validator = mock( Validator.class );
+        when( validators.getTrackedEntityValidators() ).thenReturn( List.of( validator ) );
+
+        ValidationHook hook = ValidationHook.builder()
+            .skipOnError( true )
+            .validateTrackedEntity( addErrorIfMatches( invalidTrackedEntity, TrackerErrorCode.E1090 ) )
+            .build();
+        service = new DefaultTrackerValidationService( List.of( hook ), emptyList(), validators, ruleEngineValidators );
+
+        service.validate( bundle );
+
+        verifyNoInteractions( validator );
+    }
+
+    @Test
+    void shouldCallValidatorIfPreCheckHookWithSkipOnErrorFail()
+    {
+        TrackedEntity invalidTrackedEntity = trackedEntity();
+        bundle = bundleBuilder
+            .trackedEntities( trackedEntities( invalidTrackedEntity ) )
+            .build();
+
+        Validator<TrackedEntity> validator = mock( Validator.class );
+        when( validator.needsToRun( any() ) ).thenReturn( true );
+        when( validators.getTrackedEntityValidators() ).thenReturn( List.of( validator ) );
+
+        ValidationHook hook = ValidationHook.builder()
+            .skipOnError( false )
+            .validateTrackedEntity( addErrorIfMatches( invalidTrackedEntity, TrackerErrorCode.E1090 ) )
+            .build();
+        service = new DefaultTrackerValidationService( List.of( hook ), emptyList(), validators, ruleEngineValidators );
+
+        service.validate( bundle );
+
+        verify( validator, times( 1 ) ).validate( any(), any(), eq( invalidTrackedEntity ) );
     }
 
     private User superUser()

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidatorTest.java
@@ -71,11 +71,11 @@ import org.mockito.quality.Strictness;
  */
 @MockitoSettings( strictness = Strictness.LENIENT )
 @ExtendWith( MockitoExtension.class )
-class TrackedEntityAttributeValidationHookTest
+class TrackedEntityAttributeValidatorTest
 {
 
     @InjectMocks
-    private TrackedEntityAttributeValidationHook trackedEntityAttributeValidationHook;
+    private TrackedEntityAttributeValidator validator;
 
     @Mock
     private TrackerPreheat preheat;
@@ -121,8 +121,7 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
         assertEquals( 0, reporter.getErrors().size() );
@@ -158,8 +157,7 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityAttribute( (MetadataIdentifier) any() ) ).thenReturn( contextAttribute );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -178,8 +176,7 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityType( (MetadataIdentifier) any() ) ).thenReturn( new TrackedEntityType() );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 2, reporter.getErrors().size() );
@@ -213,8 +210,7 @@ class TrackedEntityAttributeValidationHookTest
         when( preheat.getTrackedEntityAttribute( MetadataIdentifier.ofUid( tea ) ) )
             .thenReturn( trackedEntityAttribute );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -236,8 +232,7 @@ class TrackedEntityAttributeValidationHookTest
         }
 
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
-            trackedEntityAttribute, sbString.toString() );
+        validator.validateAttributeValue( reporter, te, trackedEntityAttribute, sbString.toString() );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -253,8 +248,7 @@ class TrackedEntityAttributeValidationHookTest
         when( trackedEntityAttribute.getValueType() ).thenReturn( ValueType.NUMBER );
 
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
-            trackedEntityAttribute, "value" );
+        validator.validateAttributeValue( reporter, te, trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -277,8 +271,7 @@ class TrackedEntityAttributeValidationHookTest
         when( preheat.getTrackedEntityAttribute( (MetadataIdentifier) any() ) ).thenReturn( trackedEntityAttribute );
 
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
-        trackedEntityAttributeValidationHook.validateAttributeValue( reporter, te,
-            trackedEntityAttribute, "value" );
+        validator.validateAttributeValue( reporter, te, trackedEntityAttribute, "value" );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -302,8 +295,7 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -326,8 +318,7 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
         assertEquals( 0, reporter.getErrors().size() );
@@ -357,8 +348,7 @@ class TrackedEntityAttributeValidationHookTest
             .trackedEntityType( MetadataIdentifier.ofUid( "trackedEntityType" ) )
             .build();
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
         assertEquals( 0, reporter.getErrors().size() );
@@ -390,8 +380,7 @@ class TrackedEntityAttributeValidationHookTest
 
         when( preheat.getTrackedEntityType( (MetadataIdentifier) any() ) ).thenReturn( trackedEntityType );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -431,8 +420,7 @@ class TrackedEntityAttributeValidationHookTest
 
         bundle.setStrategy( trackedEntity, TrackerImportStrategy.CREATE );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -445,8 +433,7 @@ class TrackedEntityAttributeValidationHookTest
 
         bundle.setStrategy( trackedEntity, TrackerImportStrategy.UPDATE );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertTrue( reporter.hasErrors() );
         assertEquals( 1, reporter.getErrors().size() );
@@ -459,8 +446,7 @@ class TrackedEntityAttributeValidationHookTest
 
         bundle.setStrategy( trackedEntity, TrackerImportStrategy.UPDATE );
 
-        trackedEntityAttributeValidationHook.validateTrackedEntity( reporter, bundle,
-            trackedEntity );
+        validator.validate( reporter, bundle, trackedEntity );
 
         assertFalse( reporter.hasErrors() );
         assertEquals( 0, reporter.getErrors().size() );


### PR DESCRIPTION
First step in breaking up the large `TrackerValidationHook`s into type specific ones. Most of our hooks are already type specific i.e. only validating trackedEntity, enrollment, ... Transitioned the first one `TrackedEntityAttributeValidator` over to the new `Validator` interface.

Smaller Validator interface

`void validate( ValidationErrorReporter reporter, TrackerBundle bundle, T input );`

allows us to define hooks only for trackedEntity, enrollment, ...

All the type specific hooks have `skipOnError=false` so we can simply run them after the `PreCheck` hooks in case they succeeded or have `skipOnError=false`.

I will first migrate the type specific hooks https://github.com/dhis2/dhis2-core/blob/2f607f53c7c920bab48832e9effb2de8696652a3/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/config/TrackerValidationConfig.java#L112-L134

After that I will migrate/break up the `PreCheck` hooks.

Since rule engine validations are different we need 2 `Validators` configurations. Like we already have in our `TrackerValidationConfig`. Aggregating the type specific `Validators` in an interface/implementations will make the transition easier. It also makes testing easier. A `Validator` that needs a service like the `aclService` is easier to build this way as well then what we currently have in the `TrackerValidationConfig`.