### PR TITLE
fix: set group of /opt/dhis2 in Docker image to nogroup

### DIFF
--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -75,11 +75,11 @@
                                 <rules>
                                     <rule>
                                         <glob>/opt/dhis2</glob>
-                                        <ownership>${jib.container.user}</ownership>
+                                        <ownership>${jib.container.user}:${jib.container.user}</ownership>
                                     </rule>
                                     <rule>
                                         <glob>/opt/dhis2/**</glob>
-                                        <ownership>${jib.container.user}</ownership>
+                                        <ownership>${jib.container.user}:${jib.container.user}</ownership>
                                     </rule>
                                 </rules>
                             </configuration>
@@ -128,7 +128,7 @@
         <jib.version>3.3.1</jib.version>
         <jib.from.image>tomcat:9.0-jre11</jib.from.image>
         <jib.to.image>dhis2/core-dev:local</jib.to.image>
-        <!-- uid=65534(nobody) present in Tomcat image -->
+        <!-- uid=65534(nobody) gid=65534(nogroup) present in Tomcat image -->
         <jib.container.user>65534</jib.container.user>
         <jib.container.appRoot>/usr/local/tomcat/webapps/ROOT</jib.container.appRoot>
     </properties>


### PR DESCRIPTION
We only set the user to 65534 while the group defaulted to root.

Before

```sh
docker compose exec web ls -ld /opt/dhis2
drwxr-xr-x 1 nobody root 4096 Dec 20 06:25 /opt/dhis2
```

After

```sh
docker compose exec web ls -ld /opt/dhis2
drwxr-xr-x 1 nobody nogroup 4096 Dec 20 06:42 /opt/dhis2
```