### PR TITLE
fix: always sort notifications newest first on redis [DHIS2-9048] (2.39)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/notification/RedisNotifier.java
@@ -36,8 +36,6 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
@@ -93,7 +91,7 @@ public class RedisNotifier implements Notifier
     // -------------------------------------------------------------------------
 
     @Override
-    public Notifier notify( JobConfiguration id, @Nonnull NotificationLevel level, String message, boolean completed )
+    public Notifier notify( JobConfiguration id, NotificationLevel level, String message, boolean completed )
     {
         if ( id != null && !level.isOff() )
         {


### PR DESCRIPTION
backported by picking the entire file from `master` since other changes where not backported causing conflicts.