### PR TITLE
feat: Add orgUnitField to program indicators [DHIS2-13373]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -98,6 +98,8 @@ public class ProgramIndicator
 
     private String formName;
 
+    private String orgUnitField;
+
     /**
      * Number of decimals to use for indicator value, null implies default.
      */
@@ -442,5 +444,17 @@ public class ProgramIndicator
     public void setFormName( String formName )
     {
         this.formName = formName;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getOrgUnitField()
+    {
+        return orgUnitField;
+    }
+
+    public void setOrgUnitField( String orgUnitField )
+    {
+        this.orgUnitField = orgUnitField;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryPlanner.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryPlanner.java
@@ -38,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.AnalyticsTableType;
+import org.hisp.dhis.analytics.OrgUnitField;
 import org.hisp.dhis.analytics.Partitions;
 import org.hisp.dhis.analytics.QueryPlanner;
 import org.hisp.dhis.analytics.data.QueryPlannerUtils;
@@ -220,6 +221,7 @@ public class DefaultEventQueryPlanner
                     .removeItemProgramIndicators()
                     .withProgramIndicator( programIndicator )
                     .withProgram( programIndicator.getProgram() )
+                    .withOrgUnitField( new OrgUnitField( programIndicator.getOrgUnitField() ) )
                     .build();
 
                 queries.add( query );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -34,7 +34,6 @@ import static org.hisp.dhis.analytics.ColumnDataType.DATE;
 import static org.hisp.dhis.analytics.ColumnNotNullConstraint.NOT_NULL;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.program.ProgramType.WITHOUT_REGISTRATION;
-import static org.hisp.dhis.util.DateUtils.getLongDateString;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -85,6 +84,11 @@ public class JdbcOwnershipAnalyticsTableManager
 {
     private final JdbcConfiguration jdbcConfiguration;
 
+    private static final String HISTORY_TABLE_ID = "1001-01-01";
+
+    // Must be later than the dummy HISTORY_TABLE_ID for SQL query order.
+    private static final String TEI_OWN_TABLE_ID = "2002-02-02";
+
     public JdbcOwnershipAnalyticsTableManager( IdentifiableObjectManager idObjectManager,
         OrganisationUnitService organisationUnitService, CategoryService categoryService,
         SystemSettingManager systemSettingManager, DataApprovalLevelService dataApprovalLevelService,
@@ -101,10 +105,8 @@ public class JdbcOwnershipAnalyticsTableManager
 
     private static final List<AnalyticsTableColumn> FIXED_COLS = List.of(
         new AnalyticsTableColumn( quote( "teiuid" ), CHARACTER_11, "tei.uid" ),
-        new AnalyticsTableColumn( quote( "startdate" ), DATE, "o.owndate" ),
-        // Repeating the same alias "o.owndate" is not a typo. This column is
-        // not read.
-        new AnalyticsTableColumn( quote( "enddate" ), DATE, "o.owndate" ),
+        new AnalyticsTableColumn( quote( "startdate" ), DATE, "a.startdate" ),
+        new AnalyticsTableColumn( quote( "enddate" ), DATE, "a.enddate" ),
         new AnalyticsTableColumn( quote( "ou" ), CHARACTER_11, NOT_NULL, "ou.uid" ) );
 
     @Override
@@ -181,7 +183,7 @@ public class JdbcOwnershipAnalyticsTableManager
         } );
 
         log.info( "OwnershipAnalytics query row count was {} for {}", queryRowCount, partition.getTempTableName() );
-        writer.flush();
+        batchHandler.flush();
     }
 
     private String getInputSql( AnalyticsTableUpdateParams params, Program program )
@@ -199,30 +201,36 @@ public class JdbcOwnershipAnalyticsTableManager
 
         // FROM clause
 
-        // Gets no more than one row per ownership start day. If there are
-        // multiple enrollments and/or owner changes, gets the last change
-        // before midnight that starts the ownership day.
+        // For TEIs in this program that are in programownershiphistory, get
+        // one row for each programownershiphistory row and then get a final
+        // row from the trackedentityprogramowner table to show the final owner.
+        //
+        // The start date values are dummy so that all the history table rows
+        // will be ordered first and the tei owner table row will come last.
+        //
+        // (The start date in the analytics table will be a far past date for
+        // the first row for each TEI, or the previous row's end date plus one
+        // day in subsequent rows for that TEI.)
 
         return sb.append( " from (" +
-            "select pi.trackedentityinstanceid, pi.enrollmentDate as owndate, pi.organisationunitid " +
-            "from programinstance pi " +
-            "where pi.programid=" + program.getId() + " " +
-            "and pi.trackedentityinstanceid is not null " +
-            "and pi.organisationunitid is not null " +
-            "and pi.lastupdated <= '" + getLongDateString( params.getStartTime() ) + "' " +
+            "select h.trackedentityinstanceid, '" + HISTORY_TABLE_ID
+            + "' as startdate, h.enddate as enddate, h.organisationunitid " +
+            "from programownershiphistory h " +
+            "where h.programid=" + program.getId() + " " +
             "union " +
-            "select poh.trackedentityinstanceid, poh.startdate as owndate, poh.organisationunitid " +
-            "from programownershiphistory poh " +
-            "where poh.programid=" + program.getId() + " " +
-            "and poh.trackedentityinstanceid is not null " +
-            "and poh.organisationunitid is not null " +
-            ") o " +
-            "inner join trackedentityinstance tei on o.trackedentityinstanceid=tei.trackedentityinstanceid " +
-            "and tei.deleted is false " +
-            "inner join organisationunit ou on o.organisationunitid=ou.organisationunitid " +
-            "left join _orgunitstructure ous on o.organisationunitid=ous.organisationunitid " +
-            "left join _organisationunitgroupsetstructure ougs on o.organisationunitid=ougs.organisationunitid " +
-            "order by tei.uid, o.owndate" ).toString();
+            "select o.trackedentityinstanceid, '" + TEI_OWN_TABLE_ID
+            + "' as startdate, null as enddate, o.organisationunitid " +
+            "from trackedentityprogramowner o " +
+            "where o.programid=" + program.getId() + " " +
+            "and exists (select programid from programownershiphistory p where o.trackedentityinstanceid = p.trackedentityinstanceid "
+            +
+            "and p.programid=" + program.getId() + ")" +
+            ") a " +
+            "inner join trackedentityinstance tei on a.trackedentityinstanceid = tei.trackedentityinstanceid " +
+            "inner join organisationunit ou on a.organisationunitid = ou.organisationunitid " +
+            "left join _orgunitstructure ous on a.organisationunitid = ous.organisationunitid " +
+            "left join _organisationunitgroupsetstructure ougs on a.organisationunitid = ougs.organisationunitid " +
+            "order by tei.uid, a.startdate, a.enddate" ).toString();
     }
 
     private Map<String, Object> getRowMap( List<String> columnNames, ResultSet resultSet )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -150,7 +150,7 @@ public class JdbcOwnershipAnalyticsTableManager
             return; // Builds an empty table, but it may be joined in queries.
         }
 
