### PR TITLE
chore: remove prefix from ValidationErrorReporter DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -88,7 +88,7 @@ public class DefaultTrackerValidationService
 
         // Note that the bundle gets cloned internally, so the original bundle
         // is always available
-        ValidationErrorReporter reporter = new ValidationErrorReporter( bundle.getPreheat().getIdSchemes(),
+        Reporter reporter = new Reporter( bundle.getPreheat().getIdSchemes(),
             bundle.getValidationMode() == ValidationMode.FAIL_FAST );
 
         try
@@ -118,7 +118,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateTrackedEntities( TrackerBundle bundle, List<Validator<TrackedEntity>> validators,
-        ValidationErrorReporter reporter )
+        Reporter reporter )
     {
         for ( TrackedEntity tei : bundle.getTrackedEntities() )
         {
@@ -144,7 +144,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateEnrollments( TrackerBundle bundle, List<Validator<Enrollment>> validators,
-        ValidationErrorReporter reporter )
+        Reporter reporter )
     {
         for ( Enrollment enrollment : bundle.getEnrollments() )
         {
@@ -170,7 +170,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateEvents( TrackerBundle bundle, List<Validator<Event>> validators,
-        ValidationErrorReporter reporter )
+        Reporter reporter )
     {
         for ( Event event : bundle.getEvents() )
         {
@@ -196,7 +196,7 @@ public class DefaultTrackerValidationService
     }
 
     private void validateRelationships( TrackerBundle bundle, List<Validator<Relationship>> validators,
-        ValidationErrorReporter reporter )
+        Reporter reporter )
     {
         for ( Relationship relationship : bundle.getRelationships() )
         {
@@ -222,7 +222,7 @@ public class DefaultTrackerValidationService
     }
 
     private static void validateBundle( TrackerBundle bundle, List<Validator<TrackerBundle>> validators,
-        ValidationErrorReporter reporter )
+        Reporter reporter )
     {
         for ( Validator<TrackerBundle> hook : validators )
         {
@@ -236,7 +236,7 @@ public class DefaultTrackerValidationService
         }
     }
 
-    private boolean didNotPassValidation( ValidationErrorReporter reporter, String uid )
+    private boolean didNotPassValidation( Reporter reporter, String uid )
     {
         return reporter.getErrors().stream().anyMatch( r -> r.getUid().equals( uid ) );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Reporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Reporter.java
@@ -57,7 +57,7 @@ import org.hisp.dhis.tracker.domain.TrackerDto;
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
 @Value
-public class ValidationErrorReporter
+public class Reporter
 {
     List<Error> errors;
 
@@ -72,21 +72,20 @@ public class ValidationErrorReporter
     @Getter( AccessLevel.PACKAGE )
     /*
      * Keeps track of all the invalid Tracker objects (i.e. objects with at
-     * least one Error in the ValidationErrorReporter) encountered during the
-     * validation process.
+     * least one Error in the Reporter) encountered during the validation
+     * process.
      */
     EnumMap<TrackerType, Set<String>> invalidDTOs;
 
     /**
-     * Create a {@link ValidationErrorReporter} reporting all errors and
-     * warnings with identifiers in given idSchemes. {@link #addError(Error)}
-     * will only throw a {@link ValidationFailFastException} if {@code failFast}
-     * true is given.
+     * Create a {@link Reporter} reporting all errors and warnings with
+     * identifiers in given idSchemes. {@link #addError(Error)} will only throw
+     * a {@link ValidationFailFastException} if {@code failFast} true is given.
      *
      * @param idSchemes idSchemes in which to report errors and warnings
      * @param failFast reporter throws exception on first error added when true
      */
-    public ValidationErrorReporter( TrackerIdSchemeParams idSchemes, boolean failFast )
+    public Reporter( TrackerIdSchemeParams idSchemes, boolean failFast )
     {
         this.errors = new ArrayList<>();
         this.warnings = new ArrayList<>();
@@ -101,14 +100,14 @@ public class ValidationErrorReporter
     }
 
     /**
-     * Create a {@link ValidationErrorReporter} reporting all errors and
-     * warnings ({@link #isFailFast} = false) with identifiers in given
-     * idSchemes. {@link #addError(Error)} will not throw a
+     * Create a {@link Reporter} reporting all errors and warnings
+     * ({@link #isFailFast} = false) with identifiers in given idSchemes.
+     * {@link #addError(Error)} will not throw a
      * {@link ValidationFailFastException}.
      *
      * @param idSchemes idSchemes in which to report errors and warnings
      */
-    public ValidationErrorReporter( TrackerIdSchemeParams idSchemes )
+    public Reporter( TrackerIdSchemeParams idSchemes )
     {
         this( idSchemes, false );
     }
@@ -187,7 +186,7 @@ public class ValidationErrorReporter
 
     /**
      * Checks if a TrackerDto is invalid (i.e. has at least one Error in the
-     * ValidationErrorReporter).
+     * Reporter).
      */
     public boolean isInvalid( TrackerDto dto )
     {
@@ -196,20 +195,20 @@ public class ValidationErrorReporter
 
     /**
      * Checks if a TrackerDto with given type and uid is invalid (i.e. has at
-     * least one Error in the ValidationErrorReporter).
+     * least one Error in the Reporter).
      */
     public boolean isInvalid( TrackerType trackerType, String uid )
     {
         return this.invalidDTOs.getOrDefault( trackerType, new HashSet<>() ).contains( uid );
     }
 
-    public ValidationErrorReporter addTiming( Timing timing )
+    public Reporter addTiming( Timing timing )
     {
         timings.add( timing );
         return this;
     }
 
-    public ValidationErrorReporter addTimings( List<Timing> timings )
+    public Reporter addTimings( List<Timing> timings )
     {
         this.timings.addAll( timings );
         return this;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validator.java
@@ -40,7 +40,7 @@ public interface Validator<T>
      * @param bundle tracker bundle
      * @param input input to validate
      */
-    void validate( ValidationErrorReporter reporter, TrackerBundle bundle, T input );
+    void validate( Reporter reporter, TrackerBundle bundle, T input );
 
     default boolean needsToRun( TrackerImportStrategy strategy )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidator.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +44,7 @@ public class AssignedUserValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         if ( event.getAssignedUser() != null && !event.getAssignedUser().isEmpty() )
         {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/AttributeValidationHook.java
@@ -50,8 +50,8 @@ import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.preheat.UniqueAttributeValue;
 import org.hisp.dhis.tracker.util.Constant;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 
 /**
@@ -71,7 +71,7 @@ public abstract class AttributeValidationHook
         this.dhisConfigurationProvider = dhisConfigurationProvider;
     }
 
-    protected void validateAttrValueType( ValidationErrorReporter reporter, TrackerPreheat preheat, TrackerDto dto,
+    protected void validateAttrValueType( Reporter reporter, TrackerPreheat preheat, TrackerDto dto,
         Attribute attr,
         TrackedEntityAttribute teAttr )
     {
@@ -115,7 +115,7 @@ public abstract class AttributeValidationHook
         }
     }
 
-    protected void validateAttributeValue( ValidationErrorReporter reporter, TrackerDto trackerDto,
+    protected void validateAttributeValue( Reporter reporter, TrackerDto trackerDto,
         TrackedEntityAttribute tea,
         String value )
     {
@@ -140,7 +140,7 @@ public abstract class AttributeValidationHook
         reporter.addErrorIf( () -> result != null, trackerDto, E1085, tea, result );
     }
 
-    protected void validateAttributeUniqueness( ValidationErrorReporter reporter,
+    protected void validateAttributeUniqueness( Reporter reporter,
         TrackerPreheat preheat, TrackerDto dto,
         String value,
         TrackedEntityAttribute trackedEntityAttribute,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidator.java
@@ -55,7 +55,7 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 import org.springframework.stereotype.Component;
@@ -78,7 +78,7 @@ public class EnrollmentAttributeValidator extends AttributeValidationHook
     }
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         TrackerPreheat preheat = bundle.getPreheat();
         Program program = preheat.getProgram( enrollment.getProgram() );
@@ -120,7 +120,7 @@ public class EnrollmentAttributeValidator extends AttributeValidationHook
         validateMandatoryAttributes( reporter, bundle, program, attributeValueMap, enrollment );
     }
 
-    protected void validateRequiredProperties( ValidationErrorReporter reporter, TrackerPreheat preheat,
+    protected void validateRequiredProperties( Reporter reporter, TrackerPreheat preheat,
         Enrollment enrollment,
         Attribute attribute, Program program )
     {
@@ -144,7 +144,7 @@ public class EnrollmentAttributeValidator extends AttributeValidationHook
         reporter.addErrorIfNull( teAttribute, enrollment, E1006, attribute.getAttribute() );
     }
 
-    private void validateMandatoryAttributes( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateMandatoryAttributes( Reporter reporter, TrackerBundle bundle,
         Program program, Map<MetadataIdentifier, String> enrollmentNonEmptyAttributes, Enrollment enrollment )
     {
         // Build a data structures of attributes eligible for mandatory

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidator.java
@@ -42,7 +42,7 @@ import java.util.Objects;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +54,7 @@ public class EnrollmentDateValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         validateMandatoryDates( reporter, enrollment );
 
@@ -69,7 +69,7 @@ public class EnrollmentDateValidator
         }
     }
 
-    private void validateMandatoryDates( ValidationErrorReporter reporter, Enrollment enrollment )
+    private void validateMandatoryDates( Reporter reporter, Enrollment enrollment )
     {
         checkNotNull( enrollment, ENROLLMENT_CANT_BE_NULL );
 
@@ -79,7 +79,7 @@ public class EnrollmentDateValidator
         }
     }
 
-    private void validateEnrollmentDatesNotInFuture( ValidationErrorReporter reporter, Program program,
+    private void validateEnrollmentDatesNotInFuture( Reporter reporter, Program program,
         Enrollment enrollment )
     {
         checkNotNull( program, PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidator.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +44,7 @@ public class EnrollmentGeoValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         Program program = bundle.getPreheat().getProgram( enrollment.getProgram() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidator.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -60,7 +60,7 @@ public class EnrollmentInExistingValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         checkNotNull( enrollment, ENROLLMENT_CANT_BE_NULL );
 
@@ -82,7 +82,7 @@ public class EnrollmentInExistingValidator
         validateTeiNotEnrolledAlready( reporter, bundle, enrollment, program );
     }
 
-    private void validateTeiNotEnrolledAlready( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateTeiNotEnrolledAlready( Reporter reporter, TrackerBundle bundle,
         Enrollment enrollment, Program program )
     {
         checkNotNull( enrollment.getTrackedEntity(), TRACKED_ENTITY_INSTANCE_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidator.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 public class EnrollmentNoteValidator implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         enrollment.setNotes( ValidationUtils.validateNotes( reporter, bundle.getPreheat(), enrollment,
             enrollment.getNotes() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckDataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckDataRelationsValidator.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +55,7 @@ public class EnrollmentPreCheckDataRelationsValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         Program program = bundle.getPreheat().getProgram( enrollment.getProgram() );
         OrganisationUnit organisationUnit = bundle.getPreheat()
@@ -79,7 +79,7 @@ public class EnrollmentPreCheckDataRelationsValidator
             || !programAndOrgUnitsMap.get( program.getUid() ).contains( orgUnit.getUid() );
     }
 
-    private void validateTrackedEntityTypeMatchesPrograms( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateTrackedEntityTypeMatchesPrograms( Reporter reporter, TrackerBundle bundle,
         Program program,
         Enrollment enrollment )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckExistenceValidator.java
@@ -35,7 +35,7 @@ import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -47,7 +47,7 @@ public class EnrollmentPreCheckExistenceValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         TrackerImportStrategy importStrategy = bundle.getStrategy( enrollment );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMandatoryFieldsValidator.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E1122;
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +44,7 @@ public class EnrollmentPreCheckMandatoryFieldsValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         reporter.addErrorIf( () -> enrollment.getOrgUnit().isBlank(), enrollment, E1122, "orgUnit" );
         reporter.addErrorIf( () -> enrollment.getProgram().isBlank(), enrollment, E1122, "program" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMetaValidator.java
@@ -36,7 +36,7 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -48,7 +48,7 @@ public class EnrollmentPreCheckMetaValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( enrollment.getOrgUnit() );
         reporter.addErrorIfNull( organisationUnit, enrollment, E1070, enrollment.getOrgUnit() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckSecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckSecurityOwnershipValidator.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
@@ -83,7 +83,7 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
     private static final String ORG_UNIT_NO_USER_ASSIGNED = " has no organisation unit assigned, so we skip user validation";
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         TrackerImportStrategy strategy = bundle.getStrategy( enrollment );
         TrackerPreheat preheat = bundle.getPreheat();
@@ -135,7 +135,7 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
         return preheat.getProgramInstanceWithOneOrMoreNonDeletedEvent().contains( programInstanceUid );
     }
 
-    private void checkEnrollmentOrgUnit( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void checkEnrollmentOrgUnit( Reporter reporter, TrackerBundle bundle,
         TrackerImportStrategy strategy, Enrollment enrollment, Program program )
     {
         OrganisationUnit enrollmentOrgUnit;
@@ -179,7 +179,7 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
         return true;
     }
 
-    private void checkOrgUnitInCaptureScope( ValidationErrorReporter reporter, TrackerBundle bundle, TrackerDto dto,
+    private void checkOrgUnitInCaptureScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {
         User user = bundle.getUser();
@@ -193,7 +193,7 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkTeiTypeAndTeiProgramAccess( ValidationErrorReporter reporter, TrackerDto dto,
+    private void checkTeiTypeAndTeiProgramAccess( Reporter reporter, TrackerDto dto,
         User user,
         String trackedEntityInstance,
         OrganisationUnit ownerOrganisationUnit,
@@ -217,7 +217,7 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkWriteEnrollmentAccess( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void checkWriteEnrollmentAccess( Reporter reporter, TrackerBundle bundle,
         Enrollment enrollment, Program program,
         OrganisationUnit ownerOrgUnit )
     {
@@ -240,7 +240,7 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkProgramWriteAccess( ValidationErrorReporter reporter, TrackerDto dto,
+    private void checkProgramWriteAccess( Reporter reporter, TrackerDto dto,
         User user,
         Program program )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUidValidator.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.validateNot
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +44,7 @@ public class EnrollmentPreCheckUidValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         checkUidFormat( enrollment.getEnrollment(), reporter, enrollment, enrollment, enrollment.getEnrollment() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUpdatableFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUpdatableFieldsValidator.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +50,7 @@ public class EnrollmentPreCheckUpdatableFieldsValidator
     implements Validator<Enrollment>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         ProgramInstance pi = bundle.getPreheat().getEnrollment( enrollment.getEnrollment() );
         Program program = pi.getProgram();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentRuleValidationHook.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -58,7 +58,7 @@ public class EnrollmentRuleValidationHook
     }
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+    public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
     {
         List<RuleEffect> ruleEffects = bundle.getEnrollmentRuleEffects().get( enrollment.getEnrollment() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidator.java
@@ -45,7 +45,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.util.DateUtils;
 import org.springframework.stereotype.Component;
@@ -67,7 +67,7 @@ public class EventCategoryOptValidator
     }
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         Program program = bundle.getPreheat().getProgram( event.getProgram() );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidator.java
@@ -52,8 +52,8 @@ import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -65,7 +65,7 @@ public class EventDataValuesValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
 
@@ -91,7 +91,7 @@ public class EventDataValuesValidator
         validateDataValueDataElementIsConnectedToProgramStage( reporter, bundle, event, programStage );
     }
 
-    private void validateMandatoryDataValues( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    private void validateMandatoryDataValues( Reporter reporter, TrackerBundle bundle, Event event )
     {
         if ( event.getProgramStage().isBlank() )
         {
@@ -111,7 +111,7 @@ public class EventDataValuesValidator
             .forEach( de -> reporter.addError( event, E1303, de ) );
     }
 
-    private void validateDataValue( ValidationErrorReporter reporter, TrackerBundle bundle, DataElement dataElement,
+    private void validateDataValue( Reporter reporter, TrackerBundle bundle, DataElement dataElement,
         DataValue dataValue, ProgramStage programStage, Event event )
     {
         String status = null;
@@ -149,7 +149,7 @@ public class EventDataValuesValidator
         }
     }
 
-    private void validateNullDataValues( ValidationErrorReporter reporter, DataElement dataElement,
+    private void validateNullDataValues( Reporter reporter, DataElement dataElement,
         ProgramStage programStage, DataValue dataValue, Event event )
     {
         if ( dataValue.getValue() != null || !needsToValidateDataValues( event, programStage ) )
@@ -170,7 +170,7 @@ public class EventDataValuesValidator
         }
     }
 
-    private void validateDataValueDataElementIsConnectedToProgramStage( ValidationErrorReporter reporter,
+    private void validateDataValueDataElementIsConnectedToProgramStage( Reporter reporter,
         TrackerBundle bundle, Event event,
         ProgramStage programStage )
     {
@@ -193,7 +193,7 @@ public class EventDataValuesValidator
         }
     }
 
-    private void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void validateFileNotAlreadyAssigned( Reporter reporter, TrackerBundle bundle, Event event,
         DataValue dataValue,
         DataElement dataElement )
     {
@@ -225,7 +225,7 @@ public class EventDataValuesValidator
         }
     }
 
-    private void validateOrgUnitValueType( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void validateOrgUnitValueType( Reporter reporter, TrackerBundle bundle, Event event,
         DataValue dataValue,
         DataElement dataElement )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidator.java
@@ -49,7 +49,7 @@ import org.hisp.dhis.security.Authorities;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
@@ -62,7 +62,7 @@ public class EventDateValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         TrackerPreheat preheat = bundle.getPreheat();
 
@@ -84,7 +84,7 @@ public class EventDateValidator
         validatePeriodType( reporter, event, program );
     }
 
-    private void validateExpiryDays( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void validateExpiryDays( Reporter reporter, TrackerBundle bundle, Event event,
         Program program )
     {
         User actingUser = bundle.getUser();
@@ -114,7 +114,7 @@ public class EventDateValidator
         }
     }
 
-    private void validatePeriodType( ValidationErrorReporter reporter, Event event, Program program )
+    private void validatePeriodType( Reporter reporter, Event event, Program program )
     {
         checkNotNull( event, TrackerImporterAssertErrors.EVENT_CANT_BE_NULL );
         checkNotNull( program, TrackerImporterAssertErrors.PROGRAM_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidator.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +44,7 @@ public class EventGeoValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         checkNotNull( programStage, TrackerImporterAssertErrors.PROGRAM_STAGE_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidator.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 public class EventNoteValidator implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         event
             .setNotes( ValidationUtils.validateNotes( reporter, bundle.getPreheat(), event, event.getNotes() ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckDataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckDataRelationsValidator.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -69,7 +69,7 @@ public class EventPreCheckDataRelationsValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );
         OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( event.getOrgUnit() );
@@ -81,7 +81,7 @@ public class EventPreCheckDataRelationsValidator
         validateEventCategoryOptionCombo( reporter, bundle.getPreheat(), event, program );
     }
 
-    private void validateProgramStageInProgram( ValidationErrorReporter reporter, Event event,
+    private void validateProgramStageInProgram( Reporter reporter, Event event,
         ProgramStage programStage, Program program )
     {
         if ( !program.getUid().equals( programStage.getProgram().getUid() ) )
@@ -90,7 +90,7 @@ public class EventPreCheckDataRelationsValidator
         }
     }
 
-    private void validateRegistrationProgram( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void validateRegistrationProgram( Reporter reporter, TrackerBundle bundle, Event event,
         Program eventProgram )
     {
         if ( eventProgram.isRegistration() )
@@ -111,7 +111,7 @@ public class EventPreCheckDataRelationsValidator
         }
     }
 
-    private void validateProgramHasOrgUnit( ValidationErrorReporter reporter, TrackerPreheat preheat, Event event,
+    private void validateProgramHasOrgUnit( Reporter reporter, TrackerPreheat preheat, Event event,
         OrganisationUnit organisationUnit, Program program )
     {
         if ( programDoesNotHaveOrgUnit( program, organisationUnit, preheat.getProgramWithOrgUnitsMap() ) )
@@ -127,7 +127,7 @@ public class EventPreCheckDataRelationsValidator
             || !programAndOrgUnitsMap.get( program.getUid() ).contains( orgUnit.getUid() );
     }
 
-    private void validateEventCategoryOptionCombo( ValidationErrorReporter reporter,
+    private void validateEventCategoryOptionCombo( Reporter reporter,
         TrackerPreheat preheat, Event event, Program program )
     {
         boolean isValid = validateAttributeOptionComboExists( reporter, preheat, event );
@@ -155,7 +155,7 @@ public class EventPreCheckDataRelationsValidator
         validateAttributeOptionComboMatchesCategoryOptions( reporter, preheat, event, program, aoc );
     }
 
-    private boolean validateAttributeOptionComboExists( ValidationErrorReporter reporter, TrackerPreheat preheat,
+    private boolean validateAttributeOptionComboExists( Reporter reporter, TrackerPreheat preheat,
         Event event )
     {
         if ( hasNoAttributeOptionComboSet( event ) )
@@ -177,7 +177,7 @@ public class EventPreCheckDataRelationsValidator
         return event.getAttributeOptionCombo().isBlank();
     }
 
-    private boolean validateCategoryOptionsExist( ValidationErrorReporter reporter, TrackerPreheat preheat,
+    private boolean validateCategoryOptionsExist( Reporter reporter, TrackerPreheat preheat,
         Event event )
     {
         if ( hasNoAttributeCategoryOptionsSet( event ) )
@@ -213,7 +213,7 @@ public class EventPreCheckDataRelationsValidator
      * @return return true if event program is default with valid aoc and co
      *         combinations
      */
-    private boolean validateDefaultProgramCategoryCombo( ValidationErrorReporter reporter, TrackerPreheat preheat,
+    private boolean validateDefaultProgramCategoryCombo( Reporter reporter, TrackerPreheat preheat,
         Event event,
         Program program )
     {
@@ -241,7 +241,7 @@ public class EventPreCheckDataRelationsValidator
         return !hasNoAttributeOptionComboSet( event );
     }
 
-    private boolean validateAttributeOptionComboIsInProgramCategoryCombo( ValidationErrorReporter reporter,
+    private boolean validateAttributeOptionComboIsInProgramCategoryCombo( Reporter reporter,
         TrackerPreheat preheat, Event event,
         Program program )
     {
@@ -293,7 +293,7 @@ public class EventPreCheckDataRelationsValidator
         return categoryOptions;
     }
 
-    private boolean validateAttributeOptionComboFound( ValidationErrorReporter reporter, Event event, Program program,
+    private boolean validateAttributeOptionComboFound( Reporter reporter, Event event, Program program,
         CategoryOptionCombo aoc )
     {
         if ( aoc != null )
@@ -305,7 +305,7 @@ public class EventPreCheckDataRelationsValidator
         return false;
     }
 
-    private void validateAttributeOptionComboMatchesCategoryOptions( ValidationErrorReporter reporter,
+    private void validateAttributeOptionComboMatchesCategoryOptions( Reporter reporter,
         TrackerPreheat preheat, Event event,
         Program program,
         CategoryOptionCombo aoc )
@@ -322,7 +322,7 @@ public class EventPreCheckDataRelationsValidator
 
     }
 
-    private void addAOCAndCOCombinationError( Event event, ValidationErrorReporter reporter, Program program )
+    private void addAOCAndCOCombinationError( Event event, Reporter reporter, Program program )
     {
         // we used the program CC in finding the AOC id, if the AOC id was not
         // provided in the payload

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckExistenceValidator.java
@@ -35,7 +35,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -47,7 +47,7 @@ public class EventPreCheckExistenceValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         TrackerImportStrategy importStrategy = bundle.getStrategy( event );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMandatoryFieldsValidator.java
@@ -33,7 +33,7 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E1123;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +45,7 @@ public class EventPreCheckMandatoryFieldsValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         reporter.addErrorIf( () -> event.getOrgUnit().isBlank(), event, E1123, "orgUnit" );
         reporter.addErrorIf( () -> event.getProgramStage().isBlank(), event, E1123, "programStage" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMetaValidator.java
@@ -36,7 +36,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramStage;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -48,7 +48,7 @@ public class EventPreCheckMetaValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( event.getOrgUnit() );
         reporter.addErrorIfNull( organisationUnit, event, E1011, event.getOrgUnit() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckSecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckSecurityOwnershipValidator.java
@@ -64,8 +64,8 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
@@ -92,7 +92,7 @@ public class EventPreCheckSecurityOwnershipValidator
     private static final String ORG_UNIT_NO_USER_ASSIGNED = " has no organisation unit assigned, so we skip user validation";
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         TrackerImportStrategy strategy = bundle.getStrategy( event );
         TrackerPreheat preheat = bundle.getPreheat();
@@ -159,7 +159,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void validateCreateEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void validateCreateEvent( Reporter reporter, TrackerBundle bundle, Event event,
         User actingUser,
         CategoryOptionCombo categoryOptionCombo, ProgramStage programStage, String teiUid,
         OrganisationUnit organisationUnit, OrganisationUnit ownerOrgUnit, Program program,
@@ -179,7 +179,7 @@ public class EventPreCheckSecurityOwnershipValidator
             teiUid, isCreatableInSearchScope );
     }
 
-    private void validateUpdateAndDeleteEvent( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void validateUpdateAndDeleteEvent( Reporter reporter, TrackerBundle bundle, Event event,
         ProgramStageInstance programStageInstance,
         String teiUid, OrganisationUnit ownerOrgUnit )
     {
@@ -252,7 +252,7 @@ public class EventPreCheckSecurityOwnershipValidator
         return true;
     }
 
-    private void checkOrgUnitInCaptureScope( ValidationErrorReporter reporter, TrackerBundle bundle, TrackerDto dto,
+    private void checkOrgUnitInCaptureScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {
         User user = bundle.getUser();
@@ -266,7 +266,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkTeiTypeAndTeiProgramAccess( ValidationErrorReporter reporter, TrackerDto dto,
+    private void checkTeiTypeAndTeiProgramAccess( Reporter reporter, TrackerDto dto,
         User user,
         String trackedEntityInstance,
         OrganisationUnit ownerOrganisationUnit,
@@ -290,7 +290,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkEventWriteAccess( ValidationErrorReporter reporter, TrackerBundle bundle, Event event,
+    private void checkEventWriteAccess( Reporter reporter, TrackerBundle bundle, Event event,
         ProgramStage programStage,
         OrganisationUnit eventOrgUnit, OrganisationUnit ownerOrgUnit,
         CategoryOptionCombo categoryOptionCombo,
@@ -330,7 +330,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkEventOrgUnitWriteAccess( ValidationErrorReporter reporter, Event event,
+    private void checkEventOrgUnitWriteAccess( Reporter reporter, Event event,
         OrganisationUnit eventOrgUnit,
         boolean isCreatableInSearchScope, User user )
     {
@@ -347,7 +347,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkProgramReadAccess( ValidationErrorReporter reporter, TrackerDto dto,
+    private void checkProgramReadAccess( Reporter reporter, TrackerDto dto,
         User user,
         Program program )
     {
@@ -360,7 +360,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkProgramStageWriteAccess( ValidationErrorReporter reporter, TrackerDto dto,
+    private void checkProgramStageWriteAccess( Reporter reporter, TrackerDto dto,
         User user,
         ProgramStage programStage )
     {
@@ -373,7 +373,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkProgramWriteAccess( ValidationErrorReporter reporter, TrackerDto dto,
+    private void checkProgramWriteAccess( Reporter reporter, TrackerDto dto,
         User user,
         Program program )
     {
@@ -386,7 +386,7 @@ public class EventPreCheckSecurityOwnershipValidator
         }
     }
 
-    public void checkWriteCategoryOptionComboAccess( ValidationErrorReporter reporter, User user, TrackerDto dto,
+    public void checkWriteCategoryOptionComboAccess( Reporter reporter, User user, TrackerDto dto,
         CategoryOptionCombo categoryOptionCombo )
     {
         checkNotNull( user, USER_CANT_BE_NULL );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUidValidator.java
@@ -32,7 +32,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.validateNot
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +44,7 @@ public class EventPreCheckUidValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         checkUidFormat( event.getEvent(), reporter, event, event, event.getEvent() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUpdatableFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUpdatableFieldsValidator.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +50,7 @@ public class EventPreCheckUpdatableFieldsValidator
     implements Validator<Event>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramStageInstance programStageInstance = bundle.getPreheat().getEvent( event.getEvent() );
         ProgramStage programStage = programStageInstance.getProgramStage();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventRuleValidator.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
 import org.hisp.dhis.tracker.programrule.RuleActionImplementer;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -58,7 +58,7 @@ public class EventRuleValidator
     }
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    public void validate( Reporter reporter, TrackerBundle bundle, Event event )
     {
         List<RuleEffect> ruleEffects = bundle.getEventRuleEffects().get( event.getEvent() );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckDataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckDataRelationsValidator.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -55,14 +55,14 @@ public class RelationshipPreCheckDataRelationsValidator
     implements Validator<Relationship>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
         validateRelationshipReference( reporter, bundle, relationship, relationship.getFrom() );
         validateRelationshipReference( reporter, bundle, relationship, relationship.getTo() );
     }
 
-    private void validateRelationshipReference( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateRelationshipReference( Reporter reporter, TrackerBundle bundle,
         Relationship relationship,
         RelationshipItem item )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckExistenceValidator.java
@@ -34,7 +34,7 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E4017;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +46,7 @@ public class RelationshipPreCheckExistenceValidator
     implements Validator<Relationship>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
 
@@ -60,7 +60,7 @@ public class RelationshipPreCheckExistenceValidator
         validateUpdatedOrDeletedRelationshipExists( reporter, existingRelationship, relationship, importStrategy );
     }
 
-    private void validateRelationshipNotDeleted( ValidationErrorReporter reporter,
+    private void validateRelationshipNotDeleted( Reporter reporter,
         org.hisp.dhis.relationship.Relationship existingRelationship,
         Relationship relationship )
     {
@@ -68,7 +68,7 @@ public class RelationshipPreCheckExistenceValidator
             E4017, relationship.getRelationship() );
     }
 
-    private void validateRelationshipNotUpdated( ValidationErrorReporter reporter,
+    private void validateRelationshipNotUpdated( Reporter reporter,
         org.hisp.dhis.relationship.Relationship existingRelationship,
         Relationship relationship,
         TrackerImportStrategy importStrategy )
@@ -78,7 +78,7 @@ public class RelationshipPreCheckExistenceValidator
             relationship, E4015, relationship.getRelationship() );
     }
 
-    private void validateNewRelationshipNotExistAlready( ValidationErrorReporter reporter,
+    private void validateNewRelationshipNotExistAlready( Reporter reporter,
         org.hisp.dhis.relationship.Relationship existingRelationship,
         Relationship relationship,
         TrackerImportStrategy importStrategy )
@@ -88,7 +88,7 @@ public class RelationshipPreCheckExistenceValidator
             relationship, E4015, relationship.getRelationship() );
     }
 
-    private void validateUpdatedOrDeletedRelationshipExists( ValidationErrorReporter reporter,
+    private void validateUpdatedOrDeletedRelationshipExists( Reporter reporter,
         org.hisp.dhis.relationship.Relationship existingRelationship,
         Relationship relationship,
         TrackerImportStrategy importStrategy )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMandatoryFieldsValidator.java
@@ -31,7 +31,7 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E1124;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +43,7 @@ public class RelationshipPreCheckMandatoryFieldsValidator
     implements Validator<Relationship>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
         reporter.addErrorIfNull( relationship.getFrom(), relationship, E1124, "from" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMetaValidator.java
@@ -33,7 +33,7 @@ import org.hisp.dhis.relationship.RelationshipType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +45,7 @@ public class RelationshipPreCheckMetaValidator
     implements Validator<Relationship>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
         TrackerPreheat preheat = bundle.getPreheat();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckUidValidator.java
@@ -31,7 +31,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.checkUidFor
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +43,7 @@ public class RelationshipPreCheckUidValidator
     implements Validator<Relationship>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Relationship relationship )
+    public void validate( Reporter reporter, TrackerBundle bundle, Relationship relationship )
     {
         checkUidFormat( relationship.getRelationship(), reporter, relationship, relationship,
             relationship.getRelationship() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidator.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -67,7 +67,7 @@ public class RelationshipsValidator
 {
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
         boolean isValid = validateMandatoryData( reporter, relationship,
@@ -86,7 +86,7 @@ public class RelationshipsValidator
         }
     }
 
-    private void validateDuplication( ValidationErrorReporter reporter, Relationship relationship,
+    private void validateDuplication( Reporter reporter, Relationship relationship,
         TrackerBundle bundle )
     {
         if ( bundle.getPreheat().isDuplicate( relationship ) )
@@ -100,7 +100,7 @@ public class RelationshipsValidator
         }
     }
 
-    private void validateRelationshipLinkToOneEntity( ValidationErrorReporter reporter,
+    private void validateRelationshipLinkToOneEntity( Reporter reporter,
         Relationship relationship )
     {
         // make sure that both Relationship Item only contain *one* reference
@@ -111,7 +111,7 @@ public class RelationshipsValidator
             relationship, E4001, "to", relationship.getRelationship() );
     }
 
-    private void validateRelationshipConstraint( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateRelationshipConstraint( Reporter reporter, TrackerBundle bundle,
         Relationship relationship )
     {
         getRelationshipType( bundle.getPreheat().getAll( RelationshipType.class ),
@@ -123,7 +123,7 @@ public class RelationshipsValidator
             } );
     }
 
-    private boolean validateMandatoryData( ValidationErrorReporter reporter, Relationship relationship,
+    private boolean validateMandatoryData( Reporter reporter, Relationship relationship,
         List<RelationshipType> relationshipsTypes )
     {
         reporter.addErrorIf(
@@ -141,7 +141,7 @@ public class RelationshipsValidator
         return relationshipsTypes.stream().filter( relationshipType::isEqualTo ).findFirst();
     }
 
-    private void validateAutoRelationship( ValidationErrorReporter reporter, Relationship relationship )
+    private void validateAutoRelationship( Reporter reporter, Relationship relationship )
     {
         if ( Objects.equals( relationship.getFrom(), relationship.getTo() ) )
         {
@@ -149,7 +149,7 @@ public class RelationshipsValidator
         }
     }
 
-    private void validateRelationshipConstraint( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateRelationshipConstraint( Reporter reporter, TrackerBundle bundle,
         Relationship relationship,
         String relSide,
         RelationshipItem item,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHook.java
@@ -38,8 +38,8 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +54,7 @@ public class RepeatedEventsValidationHook
     implements Validator<TrackerBundle>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle __, TrackerBundle bundle )
+    public void validate( Reporter reporter, TrackerBundle __, TrackerBundle bundle )
     {
         Map<Pair<MetadataIdentifier, String>, List<Event>> eventsByEnrollmentAndNotRepeatableProgramStage = bundle
             .getEvents()
@@ -83,7 +83,7 @@ public class RepeatedEventsValidationHook
             .forEach( e -> validateNotMultipleEvents( reporter, bundle, e ) );
     }
 
-    private void validateNotMultipleEvents( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+    private void validateNotMultipleEvents( Reporter reporter, TrackerBundle bundle, Event event )
     {
         ProgramInstance programInstance = bundle.getPreheat().getEnrollment( event.getEnrollment() );
         ProgramStage programStage = bundle.getPreheat().getProgramStage( event.getProgramStage() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidator.java
@@ -56,7 +56,7 @@ import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 import org.springframework.stereotype.Component;
@@ -75,7 +75,7 @@ public class TrackedEntityAttributeValidator extends AttributeValidationHook
     }
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
+    public void validate( Reporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         TrackedEntityType trackedEntityType = bundle.getPreheat()
             .getTrackedEntityType( trackedEntity.getTrackedEntityType() );
@@ -88,7 +88,7 @@ public class TrackedEntityAttributeValidator extends AttributeValidationHook
         validateAttributes( reporter, bundle, trackedEntity, tei, organisationUnit, trackedEntityType );
     }
 
-    private void validateMandatoryAttributes( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void validateMandatoryAttributes( Reporter reporter, TrackerBundle bundle,
         TrackedEntity trackedEntity,
         TrackedEntityType trackedEntityType )
     {
@@ -112,7 +112,7 @@ public class TrackedEntityAttributeValidator extends AttributeValidationHook
         }
     }
 
-    protected void validateAttributes( ValidationErrorReporter reporter,
+    protected void validateAttributes( Reporter reporter,
         TrackerBundle bundle, TrackedEntity trackedEntity, TrackedEntityInstance tei, OrganisationUnit orgUnit,
         TrackedEntityType trackedEntityType )
     {
@@ -165,7 +165,7 @@ public class TrackedEntityAttributeValidator extends AttributeValidationHook
         }
     }
 
-    protected void validateFileNotAlreadyAssigned( ValidationErrorReporter reporter, TrackerBundle bundle,
+    protected void validateFileNotAlreadyAssigned( Reporter reporter, TrackerBundle bundle,
         TrackedEntity te,
         Attribute attr, Map<MetadataIdentifier, TrackedEntityAttributeValue> valueMap )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckExistenceValidator.java
@@ -35,7 +35,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -47,7 +47,7 @@ public class TrackedEntityPreCheckExistenceValidator
     implements Validator<TrackedEntity>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         TrackedEntity trackedEntity )
     {
         TrackerImportStrategy importStrategy = bundle.getStrategy( trackedEntity );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMandatoryFieldsValidator.java
@@ -31,7 +31,7 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E1121;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +43,7 @@ public class TrackedEntityPreCheckMandatoryFieldsValidator
     implements Validator<TrackedEntity>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle,
+    public void validate( Reporter reporter, TrackerBundle bundle,
         TrackedEntity trackedEntity )
     {
         reporter.addErrorIf( () -> trackedEntity.getTrackedEntityType().isBlank(), trackedEntity, E1121,

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMetaValidator.java
@@ -33,8 +33,8 @@ import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +46,7 @@ public class TrackedEntityPreCheckMetaValidator
     implements Validator<TrackedEntity>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity tei )
+    public void validate( Reporter reporter, TrackerBundle bundle, TrackedEntity tei )
     {
         OrganisationUnit organisationUnit = bundle.getPreheat().getOrganisationUnit( tei.getOrgUnit() );
         if ( organisationUnit == null )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckSecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckSecurityOwnershipValidator.java
@@ -49,8 +49,8 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.domain.TrackerDto;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
@@ -72,7 +72,7 @@ public class TrackedEntityPreCheckSecurityOwnershipValidator
     private final OrganisationUnitService organisationUnitService;
 
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
+    public void validate( Reporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         TrackerImportStrategy strategy = bundle.getStrategy( trackedEntity );
         User user = bundle.getUser();
@@ -115,7 +115,7 @@ public class TrackedEntityPreCheckSecurityOwnershipValidator
         checkTeiTypeWriteAccess( reporter, bundle, trackedEntity, trackedEntityType );
     }
 
-    private void checkTeiTypeWriteAccess( ValidationErrorReporter reporter, TrackerBundle bundle,
+    private void checkTeiTypeWriteAccess( Reporter reporter, TrackerBundle bundle,
         TrackedEntity trackedEntity,
         TrackedEntityType trackedEntityType )
     {
@@ -142,7 +142,7 @@ public class TrackedEntityPreCheckSecurityOwnershipValidator
         return true;
     }
 
-    private void checkOrgUnitInCaptureScope( ValidationErrorReporter reporter, TrackerBundle bundle, TrackerDto dto,
+    private void checkOrgUnitInCaptureScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {
         User user = bundle.getUser();
@@ -156,7 +156,7 @@ public class TrackedEntityPreCheckSecurityOwnershipValidator
         }
     }
 
-    private void checkOrgUnitInSearchScope( ValidationErrorReporter reporter, TrackerBundle bundle, TrackerDto dto,
+    private void checkOrgUnitInSearchScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {
         User user = bundle.getUser();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUidValidator.java
@@ -31,7 +31,7 @@ import static org.hisp.dhis.tracker.validation.hooks.ValidationUtils.checkUidFor
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +43,7 @@ public class TrackedEntityPreCheckUidValidator
     implements Validator<TrackedEntity>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
+    public void validate( Reporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         checkUidFormat( trackedEntity.getTrackedEntity(), reporter, trackedEntity, trackedEntity,
             trackedEntity.getTrackedEntity() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUpdatableFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUpdatableFieldsValidator.java
@@ -35,7 +35,7 @@ import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
@@ -48,7 +48,7 @@ public class TrackedEntityPreCheckUpdatableFieldsValidator
     implements Validator<TrackedEntity>
 {
     @Override
-    public void validate( ValidationErrorReporter reporter,
+    public void validate( Reporter reporter,
         TrackerBundle bundle, TrackedEntity trackedEntity )
     {
         TrackedEntityInstance trackedEntityInstance = bundle

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/ValidationUtils.java
@@ -56,8 +56,8 @@ import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.domain.TrackerDto;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.programrule.ProgramRuleIssue;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.locationtech.jts.geom.Geometry;
 
 import com.google.common.collect.Lists;
@@ -72,7 +72,7 @@ public class ValidationUtils
         throw new IllegalStateException( "Utility class" );
     }
 
-    static void validateGeometry( ValidationErrorReporter reporter, TrackerDto dto, Geometry geometry,
+    static void validateGeometry( Reporter reporter, TrackerDto dto, Geometry geometry,
         FeatureType featureType )
     {
         checkNotNull( geometry, GEOMETRY_CANT_BE_NULL );
@@ -91,7 +91,7 @@ public class ValidationUtils
         }
     }
 
-    protected static List<Note> validateNotes( ValidationErrorReporter reporter, TrackerPreheat preheat, TrackerDto dto,
+    protected static List<Note> validateNotes( Reporter reporter, TrackerPreheat preheat, TrackerDto dto,
         List<Note> notesToCheck )
     {
         final List<Note> notes = new ArrayList<>();
@@ -156,7 +156,7 @@ public class ValidationUtils
         }
     }
 
-    public static void addIssuesToReporter( ValidationErrorReporter reporter, TrackerDto dto,
+    public static void addIssuesToReporter( Reporter reporter, TrackerDto dto,
         List<ProgramRuleIssue> programRuleIssues )
     {
         programRuleIssues
@@ -197,7 +197,7 @@ public class ValidationUtils
             || bundle.findEventByUid( eventUid ).isPresent();
     }
 
-    public static <T extends ValueTypedDimensionalItemObject> void validateOptionSet( ValidationErrorReporter reporter,
+    public static <T extends ValueTypedDimensionalItemObject> void validateOptionSet( Reporter reporter,
         TrackerDto dto,
         T optionalObject, String value )
     {
@@ -216,7 +216,7 @@ public class ValidationUtils
                     .collect( Collectors.joining( "," ) ) ) );
     }
 
-    public static void validateNotesUid( List<Note> notes, ValidationErrorReporter reporter, TrackerDto dto )
+    public static void validateNotesUid( List<Note> notes, Reporter reporter, TrackerDto dto )
     {
         for ( Note note : notes )
         {
@@ -228,12 +228,11 @@ public class ValidationUtils
      * Check if the given UID has a valid format.
      *
      * @param checkUid a UID to be checked
-     * @param reporter a {@see ValidationErrorReporter} to which the error is
-     *        added
+     * @param reporter a {@see Reporter} to which the error is added
      * @param dto the dto to which the report will be linked to
      * @param args list of arguments for the Error report
      */
-    public static void checkUidFormat( String checkUid, ValidationErrorReporter reporter, TrackerDto dto,
+    public static void checkUidFormat( String checkUid, Reporter reporter, TrackerDto dto,
         Object... args )
     {
         if ( !CodeGenerator.isValidUid( checkUid ) )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationServiceTest.java
@@ -161,7 +161,7 @@ class DefaultTrackerValidationServiceTest
         Validator<TrackedEntity> skipOnError = new Validator<>()
         {
             @Override
-            public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
+            public void validate( Reporter reporter, TrackerBundle bundle, TrackedEntity trackedEntity )
             {
                 addErrorOnMatch( reporter, invalidTrackedEntity, trackedEntity, ValidationCode.E1032 );
             }
@@ -236,7 +236,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Enrollment> skipOnError = new Validator<>()
         {
             @Override
-            public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Enrollment enrollment )
+            public void validate( Reporter reporter, TrackerBundle bundle, Enrollment enrollment )
             {
                 addErrorOnMatch( reporter, invalidEnrollment, enrollment, ValidationCode.E1032 );
             }
@@ -311,7 +311,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Event> skipOnError = new Validator<>()
         {
             @Override
-            public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+            public void validate( Reporter reporter, TrackerBundle bundle, Event event )
             {
                 addErrorOnMatch( reporter, invalidEvent, event, ValidationCode.E1032 );
             }
@@ -371,7 +371,7 @@ class DefaultTrackerValidationServiceTest
             () -> assertTrue( bundle.getEvents().contains( validEvent ) ) );
     }
 
-    private static <T extends TrackerDto> void addErrorOnMatch( ValidationErrorReporter reporter, T expected, T actual,
+    private static <T extends TrackerDto> void addErrorOnMatch( Reporter reporter, T expected, T actual,
         ValidationCode code )
     {
         reporter.addErrorIf( () -> Objects.equals( expected, actual ), actual, code );
@@ -438,7 +438,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Event> v1 = new Validator<>()
         {
             @Override
-            public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+            public void validate( Reporter reporter, TrackerBundle bundle, Event event )
             {
                 reporter.addError( event, ValidationCode.E1000 );
             }
@@ -468,7 +468,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Event> v1 = new Validator<>()
         {
             @Override
-            public void validate( ValidationErrorReporter reporter, TrackerBundle bundle, Event event )
+            public void validate( Reporter reporter, TrackerBundle bundle, Event event )
             {
                 reporter.addError( event, ValidationCode.E1032 );
             }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ReporterTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ReporterTest.java
@@ -34,14 +34,14 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.TrackerType;
 import org.junit.jupiter.api.Test;
 
-class ValidationErrorReporterTest
+class ReporterTest
 {
 
     @Test
     void hasErrorReportFound()
     {
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        Reporter reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
         reporter.addError( eventError() );
 
         assertTrue( reporter.hasErrorReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
@@ -51,7 +51,7 @@ class ValidationErrorReporterTest
     void hasErrorReportNotFound()
     {
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        Reporter reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
         reporter.addError( eventError() );
 
         assertFalse( reporter.hasErrorReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
@@ -61,7 +61,7 @@ class ValidationErrorReporterTest
     void hasWarningReportFound()
     {
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        Reporter reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
         reporter.addWarning( eventWarning() );
 
         assertTrue( reporter.hasWarningReport( r -> TrackerType.EVENT.equals( r.getTrackerType() ) ) );
@@ -71,7 +71,7 @@ class ValidationErrorReporterTest
     void hasWarningReportNotFound()
     {
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        Reporter reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
         reporter.addWarning( eventWarning() );
 
         assertFalse( reporter.hasWarningReport( r -> TrackerType.TRACKED_ENTITY.equals( r.getTrackerType() ) ) );
@@ -81,7 +81,7 @@ class ValidationErrorReporterTest
     void hasPerfsReturnsFalse()
     {
 
-        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        Reporter reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
 
         assertFalse( reporter.hasTimings() );
     }
@@ -89,7 +89,7 @@ class ValidationErrorReporterTest
     @Test
     void hasPerfsReturnsTrue()
     {
-        ValidationErrorReporter reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        Reporter reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
 
         reporter.addTiming( new Timing( "1min", "validation" ) );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertValidationErrorReporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssertValidationErrorReporter.java
@@ -31,8 +31,8 @@ import static org.hisp.dhis.tracker.validation.hooks.AssertTrackerValidationRepo
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.tracker.TrackerType;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 
 public class AssertValidationErrorReporter
 {
@@ -41,7 +41,7 @@ public class AssertValidationErrorReporter
         throw new IllegalStateException( "utility class" );
     }
 
-    public static void assertMissingProperty( ValidationErrorReporter reporter, TrackerType type, String entity,
+    public static void assertMissingProperty( Reporter reporter, TrackerType type, String entity,
         String uid,
         String property,
         ValidationCode errorCode )
@@ -50,7 +50,7 @@ public class AssertValidationErrorReporter
             "Missing required " + entity + " property: `" + property + "`." );
     }
 
-    public static void hasTrackerError( ValidationErrorReporter reporter, ValidationCode code, TrackerType type,
+    public static void hasTrackerError( Reporter reporter, ValidationCode code, TrackerType type,
         String uid )
     {
         assertTrue( reporter.hasErrors(), "error not found since reporter has no errors" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/AssignedUserValidatorTest.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.User;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +68,7 @@ class AssignedUserValidatorTest extends DhisConvenienceTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private ProgramStage programStage;
 
@@ -94,7 +94,7 @@ class AssignedUserValidatorTest extends DhisConvenienceTest
         preheat.put( programStage );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentAttributeValidatorTest.java
@@ -53,8 +53,8 @@ import org.hisp.dhis.tracker.domain.Attribute;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -106,7 +106,7 @@ class EnrollmentAttributeValidatorTest
 
     private TrackedEntityAttribute trackedEntityAttributeP;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -148,7 +148,7 @@ class EnrollmentAttributeValidatorTest
             .build();
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentDateValidatorTest.java
@@ -46,7 +46,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,7 +67,7 @@ class EnrollmentDateValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -79,7 +79,7 @@ class EnrollmentDateValidatorTest
             .build();
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentGeoValidatorTest.java
@@ -43,7 +43,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +70,7 @@ class EnrollmentGeoValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -86,7 +86,7 @@ class EnrollmentGeoValidatorTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( PROGRAM ) ) ).thenReturn( program );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentInExistingValidatorTest.java
@@ -52,7 +52,7 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.EnrollmentStatus;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,7 +80,7 @@ class EnrollmentInExistingValidatorTest
     @Mock
     private TrackedEntityInstance trackedEntityInstance;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private static final String programUid = "program";
 
@@ -112,7 +112,7 @@ class EnrollmentInExistingValidatorTest
         when( preheat.getProgram( MetadataIdentifier.ofUid( programUid ) ) ).thenReturn( program );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentNoteValidatorTest.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,7 +70,7 @@ class EnrollmentNoteValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -83,7 +83,7 @@ class EnrollmentNoteValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckDataRelationsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckDataRelationsValidatorTest.java
@@ -46,8 +46,8 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,7 +81,7 @@ class EnrollmentPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -91,7 +91,7 @@ class EnrollmentPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckExistenceValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckExistenceValidatorTest.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,7 +69,7 @@ class EnrollmentPreCheckExistenceValidatorTest
 
     private EnrollmentPreCheckExistenceValidator validator;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -77,7 +77,7 @@ class EnrollmentPreCheckExistenceValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new EnrollmentPreCheckExistenceValidator();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMandatoryFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMandatoryFieldsValidatorTest.java
@@ -39,8 +39,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,7 +65,7 @@ class EnrollmentPreCheckMandatoryFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -77,7 +77,7 @@ class EnrollmentPreCheckMandatoryFieldsValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test
@@ -140,7 +140,7 @@ class EnrollmentPreCheckMandatoryFieldsValidatorTest
         assertMissingProperty( reporter, enrollment.getUid(), "orgUnit" );
     }
 
-    private void assertMissingProperty( ValidationErrorReporter reporter, String uid, String property )
+    private void assertMissingProperty( Reporter reporter, String uid, String property )
     {
         AssertValidationErrorReporter.assertMissingProperty( reporter, ENROLLMENT, "enrollment", uid, property,
             ValidationCode.E1122 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMetaValidatorTest.java
@@ -47,7 +47,7 @@ import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,7 +74,7 @@ class EnrollmentPreCheckMetaValidatorTest
     @Mock
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -84,7 +84,7 @@ class EnrollmentPreCheckMetaValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckSecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckSecurityOwnershipValidatorTest.java
@@ -61,7 +61,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -107,7 +107,7 @@ class EnrollmentPreCheckSecurityOwnershipValidatorTest extends DhisConvenienceTe
 
     private User user;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private OrganisationUnit organisationUnit;
 
@@ -137,7 +137,7 @@ class EnrollmentPreCheckSecurityOwnershipValidatorTest extends DhisConvenienceTe
         programStage.setUid( PS_ID );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new EnrollmentPreCheckSecurityOwnershipValidator( aclService, ownershipAccessManager,
             organisationUnitService );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUidValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUidValidatorTest.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Enrollment;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +56,7 @@ class EnrollmentPreCheckUidValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -64,7 +64,7 @@ class EnrollmentPreCheckUidValidatorTest
         TrackerPreheat preheat = new TrackerPreheat();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         preheat.setIdSchemes( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         bundle = TrackerBundle.builder().preheat( preheat ).build();
 
         validator = new EnrollmentPreCheckUidValidator();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUpdatableFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUpdatableFieldsValidatorTest.java
@@ -50,7 +50,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,7 +87,7 @@ class EnrollmentPreCheckUpdatableFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -106,7 +106,7 @@ class EnrollmentPreCheckUpdatableFieldsValidatorTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
 
-        reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventCategoryOptValidatorTest.java
@@ -54,7 +54,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,7 +99,7 @@ class EventCategoryOptValidatorTest extends DhisConvenienceTest
 
     private Event event;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private final Date ONE_YEAR_BEFORE_EVENT = getDate( 2020, 1, 1 );
 
@@ -150,7 +150,7 @@ class EventCategoryOptValidatorTest extends DhisConvenienceTest
         when( i18nManager.getI18nFormat() ).thenReturn( I18N_FORMAT );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDataValuesValidatorTest.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.tracker.domain.DataValue;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.util.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -85,7 +85,7 @@ class EventDataValuesValidatorTest
     @Mock
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private TrackerIdSchemeParams idSchemes;
 
@@ -98,7 +98,7 @@ class EventDataValuesValidatorTest
 
         idSchemes = TrackerIdSchemeParams.builder().build();
         when( preheat.getIdSchemes() ).thenReturn( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test
@@ -642,7 +642,7 @@ class EventDataValuesValidatorTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator.validate( reporter, bundle, event );
 
@@ -681,7 +681,7 @@ class EventDataValuesValidatorTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator.validate( reporter, bundle, event );
 
@@ -693,7 +693,7 @@ class EventDataValuesValidatorTest
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator.validate( reporter, bundle, event );
 
@@ -858,7 +858,7 @@ class EventDataValuesValidatorTest
             .dataValues( Set.of( validDataValue ) )
             .build();
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         validator.validate( reporter, bundle, event );
 
         assertThat( reporter.getErrors(), hasSize( 1 ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventDateValidatorTest.java
@@ -55,7 +55,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.user.User;
 import org.hisp.dhis.user.UserRole;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +87,7 @@ class EventDateValidatorTest extends DhisConvenienceTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -107,7 +107,7 @@ class EventDateValidatorTest extends DhisConvenienceTest
             .thenReturn( getProgramWithoutRegistration() );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventGeoValidatorTest.java
@@ -45,7 +45,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +72,7 @@ class EventGeoValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -89,7 +89,7 @@ class EventGeoValidatorTest
             .thenReturn( programStage );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventNoteValidatorTest.java
@@ -47,8 +47,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +72,7 @@ class EventNoteValidatorTest
 
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -85,7 +85,7 @@ class EventNoteValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckDataRelationsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckDataRelationsValidatorTest.java
@@ -54,8 +54,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -89,7 +89,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -99,7 +99,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckExistenceValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckExistenceValidatorTest.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,7 +69,7 @@ class EventPreCheckExistenceValidatorTest
 
     private EventPreCheckExistenceValidator validator;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -77,7 +77,7 @@ class EventPreCheckExistenceValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new EventPreCheckExistenceValidator();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMandatoryFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMandatoryFieldsValidatorTest.java
@@ -45,8 +45,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +71,7 @@ class EventPreCheckMandatoryFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -83,7 +83,7 @@ class EventPreCheckMandatoryFieldsValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test
@@ -166,7 +166,7 @@ class EventPreCheckMandatoryFieldsValidatorTest
         assertMissingProperty( reporter, event.getUid(), "orgUnit" );
     }
 
-    private void assertMissingProperty( ValidationErrorReporter reporter, String uid, String property )
+    private void assertMissingProperty( Reporter reporter, String uid, String property )
     {
         AssertValidationErrorReporter.assertMissingProperty( reporter, EVENT, "event", uid, property,
             ValidationCode.E1123 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMetaValidatorTest.java
@@ -44,7 +44,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +72,7 @@ class EventPreCheckMetaValidatorTest
     @Mock
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -82,7 +82,7 @@ class EventPreCheckMetaValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckSecurityOwnershipValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckSecurityOwnershipValidatorTest.java
@@ -61,8 +61,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,7 +108,7 @@ class EventPreCheckSecurityOwnershipValidatorTest extends DhisConvenienceTest
 
     private User user;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private OrganisationUnit organisationUnit;
 
@@ -142,7 +142,7 @@ class EventPreCheckSecurityOwnershipValidatorTest extends DhisConvenienceTest
         programStage.setUid( PS_ID );
 
         idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new EventPreCheckSecurityOwnershipValidator( aclService, ownershipAccessManager,
             organisationUnitService );
@@ -328,7 +328,7 @@ class EventPreCheckSecurityOwnershipValidatorTest extends DhisConvenienceTest
 
         when( ownershipAccessManager.hasAccess( user, TEI_ID, organisationUnit, program ) ).thenReturn( true );
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         validator.validate( reporter, bundle, event );
 
         assertFalse( reporter.hasErrors() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUidValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUidValidatorTest.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.Note;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +56,7 @@ class EventPreCheckUidValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -64,7 +64,7 @@ class EventPreCheckUidValidatorTest
         TrackerPreheat preheat = new TrackerPreheat();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         preheat.setIdSchemes( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         bundle = TrackerBundle.builder().preheat( preheat ).build();
 
         validator = new EventPreCheckUidValidator();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUpdatableFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUpdatableFieldsValidatorTest.java
@@ -50,7 +50,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,7 +87,7 @@ class EventPreCheckUpdatableFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -106,7 +106,7 @@ class EventPreCheckUpdatableFieldsValidatorTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
 
-        reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckDataRelationsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckDataRelationsValidatorTest.java
@@ -48,9 +48,9 @@ import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validation;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +72,7 @@ class RelationshipPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -82,7 +82,7 @@ class RelationshipPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckExistenceValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckExistenceValidatorTest.java
@@ -44,7 +44,7 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +71,7 @@ class RelationshipPreCheckExistenceValidatorTest
 
     private RelationshipPreCheckExistenceValidator validator;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -79,7 +79,7 @@ class RelationshipPreCheckExistenceValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new RelationshipPreCheckExistenceValidator();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMandatoryFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMandatoryFieldsValidatorTest.java
@@ -40,8 +40,8 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -66,7 +66,7 @@ class RelationshipPreCheckMandatoryFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -78,7 +78,7 @@ class RelationshipPreCheckMandatoryFieldsValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test
@@ -151,7 +151,7 @@ class RelationshipPreCheckMandatoryFieldsValidatorTest
         assertMissingProperty( reporter, relationship.getUid(), "relationshipType" );
     }
 
-    private void assertMissingProperty( ValidationErrorReporter reporter, String uid, String property )
+    private void assertMissingProperty( Reporter reporter, String uid, String property )
     {
         AssertValidationErrorReporter.assertMissingProperty( reporter, RELATIONSHIP, "relationship", uid, property,
             ValidationCode.E1124 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMetaValidatorTest.java
@@ -40,7 +40,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,7 +63,7 @@ class RelationshipPreCheckMetaValidatorTest
     @Mock
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -73,7 +73,7 @@ class RelationshipPreCheckMetaValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckUidValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckUidValidatorTest.java
@@ -37,7 +37,7 @@ import org.hisp.dhis.tracker.TrackerIdSchemeParams;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,7 +53,7 @@ class RelationshipPreCheckUidValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -61,7 +61,7 @@ class RelationshipPreCheckUidValidatorTest
         TrackerPreheat preheat = new TrackerPreheat();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         preheat.setIdSchemes( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         bundle = TrackerBundle.builder().preheat( preheat ).build();
 
         validator = new RelationshipPreCheckUidValidator();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RelationshipsValidatorTest.java
@@ -62,8 +62,8 @@ import org.hisp.dhis.tracker.domain.Relationship;
 import org.hisp.dhis.tracker.domain.RelationshipItem;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,7 +85,7 @@ class RelationshipsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -95,7 +95,7 @@ class RelationshipsValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidationHookTest.java
@@ -51,7 +51,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.validation.Error;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -86,7 +86,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -97,7 +97,7 @@ class RepeatedEventsValidationHookTest extends DhisConvenienceTest
         bundle.setPreheat( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityAttributeValidatorTest.java
@@ -55,8 +55,8 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.util.Constant;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -88,7 +88,7 @@ class TrackedEntityAttributeValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private TrackerIdSchemeParams idSchemes;
 
@@ -100,7 +100,7 @@ class TrackedEntityAttributeValidatorTest
             .build();
         idSchemes = TrackerIdSchemeParams.builder().build();
         when( preheat.getIdSchemes() ).thenReturn( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         when( dhisConfigurationProvider.getEncryptionStatus() ).thenReturn( EncryptionStatus.OK );
     }
 
@@ -426,7 +426,7 @@ class TrackedEntityAttributeValidatorTest
         assertEquals( 1, reporter.getErrors().size() );
         assertEquals( ValidationCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         trackedEntity.setTrackedEntity( "XYZ" );
         fileResource.setFileResourceOwner( "ABC" );
@@ -439,7 +439,7 @@ class TrackedEntityAttributeValidatorTest
         assertEquals( 1, reporter.getErrors().size() );
         assertEquals( ValidationCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
 
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         trackedEntity.setTrackedEntity( "ABC" );
         fileResource.setFileResourceOwner( "ABC" );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityCheckUidValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityCheckUidValidatorTest.java
@@ -38,7 +38,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,7 +54,7 @@ class TrackedEntityCheckUidValidatorTest
 
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -62,7 +62,7 @@ class TrackedEntityCheckUidValidatorTest
         TrackerPreheat preheat = new TrackerPreheat();
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
         preheat.setIdSchemes( idSchemes );
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
         bundle = TrackerBundle.builder().preheat( preheat ).build();
 
         validator = new TrackedEntityPreCheckUidValidator();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckExistenceValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckExistenceValidatorTest.java
@@ -42,7 +42,7 @@ import org.hisp.dhis.tracker.TrackerImportStrategy;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,7 +69,7 @@ class TrackedEntityPreCheckExistenceValidatorTest
 
     private TrackedEntityPreCheckExistenceValidator validator;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     void setUp()
@@ -77,7 +77,7 @@ class TrackedEntityPreCheckExistenceValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new TrackedEntityPreCheckExistenceValidator();
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMandatoryFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMandatoryFieldsValidatorTest.java
@@ -39,8 +39,8 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,7 +65,7 @@ class TrackedEntityPreCheckMandatoryFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -77,7 +77,7 @@ class TrackedEntityPreCheckMandatoryFieldsValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test
@@ -122,7 +122,7 @@ class TrackedEntityPreCheckMandatoryFieldsValidatorTest
         assertMissingProperty( reporter, trackedEntity.getUid(), "trackedEntityType" );
     }
 
-    private void assertMissingProperty( ValidationErrorReporter reporter, String uid, String property )
+    private void assertMissingProperty( Reporter reporter, String uid, String property )
     {
         AssertValidationErrorReporter.assertMissingProperty( reporter, TRACKED_ENTITY, "tracked entity", uid, property,
             ValidationCode.E1121 );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMetaValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMetaValidatorTest.java
@@ -41,7 +41,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +68,7 @@ class TrackedEntityPreCheckMetaValidatorTest
     @Mock
     private TrackerBundle bundle;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -78,7 +78,7 @@ class TrackedEntityPreCheckMetaValidatorTest
         when( bundle.getPreheat() ).thenReturn( preheat );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckSecurityOwnershipValidatorHookTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckSecurityOwnershipValidatorHookTest.java
@@ -54,7 +54,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,7 +98,7 @@ class TrackedEntityPreCheckSecurityOwnershipValidatorHookTest extends DhisConven
 
     private User user;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     private OrganisationUnit organisationUnit;
 
@@ -126,7 +126,7 @@ class TrackedEntityPreCheckSecurityOwnershipValidatorHookTest extends DhisConven
         programStage.setUid( PS_ID );
 
         TrackerIdSchemeParams idSchemes = TrackerIdSchemeParams.builder().build();
-        reporter = new ValidationErrorReporter( idSchemes );
+        reporter = new Reporter( idSchemes );
 
         validator = new TrackedEntityPreCheckSecurityOwnershipValidator( aclService, organisationUnitService );
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUpdatableFieldsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUpdatableFieldsValidatorTest.java
@@ -48,7 +48,7 @@ import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
-import org.hisp.dhis.tracker.validation.ValidationErrorReporter;
+import org.hisp.dhis.tracker.validation.Reporter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,7 +85,7 @@ class TrackedEntityPreCheckUpdatableFieldsValidatorTest
     @Mock
     private TrackerPreheat preheat;
 
-    private ValidationErrorReporter reporter;
+    private Reporter reporter;
 
     @BeforeEach
     public void setUp()
@@ -104,7 +104,7 @@ class TrackedEntityPreCheckUpdatableFieldsValidatorTest
 
         when( bundle.getPreheat() ).thenReturn( preheat );
 
-        reporter = new ValidationErrorReporter( TrackerIdSchemeParams.builder().build() );
+        reporter = new Reporter( TrackerIdSchemeParams.builder().build() );
     }
 
     @Test


### PR DESCRIPTION
its clear that we are dealing with validation as we are in the validation package. This reporter is only used in the validation package so it does not need this prefix. It does not only collect errors so the error prefix is misleading.

This PR only contains the result of Intellij rename refactoring `ValidationErrorReporter` -> `Reporter`. So you don't need to review every file 😋 