### PR TITLE
test: dont assert error count in unit tests DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EnrollmentAttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EnrollmentAttributeValidatorTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.tracker.validation.validator;
 import static org.hisp.dhis.tracker.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -176,9 +175,7 @@ class EnrollmentAttributeValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, ValidationCode.E1076 ) );
+        assertHasError( reporter, enrollment, ValidationCode.E1076 );
     }
 
     @Test
@@ -234,9 +231,7 @@ class EnrollmentAttributeValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, ValidationCode.E1085 ) );
+        assertHasError( reporter, enrollment, ValidationCode.E1085 );
     }
 
     @Test
@@ -264,7 +259,6 @@ class EnrollmentAttributeValidatorTest
         validator.validate( reporter, bundle, enrollment );
 
         assertAll(
-            () -> assertEquals( 2, reporter.getErrors().size() ),
             () -> assertHasError( reporter, enrollment, ValidationCode.E1076 ),
             () -> assertHasError( reporter, enrollment, ValidationCode.E1018 ) );
     }
@@ -289,8 +283,6 @@ class EnrollmentAttributeValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, ValidationCode.E1006 ) );
+        assertHasError( reporter, enrollment, ValidationCode.E1006 );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EnrollmentInExistingValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EnrollmentInExistingValidatorTest.java
@@ -31,8 +31,6 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E1015;
 import static org.hisp.dhis.tracker.validation.ValidationCode.E1016;
 import static org.hisp.dhis.tracker.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -179,9 +177,7 @@ class EnrollmentInExistingValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, E1015 ) );
+        assertHasError( reporter, enrollment, E1015 );
     }
 
     @Test
@@ -196,9 +192,7 @@ class EnrollmentInExistingValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, E1016 ) );
+        assertHasError( reporter, enrollment, E1016 );
     }
 
     @Test
@@ -218,9 +212,7 @@ class EnrollmentInExistingValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, E1015 ) );
+        assertHasError( reporter, enrollment, E1015 );
     }
 
     @Test
@@ -235,9 +227,7 @@ class EnrollmentInExistingValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, E1016 ) );
+        assertHasError( reporter, enrollment, E1016 );
     }
 
     @Test
@@ -263,9 +253,7 @@ class EnrollmentInExistingValidatorTest
 
         validator.validate( reporter, bundle, enrollment );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, enrollment, E1016 ) );
+        assertHasError( reporter, enrollment, E1016 );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EventDataValuesValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EventDataValuesValidatorTest.java
@@ -27,12 +27,8 @@
  */
 package org.hisp.dhis.tracker.validation.validator;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hisp.dhis.tracker.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -185,9 +181,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1304 ) );
+        assertHasError( reporter, event, ValidationCode.E1304 );
     }
 
     @Test
@@ -220,9 +214,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1303 ) );
+        assertHasError( reporter, event, ValidationCode.E1303 );
     }
 
     @Test
@@ -320,9 +312,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1305 ) );
+        assertHasError( reporter, event, ValidationCode.E1305 );
     }
 
     @Test
@@ -376,9 +366,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1302 ) );
+        assertHasError( reporter, event, ValidationCode.E1302 );
     }
 
     @Test
@@ -405,9 +393,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1084 ) );
+        assertHasError( reporter, event, ValidationCode.E1084 );
     }
 
     @Test
@@ -454,9 +440,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1076 ) );
+        assertHasError( reporter, event, ValidationCode.E1076 );
     }
 
     @Test
@@ -481,9 +465,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1076 ) );
+        assertHasError( reporter, event, ValidationCode.E1076 );
     }
 
     @Test
@@ -508,9 +490,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1076 ) );
+        assertHasError( reporter, event, ValidationCode.E1076 );
     }
 
     @Test
@@ -559,9 +539,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1076 ) );
+        assertHasError( reporter, event, ValidationCode.E1076 );
     }
 
     @Test
@@ -658,9 +636,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1009 ) );
+        assertHasError( reporter, event, ValidationCode.E1009 );
 
         when( bundle.getStrategy( event ) ).thenReturn( TrackerImportStrategy.UPDATE );
 
