### PR TITLE
chore: don't mutate bundle in validation DHIS2-14298

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/DefaultTrackerImportService.java
@@ -197,26 +197,34 @@ public class DefaultTrackerImportService
         trackerBundleService.postCommit( trackerBundle );
     }
 
-    protected ValidationResult validateBundle( TrackerImportParams params, TrackerBundle trackerBundle,
+    protected ValidationResult validateBundle( TrackerImportParams params, TrackerBundle bundle,
         TimingsStats opsTimer )
     {
-        ValidationResult validationResult = validationService.validate( trackerBundle );
+        ValidationResult result = validationService.validate( bundle );
+        bundle.setTrackedEntities( result.getTrackedEntities() );
+        bundle.setEnrollments( result.getEnrollments() );
+        bundle.setEvents( result.getEvents() );
+        bundle.setRelationships( result.getRelationships() );
 
         notifyOps( params, VALIDATION_OPS, opsTimer );
 
-        return validationResult;
+        return result;
     }
 
     private ValidationResult execRuleEngine( TrackerImportParams params, TimingsStats opsTimer,
-        TrackerBundle trackerBundle )
+        TrackerBundle bundle )
     {
         opsTimer.execVoid( PROGRAMRULE_OPS,
-            () -> trackerBundleService.runRuleEngine( trackerBundle ) );
+            () -> trackerBundleService.runRuleEngine( bundle ) );
 
         notifyOps( params, PROGRAMRULE_OPS, opsTimer );
 
         ValidationResult result = opsTimer.exec( VALIDATE_PROGRAMRULE_OPS,
-            () -> validationService.validateRuleEngine( trackerBundle ) );
+            () -> validationService.validateRuleEngine( bundle ) );
+        bundle.setTrackedEntities( result.getTrackedEntities() );
+        bundle.setEnrollments( result.getEnrollments() );
+        bundle.setEvents( result.getEvents() );
+        bundle.setRelationships( result.getRelationships() );
 
         notifyOps( params, VALIDATE_PROGRAMRULE_OPS, opsTimer );
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidationService.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/DefaultValidationService.java
@@ -29,8 +29,7 @@ package org.hisp.dhis.tracker.validation;
 
 import static org.hisp.dhis.tracker.validation.PersistablesFilter.filter;
 
-import java.util.List;
-import java.util.Set;
+import java.util.HashSet;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -95,12 +94,12 @@ public class DefaultValidationService
         PersistablesFilter.Result persistables = filter( bundle, reporter.getInvalidDTOs(),
             bundle.getImportStrategy() );
 
