### PR TITLE
chore: remove prefix from TrackerValidationService DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -60,8 +60,8 @@ import org.hisp.dhis.tracker.report.Status;
 import org.hisp.dhis.tracker.report.TimingsStats;
 import org.hisp.dhis.tracker.report.TrackerTypeReport;
 import org.hisp.dhis.tracker.report.ValidationReport;
-import org.hisp.dhis.tracker.validation.TrackerValidationService;
 import org.hisp.dhis.tracker.validation.ValidationResult;
+import org.hisp.dhis.tracker.validation.ValidationService;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -81,7 +81,7 @@ public class DefaultTrackerImportService
     private final TrackerBundleService trackerBundleService;
 
     @Nonnull
-    private final TrackerValidationService trackerValidationService;
+    private final ValidationService validationService;
 
     @Nonnull
     private final TrackerPreprocessService trackerPreprocessService;
@@ -204,7 +204,7 @@ public class DefaultTrackerImportService
     protected ValidationResult validateBundle( TrackerImportParams params, TrackerBundle trackerBundle,
         TimingsStats opsTimer )
     {
-        ValidationResult validationResult = trackerValidationService.validate( trackerBundle );
+        ValidationResult validationResult = validationService.validate( trackerBundle );
 
         notifyOps( params, VALIDATION_OPS, opsTimer );
 
@@ -231,7 +231,7 @@ public class DefaultTrackerImportService
     {
         ValidationResult ruleEngineValidationResult = new ValidationResult();
 
-        ruleEngineValidationResult.addValidationResult( trackerValidationService.validateRuleEngine( trackerBundle ) );
+        ruleEngineValidationResult.addValidationResult( validationService.validateRuleEngine( trackerBundle ) );
 
         return ruleEngineValidationResult;
     }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidationService.java
@@ -51,8 +51,8 @@ import org.springframework.stereotype.Service;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class DefaultTrackerValidationService
-    implements TrackerValidationService
+public class DefaultValidationService
+    implements ValidationService
 {
 
     @Qualifier( "org.hisp.dhis.tracker.validation.DefaultValidators" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidators.java
@@ -78,8 +78,7 @@ import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckUpdatableFiel
 import org.springframework.stereotype.Component;
 
 /**
- * {@link Validators} used in
- * {@link TrackerValidationService#validate(TrackerBundle)}.
+ * {@link Validators} used in {@link ValidationService#validate(TrackerBundle)}.
  */
 @RequiredArgsConstructor
 @Component( "org.hisp.dhis.tracker.validation.DefaultValidators" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/RuleEngineValidators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/RuleEngineValidators.java
@@ -46,7 +46,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * {@link Validators} used in
- * {@link TrackerValidationService#validateRuleEngine(TrackerBundle)}.
+ * {@link ValidationService#validateRuleEngine(TrackerBundle)}.
  */
 @RequiredArgsConstructor
 @Component( "org.hisp.dhis.tracker.validation.RuleEngineValidators" )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationService.java
@@ -32,7 +32,7 @@ import org.hisp.dhis.tracker.bundle.TrackerBundle;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-public interface TrackerValidationService
+public interface ValidationService
 {
     /**
      * Validate tracker bundle

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/package-info.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/package-info.java
@@ -5,9 +5,9 @@
  * warnings to entities in the payload. The
  * {@link org.hisp.dhis.tracker.bundle.TrackerBundle} leaving this package can
  * be persisted (created, updated, deleted) and thus trusted to be in a valid
- * state. {@link org.hisp.dhis.tracker.validation.TrackerValidationService} is
- * the main entry point into this package. The result of the validation would be
- * a {@link org.hisp.dhis.tracker.validation.ValidationResult} that contains a
+ * state. {@link org.hisp.dhis.tracker.validation.ValidationService} is the main
+ * entry point into this package. The result of the validation would be a
+ * {@link org.hisp.dhis.tracker.validation.ValidationResult} that contains a
  * list of errors and a list of warnings both of them exposed as
  * {@link org.hisp.dhis.tracker.validation.Validation}s.
  */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerImporterServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/bundle/TrackerImporterServiceTest.java
@@ -48,8 +48,8 @@ import org.hisp.dhis.tracker.TrackerUserService;
 import org.hisp.dhis.tracker.domain.Event;
 import org.hisp.dhis.tracker.preprocess.TrackerPreprocessService;
 import org.hisp.dhis.tracker.report.PersistenceReport;
-import org.hisp.dhis.tracker.validation.TrackerValidationService;
 import org.hisp.dhis.tracker.validation.ValidationResult;
+import org.hisp.dhis.tracker.validation.ValidationService;
 import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ class TrackerImporterServiceTest
     private TrackerBundleService trackerBundleService;
 
     @Mock
-    private TrackerValidationService trackerValidationService;
+    private ValidationService validationService;
 
     @Mock
     private TrackerPreprocessService trackerPreprocessService;
@@ -88,7 +88,7 @@ class TrackerImporterServiceTest
     @BeforeEach
     public void setUp()
     {
-        subject = new DefaultTrackerImportService( trackerBundleService, trackerValidationService,
+        subject = new DefaultTrackerImportService( trackerBundleService, validationService,
             trackerPreprocessService,
             trackerUserService, notifier );
 
@@ -107,9 +107,9 @@ class TrackerImporterServiceTest
 
         when( trackerBundleService.commit( any( TrackerBundle.class ) ) ).thenReturn( persistenceReport );
 
-        when( trackerValidationService.validate( any( TrackerBundle.class ) ) )
+        when( validationService.validate( any( TrackerBundle.class ) ) )
             .thenReturn( new ValidationResult() );
-        when( trackerValidationService.validateRuleEngine( any( TrackerBundle.class ) ) )
+        when( validationService.validateRuleEngine( any( TrackerBundle.class ) ) )
             .thenReturn( new ValidationResult() );
         when( trackerPreprocessService.preprocess( any( TrackerBundle.class ) ) )
             .thenReturn( ParamsConverter.convert( params ) );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/report/TrackerBundleImportReportTest.java
@@ -55,10 +55,10 @@ import org.hisp.dhis.tracker.TrackerType;
 import org.hisp.dhis.tracker.TrackerUserService;
 import org.hisp.dhis.tracker.bundle.TrackerBundleService;
 import org.hisp.dhis.tracker.preprocess.TrackerPreprocessService;
-import org.hisp.dhis.tracker.validation.TrackerValidationService;
 import org.hisp.dhis.tracker.validation.Validation;
 import org.hisp.dhis.tracker.validation.ValidationCode;
 import org.hisp.dhis.tracker.validation.ValidationResult;
+import org.hisp.dhis.tracker.validation.ValidationService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -78,7 +78,7 @@ class TrackerBundleImportReportTest
     private TrackerBundleService trackerBundleService;
 
     @Mock
-    private TrackerValidationService trackerValidationService;
+    private ValidationService validationService;
 
     @Mock
     private TrackerPreprocessService trackerPreprocessService;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultValidationServiceConfigOrderTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultValidationServiceConfigOrderTest.java
@@ -43,17 +43,17 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class DefaultTrackerValidationServiceConfigOrderTest extends TrackerTest
+class DefaultValidationServiceConfigOrderTest extends TrackerTest
 {
     @Autowired
-    TrackerValidationService trackerValidationService;
+    ValidationService validationService;
 
     @Test
     void hooksAreExecutedInTrackerValidationConfigOrder()
     {
         // Test that hooks declared in TrackerValidationConfig validationHooks()
         // are injected
-        // into the TrackerValidationService. This is important since order
+        // into the ValidationService. This is important since order
         // matters in the current implementation.
         // Note that FAIL_FAST shows that although the event is also invalid due
         // to not having an orgUnit and more it
@@ -72,7 +72,7 @@ class DefaultTrackerValidationServiceConfigOrderTest extends TrackerTest
             .events( Collections.singletonList( event ) )
             .build();
 
-        ValidationResult report = trackerValidationService.validate( bundle );
+        ValidationResult report = validationService.validate( bundle );
 
         assertTrue( report.hasErrors() );
         assertEquals( 1, report.getErrors().size() );

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultValidationServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/DefaultValidationServiceTest.java
@@ -60,10 +60,10 @@ import org.hisp.dhis.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class DefaultTrackerValidationServiceTest
+class DefaultValidationServiceTest
 {
 
-    private DefaultTrackerValidationService service;
+    private DefaultValidationService service;
 
     private TrackerPreheat preheat;
 
@@ -105,7 +105,7 @@ class DefaultTrackerValidationServiceTest
             .trackedEntities( trackedEntities( trackedEntity() ) )
             .build();
         when( validators.getTrackedEntityValidators() ).thenReturn( List.of( validator1 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         service.validate( bundle );
 
@@ -121,7 +121,7 @@ class DefaultTrackerValidationServiceTest
             .trackedEntities( trackedEntities( trackedEntity() ) )
             .build();
         when( validators.getTrackedEntityValidators() ).thenReturn( List.of( validator1 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         service.validate( bundle );
 
@@ -138,7 +138,7 @@ class DefaultTrackerValidationServiceTest
             .trackedEntities( trackedEntities( trackedEntity ) )
             .build();
         when( validators.getTrackedEntityValidators() ).thenReturn( List.of( validator1, validator2 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         service.validate( bundle );
 
@@ -176,7 +176,7 @@ class DefaultTrackerValidationServiceTest
         Validator<TrackedEntity> doNotSkipOnError = ( r, b, e ) -> addErrorOnMatch( r, invalidTrackedEntity, e,
             ValidationCode.E9999 );
         when( validators.getTrackedEntityValidators() ).thenReturn( List.of( skipOnError, doNotSkipOnError ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -207,7 +207,7 @@ class DefaultTrackerValidationServiceTest
         Validator<TrackedEntity> v2 = ( r, b, e ) -> addErrorOnMatch( r, invalidTrackedEntity, e,
             ValidationCode.E9999 );
         when( validators.getTrackedEntityValidators() ).thenReturn( List.of( v1, v2 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -251,7 +251,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Enrollment> doNotSkipOnError = ( r, b, e ) -> addErrorOnMatch( r, invalidEnrollment, e,
             ValidationCode.E9999 );
         when( validators.getEnrollmentValidators() ).thenReturn( List.of( skipOnError, doNotSkipOnError ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -280,7 +280,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Enrollment> v1 = ( r, b, e ) -> addErrorOnMatch( r, invalidEnrollment, e, ValidationCode.E1032 );
         Validator<Enrollment> v2 = ( r, b, e ) -> addErrorOnMatch( r, invalidEnrollment, e, ValidationCode.E9999 );
         when( validators.getEnrollmentValidators() ).thenReturn( List.of( v1, v2 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -326,7 +326,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Event> doNotSkipOnError = ( r, b, e ) -> addErrorOnMatch( r, invalidEvent, e,
             ValidationCode.E9999 );
         when( validators.getEventValidators() ).thenReturn( List.of( skipOnError, doNotSkipOnError ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -356,7 +356,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Event> v1 = ( r, b, e ) -> addErrorOnMatch( r, invalidEvent, e, ValidationCode.E1032 );
         Validator<Event> v2 = ( r, b, e ) -> addErrorOnMatch( r, invalidEvent, e, ValidationCode.E9999 );
         when( validators.getEventValidators() ).thenReturn( List.of( v1, v2 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -391,7 +391,7 @@ class DefaultTrackerValidationServiceTest
         Validator<Event> v1 = ( r, b, e ) -> addErrorOnMatch( r, invalidEvent, e, ValidationCode.E1032 );
         Validator<Event> v2 = ( r, b, e ) -> addErrorOnMatch( r, invalidEvent, e, ValidationCode.E9999 );
         when( validators.getEventValidators() ).thenReturn( List.of( v1, v2 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -421,7 +421,7 @@ class DefaultTrackerValidationServiceTest
 
         Validator<Event> v1 = ( r, b, e ) -> addErrorOnMatch( r, invalidEvent, e, ValidationCode.E1032 );
         when( validators.getEventValidators() ).thenReturn( List.of( v1 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -450,7 +450,7 @@ class DefaultTrackerValidationServiceTest
             }
         };
         when( validators.getEventValidators() ).thenReturn( List.of( v1 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -480,7 +480,7 @@ class DefaultTrackerValidationServiceTest
             }
         };
         when( validators.getEventValidators() ).thenReturn( List.of( v1 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -499,7 +499,7 @@ class DefaultTrackerValidationServiceTest
 
         Validator<Event> v1 = ( r, b, e ) -> r.addWarning( validEvent, ValidationCode.E1120 );
         when( validators.getEventValidators() ).thenReturn( List.of( v1 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 
@@ -536,7 +536,7 @@ class DefaultTrackerValidationServiceTest
         when( validators.getTrackedEntityValidators() ).thenReturn( List.of( v1 ) );
         when( validators.getEnrollmentValidators() ).thenReturn( List.of( v2 ) );
         when( validators.getEventValidators() ).thenReturn( List.of( v3 ) );
-        service = new DefaultTrackerValidationService( validators, ruleEngineValidators );
+        service = new DefaultValidationService( validators, ruleEngineValidators );
 
         ValidationResult report = service.validate( bundle );
 


### PR DESCRIPTION
its clear that we are in the tracker domain as we are in the tracker module. This service is used outside of the validation package so we should not strip the Validation prefix so it can be differentiated to other services. Service would also be too generic.