-        String sql = getInputSql( params, program );
+        String sql = getInputSql( program );
 
         log.debug( "Populate {} with SQL: '{}'", partition.getTempTableName(), sql );
 
@@ -186,7 +186,7 @@ public class JdbcOwnershipAnalyticsTableManager
         batchHandler.flush();
     }
 
-    private String getInputSql( AnalyticsTableUpdateParams params, Program program )
+    private String getInputSql( Program program )
     {
         // SELECT clause
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManager.java
@@ -222,8 +222,8 @@ public class JdbcOwnershipAnalyticsTableManager
             + "' as startdate, null as enddate, o.organisationunitid " +
             "from trackedentityprogramowner o " +
             "where o.programid=" + program.getId() + " " +
-            "and exists (select programid from programownershiphistory p where o.trackedentityinstanceid = p.trackedentityinstanceid "
-            +
+            "and exists (select programid from programownershiphistory p " +
+            "where o.trackedentityinstanceid = p.trackedentityinstanceid " +
             "and p.programid=" + program.getId() + ")" +
             ") a " +
             "inner join trackedentityinstance tei on a.trackedentityinstanceid = tei.trackedentityinstanceid " +

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/OrgUnitTableJoinerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/OrgUnitTableJoinerTest.java
@@ -68,6 +68,8 @@ class OrgUnitTableJoinerTest
 
     private static final Program programA = createProgram( 'A' );
 
+    private static final Period periodDaily = PeriodType.getPeriodFromIsoString( "20230101" );
+
     private static final Period periodMonthly = PeriodType.getPeriodFromIsoString( "202201" );
 
     private static final Period periodQuarterly = PeriodType.getPeriodFromIsoString( "2022Q1" );
@@ -117,7 +119,29 @@ class OrgUnitTableJoinerTest
     }
 
     @Test
