### PR TITLE
fix: Handle numeric aggregation logic in analytics [DHIS2-14302]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -73,6 +73,7 @@ import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.OrganisationUnitSelectionMode;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.RequestTypeAware;
+import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.event.EventStatus;
@@ -843,9 +844,27 @@ public class EventQueryParams
         return isNotEmpty( getEventStatus() );
     }
 
+    /**
+     * Checks if a value dimension exists.
+     *
+     * @return true if a value dimension exists, false if not.
+     */
     public boolean hasValueDimension()
     {
         return value != null;
+    }
+
+    /**
+     * Checks if a value dimension with a numeric value type exists.
+     *
+     * @return true if a value dimension with a numeric value type exists, false
+     *         if not.
+     */
+    public boolean hasNumericValueDimension()
+    {
+        return hasValueDimension() &&
+            value instanceof ValueTypedDimensionalItemObject &&
+            ((ValueTypedDimensionalItemObject) value).getValueType().isNumeric();
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -96,7 +96,6 @@ import org.hisp.dhis.common.QueryRuntimeException;
 import org.hisp.dhis.common.Reference;
 import org.hisp.dhis.common.RepeatableStageParams;
 import org.hisp.dhis.common.ValueType;
-import org.hisp.dhis.common.ValueTypedDimensionalItemObject;
 import org.hisp.dhis.commons.util.SqlHelper;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -657,7 +656,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
 
         EventOutputType outputType = params.getOutputType();
 
-        if ( params.hasValueDimension() && isParamsValueTypeNumeric( params ) )
+        if ( params.hasNumericValueDimension() )
         {
             Assert.isTrue( params.getAggregationTypeFallback().getAggregationType().isAggregatable(),
                 "Event query aggregation type must be aggregatable" );
@@ -817,19 +816,6 @@ public abstract class AbstractJdbcEventAnalyticsManager
         {
             return filter.getSqlFilterColumn( getColumn( item ), item.getValueType() );
         }
-    }
-
-    /**
-     * Checks if the ValueType, in the given parameters, is of type NUMERIC.
-     *
-     * @param params the {@link EventQueryParams}.
-     * @return true if the parameter value type is numeric, false otherwise.
-     */
-    private boolean isParamsValueTypeNumeric( EventQueryParams params )
-    {
-        return params != null &&
-            params.getValue() instanceof ValueTypedDimensionalItemObject &&
-            ((ValueTypedDimensionalItemObject) params.getValue()).getValueType() == ValueType.NUMBER;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
@@ -154,6 +154,34 @@ class EventQueryParamsTest extends DhisConvenienceTest
     }
 
     @Test
+    void testHasDimensionValue()
+    {
+        EventQueryParams paramsA = new EventQueryParams.Builder()
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deA )
+            .build();
+
+        assertTrue( paramsA.hasValueDimension() );
+    }
+
+    @Test
+    void testHasNumericDimensionValue()
+    {
+        EventQueryParams paramsA = new EventQueryParams.Builder()
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deA )
+            .build();
+
+        EventQueryParams paramsB = new EventQueryParams.Builder()
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deC )
+            .build();
+
+        assertTrue( paramsA.hasNumericValueDimension() );
+        assertFalse( paramsB.hasNumericValueDimension() );
+    }
+
+    @Test
     void testGetKey()
     {
         QueryItem qiA = new QueryItem( deA, null, deA.getValueType(), deA.getAggregationType(), osA );


### PR DESCRIPTION
The code for checking whether a value dimension was numeric used `getValueType() == ValueType.NUMBER` which only covers one of the many numeric value types. The right approach is `getValueType().isNumeric()`.