### PR TITLE
feat: Support unlogged tables in analytics export [DHIS2-14208]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/DefaultResourceTableService.java
@@ -36,6 +36,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionGroupSet;
@@ -98,12 +99,15 @@ public class DefaultResourceTableService
 
     private final StatementBuilder statementBuilder;
 
+    private final AnalyticsExportSettings analyticsExportSettings;
+
     @Override
     @Transactional
     public void generateOrganisationUnitStructures()
     {
         resourceTableStore.generateResourceTable( new OrganisationUnitStructureResourceTable(
-            null, organisationUnitService, organisationUnitService.getNumberOfOrganisationalLevels() ) );
+            null, organisationUnitService, organisationUnitService.getNumberOfOrganisationalLevels(),
+            analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -111,7 +115,8 @@ public class DefaultResourceTableService
     public void generateDataSetOrganisationUnitCategoryTable()
     {
         resourceTableStore.generateResourceTable( new DataSetOrganisationUnitCategoryResourceTable(
-            idObjectManager.getAllNoAcl( DataSet.class ), categoryService.getDefaultCategoryOptionCombo() ) );
+            idObjectManager.getAllNoAcl( DataSet.class ), categoryService.getDefaultCategoryOptionCombo(),
+            analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -119,7 +124,7 @@ public class DefaultResourceTableService
     public void generateCategoryOptionComboNames()
     {
         resourceTableStore.generateResourceTable( new CategoryOptionComboNameResourceTable(
-            idObjectManager.getAllNoAcl( CategoryCombo.class ) ) );
+            idObjectManager.getAllNoAcl( CategoryCombo.class ), analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -127,7 +132,8 @@ public class DefaultResourceTableService
     public void generateDataElementGroupSetTable()
     {
         resourceTableStore.generateResourceTable( new DataElementGroupSetResourceTable(
-            idObjectManager.getDataDimensionsNoAcl( DataElementGroupSet.class ) ) );
+            idObjectManager.getDataDimensionsNoAcl( DataElementGroupSet.class ),
+            analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -135,7 +141,7 @@ public class DefaultResourceTableService
     public void generateIndicatorGroupSetTable()
     {
         resourceTableStore.generateResourceTable( new IndicatorGroupSetResourceTable(
-            idObjectManager.getAllNoAcl( IndicatorGroupSet.class ) ) );
+            idObjectManager.getAllNoAcl( IndicatorGroupSet.class ), analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -144,7 +150,8 @@ public class DefaultResourceTableService
     {
         resourceTableStore.generateResourceTable( new OrganisationUnitGroupSetResourceTable(
             idObjectManager.getDataDimensionsNoAcl( OrganisationUnitGroupSet.class ),
-            statementBuilder.supportsPartialIndexes(), organisationUnitService.getNumberOfOrganisationalLevels() ) );
+            statementBuilder.supportsPartialIndexes(), organisationUnitService.getNumberOfOrganisationalLevels(),
+            analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -153,7 +160,8 @@ public class DefaultResourceTableService
     {
         resourceTableStore.generateResourceTable( new CategoryResourceTable(
             idObjectManager.getDataDimensionsNoAcl( Category.class ),
-            idObjectManager.getDataDimensionsNoAcl( CategoryOptionGroupSet.class ) ) );
+            idObjectManager.getDataDimensionsNoAcl( CategoryOptionGroupSet.class ),
+            analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -161,33 +169,38 @@ public class DefaultResourceTableService
     public void generateDataElementTable()
     {
         resourceTableStore.generateResourceTable( new DataElementResourceTable(
-            idObjectManager.getAllNoAcl( DataElement.class ) ) );
+            idObjectManager.getAllNoAcl( DataElement.class ), analyticsExportSettings.getTableType() ) );
     }
 
     @Override
     public void generateDatePeriodTable()
     {
-        resourceTableStore.generateResourceTable( new DatePeriodResourceTable( null ) );
+        resourceTableStore
+            .generateResourceTable( new DatePeriodResourceTable( null, analyticsExportSettings.getTableType() ) );
     }
 
     @Override
     @Transactional
     public void generatePeriodTable()
     {
-        resourceTableStore.generateResourceTable( new PeriodResourceTable( periodService.getAllPeriods() ) );
+        resourceTableStore
+            .generateResourceTable(
+                new PeriodResourceTable( periodService.getAllPeriods(), analyticsExportSettings.getTableType() ) );
     }
 
     @Override
     @Transactional
     public void generateCategoryOptionComboTable()
     {
-        resourceTableStore.generateResourceTable( new CategoryOptionComboResourceTable( null ) );
+        resourceTableStore.generateResourceTable(
+            new CategoryOptionComboResourceTable( null, analyticsExportSettings.getTableType() ) );
     }
 
     @Override
     public void generateDataApprovalRemapLevelTable()
     {
-        resourceTableStore.generateResourceTable( new DataApprovalRemapLevelResourceTable( null ) );
+        resourceTableStore.generateResourceTable(
+            new DataApprovalRemapLevelResourceTable( null, analyticsExportSettings.getTableType() ) );
     }
 
     @Override
@@ -198,7 +211,9 @@ public class DefaultResourceTableService
 
         if ( orgUnitLevels.size() > 0 )
         {
-            resourceTableStore.generateResourceTable( new DataApprovalMinLevelResourceTable( orgUnitLevels ) );
+            resourceTableStore
+                .generateResourceTable(
+                    new DataApprovalMinLevelResourceTable( orgUnitLevels, analyticsExportSettings.getTableType() ) );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboNameResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboNameResourceTable.java
@@ -49,9 +49,12 @@ import com.google.common.collect.Lists;
 public class CategoryOptionComboNameResourceTable
     extends ResourceTable<CategoryCombo>
 {
-    public CategoryOptionComboNameResourceTable( List<CategoryCombo> objects )
+    private final String tableType;
+
+    public CategoryOptionComboNameResourceTable( List<CategoryCombo> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -63,7 +66,7 @@ public class CategoryOptionComboNameResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        return "create table " + getTempTableName() +
+        return "create " + tableType + " table " + getTempTableName() +
             " (categoryoptioncomboid bigint not null primary key, " +
             "categoryoptioncomboname varchar(255), approvallevel integer, " +
             "startdate date, enddate date)";

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryOptionComboResourceTable.java
@@ -42,9 +42,12 @@ import com.google.common.collect.Lists;
 public class CategoryOptionComboResourceTable
     extends ResourceTable<CategoryOptionCombo>
 {
-    public CategoryOptionComboResourceTable( List<CategoryOptionCombo> objects )
+    private final String tableType;
+
+    public CategoryOptionComboResourceTable( List<CategoryOptionCombo> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -56,13 +59,11 @@ public class CategoryOptionComboResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String sql = "CREATE TABLE " + getTempTableName() + " (" +
-            "dataelementid BIGINT NOT NULL, " +
-            "dataelementuid VARCHAR(11) NOT NULL, " +
-            "categoryoptioncomboid BIGINT NOT NULL, " +
-            "categoryoptioncombouid VARCHAR(11) NOT NULL)";
-
-        return sql;
+        return "create " + tableType + " table " + getTempTableName() + " (" +
+            "dataelementid bigint not null, " +
+            "dataelementuid varchar(11) not null, " +
+            "categoryoptioncomboid bigint not null, " +
+            "categoryoptioncombouid varchar(11) not null)";
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/CategoryResourceTable.java
@@ -46,12 +46,15 @@ import com.google.common.collect.Lists;
 public class CategoryResourceTable
     extends ResourceTable<Category>
 {
-    private List<CategoryOptionGroupSet> groupSets;
+    private final List<CategoryOptionGroupSet> groupSets;
 
-    public CategoryResourceTable( List<Category> objects, List<CategoryOptionGroupSet> groupSets )
+    private final String tableType;
+
+    public CategoryResourceTable( List<Category> objects, List<CategoryOptionGroupSet> groupSets, String tableType )
     {
         super( objects );
         this.groupSets = groupSets;
+        this.tableType = tableType;
     }
 
     @Override
@@ -63,11 +66,12 @@ public class CategoryResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String statement = "create table " + getTempTableName() + " (" +
+        String statement = "create " + tableType + " table " + getTempTableName() + " (" +
             "categoryoptioncomboid bigint not null, " +
             "categoryoptioncomboname varchar(255), ";
 
         UniqueNameContext nameContext = new UniqueNameContext();
+
         for ( Category category : objects )
         {
             statement += quote( nameContext.uniqueName( category.getShortName() ) ) + " varchar(230), ";

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalMinLevelResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalMinLevelResourceTable.java
@@ -43,9 +43,12 @@ import com.google.common.collect.Lists;
 public class DataApprovalMinLevelResourceTable
     extends ResourceTable<OrganisationUnitLevel>
 {
-    public DataApprovalMinLevelResourceTable( List<OrganisationUnitLevel> objects )
+    private final String tableType;
+
+    public DataApprovalMinLevelResourceTable( List<OrganisationUnitLevel> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -57,15 +60,13 @@ public class DataApprovalMinLevelResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String sql = "create table " + getTempTableName() + "(" +
+        return "create " + tableType + " table " + getTempTableName() + "(" +
             "workflowid bigint not null, " +
             "periodid bigint not null, " +
             "organisationunitid bigint not null, " +
             "attributeoptioncomboid bigint not null, " +
             "minlevel integer not null, " +
             "primary key (workflowid,periodid,attributeoptioncomboid,organisationunitid))";
-
-        return sql;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalRemapLevelResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataApprovalRemapLevelResourceTable.java
@@ -55,9 +55,12 @@ import com.google.common.collect.Lists;
 public class DataApprovalRemapLevelResourceTable
     extends ResourceTable<DataApprovalWorkflow>
 {
-    public DataApprovalRemapLevelResourceTable( List<DataApprovalWorkflow> objects )
+    private final String tableType;
+
+    public DataApprovalRemapLevelResourceTable( List<DataApprovalWorkflow> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -69,13 +72,11 @@ public class DataApprovalRemapLevelResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String sql = "create table " + getTempTableName() + "(" +
+        return "create " + tableType + " table " + getTempTableName() + "(" +
             "workflowid bigint not null, " +
             "dataapprovallevelid bigint not null, " +
             "level integer not null, " +
             "primary key (workflowid,dataapprovallevelid))";
-
-        return sql;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementGroupSetResourceTable.java
@@ -45,9 +45,12 @@ import com.google.common.collect.Lists;
 public class DataElementGroupSetResourceTable
     extends ResourceTable<DataElementGroupSet>
 {
-    public DataElementGroupSetResourceTable( List<DataElementGroupSet> objects )
+    private final String tableType;
+
+    public DataElementGroupSetResourceTable( List<DataElementGroupSet> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -59,7 +62,7 @@ public class DataElementGroupSetResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String statement = "create table " + getTempTableName() + " (" +
+        String statement = "create " + tableType + " table " + getTempTableName() + " (" +
             "dataelementid bigint not null, " +
             "dataelementname varchar(230), ";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementResourceTable.java
@@ -47,9 +47,12 @@ import com.google.common.collect.Lists;
 public class DataElementResourceTable
     extends ResourceTable<DataElement>
 {
-    public DataElementResourceTable( List<DataElement> objects )
+    private final String tableType;
+
+    public DataElementResourceTable( List<DataElement> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -61,7 +64,7 @@ public class DataElementResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String sql = "CREATE TABLE " + getTempTableName() + " (" +
+        return "create " + tableType + " table " + getTempTableName() + " (" +
             "dataelementid BIGINT NOT NULL PRIMARY KEY, " +
             "dataelementuid CHARACTER(11), " +
             "dataelementname VARCHAR(230), " +
@@ -72,8 +75,6 @@ public class DataElementResourceTable
             "workflowid BIGINT, " +
             "periodtypeid INTEGER, " +
             "periodtypename VARCHAR(230))";
-
-        return sql;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataElementResourceTable.java
@@ -65,16 +65,16 @@ public class DataElementResourceTable
     public String getCreateTempTableStatement()
     {
         return "create " + tableType + " table " + getTempTableName() + " (" +
-            "dataelementid BIGINT NOT NULL PRIMARY KEY, " +
-            "dataelementuid CHARACTER(11), " +
-            "dataelementname VARCHAR(230), " +
-            "datasetid BIGINT, " +
-            "datasetuid CHARACTER(11), " +
-            "datasetname VARCHAR(230), " +
-            "datasetapprovallevel INTEGER, " +
-            "workflowid BIGINT, " +
-            "periodtypeid INTEGER, " +
-            "periodtypename VARCHAR(230))";
+            "dataelementid bigint not null primary key, " +
+            "dataelementuid character(11), " +
+            "dataelementname varchar(230), " +
+            "datasetid bigint, " +
+            "datasetuid character(11), " +
+            "datasetname varchar(230), " +
+            "datasetapprovallevel integer, " +
+            "workflowid bigint, " +
+            "periodtypeid integer, " +
+            "periodtypename varchar(230))";
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataSetOrganisationUnitCategoryResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DataSetOrganisationUnitCategoryResourceTable.java
@@ -53,10 +53,14 @@ public class DataSetOrganisationUnitCategoryResourceTable
 {
     private CategoryOptionCombo defaultOptionCombo;
 
-    public DataSetOrganisationUnitCategoryResourceTable( List<DataSet> objects, CategoryOptionCombo defaultOptionCombo )
+    private final String tableType;
+
+    public DataSetOrganisationUnitCategoryResourceTable( List<DataSet> objects, CategoryOptionCombo defaultOptionCombo,
+        String tableType )
     {
         this.objects = objects;
         this.defaultOptionCombo = defaultOptionCombo;
+        this.tableType = tableType;
     }
 
     @Override
@@ -68,7 +72,7 @@ public class DataSetOrganisationUnitCategoryResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        return "create table " + getTempTableName() + " " +
+        return "create " + tableType + " table " + getTempTableName() +
             "(datasetid bigint not null, organisationunitid bigint not null, " +
             "attributeoptioncomboid bigint not null, costartdate date, coenddate date)";
     }

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/DatePeriodResourceTable.java
@@ -50,9 +50,12 @@ import org.hisp.dhis.resourcetable.ResourceTableType;
 public class DatePeriodResourceTable
     extends ResourceTable<Period>
 {
-    public DatePeriodResourceTable( List<Period> objects )
+    private final String tableType;
+
+    public DatePeriodResourceTable( List<Period> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -64,7 +67,7 @@ public class DatePeriodResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String sql = "create table " + getTempTableName()
+        String sql = "create " + tableType + " table " + getTempTableName()
             + " (dateperiod date not null primary key, year integer not null";
 
         for ( PeriodType periodType : PeriodType.PERIOD_TYPES )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/IndicatorGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/IndicatorGroupSetResourceTable.java
@@ -45,9 +45,12 @@ import com.google.common.collect.Lists;
 public class IndicatorGroupSetResourceTable
     extends ResourceTable<IndicatorGroupSet>
 {
-    public IndicatorGroupSetResourceTable( List<IndicatorGroupSet> objects )
+    private final String tableType;
+
+    public IndicatorGroupSetResourceTable( List<IndicatorGroupSet> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -59,7 +62,7 @@ public class IndicatorGroupSetResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String statement = "create table " + getTempTableName() + " (" +
+        String statement = "create " + tableType + " table " + getTempTableName() + " (" +
             "indicatorid bigint not null, " +
             "indicatorname varchar(230), ";
 

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitGroupSetResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitGroupSetResourceTable.java
@@ -46,16 +46,19 @@ import com.google.common.collect.Lists;
 public class OrganisationUnitGroupSetResourceTable
     extends ResourceTable<OrganisationUnitGroupSet>
 {
-    private boolean supportsPartialIndexes;
+    private final boolean supportsPartialIndexes;
 
-    private int organisationUnitLevels;
+    private final int organisationUnitLevels;
+
+    private final String tableType;
 
     public OrganisationUnitGroupSetResourceTable( List<OrganisationUnitGroupSet> objects,
-        boolean supportsPartialIndexes, int organisationUnitLevels )
+        boolean supportsPartialIndexes, int organisationUnitLevels, String tableType )
     {
         super( objects );
         this.supportsPartialIndexes = supportsPartialIndexes;
         this.organisationUnitLevels = organisationUnitLevels;
+        this.tableType = tableType;
     }
 
     @Override
@@ -67,7 +70,7 @@ public class OrganisationUnitGroupSetResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String statement = "create table " + getTempTableName() + " (" +
+        String statement = "create " + tableType + " table " + getTempTableName() + " (" +
             "organisationunitid bigint not null, " +
             "organisationunitname varchar(230), " +
             "startdate date, ";

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitStructureResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/OrganisationUnitStructureResourceTable.java
@@ -49,16 +49,19 @@ import com.google.common.collect.Lists;
 public class OrganisationUnitStructureResourceTable
     extends ResourceTable<OrganisationUnit>
 {
-    private OrganisationUnitService organisationUnitService; // Nasty
+    private final OrganisationUnitService organisationUnitService; // Nasty
 
-    private int organisationUnitLevels;
+    private final int organisationUnitLevels;
+
+    private final String tableType;
 
     public OrganisationUnitStructureResourceTable( List<OrganisationUnit> objects,
-        OrganisationUnitService organisationUnitService, int organisationUnitLevels )
+        OrganisationUnitService organisationUnitService, int organisationUnitLevels, String tableType )
     {
         super( objects );
         this.organisationUnitService = organisationUnitService;
         this.organisationUnitLevels = organisationUnitLevels;
+        this.tableType = tableType;
     }
 
     @Override
@@ -72,8 +75,9 @@ public class OrganisationUnitStructureResourceTable
     {
         StringBuilder sql = new StringBuilder();
 
-        sql.append( "create table " ).append( getTempTableName() ).append(
-            " (organisationunitid bigint not null primary key, organisationunituid character(11), level integer" );
+        sql.append( "create " ).append( tableType ).append( " table " ).append( getTempTableName() )
+            .append( "(organisationunitid bigint not null primary key," )
+            .append( "organisationunituid character(11), level integer" );
 
         for ( int k = 1; k <= organisationUnitLevels; k++ )
         {

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/resourcetable/table/PeriodResourceTable.java
@@ -55,9 +55,12 @@ import com.google.common.collect.Lists;
 public class PeriodResourceTable
     extends ResourceTable<Period>
 {
-    public PeriodResourceTable( List<Period> objects )
+    private final String tableType;
+
+    public PeriodResourceTable( List<Period> objects, String tableType )
     {
         super( objects );
+        this.tableType = tableType;
     }
 
     @Override
@@ -69,7 +72,7 @@ public class PeriodResourceTable
     @Override
     public String getCreateTempTableStatement()
     {
-        String sql = "create table " + getTempTableName() +
+        String sql = "create " + tableType + " table " + getTempTableName() +
             " (periodid bigint not null primary key, iso varchar(15) not null, daysno integer not null, startdate date not null, enddate date not null, year integer not null";
 
         for ( PeriodType periodType : PeriodType.PERIOD_TYPES )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/AbstractEventJdbcTableManager.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTablePartition;
@@ -84,11 +85,11 @@ public abstract class AbstractEventJdbcTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManager.java
@@ -50,6 +50,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -110,18 +111,6 @@ import com.google.common.collect.Sets;
 public class JdbcAnalyticsTableManager
     extends AbstractJdbcTableManager
 {
-    public JdbcAnalyticsTableManager( IdentifiableObjectManager idObjectManager,
-        OrganisationUnitService organisationUnitService, CategoryService categoryService,
-        SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
-        ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
-        StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
-    {
-        super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
-            dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
-    }
-
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(
         new AnalyticsTableColumn( quote( "dx" ), CHARACTER_11, NOT_NULL, "de.uid" ),
         new AnalyticsTableColumn( quote( "co" ), CHARACTER_11, NOT_NULL, "co.uid" )
@@ -134,6 +123,18 @@ public class JdbcAnalyticsTableManager
         new AnalyticsTableColumn( quote( "pe" ), TEXT, NOT_NULL, "ps.iso" ),
         new AnalyticsTableColumn( quote( "ou" ), CHARACTER_11, NOT_NULL, "ou.uid" ),
         new AnalyticsTableColumn( quote( "oulevel" ), INTEGER, "ous.level" ) );
+
+    public JdbcAnalyticsTableManager( IdentifiableObjectManager idObjectManager,
+        OrganisationUnitService organisationUnitService, CategoryService categoryService,
+        SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
+        ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
+        StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
+    {
+        super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
+            dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
+    }
 
     // -------------------------------------------------------------------------
     // Implementation

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTableManager.java
@@ -42,6 +42,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -85,11 +86,11 @@ public class JdbcCompletenessTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcCompletenessTargetTableManager.java
@@ -39,6 +39,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -80,11 +81,11 @@ public class JdbcCompletenessTargetTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManager.java
@@ -43,6 +43,7 @@ import static org.hisp.dhis.util.DateUtils.getLongDateString;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -80,11 +81,11 @@ public class JdbcEnrollmentAnalyticsTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManager.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -105,11 +106,11 @@ public class JdbcEventAnalyticsTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOrgUnitTargetTableManager.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -75,11 +76,11 @@ public class JdbcOrgUnitTargetTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = Lists.newArrayList(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcValidationResultTableManager.java
@@ -41,6 +41,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -82,11 +83,11 @@ public class JdbcValidationResultTableManager
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
         ResourceTableService resourceTableService, AnalyticsTableHookService tableHookService,
         StatementBuilder statementBuilder, PartitionManager partitionManager, DatabaseInfo databaseInfo,
-        JdbcTemplate jdbcTemplate )
+        JdbcTemplate jdbcTemplate, AnalyticsExportSettings analyticsExportSettings )
     {
         super( idObjectManager, organisationUnitService, categoryService, systemSettingManager,
             dataApprovalLevelService, resourceTableService, tableHookService, statementBuilder, partitionManager,
-            databaseInfo, jdbcTemplate );
+            databaseInfo, jdbcTemplate, analyticsExportSettings );
     }
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = ImmutableList.of(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcAnalyticsTableManagerTest.java
@@ -38,6 +38,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableManager;
@@ -82,6 +83,9 @@ class JdbcAnalyticsTableManagerTest
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private AnalyticsExportSettings analyticsExportSettings;
+
     private AnalyticsTableManager subject;
 
     @BeforeEach
@@ -91,7 +95,7 @@ class JdbcAnalyticsTableManagerTest
             mock( OrganisationUnitService.class ),
             mock( CategoryService.class ), systemSettingManager, mock( DataApprovalLevelService.class ),
             mock( ResourceTableService.class ), mock( AnalyticsTableHookService.class ), mock( StatementBuilder.class ),
-            mock( PartitionManager.class ), mock( DatabaseInfo.class ), jdbcTemplate );
+            mock( PartitionManager.class ), mock( DatabaseInfo.class ), jdbcTemplate, analyticsExportSettings );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEnrollmentAnalyticsTableManagerTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Date;
 
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
 import org.hisp.dhis.analytics.AnalyticsTableUpdateParams;
 import org.hisp.dhis.analytics.partition.PartitionManager;
@@ -80,6 +81,9 @@ class JdbcEnrollmentAnalyticsTableManagerTest
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private AnalyticsExportSettings analyticsExportSettings;
+
     private JdbcEnrollmentAnalyticsTableManager subject;
 
     private static final Date START_TIME = new DateTime( 2019, 8, 1, 0, 0 ).toDate();
@@ -90,7 +94,8 @@ class JdbcEnrollmentAnalyticsTableManagerTest
         subject = new JdbcEnrollmentAnalyticsTableManager( idObjectManager, mock( OrganisationUnitService.class ),
             mock( CategoryService.class ), mock( SystemSettingManager.class ), mock( DataApprovalLevelService.class ),
             mock( ResourceTableService.class ), mock( AnalyticsTableHookService.class ),
-            new PostgreSQLStatementBuilder(), mock( PartitionManager.class ), databaseInfo, jdbcTemplate );
+            new PostgreSQLStatementBuilder(), mock( PartitionManager.class ), databaseInfo, jdbcTemplate,
+            analyticsExportSettings );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcEventAnalyticsTableManagerTest.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.hisp.dhis.analytics.AggregationType;
+import org.hisp.dhis.analytics.AnalyticsExportSettings;
 import org.hisp.dhis.analytics.AnalyticsTable;
 import org.hisp.dhis.analytics.AnalyticsTableColumn;
 import org.hisp.dhis.analytics.AnalyticsTableHookService;
@@ -140,6 +141,9 @@ class JdbcEventAnalyticsTableManagerTest
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private AnalyticsExportSettings analyticsExportSettings;
+
     private JdbcEventAnalyticsTableManager subject;
 
     private Date today;
@@ -167,7 +171,7 @@ class JdbcEventAnalyticsTableManagerTest
         subject = new JdbcEventAnalyticsTableManager( idObjectManager, organisationUnitService, categoryService,
             systemSettingManager, mock( DataApprovalLevelService.class ), mock( ResourceTableService.class ),
             mock( AnalyticsTableHookService.class ), statementBuilder, mock( PartitionManager.class ), databaseInfo,
-            jdbcTemplate );
+            jdbcTemplate, analyticsExportSettings );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.hisp.dhis.external.conf.ConfigurationKey.ANALYTICS_TABLE_UNLOGGED;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * Component responsible for exposing analytics table export settings. Can hold
+ * settings living in configuration files (ie. dhis.conf) or in system settings.
+ *
+ * @author maikel arabori
+ */
+@Component
+@RequiredArgsConstructor
+public class AnalyticsExportSettings
+{
+    private final DhisConfigurationProvider dhisConfigurationProvider;
+
+    private static final String UNLOGGED = "unlogged";
+
+    /**
+     * Returns the respective string that represents the table type to be
+     * exported. Two types are supported: UNLOGGED and DEFAULT. See
+     * {@link AnalyticsTableType}
+     *
+     * @return the string representation of {@link AnalyticsTableType}.
+     */
+    public String getTableType()
+    {
+        if ( dhisConfigurationProvider.isEnabled( ANALYTICS_TABLE_UNLOGGED ) )
+        {
+            return UNLOGGED;
+        }
+
+        return EMPTY;
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/analytics/AnalyticsExportSettings.java
@@ -51,10 +51,10 @@ public class AnalyticsExportSettings
 
     /**
      * Returns the respective string that represents the table type to be
-     * exported. Two types are supported: UNLOGGED and DEFAULT. See
+     * exported. Two types are supported: UNLOGGED and EMPTY. See
      * {@link AnalyticsTableType}
      *
-     * @return the string representation of {@link AnalyticsTableType}.
+     * @return the string representation of the type
      */
     public String getTableType()
     {

--- a/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
+++ b/dhis-2/dhis-support/dhis-support-external/src/main/java/org/hisp/dhis/external/conf/ConfigurationKey.java
@@ -352,6 +352,11 @@ public enum ConfigurationKey
     ANALYTICS_CACHE_EXPIRATION( "analytics.cache.expiration", "0" ),
 
     /**
+     * Use unlogged tables during analytics export. (default: off)
+     */
+    ANALYTICS_TABLE_UNLOGGED( "analytics.table.unlogged", Constants.OFF ),
+
+    /**
      * Artemis support mode, 2 modes supported: EMBEDDED (starts up an embedded
      * Artemis which lives in the same process as your DHIS2 instance), NATIVE
      * (connects to an external Artemis instance, remember to set username /


### PR DESCRIPTION
_[Backport from master/2.40]_

This set of changes is adding support for a new `dhis.conf` property named `analytics.table.unlogged`.

When this property is set to `on`, the analytics table export process will create tables using the `unlogged` flag. This will make the table export much faster (about ~40% faster on my local desktop). The SQL will look like this:
```
create unlogged table ...
```

The drawbacks of this approach are that tables generated in this mode cannot be replicated, and if Postgres crashes or is shut down abruptly all `unlogged` tables are truncated. So this flag is not recommended if clients need replication or don't want to have analytics tables eventually truncated.

If the flag is not present or is set to `off`, the tables are generated as usual. ie.:
```
create table ...
```

As most clients do not use or need analytics tables replication, this new property might give them a good performance boost.