-    void testJoinOrgUnitTablesOwnerAtStartWithPeriods()
+    void testJoinOrgUnitTablesOwnerAtStartWithDailyPeriods()
+    {
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( programA )
+            .withOrganisationUnits( List.of( ouA ) )
+            .withOrgUnitField( OWNER_AT_START )
+            .withPeriods( List.of( periodDaily ), periodDaily.getPeriodType().getName().toLowerCase() )
+            .addDimension( ouGroupSetA )
+            .build();
+
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and cast(ax.\"daily\" as date) between own.\"startdate\" and own.\"enddate\" " +
+            "left join _orgunitstructure as ous on ax.\"enrollmentou\" = ous.\"organisationunituid\" " +
+            "left join _organisationunitgroupsetstructure as ougs on ous.\"organisationunitid\" = ougs.\"organisationunitid\" ",
+            joinOrgUnitTables( params, EVENT ) );
+
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and cast(ax.\"daily\" as date) between own.\"startdate\" and own.\"enddate\" ",
+            joinOrgUnitTables( params, ENROLLMENT ) );
+    }
+
+    @Test
+    void testJoinOrgUnitTablesOwnerAtStartWithNonDailyPeriods()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( programA )
@@ -164,7 +188,29 @@ class OrgUnitTableJoinerTest
     }
 
     @Test
-    void testJoinOrgUnitTablesOwnerAtEndWithPeriods()
+    void testJoinOrgUnitTablesOwnerAtEndWithDailyPeriods()
+    {
+        EventQueryParams params = new EventQueryParams.Builder()
+            .withProgram( programA )
+            .withOrganisationUnits( List.of( ouA ) )
+            .withOrgUnitField( OWNER_AT_END )
+            .withPeriods( List.of( periodDaily ), periodDaily.getPeriodType().getName().toLowerCase() )
+            .addDimension( ouGroupSetA )
+            .build();
+
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and cast(ax.\"daily\" as date) + INTERVAL '1 day' between own.\"startdate\" and own.\"enddate\" " +
+            "left join _orgunitstructure as ous on ax.\"enrollmentou\" = ous.\"organisationunituid\" " +
+            "left join _organisationunitgroupsetstructure as ougs on ous.\"organisationunitid\" = ougs.\"organisationunitid\" ",
+            joinOrgUnitTables( params, EVENT ) );
+
+        assertEquals( "left join analytics_ownership_prabcdefgha as own on ax.\"tei\" = own.\"teiuid\" " +
+            "and cast(ax.\"daily\" as date) + INTERVAL '1 day' between own.\"startdate\" and own.\"enddate\" ",
+            joinOrgUnitTables( params, ENROLLMENT ) );
+    }
+
+    @Test
+    void testJoinOrgUnitTablesOwnerAtEndWithNonDailyPeriods()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .withProgram( programA )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
@@ -302,12 +302,11 @@ class JdbcOwnershipAnalyticsTableManagerTest
             sqlMasked );
 
         List<Invocation> writerInvocations = getInvocations( writer );
-        assertEquals( 4, writerInvocations.size() );
+        assertEquals( 3, writerInvocations.size() );
 
         assertEquals( "write", writerInvocations.get( 0 ).getMethod().getName() );
         assertEquals( "write", writerInvocations.get( 1 ).getMethod().getName() );
         assertEquals( "write", writerInvocations.get( 2 ).getMethod().getName() );
