### PR TITLE
fix: api/events.json ignores skipPaging parameter

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -298,25 +298,27 @@ public abstract class AbstractEventService implements EventService
         Events events = new Events();
         List<Event> eventList = new ArrayList<>();
 
-        if ( params.isPaging() )
+        if ( params.isSkipPaging() )
         {
-            final Pager pager;
-
-            if ( params.isTotalPages() )
-            {
-                eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
-
-                int count = eventStore.getEventCount( params, organisationUnits );
-                pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
-            }
-            else
-            {
-                pager = handleLastPageFlag( params, eventList, organisationUnits );
-            }
-
-            events.setPager( pager );
+            events.setEvents( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
+            return events;
         }
 
+        final Pager pager;
+
+        if ( params.isTotalPages() )
+        {
+            eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
+
+            int count = eventStore.getEventCount( params, organisationUnits );
+            pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
+        }
+        else
+        {
+            pager = handleLastPageFlag( params, eventList, organisationUnits );
+        }
+
+        events.setPager( pager );
         events.setEvents( eventList );
 
         return events;

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/EventControllerIntegrationTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/event/EventControllerIntegrationTest.java
@@ -28,7 +28,10 @@
 package org.hisp.dhis.webapi.controller.event;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.hisp.dhis.jsontree.JsonResponse;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
@@ -106,5 +109,15 @@ class EventControllerIntegrationTest extends DhisControllerIntegrationTest
         assertEquals( HttpStatus.OK, res.status() );
         assertEquals( "application/json+zip", res.header( "Content-Type" ) );
         assertEquals( "attachment; filename=events.json.zip", res.header( "Content-Disposition" ) );
+    }
+
+    @Test
+    void testSkipPaging()
+    {
+        JsonResponse res = GET( "/events.json?skipPaging=true" ).content( HttpStatus.OK );
+        assertFalse( res.get( "pager" ).exists() );
+
+        res = GET( "/events.json?skipPaging=false" ).content( HttpStatus.OK );
+        assertTrue( res.get( "pager" ).exists() );
     }
 }


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14304


### Issue
There are 2 issues affecting Event Export function in Import/Export app.
1.  Form version 2.37 to 2.40 : request with `skipPaging=true`  to `api/events.json` **_always_** get first 50 events back. Because the `skipPaging` parameter is ignored in backend and the method `AbstractEventService.getEvents()` always does the pagination with default paging settings.
2. In 2.36: we always get empty file from Event Export. The code is a bit different comparing to other versions, caused by incomplete backport. The result is AbstractEventService.getEvents() always returns empty list. 

This PR fix the first issue and it will also solve the second one.  [PR for 2.36](https://github.com/dhis2/dhis2-core/pull/12539)



### Fix
- Add an if condition to handle the case where `skipPaging=true` is sent from client.


### Test
- Added controller test.
- Manually tested by sending below request to server.
```
api/events.json?links=false&skipPaging=true&orgUnit=DiszpKrYNg8&program=IpHINAT79UW&includeDeleted=false&dataElementIdScheme=UID&orgUnitIdScheme=UID&idScheme=UID&attachment=events.json&startDate=2020-03-13&endDate=2022-12-13
```