### PR TITLE
Dhis2 14417 tests

### DIFF
--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -1086,9 +1086,12 @@ class AnalyticsServiceTest
 
         Date tableLastUpdated = systemSettingManager
             .getSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE, Date.class );
+        assertTrue( !tableLastUpdated.equals( null ) );
         Date resourceTablesUpdated = systemSettingManager
             .getSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE, Date.class );
+        assertTrue( !resourceTablesUpdated.equals( null ) );
         assertTrue( tableLastUpdated.compareTo( processStartTime ) > 0 );
         assertTrue( resourceTablesUpdated.compareTo( processStartTime ) > 0 );
     }
+
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -37,7 +37,10 @@ import static org.hisp.dhis.common.ValueType.INTEGER;
 import static org.hisp.dhis.common.ValueType.TEXT;
 import static org.hisp.dhis.expression.Operator.equal_to;
 import static org.hisp.dhis.utils.Assertions.assertMapEquals;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -1086,10 +1089,10 @@ class AnalyticsServiceTest
 
         Date tableLastUpdated = systemSettingManager
             .getSystemSetting( SettingKey.LAST_SUCCESSFUL_ANALYTICS_TABLES_UPDATE, Date.class );
-        assertTrue( !tableLastUpdated.equals( null ) );
+        assertNotEquals( null, tableLastUpdated );
         Date resourceTablesUpdated = systemSettingManager
             .getSystemSetting( SettingKey.LAST_SUCCESSFUL_RESOURCE_TABLES_UPDATE, Date.class );
-        assertTrue( !resourceTablesUpdated.equals( null ) );
+        assertNotEquals( null, resourceTablesUpdated );
         assertTrue( tableLastUpdated.compareTo( processStartTime ) > 0 );
         assertTrue( resourceTablesUpdated.compareTo( processStartTime ) > 0 );
     }


### PR DESCRIPTION
The added test fails on the current version of master because the resource tables timestamp is not updated. 