-        assertEquals( "flush", writerInvocations.get( 3 ).getMethod().getName() );
 
         Map<String, Object> map0 = writerInvocations.get( 0 ).getArgument( 0 );
         Map<String, Object> map1 = writerInvocations.get( 1 ).getArgument( 0 );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipAnalyticsTableManagerTest.java
@@ -282,21 +282,23 @@ class JdbcOwnershipAnalyticsTableManagerTest
         String sql = jdbcInvocations.get( 0 ).getArgument( 0 );
         String sqlMasked = sql.replaceAll( "lastupdated <= '\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}'",
             "lastupdated <= 'yyyy-mm-ddThh:mm:ss'" );
-        assertEquals( "select tei.uid,o.owndate,o.owndate,ou.uid from (" +
-            "select pi.trackedentityinstanceid, pi.enrollmentDate as owndate, pi.organisationunitid " +
-            "from programinstance pi " +
-            "where pi.programid=0 and pi.trackedentityinstanceid is not null " +
-            "and pi.organisationunitid is not null " +
-            "and pi.lastupdated <= 'yyyy-mm-ddThh:mm:ss' " +
-            "union select poh.trackedentityinstanceid, poh.startdate as owndate, poh.organisationunitid " +
-            "from programownershiphistory poh where poh.programid=0 and poh.trackedentityinstanceid is not null " +
-            "and poh.organisationunitid is not null ) o " +
-            "inner join trackedentityinstance tei on o.trackedentityinstanceid=tei.trackedentityinstanceid " +
-            "and tei.deleted is false " +
-            "inner join organisationunit ou on o.organisationunitid=ou.organisationunitid " +
-            "left join _orgunitstructure ous on o.organisationunitid=ous.organisationunitid " +
-            "left join _organisationunitgroupsetstructure ougs on o.organisationunitid=ougs.organisationunitid " +
-            "order by tei.uid, o.owndate",
+        assertEquals( "select tei.uid,a.startdate,a.enddate,ou.uid from (" +
+            "select h.trackedentityinstanceid, '1001-01-01' as startdate, h.enddate as enddate, h.organisationunitid " +
+            "from programownershiphistory h " +
+            "where h.programid=0 " +
+            "union " +
+            "select o.trackedentityinstanceid, '2002-02-02' as startdate, null as enddate, o.organisationunitid " +
+            "from trackedentityprogramowner o " +
+            "where o.programid=0 " +
+            "and exists (select programid from programownershiphistory p " +
+            "where o.trackedentityinstanceid = p.trackedentityinstanceid " +
+            "and p.programid=0)" +
+            ") a " +
+            "inner join trackedentityinstance tei on a.trackedentityinstanceid = tei.trackedentityinstanceid " +
+            "inner join organisationunit ou on a.organisationunitid = ou.organisationunitid " +
+            "left join _orgunitstructure ous on a.organisationunitid = ous.organisationunitid " +
+            "left join _organisationunitgroupsetstructure ougs on a.organisationunitid = ougs.organisationunitid " +
+            "order by tei.uid, a.startdate, a.enddate",
             sqlMasked );
 
         List<Invocation> writerInvocations = getInvocations( writer );
@@ -321,8 +323,8 @@ class JdbcOwnershipAnalyticsTableManagerTest
     {
         List<AnalyticsTableColumn> expected = List.of(
             new AnalyticsTableColumn( quote( "teiuid" ), CHARACTER_11, "tei.uid" ),
-            new AnalyticsTableColumn( quote( "startdate" ), DATE, "o.owndate" ),
-            new AnalyticsTableColumn( quote( "enddate" ), DATE, "o.owndate" ),
+            new AnalyticsTableColumn( quote( "startdate" ), DATE, "a.startdate" ),
+            new AnalyticsTableColumn( quote( "enddate" ), DATE, "a.enddate" ),
             new AnalyticsTableColumn( quote( "ou" ), CHARACTER_11, NOT_NULL, "ou.uid" ) );
 
         assertEquals( expected, target.getFixedColumns() );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipWriterTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/table/JdbcOwnershipWriterTest.java
@@ -29,7 +29,6 @@ package org.hisp.dhis.analytics.table;
 
 import static java.util.Calendar.FEBRUARY;
 import static java.util.Calendar.JANUARY;
-import static java.util.Calendar.MARCH;
 import static org.hisp.dhis.analytics.table.JdbcOwnershipWriter.ENDDATE;
 import static org.hisp.dhis.analytics.table.JdbcOwnershipWriter.OU;
 import static org.hisp.dhis.analytics.table.JdbcOwnershipWriter.STARTDATE;
@@ -47,6 +46,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -95,8 +95,6 @@ class JdbcOwnershipWriterTest
 
     private static final Date date_2022_02 = new GregorianCalendar( 2022, FEBRUARY, 1 ).getTime();
 
-    private static final Date date_2022_03 = new GregorianCalendar( 2022, MARCH, 1 ).getTime();
-
     private static final List<String> columns = List.of( TEIUID, OU, STARTDATE, ENDDATE );
 
     @BeforeEach
@@ -122,13 +120,12 @@ class JdbcOwnershipWriterTest
     void testWriteNoOwnershipChanges()
         throws SQLException
     {
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_03 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouB, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouB, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouB, STARTDATE, date_2022_03 ) );
-        writer.flush();
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, null ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouB, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouB, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouB, ENDDATE, null ) );
 
         batchHandler.flush();
 
