### PR TITLE
chore: extract 'root' validators for other types DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidationService.java
@@ -29,17 +29,11 @@ package org.hisp.dhis.tracker.validation;
 
 import static org.hisp.dhis.tracker.validation.PersistablesFilter.filter;
 
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.hisp.dhis.commons.timer.Timer;
 import org.hisp.dhis.tracker.ValidationMode;
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.user.User;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -92,10 +86,10 @@ public class DefaultValidationService
 
         try
         {
-            validateTrackedEntities( bundle, validators.getTrackedEntityValidators(), reporter );
-            validateEnrollments( bundle, validators.getEnrollmentValidators(), reporter );
+            validators.getTrackedEntityValidator().validate( reporter, bundle, bundle );
+            validators.getEnrollmentValidator().validate( reporter, bundle, bundle );
             validators.getEventValidator().validate( reporter, bundle, bundle );
-            validateRelationships( bundle, validators.getRelationshipValidators(), reporter );
+            validators.getRelationshipValidator().validate( reporter, bundle, bundle );
         }
         catch ( FailFastException e )
         {
@@ -113,88 +107,5 @@ public class DefaultValidationService
         reporter.getErrors().addAll( persistables.getErrors() );
 
         return new ValidationResult().addErrors( reporter.getErrors() ).addWarnings( reporter.getWarnings() );
-    }
-
-    private void validateTrackedEntities( TrackerBundle bundle, List<Validator<TrackedEntity>> validators,
-        Reporter reporter )
-    {
-        for ( TrackedEntity tei : bundle.getTrackedEntities() )
-        {
-            for ( Validator<TrackedEntity> validator : validators )
-            {
-                if ( validator.needsToRun( bundle.getStrategy( tei ) ) )
-                {
-                    Timer hookTimer = Timer.startTimer();
-
-                    validator.validate( reporter, bundle, tei );
-
-                    reporter.addTiming( new Timing(
-                        validator.getClass().getName(),
-                        hookTimer.toString() ) );
-
-                    if ( validator.skipOnError() && didNotPassValidation( reporter, tei.getUid() ) )
-                    {
-                        break; // skip subsequent validation for this invalid entity
-                    }
-                }
-            }
-        }
-    }
-
-    private void validateEnrollments( TrackerBundle bundle, List<Validator<Enrollment>> validators,
-        Reporter reporter )
-    {
-        for ( Enrollment enrollment : bundle.getEnrollments() )
-        {
-            for ( Validator<Enrollment> validator : validators )
-            {
-                if ( validator.needsToRun( bundle.getStrategy( enrollment ) ) )
-                {
-                    Timer hookTimer = Timer.startTimer();
-
-                    validator.validate( reporter, bundle, enrollment );
-
-                    reporter.addTiming( new Timing(
-                        validator.getClass().getName(),
-                        hookTimer.toString() ) );
-
-                    if ( validator.skipOnError() && didNotPassValidation( reporter, enrollment.getUid() ) )
-                    {
-                        break; // skip subsequent validation for this invalid entity
-                    }
-                }
-            }
-        }
-    }
-
-    private void validateRelationships( TrackerBundle bundle, List<Validator<Relationship>> validators,
-        Reporter reporter )
-    {
-        for ( Relationship relationship : bundle.getRelationships() )
-        {
-            for ( Validator<Relationship> validator : validators )
-            {
-                if ( validator.needsToRun( bundle.getStrategy( relationship ) ) )
-                {
-                    Timer hookTimer = Timer.startTimer();
-
-                    validator.validate( reporter, bundle, relationship );
-
-                    reporter.addTiming( new Timing(
-                        validator.getClass().getName(),
-                        hookTimer.toString() ) );
-
-                    if ( validator.skipOnError() && didNotPassValidation( reporter, relationship.getUid() ) )
-                    {
-                        break; // skip subsequent validation for this invalid entity
-                    }
-                }
-            }
-        }
-    }
-
-    private boolean didNotPassValidation( Reporter reporter, String uid )
-    {
-        return reporter.getErrors().stream().anyMatch( r -> r.getUid().equals( uid ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidators.java
@@ -27,40 +27,13 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentAttributeValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentDateValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentGeoValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentInExistingValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentNoteValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckDataRelationsValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckExistenceValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckMandatoryFieldsValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckMetaValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckSecurityOwnershipValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckUidValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentPreCheckUpdatableFieldsValidator;
+import org.hisp.dhis.tracker.validation.hooks.EnrollmentValidator;
 import org.hisp.dhis.tracker.validation.hooks.EventValidator;
-import org.hisp.dhis.tracker.validation.hooks.RelationshipPreCheckDataRelationsValidator;
-import org.hisp.dhis.tracker.validation.hooks.RelationshipPreCheckExistenceValidator;
-import org.hisp.dhis.tracker.validation.hooks.RelationshipPreCheckMandatoryFieldsValidator;
-import org.hisp.dhis.tracker.validation.hooks.RelationshipPreCheckMetaValidator;
-import org.hisp.dhis.tracker.validation.hooks.RelationshipPreCheckUidValidator;
-import org.hisp.dhis.tracker.validation.hooks.RelationshipsValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityAttributeValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckExistenceValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckMandatoryFieldsValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckMetaValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckSecurityOwnershipValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckUidValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityPreCheckUpdatableFieldsValidator;
+import org.hisp.dhis.tracker.validation.hooks.RelationshipValidator;
+import org.hisp.dhis.tracker.validation.hooks.TrackedEntityValidator;
 import org.springframework.stereotype.Component;
 
 /**
@@ -71,87 +44,24 @@ import org.springframework.stereotype.Component;
 public class DefaultValidators implements Validators
 {
 
-    private final TrackedEntityPreCheckUidValidator trackedEntityPreCheckUidValidator;
+    private final TrackedEntityValidator trackedEntityValidator;
 
-    private final TrackedEntityPreCheckExistenceValidator trackedEntityPreCheckExistenceValidator;
-
-    private final TrackedEntityPreCheckMandatoryFieldsValidator trackedEntityPreCheckMandatoryFieldsValidator;
-
-    private final TrackedEntityPreCheckMetaValidator trackedEntityPreCheckMetaValidator;
-
-    private final TrackedEntityPreCheckUpdatableFieldsValidator trackedEntityPreCheckUpdatableFieldsValidator;
-
-    private final TrackedEntityPreCheckSecurityOwnershipValidator trackedEntityPreCheckSecurityOwnershipValidator;
-
-    private final TrackedEntityAttributeValidator attributeValidator;
+    private final EnrollmentValidator enrollmentValidator;
 
     private final EventValidator eventValidator;
 
-    private final EnrollmentPreCheckUidValidator enrollmentPreCheckUidValidator;
-
-    private final EnrollmentPreCheckExistenceValidator enrollmentPreCheckExistenceValidator;
-
-    private final EnrollmentPreCheckMandatoryFieldsValidator enrollmentPreCheckMandatoryFieldsValidator;
-
-    private final EnrollmentPreCheckMetaValidator enrollmentPreCheckMetaValidator;
-
-    private final EnrollmentPreCheckUpdatableFieldsValidator enrollmentPreCheckUpdatableFieldsValidator;
-
-    private final EnrollmentPreCheckDataRelationsValidator enrollmentPreCheckDataRelationsValidator;
-
-    private final EnrollmentPreCheckSecurityOwnershipValidator enrollmentPreCheckSecurityOwnershipValidator;
-
-    private final EnrollmentNoteValidator enrollmentNoteValidator;
-
-    private final EnrollmentInExistingValidator enrollmentInExistingValidator;
-
-    private final EnrollmentGeoValidator enrollmentGeoValidator;
-
-    private final EnrollmentDateValidator enrollmentDateValidator;
-
-    private final EnrollmentAttributeValidator enrollmentAttributeValidator;
-
-    private final RelationshipPreCheckUidValidator relationshipPreCheckUidValidator;
-
-    private final RelationshipPreCheckExistenceValidator relationshipPreCheckExistenceValidator;
-
-    private final RelationshipPreCheckMandatoryFieldsValidator relationshipPreCheckMandatoryFieldsValidator;
-
-    private final RelationshipPreCheckMetaValidator relationshipPreCheckMetaValidator;
-
-    private final RelationshipPreCheckDataRelationsValidator relationshipPreCheckDataRelationsValidator;
-
-    private final RelationshipsValidator relationshipsValidator;
+    private final RelationshipValidator relationshipValidator;
 
     @Override
-    public List<Validator<TrackedEntity>> getTrackedEntityValidators()
+    public Validator<TrackerBundle> getTrackedEntityValidator()
     {
-        return List.of(
-            trackedEntityPreCheckUidValidator,
-            trackedEntityPreCheckExistenceValidator,
-            trackedEntityPreCheckMandatoryFieldsValidator,
-            trackedEntityPreCheckMetaValidator,
-            trackedEntityPreCheckUpdatableFieldsValidator,
-            trackedEntityPreCheckSecurityOwnershipValidator,
-            attributeValidator );
+        return trackedEntityValidator;
     }
 
     @Override
-    public List<Validator<Enrollment>> getEnrollmentValidators()
+    public Validator<TrackerBundle> getEnrollmentValidator()
     {
-        return List.of(
-            enrollmentPreCheckUidValidator,
-            enrollmentPreCheckExistenceValidator,
-            enrollmentPreCheckMandatoryFieldsValidator,
-            enrollmentPreCheckMetaValidator,
-            enrollmentPreCheckUpdatableFieldsValidator,
-            enrollmentPreCheckDataRelationsValidator,
-            enrollmentPreCheckSecurityOwnershipValidator,
-            enrollmentNoteValidator,
-            enrollmentInExistingValidator,
-            enrollmentGeoValidator,
-            enrollmentDateValidator,
-            enrollmentAttributeValidator );
+        return enrollmentValidator;
     }
 
     @Override
@@ -161,14 +71,8 @@ public class DefaultValidators implements Validators
     }
 
     @Override
-    public List<Validator<Relationship>> getRelationshipValidators()
+    public Validator<TrackerBundle> getRelationshipValidator()
     {
-        return List.of(
-            relationshipPreCheckUidValidator,
-            relationshipPreCheckExistenceValidator,
-            relationshipPreCheckMandatoryFieldsValidator,
-            relationshipPreCheckMetaValidator,
-            relationshipPreCheckDataRelationsValidator,
-            relationshipsValidator );
+        return relationshipValidator;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/RuleEngineValidators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/RuleEngineValidators.java
@@ -27,19 +27,12 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import java.util.Collections;
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentAttributeValidator;
-import org.hisp.dhis.tracker.validation.hooks.EnrollmentRuleValidationHook;
+import org.hisp.dhis.tracker.validation.hooks.EnrollmentRuleEngineValidator;
 import org.hisp.dhis.tracker.validation.hooks.EventRuleEngineValidator;
-import org.hisp.dhis.tracker.validation.hooks.TrackedEntityAttributeValidator;
+import org.hisp.dhis.tracker.validation.hooks.TrackedEntityRuleEngineValidator;
 import org.springframework.stereotype.Component;
 
 /**
@@ -51,38 +44,34 @@ import org.springframework.stereotype.Component;
 public class RuleEngineValidators implements Validators
 {
 
-    private final TrackedEntityAttributeValidator attributeValidator;
+    private final TrackedEntityRuleEngineValidator trackedEntityValidator;
 
-    private final EnrollmentRuleValidationHook enrollmentRuleValidationHook;
+    private final EnrollmentRuleEngineValidator enrollmentValidator;
 
-    private final EnrollmentAttributeValidator enrollmentAttributeValidator;
-
-    private final EventRuleEngineValidator eventRuleEngineValidator;
+    private final EventRuleEngineValidator eventValidator;
 
     @Override
-    public List<Validator<TrackedEntity>> getTrackedEntityValidators()
+    public Validator<TrackerBundle> getTrackedEntityValidator()
     {
-        return List.of(
-            attributeValidator );
+        return trackedEntityValidator;
     }
 
     @Override
-    public List<Validator<Enrollment>> getEnrollmentValidators()
+    public Validator<TrackerBundle> getEnrollmentValidator()
     {
-        return List.of(
-            enrollmentRuleValidationHook,
-            enrollmentAttributeValidator );
+        return enrollmentValidator;
     }
 
     @Override
     public Validator<TrackerBundle> getEventValidator()
     {
-        return eventRuleEngineValidator;
+        return eventValidator;
     }
 
     @Override
-    public List<Validator<Relationship>> getRelationshipValidators()
+    public Validator<TrackerBundle> getRelationshipValidator()
     {
-        return Collections.emptyList();
+        return ( r, b, t ) -> {
+        };
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validator.java
@@ -60,20 +60,4 @@ public interface Validator<T>
         return strategy != TrackerImportStrategy.DELETE;
     }
 
-    /**
-     * A signal to the orchestration of the validation that subsequent
-     * {@link Validator}s should not be run if this one fails i.e. adds an
-     * error.
-     * <p>
-     * Note: this mechanism is going to be replaced by
-     * {@link org.hisp.dhis.tracker.validation.hooks.Seq}.
-     * </p>
-     *
-     * @return true if subsequent validators should be skipped on error and
-     *         false otherwise
-     */
-    default boolean skipOnError()
-    {
-        return false;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validators.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Validators.java
@@ -27,21 +27,16 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import java.util.List;
-
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Enrollment;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.domain.TrackedEntity;
 
 public interface Validators
 {
 
-    List<Validator<TrackedEntity>> getTrackedEntityValidators();
+    Validator<TrackerBundle> getTrackedEntityValidator();
 
-    List<Validator<Enrollment>> getEnrollmentValidators();
+    Validator<TrackerBundle> getEnrollmentValidator();
 
     Validator<TrackerBundle> getEventValidator();
 
-    List<Validator<Relationship>> getRelationshipValidators();
+    Validator<TrackerBundle> getRelationshipValidator();
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckDataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckDataRelationsValidator.java
@@ -110,9 +110,4 @@ public class EnrollmentPreCheckDataRelationsValidator
             .orElse( false );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckExistenceValidator.java
@@ -76,9 +76,4 @@ public class EnrollmentPreCheckExistenceValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMandatoryFieldsValidator.java
@@ -52,9 +52,4 @@ public class EnrollmentPreCheckMandatoryFieldsValidator
             "trackedEntity" );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckMetaValidator.java
@@ -61,9 +61,4 @@ public class EnrollmentPreCheckMetaValidator
             E1068, enrollment.getTrackedEntity() );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckSecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckSecurityOwnershipValidator.java
@@ -173,12 +173,6 @@ public class EnrollmentPreCheckSecurityOwnershipValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
     private void checkOrgUnitInCaptureScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentPreCheckUidValidator.java
@@ -51,10 +51,4 @@ public class EnrollmentPreCheckUidValidator
         validateNotesUid( enrollment.getNotes(), reporter, enrollment );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EnrollmentValidator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.tracker.validation.hooks;
+
+import static org.hisp.dhis.tracker.validation.hooks.All.all;
+import static org.hisp.dhis.tracker.validation.hooks.Each.each;
+import static org.hisp.dhis.tracker.validation.hooks.Seq.seq;
+
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.tracker.bundle.TrackerBundle;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.validation.Reporter;
+import org.hisp.dhis.tracker.validation.Validator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validator to validate all {@link Enrollment}s in the {@link TrackerBundle}.
+ */
+@RequiredArgsConstructor
+@Component( "org.hisp.dhis.tracker.validation.hooks.EnrollmentValidator" )
+public class EnrollmentValidator implements Validator<TrackerBundle>
+{
+
+    private final EnrollmentPreCheckUidValidator uidValidator;
+
+    private final EnrollmentPreCheckExistenceValidator existenceValidator;
+
+    private final EnrollmentPreCheckMandatoryFieldsValidator mandatoryFieldsValidator;
+
+    private final EnrollmentPreCheckMetaValidator metaValidator;
+
+    private final EnrollmentPreCheckUpdatableFieldsValidator updatableFieldsValidator;
+
+    private final EnrollmentPreCheckDataRelationsValidator dataRelationsValidator;
+
+    private final EnrollmentPreCheckSecurityOwnershipValidator securityOwnershipValidator;
+
+    private final EnrollmentNoteValidator noteValidator;
+
+    private final EnrollmentInExistingValidator inExistingValidator;
+
+    private final EnrollmentGeoValidator geoValidator;
+
+    private final EnrollmentDateValidator dateValidator;
+
+    private final EnrollmentAttributeValidator attributeValidator;
+
+    private Validator<TrackerBundle> enrollmentValidator()
+    {
+        // @formatter:off
+        return each( TrackerBundle::getEnrollments,
+                        seq(
+                                uidValidator,
+                                existenceValidator,
+                                mandatoryFieldsValidator,
+                                metaValidator,
+                                updatableFieldsValidator,
+                                dataRelationsValidator,
+                                securityOwnershipValidator,
+                                all(
+                                        noteValidator,
+                                        inExistingValidator,
+                                        geoValidator,
+                                        dateValidator,
+                                        attributeValidator
+                                )
+                        )
+                );
+    }
+    @Override
+    public void validate(Reporter reporter, TrackerBundle bundle, TrackerBundle input) {
+
+        enrollmentValidator().validate(reporter, bundle, input);
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckDataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckDataRelationsValidator.java
@@ -370,9 +370,4 @@ public class EventPreCheckDataRelationsValidator
         return null;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckExistenceValidator.java
@@ -76,9 +76,4 @@ public class EventPreCheckExistenceValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMandatoryFieldsValidator.java
@@ -72,9 +72,4 @@ public class EventPreCheckMandatoryFieldsValidator
         reporter.addErrorIf( event.getProgram()::isBlank, event, E1123, "program" );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckMetaValidator.java
@@ -60,9 +60,4 @@ public class EventPreCheckMetaValidator
         reporter.addErrorIfNull( programStage, event, E1013, event.getProgramStage() );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckSecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckSecurityOwnershipValidator.java
@@ -246,12 +246,6 @@ public class EventPreCheckSecurityOwnershipValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
     private void checkOrgUnitInCaptureScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventPreCheckUidValidator.java
@@ -51,10 +51,4 @@ public class EventPreCheckUidValidator
         validateNotesUid( event.getNotes(), reporter, event );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/EventValidator.java
@@ -47,55 +47,55 @@ import org.springframework.stereotype.Component;
 @Component( "org.hisp.dhis.tracker.validation.hooks.EventValidator" )
 public class EventValidator implements Validator<TrackerBundle>
 {
-    private final EventPreCheckUidValidator eventPreCheckUidValidator;
+    private final EventPreCheckUidValidator uidValidator;
 
-    private final EventPreCheckExistenceValidator eventPreCheckExistenceValidator;
+    private final EventPreCheckExistenceValidator existenceValidator;
 
-    private final EventPreCheckMandatoryFieldsValidator eventPreCheckMandatoryFieldsValidator;
+    private final EventPreCheckMandatoryFieldsValidator mandatoryFieldsValidator;
 
-    private final EventPreCheckMetaValidator eventPreCheckMetaValidator;
+    private final EventPreCheckMetaValidator metaValidator;
 
-    private final EventPreCheckUpdatableFieldsValidator eventPreCheckUpdatableFieldsValidator;
+    private final EventPreCheckUpdatableFieldsValidator updatableFieldsValidator;
 
-    private final EventPreCheckDataRelationsValidator eventPreCheckDataRelationsValidator;
+    private final EventPreCheckDataRelationsValidator dataRelationsValidator;
 
-    private final EventPreCheckSecurityOwnershipValidator eventPreCheckSecurityOwnershipValidator;
+    private final EventPreCheckSecurityOwnershipValidator securityOwnershipValidator;
 
-    private final EventCategoryOptValidator eventCategoryOptValidator;
+    private final EventCategoryOptValidator categoryOptValidator;
 
-    private final EventDateValidator eventDateValidator;
+    private final EventDateValidator dateValidator;
 
-    private final EventGeoValidator eventGeoValidator;
+    private final EventGeoValidator geoValidator;
 
-    private final EventNoteValidator eventNoteValidator;
+    private final EventNoteValidator noteValidator;
 
-    private final EventDataValuesValidator eventDataValuesValidator;
+    private final EventDataValuesValidator dataValuesValidator;
 
     private final AssignedUserValidator assignedUserValidator;
 
     private final RepeatedEventsValidator repeatedEventsValidator;
 
-    public Validator<TrackerBundle> eventValidator()
+    private Validator<TrackerBundle> eventValidator()
     {
         // @formatter:off
         return all(
                 each( TrackerBundle::getEvents,
                     seq(
-                        eventPreCheckUidValidator,
-                        eventPreCheckExistenceValidator,
-                        eventPreCheckMandatoryFieldsValidator,
-                        eventPreCheckMetaValidator,
-                        eventPreCheckUpdatableFieldsValidator,
-                        eventPreCheckDataRelationsValidator,
-                        eventPreCheckSecurityOwnershipValidator,
-                        all(
-                            eventCategoryOptValidator,
-                            eventDateValidator,
-                            eventGeoValidator,
-                            eventNoteValidator,
-                            eventDataValuesValidator,
-                            assignedUserValidator
-                        )
+                            uidValidator,
+                            existenceValidator,
+                            mandatoryFieldsValidator,
+                            metaValidator,
+                            updatableFieldsValidator,
+                            dataRelationsValidator,
+                            securityOwnershipValidator,
+                            all(
+                                categoryOptValidator,
+                                dateValidator,
+                                geoValidator,
+                                noteValidator,
+                                dataValuesValidator,
+                                assignedUserValidator
+                            )
                     )
                 ),
                 field( TrackerBundle::getEvents, repeatedEventsValidator )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckDataRelationsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckDataRelationsValidator.java
@@ -89,10 +89,4 @@ public class RelationshipPreCheckDataRelationsValidator
         }
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckExistenceValidator.java
@@ -103,9 +103,4 @@ public class RelationshipPreCheckExistenceValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckMandatoryFieldsValidator.java
@@ -52,9 +52,4 @@ public class RelationshipPreCheckMandatoryFieldsValidator
             "relationshipType" );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RelationshipPreCheckUidValidator.java
@@ -49,10 +49,4 @@ public class RelationshipPreCheckUidValidator
             relationship.getRelationship() );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/RepeatedEventsValidator.java
@@ -98,9 +98,4 @@ public class RepeatedEventsValidator
         }
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckExistenceValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckExistenceValidator.java
@@ -77,9 +77,4 @@ public class TrackedEntityPreCheckExistenceValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMandatoryFieldsValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMandatoryFieldsValidator.java
@@ -51,9 +51,4 @@ public class TrackedEntityPreCheckMandatoryFieldsValidator
         reporter.addErrorIf( () -> trackedEntity.getOrgUnit().isBlank(), trackedEntity, E1121, "orgUnit" );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMetaValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckMetaValidator.java
@@ -61,9 +61,4 @@ public class TrackedEntityPreCheckMetaValidator
         }
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckSecurityOwnershipValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckSecurityOwnershipValidator.java
@@ -136,12 +136,6 @@ public class TrackedEntityPreCheckSecurityOwnershipValidator
         return true;
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
     private void checkOrgUnitInCaptureScope( Reporter reporter, TrackerBundle bundle, TrackerDto dto,
         OrganisationUnit orgUnit )
     {

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUidValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityPreCheckUidValidator.java
@@ -49,10 +49,4 @@ public class TrackedEntityPreCheckUidValidator
             trackedEntity.getTrackedEntity() );
     }
 
-    @Override
-    public boolean skipOnError()
-    {
-        return true;
-    }
-
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityRuleEngineValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityRuleEngineValidator.java
@@ -27,31 +27,36 @@
  */
 package org.hisp.dhis.tracker.validation.hooks;
 
-import static org.hisp.dhis.tracker.validation.ValidationCode.E4006;
+import static org.hisp.dhis.tracker.validation.hooks.Each.each;
 
-import org.hisp.dhis.relationship.RelationshipType;
+import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Relationship;
-import org.hisp.dhis.tracker.preheat.TrackerPreheat;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
 /**
- * @author Morten Svanæs <msvanaes@dhis2.org>
+ * Validator to validate all {@link TrackedEntity}s in the
+ * {@link TrackerBundle}.
  */
-@Component
-public class RelationshipPreCheckMetaValidator
-    implements Validator<Relationship>
+@RequiredArgsConstructor
+@Component( "org.hisp.dhis.tracker.validation.hooks.TrackedEntityRuleEngineValidator" )
+public class TrackedEntityRuleEngineValidator implements Validator<TrackerBundle>
 {
-    @Override
-    public void validate( Reporter reporter, TrackerBundle bundle,
-        Relationship relationship )
-    {
-        TrackerPreheat preheat = bundle.getPreheat();
-        RelationshipType relationshipType = preheat.getRelationshipType( relationship.getRelationshipType() );
 
-        reporter.addErrorIfNull( relationshipType, relationship, E4006, relationship.getRelationshipType() );
+    private final TrackedEntityAttributeValidator attributeValidator;
+
+    private Validator<TrackerBundle> trackedEntityValidator()
+    {
+        return each( TrackerBundle::getTrackedEntities, attributeValidator );
     }
 
+    @Override
+    public void validate( Reporter reporter, TrackerBundle bundle, TrackerBundle input )
+    {
+
+        trackedEntityValidator().validate( reporter, bundle, input );
+    }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityValidator.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/hooks/TrackedEntityValidator.java
@@ -29,40 +29,59 @@ package org.hisp.dhis.tracker.validation.hooks;
 
 import static org.hisp.dhis.tracker.validation.hooks.All.all;
 import static org.hisp.dhis.tracker.validation.hooks.Each.each;
+import static org.hisp.dhis.tracker.validation.hooks.Seq.seq;
 
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.tracker.bundle.TrackerBundle;
-import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
 import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.Validator;
 import org.springframework.stereotype.Component;
 
 /**
- * Validator to validate all {@link Event}s in the {@link TrackerBundle}.
+ * Validator to validate all {@link TrackedEntity}s in the
+ * {@link TrackerBundle}.
  */
 @RequiredArgsConstructor
-@Component( "org.hisp.dhis.tracker.validation.hooks.EventRuleEngineValidator" )
-public class EventRuleEngineValidator implements Validator<TrackerBundle>
+@Component( "org.hisp.dhis.tracker.validation.hooks.TrackedEntityValidator" )
+public class TrackedEntityValidator implements Validator<TrackerBundle>
 {
-    private final EventRuleValidator ruleValidator;
 
-    private final EventDataValuesValidator dataValuesValidator;
+    private final TrackedEntityPreCheckUidValidator uidValidator;
 
-    public Validator<TrackerBundle> eventValidator()
+    private final TrackedEntityPreCheckExistenceValidator existenceValidator;
+
+    private final TrackedEntityPreCheckMandatoryFieldsValidator mandatoryFieldsValidator;
+
+    private final TrackedEntityPreCheckMetaValidator metaValidator;
+
+    private final TrackedEntityPreCheckUpdatableFieldsValidator updatableFieldsValidator;
+
+    private final TrackedEntityPreCheckSecurityOwnershipValidator securityOwnershipValidator;
+
+    private final TrackedEntityAttributeValidator attributeValidator;
+
+    private Validator<TrackerBundle> trackedEntityValidator()
     {
         // @formatter:off
-        return each(TrackerBundle::getEvents,
-                    all(
-                            ruleValidator,
-                            dataValuesValidator
-                    )
-        );
+        return each( TrackerBundle::getTrackedEntities,
+                        seq(
+                                uidValidator,
+                                existenceValidator,
+                                mandatoryFieldsValidator,
+                                metaValidator,
+                                updatableFieldsValidator,
+                                securityOwnershipValidator,
+                                all(
+                                        attributeValidator
+                                )
+                        )
+                );
     }
-
     @Override
-    public void validate( Reporter reporter, TrackerBundle bundle, TrackerBundle input )
-    {
-        eventValidator().validate( reporter, bundle, input );
+    public void validate(Reporter reporter, TrackerBundle bundle, TrackerBundle input) {
+
+        trackedEntityValidator().validate(reporter, bundle, input);
     }
 }


### PR DESCRIPTION
follow up after https://github.com/dhis2/dhis2-core/pull/12559

* Create one `Validator` per type. Declare them in the same order as we did previously. So that `Seq` takes care of the former `skipOnError=true` mechanism.
* Remove the skipOnError as its not needed anymore.

Next PR:
* create one main `Validator<TrackerBundle>` so the `DefaultValidationService` only calls `validator.validate()`