### PR TITLE
fix: Analytics resource tables updated DHIS2-14417

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/DefaultAnalyticsTableGenerator.java
@@ -150,9 +150,6 @@ public class DefaultAnalyticsTableGenerator
             generateResourceTablesInternal( progress );
 
             progress.completedProcess( "Resource tables generated: " + clock.time() );
-
-            systemSettingManager.saveSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE,
-                new Date( clock.getStartTime() ) );
         }
         catch ( RuntimeException ex )
         {
@@ -167,6 +164,8 @@ public class DefaultAnalyticsTableGenerator
 
     private void generateResourceTablesInternal( JobProgress progress )
     {
+        final Date startTime = new Date();
+
         resourceTableService.dropAllSqlViews( progress );
 
         Map<String, Runnable> generators = new LinkedHashMap<>();
@@ -191,5 +190,7 @@ public class DefaultAnalyticsTableGenerator
         progress.runStage( generators );
 
         resourceTableService.createAllSqlViews( progress );
+
+        systemSettingManager.saveSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE, startTime );
     }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -38,6 +38,9 @@ import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.expression.Operator.equal_to;
 import static org.hisp.dhis.utils.Assertions.assertMapEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -88,6 +91,8 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodService;
 import org.hisp.dhis.period.PeriodType;
 import org.hisp.dhis.scheduling.NoopJobProgress;
+import org.hisp.dhis.setting.SettingKey;
+import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.system.util.CsvUtils;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.validation.ValidationResult;
@@ -225,6 +230,11 @@ class AnalyticsServiceTest
     private CompleteDataSetRegistrationService completeDataSetRegistrationService;
 
     @Autowired
+    private SystemSettingManager systemSettingManager;
+
+    private Date processStartTime;
+
+    @Autowired
     @Qualifier( "readOnlyJdbcTemplate" )
     private JdbcTemplate jdbcTemplate;
 
@@ -263,6 +273,11 @@ class AnalyticsServiceTest
         Date oneSecondFromNow = Date
             .from( LocalDateTime.now().plusSeconds( 1 ).atZone( ZoneId.systemDefault() ).toInstant() );
 
+        assertNull(
+            systemSettingManager.getSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE, Date.class ) );
+        assertNull(
+            systemSettingManager.getSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE, Date.class ) );
+        processStartTime = new Date();
         // Generate analytics tables
         analyticsTableGenerator.generateTables( AnalyticsTableUpdateParams.newBuilder()
             .withStartTime( oneSecondFromNow )
@@ -1067,4 +1082,19 @@ class AnalyticsServiceTest
                 .withAggregationType( AnalyticsAggregationType.COUNT )
                 .withOutputFormat( OutputFormat.ANALYTICS ).build() );
     }
+
+    @Test
+    void resourceTablesTimestampUpdated()
+    {
+
+        Date tableLastUpdated = systemSettingManager
+            .getSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE, Date.class );
+        assertNotEquals( null, tableLastUpdated );
+        Date resourceTablesUpdated = systemSettingManager
+            .getSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE, Date.class );
+        assertNotEquals( null, resourceTablesUpdated );
+        assertTrue( tableLastUpdated.compareTo( processStartTime ) > 0 );
+        assertTrue( resourceTablesUpdated.compareTo( processStartTime ) > 0 );
+    }
+
 }


### PR DESCRIPTION
See [DHIS2-14417](https://dhis2.atlassian.net/browse/DHIS2-14417). 

`SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE` needs to be updated when resource tables are rebuilt, whether this happens within an analytics run or by an independent resource table update.

This is how it worked in 2.37 but in 2.38 and following it happened only in an independent resource table update. This fix reverts to the way it worked in 2.37 and earlier.