@@ -139,18 +136,19 @@ class JdbcOwnershipWriterTest
     void testWriteOneOwnershipChange()
         throws SQLException
     {
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouB, STARTDATE, date_2022_03 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_03 ) );
-        writer.flush();
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouB, ENDDATE, null ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, null ) );
+
+        batchHandler.flush();
 
         assertEquals(
             "insert into analytics_ownership_programUidA (\"teiuid\",\"ou\",\"startdate\",\"enddate\") values " +
-                "('teiAaaaaaaa','ouAaaaaaaaa','1000-01-01','2022-03-01')," +
-                "('teiAaaaaaaa','ouBbbbbbbbb','2022-03-02','9999-12-31')",
+                "('teiAaaaaaaa','ouAaaaaaaaa','1000-01-01','2022-02-01')," +
+                "('teiAaaaaaaa','ouBbbbbbbbb','2022-02-02','9999-12-31')",
             getUpdateSql() );
     }
 
@@ -158,19 +156,20 @@ class JdbcOwnershipWriterTest
     void testWriteTwoOwnershipChanges()
         throws SQLException
     {
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouB, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_03 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_03 ) );
-        writer.flush();
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouB, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, null ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, null ) );
+
+        batchHandler.flush();
 
         assertEquals(
             "insert into analytics_ownership_programUidA (\"teiuid\",\"ou\",\"startdate\",\"enddate\") values " +
-                "('teiAaaaaaaa','ouAaaaaaaaa','1000-01-01','2022-02-01')," +
-                "('teiAaaaaaaa','ouBbbbbbbbb','2022-02-02','2022-03-01')," +
-                "('teiAaaaaaaa','ouAaaaaaaaa','2022-03-02','9999-12-31')",
+                "('teiAaaaaaaa','ouAaaaaaaaa','1000-01-01','2022-01-01')," +
+                "('teiAaaaaaaa','ouBbbbbbbbb','2022-01-02','2022-02-01')," +
+                "('teiAaaaaaaa','ouAaaaaaaaa','2022-02-02','9999-12-31')",
             getUpdateSql() );
     }
 