@@ -696,9 +672,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1009 ) );
+        assertHasError( reporter, event, ValidationCode.E1009 );
 
         event.setEvent( "XYZ" );
         fileResource.setFileResourceOwner( "ABC" );
@@ -709,8 +683,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertThat( reporter.getErrors(), hasSize( 1 ) );
-        assertEquals( ValidationCode.E1009, reporter.getErrors().get( 0 ).getErrorCode() );
+        assertHasError( reporter, event, ValidationCode.E1009 );
 
         event.setEvent( "ABC" );
         fileResource.setFileResourceOwner( "ABC" );
@@ -806,9 +779,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1125 ) );
+        assertHasError( reporter, event, ValidationCode.E1125 );
     }
 
     @Test
@@ -834,9 +805,7 @@ class EventDataValuesValidatorTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1007 ) );
+        assertHasError( reporter, event, ValidationCode.E1007 );
     }
 
     @Test
@@ -888,9 +857,7 @@ class EventDataValuesValidatorTest
         reporter = new Reporter( idSchemes );
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1302 ) );
+        assertHasError( reporter, event, ValidationCode.E1302 );
     }
 
     private DataElement dataElement( ValueType type )

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EventPreCheckDataRelationsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/EventPreCheckDataRelationsValidatorTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.tracker.validation.validator;
 
 import static org.hisp.dhis.tracker.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -199,9 +198,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1033 ) );
+        assertHasError( reporter, event, ValidationCode.E1033 );
     }
 
     @Test
@@ -236,9 +233,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1079 ) );
+        assertHasError( reporter, event, ValidationCode.E1079 );
     }
 
     @Test
@@ -274,9 +269,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1029 ) );
+        assertHasError( reporter, event, ValidationCode.E1029 );
     }
 
     @Test
@@ -291,9 +284,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1055 ) );
+        assertHasError( reporter, event, ValidationCode.E1055 );
     }
 
     @Test
@@ -448,9 +439,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1115 ) );
+        assertHasError( reporter, event, ValidationCode.E1115 );
     }
 
     @Test
@@ -469,9 +458,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1115 ) );
+        assertHasError( reporter, event, ValidationCode.E1115 );
     }
 
     @Test
@@ -513,9 +500,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1055 ) );
+        assertHasError( reporter, event, ValidationCode.E1055 );
     }
 
     @Test
@@ -610,9 +595,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1115 ) );
+        assertHasError( reporter, event, ValidationCode.E1115 );
     }
 
     @Test
@@ -637,9 +620,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1055 ) );
+        assertHasError( reporter, event, ValidationCode.E1055 );
     }
 
     @Test
@@ -663,9 +644,7 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, ValidationCode.E1116 ) );
+        assertHasError( reporter, event, ValidationCode.E1116 );
     }
 
     @Test
@@ -695,12 +674,9 @@ class EventPreCheckDataRelationsValidatorTest extends DhisConvenienceTest
 
         validator.validate( reporter, bundle, event );
 
-        assertEquals( 3, reporter.getErrors().size() );
-        assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == ValidationCode.E1115 ) );
-        assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == ValidationCode.E1116
-            && r.getMessage().contains( UNKNOWN_CO_ID1 ) ) );
-        assertTrue( reporter.hasErrorReport( r -> r.getErrorCode() == ValidationCode.E1116
-            && r.getMessage().contains( UNKNOWN_CO_ID2 ) ) );
+        assertHasError( reporter, event, ValidationCode.E1115 );
+        assertHasError( reporter, event, ValidationCode.E1116, UNKNOWN_CO_ID1 );
+        assertHasError( reporter, event, ValidationCode.E1116, UNKNOWN_CO_ID2 );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/RepeatedEventsValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/RepeatedEventsValidatorTest.java
@@ -32,7 +32,6 @@ import static org.hisp.dhis.tracker.validation.ValidationCode.E9999;
 import static org.hisp.dhis.tracker.validation.validator.AssertValidations.assertHasError;
 import static org.hisp.dhis.utils.Assertions.assertIsEmpty;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.when;
 
@@ -131,11 +130,8 @@ class RepeatedEventsValidatorTest extends DhisConvenienceTest
         validator.validate( reporter, bundle, bundle.getEvents() );
 
         // then
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, event, E1039,
-                "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
-                    "`, is not repeatable and an event already exists." ) );
+        assertHasError( reporter, event, E1039, "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION +
+            "`, is not repeatable and an event already exists." );
     }
 
     @Test
