### PR TITLE
chore: remove prefix from ValidationFailFastException DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultTrackerValidationService.java
@@ -99,7 +99,7 @@ public class DefaultTrackerValidationService
             validateRelationships( bundle, validators.getRelationshipValidators(), reporter );
             validateBundle( bundle, validators.getBundleValidators(), reporter );
         }
-        catch ( ValidationFailFastException e )
+        catch ( FailFastException e )
         {
             // exit early when in FAIL_FAST validation mode
         }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/FailFastException.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/FailFastException.java
@@ -32,12 +32,12 @@ import java.util.List;
 /**
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */
-class ValidationFailFastException
+class FailFastException
     extends RuntimeException
 {
     private final transient List<Error> errorReportRef;
 
-    public ValidationFailFastException( List<Error> errorReportRef )
+    public FailFastException( List<Error> errorReportRef )
     {
         this.errorReportRef = errorReportRef;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Reporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Reporter.java
@@ -80,7 +80,7 @@ public class Reporter
     /**
      * Create a {@link Reporter} reporting all errors and warnings with
      * identifiers in given idSchemes. {@link #addError(Error)} will only throw
-     * a {@link ValidationFailFastException} if {@code failFast} true is given.
+     * a {@link FailFastException} if {@code failFast} true is given.
      *
      * @param idSchemes idSchemes in which to report errors and warnings
      * @param failFast reporter throws exception on first error added when true
@@ -102,8 +102,7 @@ public class Reporter
     /**
      * Create a {@link Reporter} reporting all errors and warnings
      * ({@link #isFailFast} = false) with identifiers in given idSchemes.
-     * {@link #addError(Error)} will not throw a
-     * {@link ValidationFailFastException}.
+     * {@link #addError(Error)} will not throw a {@link FailFastException}.
      *
      * @param idSchemes idSchemes in which to report errors and warnings
      */
@@ -151,7 +150,7 @@ public class Reporter
 
         if ( isFailFast() )
         {
-            throw new ValidationFailFastException( getErrors() );
+            throw new FailFastException( getErrors() );
         }
     }
 


### PR DESCRIPTION
its clear that we are dealing with validation as we are in the validation package. This exception is only used in the validation package so it does not need this prefix.