-        bundle.setTrackedEntities( persistables.getTrackedEntities() );
-        bundle.setEnrollments( persistables.getEnrollments() );
-        bundle.setEvents( persistables.getEvents() );
-        bundle.setRelationships( persistables.getRelationships() );
-
-        List<Error> errors = ListUtils.union( reporter.getErrors(), persistables.getErrors() );
-        return Result.ofValidations( Set.copyOf( errors ), Set.copyOf( reporter.getWarnings() ) );
+        return new Result(
+            persistables.getTrackedEntities(),
+            persistables.getEnrollments(),
+            persistables.getEvents(),
+            persistables.getRelationships(),
+            new HashSet<>( ListUtils.union( reporter.getErrors(), persistables.getErrors() ) ),
+            new HashSet<>( reporter.getWarnings() ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Reporter.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Reporter.java
@@ -49,11 +49,6 @@ import org.hisp.dhis.tracker.domain.TrackerDto;
 /**
  * Collects {@link Error}s, {@link Warning}s and invalid entities the errors are
  * attributed to.
- * <p>
- * Long-term we would want to remove the responsibility of tracking invalid
- * entities from here. This could allow us to merge this class with
- * {@link Result}.
- * </p>
  *
  * @author Morten Svanæs <msvanaes@dhis2.org>
  */

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Result.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/Result.java
@@ -28,41 +28,53 @@
 package org.hisp.dhis.tracker.validation;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+
 @ToString
 @EqualsAndHashCode
-@RequiredArgsConstructor( access = AccessLevel.PRIVATE )
+@RequiredArgsConstructor
 class Result implements ValidationResult
 {
+    @Getter
+    private final List<TrackedEntity> trackedEntities;
+
+    @Getter
+    private final List<Enrollment> enrollments;
+
+    @Getter
+    private final List<Event> events;
+
+    @Getter
+    private final List<Relationship> relationships;
+
     private final Set<Error> errors;
 
     private final Set<Warning> warnings;
 
+    private Result()
+    {
+        this.trackedEntities = Collections.emptyList();
+        this.enrollments = Collections.emptyList();
+        this.events = Collections.emptyList();
+        this.relationships = Collections.emptyList();
+        this.errors = Collections.emptySet();
+        this.warnings = Collections.emptySet();
+    }
+
     public static Result empty()
     {
-        return new Result( Collections.emptySet(), Collections.emptySet() );
-    }
-
-    public static Result ofValidations( Set<Error> errors, Set<Warning> warnings )
-    {
-        return new Result( errors, warnings );
-    }
-
-    public static Result ofErrors( Set<Error> errors )
-    {
-        return new Result( errors, Collections.emptySet() );
-    }
-
-    public static Result ofWarnings( Set<Warning> warnings )
-    {
-        return new Result( Collections.emptySet(), warnings );
+        return new Result();
     }
 
     public Set<Validation> getErrors()
@@ -80,18 +92,8 @@ class Result implements ValidationResult
         return !errors.isEmpty();
     }
 
-    public boolean hasError( Predicate<Error> test )
-    {
-        return errors.stream().anyMatch( test );
-    }
-
     public boolean hasWarnings()
     {
         return !warnings.isEmpty();
-    }
-
-    public boolean hasWarning( Predicate<Warning> test )
-    {
-        return warnings.stream().anyMatch( test );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationResult.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/ValidationResult.java
@@ -27,14 +27,36 @@
  */
 package org.hisp.dhis.tracker.validation;
 
+import java.util.List;
 import java.util.Set;
 
+import org.hisp.dhis.tracker.TrackerImportStrategy;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.tracker.domain.Relationship;
+import org.hisp.dhis.tracker.domain.TrackedEntity;
+
 /**
- * The result of the validation step. It contains a set of {@link Validation}s
- * divided in errors and warnings.
+ * ValidationResult is the result of the validation step. The tracked entities,
+ * enrollments, events and relationships are persistable entities meaning they
+ * can be created, updated, or deleted. The meaning of persisted i.e. create,
+ * update, delete comes from the context which includes the
+ * {@link TrackerImportStrategy} and whether the entity existed or not. The
+ * persistable entities can thus be trusted to be in a valid state. Any entity
+ * that passed through the validation but cannot be persisted will have an error
+ * in {@link #getErrors()}. Persistable entities might have
+ * {@link #getWarnings()} attached to them.
  */
 public interface ValidationResult
 {
+    List<TrackedEntity> getTrackedEntities();
+
+    List<Enrollment> getEnrollments();
+
+    List<Event> getEvents();
+
+    List<Relationship> getRelationships();
+
     Set<Validation> getErrors();
 
     Set<Validation> getWarnings();

--- a/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/package-info.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/main/java/org/hisp/dhis/tracker/validation/package-info.java
@@ -2,13 +2,14 @@
  * Package validation takes a potentially invalid user payload
  * ({@link org.hisp.dhis.tracker.bundle.TrackerBundle} in and runs all our
  * {@link org.hisp.dhis.tracker.validation.Validator}s attributing errors and
- * warnings to entities in the payload. The
- * {@link org.hisp.dhis.tracker.bundle.TrackerBundle} leaving this package can
- * be persisted (created, updated, deleted) and thus trusted to be in a valid
- * state. {@link org.hisp.dhis.tracker.validation.ValidationService} is the main
- * entry point into this package. The result of the validation would be a
+ * warnings to entities {@link org.hisp.dhis.tracker.domain.TrackerDto} in the
+ * payload. {@link org.hisp.dhis.tracker.validation.ValidationService} is the
+ * main entry point into this package. The result of the validation is a
  * {@link org.hisp.dhis.tracker.validation.ValidationResult} that contains a
  * list of errors and a list of warnings both of them exposed as
- * {@link org.hisp.dhis.tracker.validation.Validation}s.
+ * {@link org.hisp.dhis.tracker.validation.Validation}s. The
+ * {@link org.hisp.dhis.tracker.validation.ValidationResult}s tracked entities,
+ * enrollments, events and relationships can be persisted (created, updated,
+ * deleted) and thus trusted to be in a valid state.
  */
 package org.hisp.dhis.tracker.validation;

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ValidationResultTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/ValidationResultTest.java
@@ -27,12 +27,9 @@
  */
 package org.hisp.dhis.tracker.validation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Objects;
 import java.util.Set;
 
 import org.hisp.dhis.common.CodeGenerator;
@@ -55,7 +52,7 @@ class ValidationResultTest
     void hasErrorsReturnsTrue()
     {
 
-        Result result = Result.ofErrors( Set.of( newError() ) );
+        Result result = new Result( null, null, null, null, Set.of( newError() ), null );
 
         assertTrue( result.hasErrors() );
     }
@@ -73,63 +70,9 @@ class ValidationResultTest
     void hasWarningsReturnsTrue()
     {
 
-        Result result = Result.ofWarnings( Set.of( newWarning() ) );
+        Result result = new Result( null, null, null, null, null, Set.of( newWarning() ) );
 
         assertTrue( result.hasWarnings() );
-    }
-
-    @Test
-    void hasErrorReportFound()
-    {
-
-        Error error = newError();
-        Result result = Result.ofErrors( Set.of( error ) );
-
-        assertTrue( result.hasError( r -> error.getUid().equals( r.getUid() ) ) );
-    }
-
-    @Test
-    void hasErrorReportNotFound()
-    {
-
-        Error error = newError( ValidationCode.E1006 );
-        Result result = Result.ofErrors( Set.of( error ) );
-
-        assertFalse( result.hasError( r -> Objects.equals( ValidationCode.E1048.name(), r.getCode() ) ) );
-    }
-
-    @Test
-    void hasWarningReportFound()
-    {
-
-        Warning warning = newWarning();
-        Result result = Result.ofWarnings( Set.of( warning ) );
-
-        assertTrue( result.hasWarning( r -> warning.getUid().equals( r.getUid() ) ) );
-    }
-
-    @Test
-    void hasWarningReportNotFound()
-    {
-
-        Warning warning = newWarning( ValidationCode.E1006 );
-        Result result = Result.ofWarnings( Set.of( warning ) );
-
-        assertFalse( result.hasWarning( r -> Objects.equals( ValidationCode.E1048.name(), r.getCode() ) ) );
-    }
-
-    @Test
-    void sizeReturnsErrorCountUniqueByUid()
-    {
-
-        Error error1 = newError( CodeGenerator.generateUid(), ValidationCode.E1006 );
-        Error error2 = newError( error1.getUid(), ValidationCode.E1000 );
-        Error error3 = newError( CodeGenerator.generateUid(), ValidationCode.E1000 );
-
-        Result result = Result.ofErrors( Set.of( error1, error2, error3 ) );
-
-        assertNotNull( result.getErrors() );
-        assertEquals( 3, result.getErrors().size() );
     }
 
     private Error newError()


### PR DESCRIPTION
Return ValidationResult with the persistable entities so that the import does the mutation. Later on we should pass the persistables to the persist step without mutating the bundle at all.

* remove unused methods and factories only used in tests from `Result`. It should be a simple container of persistable entities, errors and warnings.