@@ -150,7 +146,6 @@ class RepeatedEventsValidatorTest extends DhisConvenienceTest
         validator.validate( reporter, bundle, bundle.getEvents() );
 
         assertAll(
-            () -> assertEquals( 2, reporter.getErrors().size() ),
             () -> assertHasError( reporter, events.get( 0 ), E1039,
                 "ProgramStage: `" + NOT_REPEATABLE_PROGRAM_STAGE_WITH_REGISTRATION
                     + "`, is not repeatable and an event already exists." ),

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/TrackedEntityAttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/TrackedEntityAttributeValidatorTest.java
@@ -159,9 +159,7 @@ class TrackedEntityAttributeValidatorTest
 
         validator.validate( reporter, bundle, trackedEntity );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, trackedEntity, ValidationCode.E1090 ) );
+        assertHasError( reporter, trackedEntity, ValidationCode.E1090 );
     }
 
     @Test
@@ -212,9 +210,7 @@ class TrackedEntityAttributeValidatorTest
 
         validator.validate( reporter, bundle, trackedEntity );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, trackedEntity, ValidationCode.E1076 ) );
+        assertHasError( reporter, trackedEntity, ValidationCode.E1076 );
     }
 
     @Test
@@ -233,9 +229,7 @@ class TrackedEntityAttributeValidatorTest
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
         validator.validateAttributeValue( reporter, te, trackedEntityAttribute, sbString.toString() );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, te, ValidationCode.E1077 ) );
+        assertHasError( reporter, te, ValidationCode.E1077 );
     }
 
     @Test
@@ -247,9 +241,7 @@ class TrackedEntityAttributeValidatorTest
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
         validator.validateAttributeValue( reporter, te, trackedEntityAttribute, "value" );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, te, ValidationCode.E1085 ) );
+        assertHasError( reporter, te, ValidationCode.E1085 );
     }
 
     @Test
@@ -268,9 +260,7 @@ class TrackedEntityAttributeValidatorTest
         TrackedEntity te = TrackedEntity.builder().trackedEntity( CodeGenerator.generateUid() ).build();
         validator.validateAttributeValue( reporter, te, trackedEntityAttribute, "value" );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, te, ValidationCode.E1112 ) );
+        assertHasError( reporter, te, ValidationCode.E1112 );
     }
 
     @Test
@@ -291,9 +281,7 @@ class TrackedEntityAttributeValidatorTest
 
         validator.validate( reporter, bundle, trackedEntity );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, trackedEntity, ValidationCode.E1125 ) );
+        assertHasError( reporter, trackedEntity, ValidationCode.E1125 );
     }
 
     @Test
@@ -374,9 +362,7 @@ class TrackedEntityAttributeValidatorTest
 
         validator.validate( reporter, bundle, trackedEntity );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, trackedEntity, ValidationCode.E1076 ) );
+        assertHasError( reporter, trackedEntity, ValidationCode.E1076 );
     }
 
     @Test
@@ -415,9 +401,7 @@ class TrackedEntityAttributeValidatorTest
 
         validator.validate( reporter, bundle, trackedEntity );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, trackedEntity, ValidationCode.E1009 ) );
+        assertHasError( reporter, trackedEntity, ValidationCode.E1009 );
 
         reporter = new Reporter( idSchemes );
 
@@ -428,9 +412,7 @@ class TrackedEntityAttributeValidatorTest
 
         validator.validate( reporter, bundle, trackedEntity );
 
-        assertAll(
-            () -> assertEquals( 1, reporter.getErrors().size() ),
-            () -> assertHasError( reporter, trackedEntity, ValidationCode.E1009 ) );
+        assertHasError( reporter, trackedEntity, ValidationCode.E1009 );
 
         reporter = new Reporter( idSchemes );
 


### PR DESCRIPTION
Our validators are built to collect as many errors as possible. Unit tests are less brittle if we only assert the error/warning our test case is concerned with is collected. If the validator adds another error because we also trigger another case that is not an issue in a unit test.

Our integration tests need to assert on the exact count since that is the final result the user sees.