### PR TITLE
fix: Fix NPE when Spring try to convert XML and pathInfo is null

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/CsvMessageConverter.java
@@ -67,7 +67,7 @@ public class CsvMessageConverter extends AbstractRootNodeMessageConverter
             return super.supports( clazz );
         }
 
-        String pathInfo = request.getPathInfo();
+        String pathInfo = request.getPathInfo() == null ? "" : request.getPathInfo();
 
         for ( var pathPattern : WebMvcConfig.CSV_PATTERNS )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java
@@ -55,7 +55,7 @@ public class XmlMessageConverter extends AbstractRootNodeMessageConverter
             return super.supports( clazz );
         }
 
-        String pathInfo = request.getPathInfo();
+        String pathInfo = request.getPathInfo() == null ? "" : request.getPathInfo();
 
         for ( var pathPattern : WebMvcConfig.XML_PATTERNS )
         {


### PR DESCRIPTION
Here is a summary of what we know.
These tests are failing
```
Error:    ApiTokenAuthenticationTest.testAllowedIpRule » IllegalState Failed to load ApplicationContext
Error:    ApiTokenAuthenticationTest.testAllowedMethodRule » IllegalState Failed to load ApplicationContext
Error:    ApiTokenAuthenticationTest.testAllowedReferrerRule » IllegalState Failed to load ApplicationContext
Error:    ApiTokenAuthenticationTest.testApiTokenAuthentication » IllegalState Failed to load ApplicationContext
Error:    ApiTokenAuthenticationTest.testAuthWithDisabledUser » IllegalState Failed to load ApplicationContext
Error:    ApiTokenAuthenticationTest.testExpiredToken » IllegalState Failed to load ApplicationContext
Error:    ApiTokenAuthenticationTest.testInvalidApiTokenAuthentication » IllegalState Failed to load ApplicationContext
Error:    JwtBearerTokenTest.testExpiredToken » IllegalState Failed to load ApplicationContext
Error:    JwtBearerTokenTest.testJwkEncodeEndDecode » IllegalState Failed to load ApplicationContext
Error:    JwtBearerTokenTest.testMalformedToken » IllegalState Failed to load ApplicationContext
Error:    JwtBearerTokenTest.testMissingUser » IllegalState Failed to load ApplicationContext
Error:    JwtBearerTokenTest.testNoClientMatch » IllegalState Failed to load ApplicationContext
Error:    JwtBearerTokenTest.testSuccessfulRequest » IllegalState Failed to load ApplicationContext

```
stack traces point to
```
org.springframework.test.context.cache.DefaultCacheAwareContextLoaderDelegate.loadContext(DefaultCacheAwareContextLoaderDelegate.java:90) ~[spring-test-5.3.24.jar:5.3.24]
2022-12-15T09:01:09.1521389Z 	... 73 more
2022-12-15T09:01:09.1521652Z Caused by: java.lang.NullPointerException
2022-12-15T09:01:09.1521999Z 	at java.util.regex.Matcher.getTextLength(Matcher.java:1770) ~[?:?]
2022-12-15T09:01:09.1522372Z 	at java.util.regex.Matcher.reset(Matcher.java:416) ~[?:?]
2022-12-15T09:01:09.1522722Z 	at java.util.regex.Matcher.<init>(Matcher.java:253) ~[?:?]
2022-12-15T09:01:09.1523080Z 	at java.util.regex.Pattern.matcher(Pattern.java:1134) ~[?:?]
2022-12-15T09:01:09.1523784Z 	at org.hisp.dhis.webapi.mvc.messageconverter.XmlMessageConverter.supports(XmlMessageConverter.java:62) ~[dhis-web-api-2.40-SNAPSHOT.jar:?]
```
Points to
`[https://github.com/dhis2/dhis2-core/blob/72ee54a4419e42e08048eb5bfee0e359df8e957a/[…]/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java](https://github.com/dhis2/dhis2-core/blob/72ee54a4419e42e08048eb5bfee0e359df8e957a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java#L58)
`request path info is null.
According to https://stackoverflow.com/questions/8078364/spring-mvc-controller-getpathinfo-is-null
This is not exceptional. AFAIK if you declare a controller and make a request to this controller with the exact URL as declared in the mapping it will be null.
The ApiTokenControllerTest [createNewEmptyToken](https://github.com/dhis2/dhis2-core/blob/72ee54a4419e42e08048eb5bfee0e359df8e957a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/ApiTokenControllerTest.java#L313) for example
Request mapping declared in controller ApiTokenController: /apiToken/
Request made in test to URL: /apiToken/
Request path: null
Adapted to example from SO post:
Request mapping declared in controller: /apiToken/*
Request made to URL: /apiToken/foo
Request path: foo
If I understand this correctly [XmlMessageConverter.java](https://github.com/dhis2/dhis2-core/blob/72ee54a4419e42e08048eb5bfee0e359df8e957a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/mvc/messageconverter/XmlMessageConverter.java#L58) should be dealing with null request path info as this is a valid case.

Following @jbee suggestion I am just converting null value for PathInfo to ""