@@ -178,27 +177,41 @@ class JdbcOwnershipWriterTest
     void testWriteThreeOwnershipChanges()
         throws SQLException
     {
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouB, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiA, OU, ouA, STARTDATE, date_2022_03 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_01 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouA, STARTDATE, date_2022_02 ) );
-        writer.write( Map.of( TEIUID, teiB, OU, ouB, STARTDATE, date_2022_03 ) );
-        writer.flush();
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouB, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiA, OU, ouA, ENDDATE, null ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, date_2022_01 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouA, ENDDATE, date_2022_02 ) );
+        writer.write( mapOf( TEIUID, teiB, OU, ouB, ENDDATE, null ) );
+
+        batchHandler.flush();
 
         assertEquals(
             "insert into analytics_ownership_programUidA (\"teiuid\",\"ou\",\"startdate\",\"enddate\") values " +
-                "('teiAaaaaaaa','ouAaaaaaaaa','1000-01-01','2022-02-01')," +
-                "('teiAaaaaaaa','ouBbbbbbbbb','2022-02-02','2022-03-01')," +
-                "('teiAaaaaaaa','ouAaaaaaaaa','2022-03-02','9999-12-31')," +
-                "('teiBbbbbbbb','ouAaaaaaaaa','1000-01-01','2022-03-01')," +
-                "('teiBbbbbbbb','ouBbbbbbbbb','2022-03-02','9999-12-31')",
+                "('teiAaaaaaaa','ouAaaaaaaaa','1000-01-01','2022-01-01')," +
+                "('teiAaaaaaaa','ouBbbbbbbbb','2022-01-02','2022-02-01')," +
+                "('teiAaaaaaaa','ouAaaaaaaaa','2022-02-02','9999-12-31')," +
+                "('teiBbbbbbbb','ouAaaaaaaaa','1000-01-01','2022-02-01')," +
+                "('teiBbbbbbbb','ouBbbbbbbbb','2022-02-02','9999-12-31')",
             getUpdateSql() );
     }
 
     // -------------------------------------------------------------------------
     // Supportive methods
     // -------------------------------------------------------------------------
+
+    /**
+     * Creates a map of three key/value pairs that allows nulls (because the
+     * database can return nulls and the logic relies on that).
+     */
+    private <K, V> Map<K, V> mapOf( K key1, V value1, K key2, V value2, K key3, V value3 )
+    {
+        HashMap<K, V> map = new HashMap<>();
+        map.put( key1, value1 );
+        map.put( key2, value2 );
+        map.put( key3, value3 );
+        return map;
+    }
 
     /**
      * Gets a list of invocations of a mocked object

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicator.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/program/hibernate/ProgramIndicator.hbm.xml
@@ -23,6 +23,8 @@
 
     <property name="formName" type="text" />
 
+    <property name="orgUnitField" type="text" column="orgunitfield" />
+
     <property name="style" type="jbObjectStyle" column="style" />
 
     <property name="translations" type="jblTranslations"/>

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_6__Add_programindicator_column_orgunitfield.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_6__Add_programindicator_column_orgunitfield.sql
@@ -1,0 +1,1 @@
+alter table programindicator add column if not exists "orgunitfield" text;


### PR DESCRIPTION
See [DHIS2-13373](https://dhis2.atlassian.net/browse/DHIS2-13373). This PR adds an optional `orgUnitField` to program indicators and makes some corrections and improvements in how the ownership analytics tables are built.

As discussed in the _#ownership-analytics_ Slack channel, building the ownership analytics tables does not require querying the `programinstance` table for enrollments, only the `programownershiphistory` table for ownership changes and the `trackedentityprogramowner` for the latest (current) ownership. (The `trackedentityprogramowner` table is queried only for program/TEI combinations having entries in the `programownershiphistory` table.)

This further reduced the ownership analytics table builds on my test system for SL Demo (where there are no ownership changes) from 5 seconds to 1 second.

The logic linking the program indicator `orgUnitField` to analytics is just the one line in `DefaultEventQueryPlanner`. (If there is no `orgUnitField` in the program indicator then there will be the default (none specified) one in the analytics query):

`                    .withOrgUnitField( new OrgUnitField( programIndicator.getOrgUnitField() ) )`

In testing, I noticed that daily periods would not query correctly in analytics because they are not included in the _periodstructure table. This has been fixed. The daily period column `yyyymmdd` in the event analytics tables can be cast to a date and used as both the start and end dates of the period.

Also in testing on January 2, 2023, I noticed that no monthly or weekly periods for 2023 are generated in `_periodstructure`. This likely should be fixed in a separate ticket.

[DHIS2-13373]: https://dhis2.atlassian.net/browse/DHIS2-13373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-13373]: https://dhis2.atlassian.net/browse/DHIS2-13373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