### PR TITLE
fix: Print name of OrgUnit instead of UID [DHIS2-14294]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultQueryItemLocator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultQueryItemLocator.java
@@ -174,6 +174,13 @@ public class DefaultQueryItemLocator
             ValueType valueType = legendSet != null ? ValueType.TEXT : at.getValueType();
 
             qi = new QueryItem( at, program, legendSet, valueType, at.getAggregationType(), at.getOptionSet() );
+
+            ProgramStage programStage = getProgramStageOrFail( dimension );
+
+            if ( programStage != null )
+            {
+                qi.setProgramStage( programStage );
+            }
         }
 
         return Optional.ofNullable( qi );


### PR DESCRIPTION
Tracked Entity Attributes with `Value Type` _Organization Unit_ only show the UID of the selected OU in event reports.

This issue was fixed following the same behaviour of 2.38 and 2.39. In these versions, the org unit is displayed correctly.

Setting the respective program stage of the TEA, will make it be handled as expected (selecting name instead of uid) at querying time.