### PR TITLE
fix: validate access of DashboardItem objects when update Dashboard

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -245,6 +245,8 @@ public enum ErrorCode
 
     /* Metadata Validation (continued) */
     E4060( "Object could not be deleted: {0}" ),
+    E4061(
+        "DashboardItem `{0}` object reference `{1}` with id `{2}` not found or not accessible" ),
 
     /* SQL views */
     E4300( "SQL query is null" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/config/ServiceConfig.java
@@ -95,6 +95,7 @@ import org.hisp.dhis.dxf2.events.importer.update.validation.ProgramStageInstance
 import org.hisp.dhis.dxf2.events.importer.update.validation.ProgramStageInstanceBasicCheck;
 import org.hisp.dhis.dxf2.events.importer.update.validation.UpdateProgramStageInstanceAclCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.CreationCheck;
+import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DashboardCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DeletionCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.DuplicateIdsCheck;
 import org.hisp.dhis.dxf2.metadata.objectbundle.validation.GeoJsonAttributesCheck;
@@ -253,7 +254,8 @@ public class ServiceConfig
                 getValidationCheckByClass( NotOwnerReferencesCheck.class ),
                 getValidationCheckByClass( TranslationsCheck.class ),
                 getValidationCheckByClass( GeoJsonAttributesCheck.class ),
-                getValidationCheckByClass( MetadataAttributeCheck.class ) ),
+                getValidationCheckByClass( MetadataAttributeCheck.class ),
+                getValidationCheckByClass( DashboardCheck.class ) ),
             DELETE, newArrayList(
                 getValidationCheckByClass( SecurityCheck.class ),
                 getValidationCheckByClass( DeletionCheck.class ) ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DashboardCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/DashboardCheck.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dxf2.metadata.objectbundle.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import lombok.RequiredArgsConstructor;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.dashboard.DashboardItem;
+import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.feedback.ObjectReport;
+import org.hisp.dhis.importexport.ImportStrategy;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DashboardCheck implements ObjectValidationCheck
+{
+    @Override
+    public <T extends IdentifiableObject> void check( ObjectBundle bundle, Class<T> klass, List<T> persistedObjects,
+        List<T> nonPersistedObjects, ImportStrategy importStrategy, ValidationContext context,
+        Consumer<ObjectReport> addReports )
+    {
+        if ( !klass.isAssignableFrom( Dashboard.class ) || CollectionUtils.isEmpty( persistedObjects ) )
+        {
+            return;
+        }
+
+        persistedObjects.forEach( dashboard -> {
+            List<ErrorReport> errors = new ArrayList<>();
+            checkDashboardItemHasObject( bundle, ((Dashboard) dashboard).getItems(), errors::add );
+            if ( !errors.isEmpty() )
+            {
+                ObjectReport objectReport = new ObjectReport( klass, 0, dashboard.getUid() );
+                objectReport.addErrorReports( errors );
+                addReports.accept( objectReport );
+            }
+        } );
+    }
+
+    /**
+     * Check if all objects associate with given {@link DashboardItem} are
+     * available in Preheat.
+     *
+     * @param bundle {@link ObjectBundle}
+     * @param items {@link DashboardItem} for checking.
+     * @param addError add {@link ErrorCode#E4061} if cannot find associate
+     *        object of DashboardItem in Preheat.
+     */
+    private void checkDashboardItemHasObject( ObjectBundle bundle, List<DashboardItem> items,
+        Consumer<ErrorReport> addError )
+    {
+        if ( CollectionUtils.isEmpty( items ) )
+        {
+            return;
+        }
+
+        items.forEach( item -> {
+            if ( item.getEmbeddedItem() != null
+                && bundle.getPreheat().get( bundle.getPreheatIdentifier(), item.getEmbeddedItem() ) == null )
+            {
+                addError.accept( new ErrorReport( DashboardItem.class, ErrorCode.E4061, item.getUid(), item.getType(),
+                    item.getEmbeddedItem().getUid() ) );
+            }
+
+            if ( !CollectionUtils.isEmpty( item.getLinkItems() ) )
+            {
+                item.getLinkItems().forEach( linkItem -> {
+                    if ( bundle.getPreheat().get( bundle.getPreheatIdentifier(), linkItem ) == null )
+                    {
+                        addError.accept( new ErrorReport( DashboardItem.class, ErrorCode.E4061, item.getUid(),
+                            item.getType(), linkItem.getUid() ) );
+                    }
+                } );
+            }
+        } );
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DashboardControllerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hisp.dhis.web.WebClient.Body;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.hisp.dhis.dashboard.Dashboard;
+import org.hisp.dhis.dashboard.DashboardItem;
+import org.hisp.dhis.feedback.ErrorCode;
+import org.hisp.dhis.jsontree.JsonResponse;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.User;
+import org.hisp.dhis.visualization.Visualization;
+import org.hisp.dhis.web.HttpStatus;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
+import org.hisp.dhis.webapi.json.domain.JsonErrorReport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DashboardControllerTest extends DhisControllerIntegrationTest
+{
+    @Autowired
+    private AclService aclService;
+
+    @Test
+    void testUpdateWithNonAccessibleItems()
+    {
+        POST( "/metadata", Body( "dashboard/create_dashboard_non_accessible_visualization.json" ) )
+            .content( HttpStatus.OK );
+        User userA = userService.getUser( "XThzKnyzeYW" );
+
+        // Verify if all objects created correctly.
+        Dashboard dashboard = manager.get( Dashboard.class, "f1OijtLnf8a" );
+        assertNotNull( dashboard );
+        assertEquals( 1, dashboard.getItems().size() );
+        Visualization visualization = dashboard.getItems().stream()
+            .filter( item -> item.getUid().equals( "KnmKNIFiAwC" ) ).findFirst().get().getVisualization();
+        assertNotNull( visualization );
+
+        switchContextToUser( userA );
+        // UserA can't read visualization but can update Dashboard.
+        assertTrue( aclService.canUpdate( userA, dashboard ) );
+        assertFalse( aclService.canRead( userA, visualization ) );
+
+        // Add one more DashboardItem to the created Dashboard
+        JsonResponse response = PUT( "/dashboards/f1OijtLnf8a", Body( "dashboard/update_dashboard.json" ) )
+            .content( HttpStatus.CONFLICT );
+        assertEquals(
+            "DashboardItem `KnmKNIFiAwC` object reference `VISUALIZATION` with id `gyYXi0rXAIc` not found or not accessible",
+            response.find( JsonErrorReport.class, error -> error.getErrorCode() == ErrorCode.E4061 ).getMessage() );
+    }
+
+    @Test
+    void testUpdateWithAccessibleItems()
+    {
+        POST( "/metadata", Body( "dashboard/create_dashboard.json" ) )
+            .content( HttpStatus.OK );
+        User userA = userService.getUser( "XThzKnyzeYW" );
+
+        // Verify if all objects created correctly.
+        Dashboard dashboard = manager.get( Dashboard.class, "f1OijtLnf8a" );
+        assertNotNull( dashboard );
+        assertEquals( 1, dashboard.getItems().size() );
+        Visualization visualization = dashboard.getItems().stream()
+            .filter( item -> item.getUid().equals( "KnmKNIFiAwC" ) ).findFirst().get().getVisualization();
+        assertNotNull( visualization );
+
+        assertTrue( aclService.canUpdate( userA, dashboard ) );
+        assertTrue( aclService.canRead( userA, visualization ) );
+        switchContextToUser( userA );
+
+        // Add one more DashboardItem to the created Dashboard
+        PUT( "/dashboards/f1OijtLnf8a", Body( "dashboard/update_dashboard.json" ) ).content( HttpStatus.OK );
+        dashboard = manager.get( Dashboard.class, "f1OijtLnf8a" );
+
+        // Dashboard should have 2 items after update.
+        assertEquals( 2, dashboard.getItems().size() );
+
+        // Visualization is still attached to the dashboard item.
+        Optional<DashboardItem> dashboardItem = dashboard.getItems().stream()
+            .filter( item -> item.getUid().equals( "KnmKNIFiAwC" ) )
+            .findFirst();
+        assertTrue( dashboardItem.isPresent() );
+        assertEquals( "gyYXi0rXAIc", dashboardItem.get().getVisualization().getUid() );
+
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/resources/dashboard/create_dashboard.json
+++ b/dhis-2/dhis-web-api-test/src/test/resources/dashboard/create_dashboard.json
@@ -1,0 +1,723 @@
+{
+  "dashboards":
+  [
+    {
+      "id": "f1OijtLnf8a",
+      "name": "test",
+      "code": "",
+      "description": "",
+      "dashboardItems":
+      [
+        {
+          "x": 0,
+          "y": 0,
+          "w": 20,
+          "h": 29,
+          "id": "KnmKNIFiAwC",
+          "type": "VISUALIZATION",
+          "position": null,
+          "visualization":
+          {
+            "id": "gyYXi0rXAIc",
+            "name": "ANC: 1-3 dropout rate Yearly"
+          },
+          "i": "KnmKNIFiAwC",
+          "minH": 4,
+          "width": 20,
+          "height": 29
+        }
+      ],
+      "restrictFilters": false,
+      "itemConfig":
+      {
+        "insertPosition": "END"
+      },
+      "sharing": {
+        "public": "--------",
+        "external" : false,
+        "owner" : "M5zQapPyTZI",
+        "users" : {
+          "XThzKnyzeYW": {
+            "id" : "XThzKnyzeYW",
+            "access" : "rw------"
+          }
+        }
+      }
+    }
+  ],
+  "categories":
+  [
+    {
+      "lastUpdated": "2016-03-17T01:53:56.098+0000",
+      "code": "Gender",
+      "sharing": {
+        "public": "rw------",
+        "owner": "M5zQapPyTZI"
+      },
+      "dataDimensionType": "DISAGGREGATION",
+      "id": "XFgfIO1qQmd",
+      "name": "Gender",
+      "shortName": "Gender",
+      "created": "2016-03-17T01:53:56.097+0000",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "categoryOptions":
+      [
+        {
+          "id": "DRs8ZFxNOpW"
+        },
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "dataDimension": true
+    }
+  ],
+  "userRoles":
+  [
+    {
+      "description": "userRoleA",
+      "name": "userRoleA",
+      "id": "VIkpd2KHCb1",
+      "code": "userRoleA",
+      "authorities":
+      [
+        "F_PROGRAM_INDICATOR_PUBLIC_ADD",
+        "F_SQLVIEW_EXECUTE",
+        "F_USER_VIEW",
+        "F_GENERATE_MIN_MAX_VALUES",
+        "F_VALIDATIONRULE_PUBLIC_ADD",
+        "F_CATEGORY_PRIVATE_ADD",
+        "F_INDICATORGROUPSET_PUBLIC_ADD",
+        "F_DATAVALUE_DELETE",
+        "F_EXTERNAL_MAP_LAYER_PRIVATE_ADD",
+        "F_RELATIONSHIPTYPE_DELETE",
+        "F_REPORTTABLE_EXTERNAL",
+        "F_CATEGORY_OPTION_PRIVATE_ADD",
+        "F_CATEGORY_OPTION_GROUP_PUBLIC_ADD",
+        "F_GIS_ADMIN",
+        "M_dhis-web-event-capture",
+        "F_SEND_EMAIL",
+        "F_ORGUNITGROUPSET_PRIVATE_ADD",
+        "F_INDICATOR_DELETE",
+        "M_dhis-web-event-reports",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_OPTIONGROUPSET_DELETE",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_PROGRAM_INDICATOR_GROUP_PRIVATE_ADD",
+        "F_DOCUMENT_EXTERNAL",
+        "F_TRACKED_ENTITY_ATTRIBUTE_PUBLIC_ADD",
+        "F_PROGRAM_INDICATOR_DELETE",
+        "F_MOBILE_SENDSMS",
+        "F_TRACKED_ENTITY_ADD",
+        "F_TRACKED_ENTITY_MANAGEMENT",
+        "F_VALIDATIONRULEGROUP_PUBLIC_ADD",
+        "F_REPORT_EXTERNAL",
+        "F_DOCUMENT_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_DELETE",
+        "F_USERGROUP_DELETE",
+        "F_PROGRAM_PRIVATE_ADD",
+        "F_REPORTTABLE_PUBLIC_ADD",
+        "F_CATEGORY_COMBO_PRIVATE_ADD",
+        "F_SCHEDULING_SEND_MESSAGE",
+        "F_EXTERNAL_MAP_LAYER_PUBLIC_ADD",
+        "F_PROGRAM_INDICATOR_GROUP_DELETE",
+        "F_ORGANISATIONUNIT_MOVE",
+        "M_dhis-web-usage-analytics",
+        "F_COLOR_DELETE",
+        "F_INDICATORGROUP_DELETE",
+        "F_ORGANISATIONUNIT_DELETE",
+        "F_PROGRAM_RULE_ADD",
+        "M_dhis-web-light",
+        "F_OPTIONGROUPSET_PRIVATE_ADD",
+        "F_DATA_MART_ADMIN",
+        "M_dhis-web-maintenance-mobile",
+        "F_DATASET_PUBLIC_ADD",
+        "F_CATEGORY_COMBO_DELETE",
+        "F_SECTION_DELETE",
+        "F_USER_DELETE",
+        "F_INDICATORGROUPSET_PRIVATE_ADD",
+        "F_PROGRAM_INDICATOR_PRIVATE_ADD",
+        "F_METADATA_IMPORT",
+        "F_EXPORT_EVENTS",
+        "F_SQLVIEW_PUBLIC_ADD",
+        "F_PERFORM_MAINTENANCE",
+        "F_COLOR_SET_ADD",
+        "F_METADATA_EXPORT",
+        "F_MINMAX_DATAELEMENT_ADD",
+        "F_PROGRAMSTAGE_SECTION_ADD",
+        "F_DATAELEMENTGROUP_PRIVATE_ADD",
+        "F_VALIDATIONRULE_PRIVATE_ADD",
+        "F_APPROVE_DATA",
+        "M_dhis-web-mapping",
+        "F_DATAELEMENT_PRIVATE_ADD",
+        "F_VALIDATIONCRITERIA_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "F_PROGRAM_PUBLIC_ADD",
+        "F_CATEGORY_OPTION_GROUP_SET_PRIVATE_ADD",
+        "F_CATEGORY_OPTION_GROUP_SET_DELETE",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "M_Web_Portal",
+        "F_ORGANISATIONUNIT_ADD",
+        "M_dhis-web-user",
+        "F_LEGEND_SET_PUBLIC_ADD",
+        "F_CONSTANT_ADD",
+        "F_PREDICTORGROUP_DELETE",
+        "M_dhis-web-visualizer",
+        "F_INDICATOR_PUBLIC_ADD",
+        "F_INDICATORGROUP_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_ATTRIBUTE_PRIVATE_ADD",
+        "M_dhis-web-maintenance",
+        "F_PROGRAM_RULE_MANAGEMENT",
+        "F_TEI_CASCADE_DELETE",
+        "F_FRED_UPDATE",
+        "M_dhis-web-cache-cleaner",
+        "F_EDIT_EXPIRED",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_ORGANISATIONUNITLEVEL_UPDATE",
+        "F_CATEGORY_OPTION_PUBLIC_ADD",
+        "M_dhis-web-datastore",
+        "F_CATEGORY_OPTION_DELETE",
+        "M_Data_Table",
+        "M_dhis-web-menu-management",
+        "F_REPORT_PUBLIC_ADD",
+        "F_VALIDATIONRULEGROUP_DELETE",
+        "F_PROGRAM_TRACKED_ENTITY_ATTRIBUTE_GROUP_ADD",
+        "F_COLOR_ADD",
+        "F_OPTIONSET_PRIVATE_ADD",
+        "F_PROGRAM_RULE_DELETE",
+        "F_ORGUNITGROUP_DELETE",
+        "F_DATAELEMENTGROUPSET_PRIVATE_ADD",
+        "M_dhis-web-tracker-capture",
+        "F_LOCALE_ADD",
+        "F_LEGEND_ADD",
+        "F_CATEGORY_OPTION_GROUP_PRIVATE_ADD",
+        "M_dhis-web-reporting",
+        "F_CATEGORY_PUBLIC_ADD",
+        "F_SECTION_ADD",
+        "F_CATEGORY_COMBO_PUBLIC_ADD",
+        "F_DATASET_DELETE",
+        "F_INDICATORGROUPSET_DELETE",
+        "F_USER_DELETE_WITHIN_MANAGED_GROUP",
+        "F_ADD_TRACKED_ENTITY_FORM",
+        "M_dhis-web-scheduler",
+        "F_OPTIONGROUP_PUBLIC_ADD",
+        "F_USERROLE_PRIVATE_ADD",
+        "M_dhis-web-messaging",
+        "M_dhis-web-maintenance-program",
+        "F_EXTERNALFILERESOURCE_ADD",
+        "F_MAP_EXTERNAL",
+        "M_bna_widget",
+        "F_DATAELEMENTGROUPSET_PUBLIC_ADD",
+        "F_DATAELEMENTGROUP_DELETE",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_ORGUNITGROUP_PRIVATE_ADD",
+        "F_DATAELEMENTGROUP_PUBLIC_ADD",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_LOCALE_DELETE",
+        "F_PREDICTOR_RUN",
+        "F_DATAELEMENT_DELETE",
+        "F_OPTIONGROUP_DELETE",
+        "F_LEGEND_SET_PRIVATE_ADD",
+        "F_PROGRAMSTAGE_DELETE",
+        "F_ATTRIBUTE_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_FORM_DELETE",
+        "F_USERROLE_DELETE",
+        "F_DOCUMENT_DELETE",
+        "F_ORGUNITGROUPSET_DELETE",
+        "M_dhis-web-translations",
+        "M_dhis-web-sms",
+        "F_SCHEDULING_CASE_AGGREGATE_QUERY_BUILDER",
+        "F_PROGRAM_DELETE",
+        "F_VALIDATIONRULE_DELETE",
+        "F_PROGRAMDATAELEMENT_ADD",
+        "M_dhis-web-mobile",
+        "F_RELATIONSHIPTYPE_PUBLIC_ADD",
+        "F_PREDICTOR_ADD",
+        "F_SQLVIEW_PRIVATE_ADD",
+        "F_EXPORT_DATA",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_ORGUNITGROUP_PUBLIC_ADD",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "M_Social_Media_Video",
+        "F_OPTIONSET_PUBLIC_ADD",
+        "F_EVENTCHART_EXTERNAL",
+        "M_dhis-web-dataentry",
+        "M_dhis-web-aggregate-data-entry",
+        "M_dhis-web-maintenance-dataset",
+        "F_USERROLE_LIST",
+        "F_USERROLE_PUBLIC_ADD",
+        "M_dhis-web-importexport",
+        "M_InterpretationsTest",
+        "F_ORGUNITGROUPSET_PUBLIC_ADD",
+        "F_SQLVIEW_EXTERNAL",
+        "F_REPORT_DELETE",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_CONSTANT_DELETE",
+        "M_dhis-web-maintenance-user",
+        "F_PREDICTOR_DELETE",
+        "F_CHART_PUBLIC_ADD",
+        "M_dhis-web-data-visualizer",
+        "F_CHART_EXTERNAL",
+        "F_TRACKED_ENTITY_MERGE",
+        "F_DATASET_PRIVATE_ADD",
+        "F_EVENTREPORT_PUBLIC_ADD",
+        "F_PROGRAMSTAGE_SECTION_DELETE",
+        "F_TRACKED_ENTITY_UPDATE",
+        "F_CATEGORY_OPTION_GROUP_SET_PUBLIC_ADD",
+        "F_METADATA_MANAGE",
+        "F_ANALYTICSTABLEHOOK_DELETE",
+        "F_UNCOMPLETE_EVENT",
+        "M_dhis-web-interpretation",
+        "F_LEGEND_DELETE",
+        "M_Custom_Js_Css",
+        "F_PROGRAM_INDICATOR_MANAGEMENT",
+        "F_MAP_PUBLIC_ADD",
+        "F_PROGRAM_VALIDATION",
+        "F_SCHEDULING_ADMIN",
+        "F_DATAELEMENT_MINMAX_DELETE",
+        "F_MOBILE_SETTINGS",
+        "F_PREDICTORGROUP_ADD",
+        "F_REPORT_PRIVATE_ADD",
+        "F_VALIDATIONRULEGROUP_PRIVATE_ADD",
+        "F_PUSH_ANALYSIS_DELETE",
+        "F_REPLICATE_USER",
+        "F_DATAVALUE_ADD",
+        "M_dhis-web-maintenance-organisationunit",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DATAELEMENTGROUPSET_DELETE",
+        "F_SQLVIEW_DELETE",
+        "F_ENROLLMENT_CASCADE_DELETE",
+        "F_PROGRAMDATAELEMENT_DELETE",
+        "F_INDICATORTYPE_ADD",
+        "F_LEGEND_SET_DELETE",
+        "F_VIEW_EVENT_ANALYTICS",
+        "F_PROGRAMSTAGE_SECTION_MANAGEMENT",
+        "F_IMPORT_EVENTS",
+        "F_INDICATOR_PRIVATE_ADD",
+        "F_FRED_CREATE",
+        "F_EVENTCHART_PUBLIC_ADD",
+        "F_PUSH_ANALYSIS_ADD",
+        "M_dhis-web-event-visualizer",
+        "F_USER_ADD",
+        "F_EXTERNAL_MAP_LAYER_DELETE",
+        "F_SYSTEM_SETTING",
+        "F_ANALYTICSTABLEHOOK_ADD",
+        "F_ATTRIBUTE_PRIVATE_ADD",
+        "F_DOCUMENT_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_ATTRIBUTE_DELETE",
+        "M_Easy_Visualization",
+        "F_DATAELEMENT_MINMAX_ADD",
+        "M_dhis-web-data-quality",
+        "M_dhis-web-pivot",
+        "F_EVENTREPORT_EXTERNAL",
+        "F_PROGRAM_RULE_UPDATE",
+        "F_DATAELEMENT_PUBLIC_ADD",
+        "M_dhis-web-validationrule",
+        "F_CONSTANT_MANAGEMENT",
+        "F_RUN_VALIDATION",
+        "F_MANAGE_TICKETS",
+        "F_OPTIONGROUP_PRIVATE_ADD",
+        "F_CATEGORY_OPTION_GROUP_DELETE",
+        "M_User_Administration",
+        "M_dhis-web-settings",
+        "F_IMPORT_DATA",
+        "F_VIEW_DATABROWSER",
+        "F_MOBILE_DELETE_SMS",
+        "F_OPTIONSET_MANAGEMENT",
+        "F_PROGRAMSTAGE_ADD",
+        "M_dhis-web-maps",
+        "F_MINMAX_DATAELEMENT_DELETE",
+        "F_ATTRIBUTE_DELETE",
+        "F_OPTIONSET_DELETE",
+        "M_dhis-web-dashboard",
+        "M_dhis-web-data-administration",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_PROGRAM_TRACKED_ENTITY_ATTRIBUTE_GROUP_DELETE",
+        "F_OPTIONGROUPSET_PUBLIC_ADD",
+        "M_dhis-web-capture",
+        "F_PROGRAM_INDICATOR_GROUP_PUBLIC_ADD",
+        "F_CATEGORY_DELETE",
+        "F_COLOR_SET_DELETE",
+        "M_dhis-web-app-management",
+        "F_INDICATORTYPE_DELETE",
+        "F_INDICATORGROUP_PRIVATE_ADD",
+        "F_FRED_DELETE",
+        "F_VALIDATIONCRITERIA_DELETE",
+        "F_TRACKER_IMPORTER_EXPERIMENTAL",
+        "F_NONE"],
+      "sharing": {
+        "public": "--------"
+      }
+    }
+  ],
+  "categoryOptions":
+  [
+    {
+      "id": "DRs8ZFxNOpW",
+      "name": "Female",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "Female",
+      "code": "Female",
+      "sharing": {
+        "public": "rw------",
+        "owner": "M5zQapPyTZI"
+      }
+    },
+    {
+      "code": "Male",
+      "sharing": {
+        "public": "rw------",
+        "owner": "M5zQapPyTZI"
+      },
+      "name": "Male",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "x3Owjhq9G7K",
+      "shortName": "Male"
+    }
+  ],
+  "organisationUnitLevels":
+  [
+    {
+      "level": 1,
+      "name": "Country",
+      "id": "knxIFcPUBz2"
+    }
+  ],
+  "categoryOptionCombos":
+  [
+    {
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      },
+      "categoryOptions":
+      [
+        {
+          "id": "DRs8ZFxNOpW"
+        }
+      ],
+      "name": "Female",
+      "ignoreApproval": false,
+      "id": "c8yQa2ZIqhL"
+    },
+    {
+      "name": "Male",
+      "ignoreApproval": false,
+      "id": "O9ZA0CUVVmL",
+      "categoryOptions":
+      [
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      }
+    }
+  ],
+  "visualizations":
+  [
+    {
+      "sharing": {
+        "public" : "--------",
+        "external": false,
+        "users": {
+          "XThzKnyzeYW": {
+            "id": "XThzKnyzeYW",
+            "access": "r-------"
+          }
+        }
+      },
+      "completedOnly": false,
+      "showData": true,
+      "organisationUnits":
+      [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "dataDimensionItems":
+      [
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement":
+          {
+            "id": "JXWenbITNIR"
+          }
+        },
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement":
+          {
+            "id": "Kvv6LltZuOd"
+          }
+        }
+      ],
+      "filterDimensions":
+      [
+        "ou"
+      ],
+      "seriesKey":
+      {
+        "hidden": true
+      },
+      "series":
+      [
+        {
+          "dimensionItem": "JXWenbITNIR",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Kvv6LltZuOd",
+          "visualizationType": "LINE"
+        }
+      ],
+      "organisationUnitLevels":
+      [],
+      "id": "gyYXi0rXAIc",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "hideEmptyRows": false,
+      "organisationUnitGroups":
+      [],
+      "name": "VisualizationA",
+      "sortOrder": 0,
+      "category": "pe",
+      "categoryOptionGroups":
+      [],
+      "dataElementGroups":
+      [],
+      "relativePeriods":
+      {
+        "lastSixMonth": false,
+        "last5Years": false,
+        "thisSixMonth": false,
+        "thisWeek": false,
+        "last4Weeks": false,
+        "last4Quarters": false,
+        "monthsThisYear": false,
+        "lastWeek": false,
+        "monthsLastYear": false,
+        "thisQuarter": false,
+        "last6BiMonths": false,
+        "thisBimonth": false,
+        "quartersThisYear": false,
+        "lastQuarter": false,
+        "thisFinancialYear": false,
+        "quartersLastYear": false,
+        "last3Months": false,
+        "thisYear": false,
+        "lastBimonth": false,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "lastYear": false,
+        "last2SixMonths": false,
+        "lastFinancialYear": false,
+        "last52Weeks": false,
+        "lastMonth": false,
+        "last6Months": false
+      },
+      "categoryDimensions":
+      [],
+      "userOrganisationUnit": false,
+      "hideSubtitle": false,
+      "hideTitle": false,
+      "regression": false,
+      "type": "COLUMN",
+      "aggregationType": "SUM",
+      "periods":
+      [],
+      "hideLegend": false,
+      "itemOrganisationUnitGroups":
+      [],
+      "userOrganisationUnitGrandChildren": false
+    }
+  ],
+  "categoryCombos":
+  [
+    {
+      "publicAccess": "rw------",
+      "lastUpdated": "2016-03-17T01:54:04.956+0000",
+      "code": "Gender",
+      "skipTotal": false,
+      "id": "v7n8H4aj8Cg",
+      "categories":
+      [
+        {
+          "id": "XFgfIO1qQmd"
+        }
+      ],
+      "userGroupAccesses":
+      [],
+      "created": "2016-03-17T01:54:04.875+0000",
+      "name": "Gender",
+      "dataDimensionType": "DISAGGREGATION",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      }
+    }
+  ],
+  "users":
+  [
+    {
+      "firstName": "userA",
+      "userRoles": [
+        {
+          "id": "VIkpd2KHCb1"
+        }
+      ],
+      "username": "userA",
+      "organisationUnits":
+      [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "code": "userA",
+      "id": "XThzKnyzeYW",
+      "surname": "userA"
+    }
+  ],
+  "dataElements":
+  [
+    {
+      "code": "DataElementCodeA",
+      "zeroIsSignificant": false,
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "aggregationLevels":
+      [],
+      "userGroupAccesses":
+      [],
+      "valueType": "NUMBER",
+      "lastUpdated": "2016-03-17T01:52:56.021+0000",
+      "publicAccess": "rw------",
+      "created": "2016-03-17T01:52:56.017+0000",
+      "name": "DataElementA",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "JXWenbITNIR",
+      "attributeValues":
+      [],
+      "shortName": "DataElementShortA"
+    },
+    {
+      "lastUpdated": "2016-03-17T01:53:21.549+0000",
+      "publicAccess": "rw------",
+      "id": "Kvv6LltZuOd",
+      "name": "DataElementB",
+      "created": "2016-03-17T01:53:21.548+0000",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "DataElementShortB",
+      "attributeValues":
+      [],
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "code": "DataElementCodeB",
+      "zeroIsSignificant": false,
+      "aggregationLevels":
+      [],
+      "userGroupAccesses":
+      [],
+      "valueType": "NUMBER"
+    },
+    {
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "DataElementC",
+      "created": "2016-03-17T01:54:39.781+0000",
+      "id": "JrpFZgTcp5m",
+      "attributeValues":
+      [],
+      "shortName": "DataElementShortC",
+      "lastUpdated": "2016-03-17T01:54:39.782+0000",
+      "publicAccess": "rw------",
+      "valueType": "NUMBER",
+      "userGroupAccesses":
+      [],
+      "code": "DataElementCodeC",
+      "zeroIsSignificant": false,
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels":
+      []
+    },
+    {
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "created": "2016-03-17T01:55:00.723+0000",
+      "name": "DataElementD",
+      "id": "Dy2uRmhOKbJ",
+      "attributeValues":
+      [],
+      "shortName": "DataElementShortD",
+      "lastUpdated": "2016-03-17T01:55:00.724+0000",
+      "publicAccess": "rw------",
+      "valueType": "NUMBER",
+      "userGroupAccesses":
+      [],
+      "zeroIsSignificant": false,
+      "code": "DataElementCodeD",
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels":
+      []
+    }
+  ],
+  "organisationUnits":
+  [
+    {
+      "path": "/uyHni0GvBpD",
+      "featureType": "NONE",
+      "uuid": "eb380b08-6cc6-4aca-9b67-e1247e02db33",
+      "lastUpdated": "2016-03-17T01:51:39.609+0000",
+      "shortName": "Country",
+      "attributeValues":
+      [],
+      "openingDate": "2016-03-17",
+      "id": "uyHni0GvBpD",
+      "description": "",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "Country",
+      "created": "2016-03-17T01:51:39.597+0000"
+    }
+  ]
+}

--- a/dhis-2/dhis-web-api-test/src/test/resources/dashboard/create_dashboard_non_accessible_visualization.json
+++ b/dhis-2/dhis-web-api-test/src/test/resources/dashboard/create_dashboard_non_accessible_visualization.json
@@ -1,0 +1,717 @@
+{
+  "dashboards":
+  [
+    {
+      "id": "f1OijtLnf8a",
+      "name": "test",
+      "code": "",
+      "description": "",
+      "dashboardItems":
+      [
+        {
+          "x": 0,
+          "y": 0,
+          "w": 20,
+          "h": 29,
+          "id": "KnmKNIFiAwC",
+          "type": "VISUALIZATION",
+          "position": null,
+          "visualization":
+          {
+            "id": "gyYXi0rXAIc",
+            "name": "ANC: 1-3 dropout rate Yearly"
+          },
+          "i": "KnmKNIFiAwC",
+          "minH": 4,
+          "width": 20,
+          "height": 29
+        }
+      ],
+      "restrictFilters": false,
+      "itemConfig":
+      {
+        "insertPosition": "END"
+      },
+      "sharing": {
+        "public": "--------",
+        "external" : false,
+        "owner" : "M5zQapPyTZI",
+        "users" : {
+          "XThzKnyzeYW": {
+            "id" : "XThzKnyzeYW",
+            "access" : "rw------"
+          }
+        }
+      }
+    }
+  ],
+  "categories":
+  [
+    {
+      "lastUpdated": "2016-03-17T01:53:56.098+0000",
+      "code": "Gender",
+      "sharing": {
+        "public": "rw------",
+        "owner": "M5zQapPyTZI"
+      },
+      "dataDimensionType": "DISAGGREGATION",
+      "id": "XFgfIO1qQmd",
+      "name": "Gender",
+      "shortName": "Gender",
+      "created": "2016-03-17T01:53:56.097+0000",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "categoryOptions":
+      [
+        {
+          "id": "DRs8ZFxNOpW"
+        },
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "dataDimension": true
+    }
+  ],
+  "userRoles":
+  [
+    {
+      "description": "userRoleA",
+      "name": "userRoleA",
+      "id": "VIkpd2KHCb1",
+      "code": "userRoleA",
+      "authorities":
+      [
+        "F_PROGRAM_INDICATOR_PUBLIC_ADD",
+        "F_SQLVIEW_EXECUTE",
+        "F_USER_VIEW",
+        "F_GENERATE_MIN_MAX_VALUES",
+        "F_VALIDATIONRULE_PUBLIC_ADD",
+        "F_CATEGORY_PRIVATE_ADD",
+        "F_INDICATORGROUPSET_PUBLIC_ADD",
+        "F_DATAVALUE_DELETE",
+        "F_EXTERNAL_MAP_LAYER_PRIVATE_ADD",
+        "F_RELATIONSHIPTYPE_DELETE",
+        "F_REPORTTABLE_EXTERNAL",
+        "F_CATEGORY_OPTION_PRIVATE_ADD",
+        "F_CATEGORY_OPTION_GROUP_PUBLIC_ADD",
+        "F_GIS_ADMIN",
+        "M_dhis-web-event-capture",
+        "F_SEND_EMAIL",
+        "F_ORGUNITGROUPSET_PRIVATE_ADD",
+        "F_INDICATOR_DELETE",
+        "M_dhis-web-event-reports",
+        "F_VIEW_UNAPPROVED_DATA",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_VIEW",
+        "F_OPTIONGROUPSET_DELETE",
+        "F_USERGROUP_PUBLIC_ADD",
+        "F_PROGRAM_INDICATOR_GROUP_PRIVATE_ADD",
+        "F_DOCUMENT_EXTERNAL",
+        "F_TRACKED_ENTITY_ATTRIBUTE_PUBLIC_ADD",
+        "F_PROGRAM_INDICATOR_DELETE",
+        "F_MOBILE_SENDSMS",
+        "F_TRACKED_ENTITY_ADD",
+        "F_TRACKED_ENTITY_MANAGEMENT",
+        "F_VALIDATIONRULEGROUP_PUBLIC_ADD",
+        "F_REPORT_EXTERNAL",
+        "F_DOCUMENT_PRIVATE_ADD",
+        "F_TRACKED_ENTITY_DELETE",
+        "F_USERGROUP_DELETE",
+        "F_PROGRAM_PRIVATE_ADD",
+        "F_REPORTTABLE_PUBLIC_ADD",
+        "F_CATEGORY_COMBO_PRIVATE_ADD",
+        "F_SCHEDULING_SEND_MESSAGE",
+        "F_EXTERNAL_MAP_LAYER_PUBLIC_ADD",
+        "F_PROGRAM_INDICATOR_GROUP_DELETE",
+        "F_ORGANISATIONUNIT_MOVE",
+        "M_dhis-web-usage-analytics",
+        "F_COLOR_DELETE",
+        "F_INDICATORGROUP_DELETE",
+        "F_ORGANISATIONUNIT_DELETE",
+        "F_PROGRAM_RULE_ADD",
+        "M_dhis-web-light",
+        "F_OPTIONGROUPSET_PRIVATE_ADD",
+        "F_DATA_MART_ADMIN",
+        "M_dhis-web-maintenance-mobile",
+        "F_DATASET_PUBLIC_ADD",
+        "F_CATEGORY_COMBO_DELETE",
+        "F_SECTION_DELETE",
+        "F_USER_DELETE",
+        "F_INDICATORGROUPSET_PRIVATE_ADD",
+        "F_PROGRAM_INDICATOR_PRIVATE_ADD",
+        "F_METADATA_IMPORT",
+        "F_EXPORT_EVENTS",
+        "F_SQLVIEW_PUBLIC_ADD",
+        "F_PERFORM_MAINTENANCE",
+        "F_COLOR_SET_ADD",
+        "F_METADATA_EXPORT",
+        "F_MINMAX_DATAELEMENT_ADD",
+        "F_PROGRAMSTAGE_SECTION_ADD",
+        "F_DATAELEMENTGROUP_PRIVATE_ADD",
+        "F_VALIDATIONRULE_PRIVATE_ADD",
+        "F_APPROVE_DATA",
+        "M_dhis-web-mapping",
+        "F_DATAELEMENT_PRIVATE_ADD",
+        "F_VALIDATIONCRITERIA_ADD",
+        "F_TRACKED_ENTITY_INSTANCE_SEARCH_IN_ALL_ORGUNITS",
+        "F_PROGRAM_PUBLIC_ADD",
+        "F_CATEGORY_OPTION_GROUP_SET_PRIVATE_ADD",
+        "F_CATEGORY_OPTION_GROUP_SET_DELETE",
+        "F_USER_ADD_WITHIN_MANAGED_GROUP",
+        "M_Web_Portal",
+        "F_ORGANISATIONUNIT_ADD",
+        "M_dhis-web-user",
+        "F_LEGEND_SET_PUBLIC_ADD",
+        "F_CONSTANT_ADD",
+        "F_PREDICTORGROUP_DELETE",
+        "M_dhis-web-visualizer",
+        "F_INDICATOR_PUBLIC_ADD",
+        "F_INDICATORGROUP_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_ATTRIBUTE_PRIVATE_ADD",
+        "M_dhis-web-maintenance",
+        "F_PROGRAM_RULE_MANAGEMENT",
+        "F_TEI_CASCADE_DELETE",
+        "F_FRED_UPDATE",
+        "M_dhis-web-cache-cleaner",
+        "F_EDIT_EXPIRED",
+        "F_PROGRAM_DASHBOARD_CONFIG_ADMIN",
+        "F_ORGANISATIONUNITLEVEL_UPDATE",
+        "F_CATEGORY_OPTION_PUBLIC_ADD",
+        "M_dhis-web-datastore",
+        "F_CATEGORY_OPTION_DELETE",
+        "M_Data_Table",
+        "M_dhis-web-menu-management",
+        "F_REPORT_PUBLIC_ADD",
+        "F_VALIDATIONRULEGROUP_DELETE",
+        "F_PROGRAM_TRACKED_ENTITY_ATTRIBUTE_GROUP_ADD",
+        "F_COLOR_ADD",
+        "F_OPTIONSET_PRIVATE_ADD",
+        "F_PROGRAM_RULE_DELETE",
+        "F_ORGUNITGROUP_DELETE",
+        "F_DATAELEMENTGROUPSET_PRIVATE_ADD",
+        "M_dhis-web-tracker-capture",
+        "F_LOCALE_ADD",
+        "F_LEGEND_ADD",
+        "F_CATEGORY_OPTION_GROUP_PRIVATE_ADD",
+        "M_dhis-web-reporting",
+        "F_CATEGORY_PUBLIC_ADD",
+        "F_SECTION_ADD",
+        "F_CATEGORY_COMBO_PUBLIC_ADD",
+        "F_DATASET_DELETE",
+        "F_INDICATORGROUPSET_DELETE",
+        "F_USER_DELETE_WITHIN_MANAGED_GROUP",
+        "F_ADD_TRACKED_ENTITY_FORM",
+        "M_dhis-web-scheduler",
+        "F_OPTIONGROUP_PUBLIC_ADD",
+        "F_USERROLE_PRIVATE_ADD",
+        "M_dhis-web-messaging",
+        "M_dhis-web-maintenance-program",
+        "F_EXTERNALFILERESOURCE_ADD",
+        "F_MAP_EXTERNAL",
+        "M_bna_widget",
+        "F_DATAELEMENTGROUPSET_PUBLIC_ADD",
+        "F_DATAELEMENTGROUP_DELETE",
+        "F_USERGROUP_MANAGING_RELATIONSHIPS_ADD",
+        "F_ORGUNITGROUP_PRIVATE_ADD",
+        "F_DATAELEMENTGROUP_PUBLIC_ADD",
+        "F_USER_GROUPS_READ_ONLY_ADD_MEMBERS",
+        "F_LOCALE_DELETE",
+        "F_PREDICTOR_RUN",
+        "F_DATAELEMENT_DELETE",
+        "F_OPTIONGROUP_DELETE",
+        "F_LEGEND_SET_PRIVATE_ADD",
+        "F_PROGRAMSTAGE_DELETE",
+        "F_ATTRIBUTE_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_FORM_DELETE",
+        "F_USERROLE_DELETE",
+        "F_DOCUMENT_DELETE",
+        "F_ORGUNITGROUPSET_DELETE",
+        "M_dhis-web-translations",
+        "M_dhis-web-sms",
+        "F_SCHEDULING_CASE_AGGREGATE_QUERY_BUILDER",
+        "F_PROGRAM_DELETE",
+        "F_VALIDATIONRULE_DELETE",
+        "F_PROGRAMDATAELEMENT_ADD",
+        "M_dhis-web-mobile",
+        "F_RELATIONSHIPTYPE_PUBLIC_ADD",
+        "F_PREDICTOR_ADD",
+        "F_SQLVIEW_PRIVATE_ADD",
+        "F_EXPORT_DATA",
+        "F_OAUTH2_CLIENT_MANAGE",
+        "F_ORGUNITGROUP_PUBLIC_ADD",
+        "F_APPROVE_DATA_LOWER_LEVELS",
+        "M_Social_Media_Video",
+        "F_OPTIONSET_PUBLIC_ADD",
+        "F_EVENTCHART_EXTERNAL",
+        "M_dhis-web-dataentry",
+        "M_dhis-web-aggregate-data-entry",
+        "M_dhis-web-maintenance-dataset",
+        "F_USERROLE_LIST",
+        "F_USERROLE_PUBLIC_ADD",
+        "M_dhis-web-importexport",
+        "M_InterpretationsTest",
+        "F_ORGUNITGROUPSET_PUBLIC_ADD",
+        "F_SQLVIEW_EXTERNAL",
+        "F_REPORT_DELETE",
+        "F_DASHBOARD_PUBLIC_ADD",
+        "F_CONSTANT_DELETE",
+        "M_dhis-web-maintenance-user",
+        "F_PREDICTOR_DELETE",
+        "F_CHART_PUBLIC_ADD",
+        "M_dhis-web-data-visualizer",
+        "F_CHART_EXTERNAL",
+        "F_TRACKED_ENTITY_MERGE",
+        "F_DATASET_PRIVATE_ADD",
+        "F_EVENTREPORT_PUBLIC_ADD",
+        "F_PROGRAMSTAGE_SECTION_DELETE",
+        "F_TRACKED_ENTITY_UPDATE",
+        "F_CATEGORY_OPTION_GROUP_SET_PUBLIC_ADD",
+        "F_METADATA_MANAGE",
+        "F_ANALYTICSTABLEHOOK_DELETE",
+        "F_UNCOMPLETE_EVENT",
+        "M_dhis-web-interpretation",
+        "F_LEGEND_DELETE",
+        "M_Custom_Js_Css",
+        "F_PROGRAM_INDICATOR_MANAGEMENT",
+        "F_MAP_PUBLIC_ADD",
+        "F_PROGRAM_VALIDATION",
+        "F_SCHEDULING_ADMIN",
+        "F_DATAELEMENT_MINMAX_DELETE",
+        "F_MOBILE_SETTINGS",
+        "F_PREDICTORGROUP_ADD",
+        "F_REPORT_PRIVATE_ADD",
+        "F_VALIDATIONRULEGROUP_PRIVATE_ADD",
+        "F_PUSH_ANALYSIS_DELETE",
+        "F_REPLICATE_USER",
+        "F_DATAVALUE_ADD",
+        "M_dhis-web-maintenance-organisationunit",
+        "F_INSERT_CUSTOM_JS_CSS",
+        "F_DATAELEMENTGROUPSET_DELETE",
+        "F_SQLVIEW_DELETE",
+        "F_ENROLLMENT_CASCADE_DELETE",
+        "F_PROGRAMDATAELEMENT_DELETE",
+        "F_INDICATORTYPE_ADD",
+        "F_LEGEND_SET_DELETE",
+        "F_VIEW_EVENT_ANALYTICS",
+        "F_PROGRAMSTAGE_SECTION_MANAGEMENT",
+        "F_IMPORT_EVENTS",
+        "F_INDICATOR_PRIVATE_ADD",
+        "F_FRED_CREATE",
+        "F_EVENTCHART_PUBLIC_ADD",
+        "F_PUSH_ANALYSIS_ADD",
+        "M_dhis-web-event-visualizer",
+        "F_USER_ADD",
+        "F_EXTERNAL_MAP_LAYER_DELETE",
+        "F_SYSTEM_SETTING",
+        "F_ANALYTICSTABLEHOOK_ADD",
+        "F_ATTRIBUTE_PRIVATE_ADD",
+        "F_DOCUMENT_PUBLIC_ADD",
+        "F_TRACKED_ENTITY_ATTRIBUTE_DELETE",
+        "M_Easy_Visualization",
+        "F_DATAELEMENT_MINMAX_ADD",
+        "M_dhis-web-data-quality",
+        "M_dhis-web-pivot",
+        "F_EVENTREPORT_EXTERNAL",
+        "F_PROGRAM_RULE_UPDATE",
+        "F_DATAELEMENT_PUBLIC_ADD",
+        "M_dhis-web-validationrule",
+        "F_CONSTANT_MANAGEMENT",
+        "F_RUN_VALIDATION",
+        "F_MANAGE_TICKETS",
+        "F_OPTIONGROUP_PRIVATE_ADD",
+        "F_CATEGORY_OPTION_GROUP_DELETE",
+        "M_User_Administration",
+        "M_dhis-web-settings",
+        "F_IMPORT_DATA",
+        "F_VIEW_DATABROWSER",
+        "F_MOBILE_DELETE_SMS",
+        "F_OPTIONSET_MANAGEMENT",
+        "F_PROGRAMSTAGE_ADD",
+        "M_dhis-web-maps",
+        "F_MINMAX_DATAELEMENT_DELETE",
+        "F_ATTRIBUTE_DELETE",
+        "F_OPTIONSET_DELETE",
+        "M_dhis-web-dashboard",
+        "M_dhis-web-data-administration",
+        "F_ACCEPT_DATA_LOWER_LEVELS",
+        "F_PROGRAM_TRACKED_ENTITY_ATTRIBUTE_GROUP_DELETE",
+        "F_OPTIONGROUPSET_PUBLIC_ADD",
+        "M_dhis-web-capture",
+        "F_PROGRAM_INDICATOR_GROUP_PUBLIC_ADD",
+        "F_CATEGORY_DELETE",
+        "F_COLOR_SET_DELETE",
+        "M_dhis-web-app-management",
+        "F_INDICATORTYPE_DELETE",
+        "F_INDICATORGROUP_PRIVATE_ADD",
+        "F_FRED_DELETE",
+        "F_VALIDATIONCRITERIA_DELETE",
+        "F_TRACKER_IMPORTER_EXPERIMENTAL",
+        "F_NONE"],
+      "sharing": {
+        "public": "--------"
+      }
+    }
+  ],
+  "categoryOptions":
+  [
+    {
+      "id": "DRs8ZFxNOpW",
+      "name": "Female",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "Female",
+      "code": "Female",
+      "sharing": {
+        "public": "rw------",
+        "owner": "M5zQapPyTZI"
+      }
+    },
+    {
+      "code": "Male",
+      "sharing": {
+        "public": "rw------",
+        "owner": "M5zQapPyTZI"
+      },
+      "name": "Male",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "x3Owjhq9G7K",
+      "shortName": "Male"
+    }
+  ],
+  "organisationUnitLevels":
+  [
+    {
+      "level": 1,
+      "name": "Country",
+      "id": "knxIFcPUBz2"
+    }
+  ],
+  "categoryOptionCombos":
+  [
+    {
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      },
+      "categoryOptions":
+      [
+        {
+          "id": "DRs8ZFxNOpW"
+        }
+      ],
+      "name": "Female",
+      "ignoreApproval": false,
+      "id": "c8yQa2ZIqhL"
+    },
+    {
+      "name": "Male",
+      "ignoreApproval": false,
+      "id": "O9ZA0CUVVmL",
+      "categoryOptions":
+      [
+        {
+          "id": "x3Owjhq9G7K"
+        }
+      ],
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      }
+    }
+  ],
+  "visualizations":
+  [
+    {
+      "sharing": {
+        "public" : "--------",
+        "external": false
+      },
+      "completedOnly": false,
+      "showData": true,
+      "organisationUnits":
+      [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "dataDimensionItems":
+      [
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement":
+          {
+            "id": "JXWenbITNIR"
+          }
+        },
+        {
+          "dataDimensionItemType": "AGGREGATE_DATA_ELEMENT",
+          "dataElement":
+          {
+            "id": "Kvv6LltZuOd"
+          }
+        }
+      ],
+      "filterDimensions":
+      [
+        "ou"
+      ],
+      "seriesKey":
+      {
+        "hidden": true
+      },
+      "series":
+      [
+        {
+          "dimensionItem": "JXWenbITNIR",
+          "visualizationType": "LINE",
+          "axis": 1
+        },
+        {
+          "dimensionItem": "Kvv6LltZuOd",
+          "visualizationType": "LINE"
+        }
+      ],
+      "organisationUnitLevels":
+      [],
+      "id": "gyYXi0rXAIc",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "userOrganisationUnitChildren": false,
+      "hideEmptyRows": false,
+      "organisationUnitGroups":
+      [],
+      "name": "VisualizationA",
+      "sortOrder": 0,
+      "category": "pe",
+      "categoryOptionGroups":
+      [],
+      "dataElementGroups":
+      [],
+      "relativePeriods":
+      {
+        "lastSixMonth": false,
+        "last5Years": false,
+        "thisSixMonth": false,
+        "thisWeek": false,
+        "last4Weeks": false,
+        "last4Quarters": false,
+        "monthsThisYear": false,
+        "lastWeek": false,
+        "monthsLastYear": false,
+        "thisQuarter": false,
+        "last6BiMonths": false,
+        "thisBimonth": false,
+        "quartersThisYear": false,
+        "lastQuarter": false,
+        "thisFinancialYear": false,
+        "quartersLastYear": false,
+        "last3Months": false,
+        "thisYear": false,
+        "lastBimonth": false,
+        "thisMonth": false,
+        "last12Weeks": false,
+        "last5FinancialYears": false,
+        "last12Months": true,
+        "lastYear": false,
+        "last2SixMonths": false,
+        "lastFinancialYear": false,
+        "last52Weeks": false,
+        "lastMonth": false,
+        "last6Months": false
+      },
+      "categoryDimensions":
+      [],
+      "userOrganisationUnit": false,
+      "hideSubtitle": false,
+      "hideTitle": false,
+      "regression": false,
+      "type": "COLUMN",
+      "aggregationType": "SUM",
+      "periods":
+      [],
+      "hideLegend": false,
+      "itemOrganisationUnitGroups":
+      [],
+      "userOrganisationUnitGrandChildren": false
+    }
+  ],
+  "categoryCombos":
+  [
+    {
+      "publicAccess": "rw------",
+      "lastUpdated": "2016-03-17T01:54:04.956+0000",
+      "code": "Gender",
+      "skipTotal": false,
+      "id": "v7n8H4aj8Cg",
+      "categories":
+      [
+        {
+          "id": "XFgfIO1qQmd"
+        }
+      ],
+      "userGroupAccesses":
+      [],
+      "created": "2016-03-17T01:54:04.875+0000",
+      "name": "Gender",
+      "dataDimensionType": "DISAGGREGATION",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      }
+    }
+  ],
+  "users":
+  [
+    {
+      "firstName": "userA",
+      "userRoles": [
+        {
+          "id": "VIkpd2KHCb1"
+        }
+      ],
+      "username": "userA",
+      "organisationUnits":
+      [
+        {
+          "id": "uyHni0GvBpD"
+        }
+      ],
+      "code": "userA",
+      "id": "XThzKnyzeYW",
+      "surname": "userA"
+    }
+  ],
+  "dataElements":
+  [
+    {
+      "code": "DataElementCodeA",
+      "zeroIsSignificant": false,
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "aggregationLevels":
+      [],
+      "userGroupAccesses":
+      [],
+      "valueType": "NUMBER",
+      "lastUpdated": "2016-03-17T01:52:56.021+0000",
+      "publicAccess": "rw------",
+      "created": "2016-03-17T01:52:56.017+0000",
+      "name": "DataElementA",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "id": "JXWenbITNIR",
+      "attributeValues":
+      [],
+      "shortName": "DataElementShortA"
+    },
+    {
+      "lastUpdated": "2016-03-17T01:53:21.549+0000",
+      "publicAccess": "rw------",
+      "id": "Kvv6LltZuOd",
+      "name": "DataElementB",
+      "created": "2016-03-17T01:53:21.548+0000",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "shortName": "DataElementShortB",
+      "attributeValues":
+      [],
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "code": "DataElementCodeB",
+      "zeroIsSignificant": false,
+      "aggregationLevels":
+      [],
+      "userGroupAccesses":
+      [],
+      "valueType": "NUMBER"
+    },
+    {
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "DataElementC",
+      "created": "2016-03-17T01:54:39.781+0000",
+      "id": "JrpFZgTcp5m",
+      "attributeValues":
+      [],
+      "shortName": "DataElementShortC",
+      "lastUpdated": "2016-03-17T01:54:39.782+0000",
+      "publicAccess": "rw------",
+      "valueType": "NUMBER",
+      "userGroupAccesses":
+      [],
+      "code": "DataElementCodeC",
+      "zeroIsSignificant": false,
+      "aggregationType": "AVERAGE",
+      "domainType": "AGGREGATE",
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels":
+      []
+    },
+    {
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "created": "2016-03-17T01:55:00.723+0000",
+      "name": "DataElementD",
+      "id": "Dy2uRmhOKbJ",
+      "attributeValues":
+      [],
+      "shortName": "DataElementShortD",
+      "lastUpdated": "2016-03-17T01:55:00.724+0000",
+      "publicAccess": "rw------",
+      "valueType": "NUMBER",
+      "userGroupAccesses":
+      [],
+      "zeroIsSignificant": false,
+      "code": "DataElementCodeD",
+      "domainType": "AGGREGATE",
+      "aggregationType": "AVERAGE",
+      "categoryCombo":
+      {
+        "id": "v7n8H4aj8Cg"
+      },
+      "aggregationLevels":
+      []
+    }
+  ],
+  "organisationUnits":
+  [
+    {
+      "path": "/uyHni0GvBpD",
+      "featureType": "NONE",
+      "uuid": "eb380b08-6cc6-4aca-9b67-e1247e02db33",
+      "lastUpdated": "2016-03-17T01:51:39.609+0000",
+      "shortName": "Country",
+      "attributeValues":
+      [],
+      "openingDate": "2016-03-17",
+      "id": "uyHni0GvBpD",
+      "description": "",
+      "user":
+      {
+        "id": "M5zQapPyTZI"
+      },
+      "name": "Country",
+      "created": "2016-03-17T01:51:39.597+0000"
+    }
+  ]
+}

--- a/dhis-2/dhis-web-api-test/src/test/resources/dashboard/update_dashboard.json
+++ b/dhis-2/dhis-web-api-test/src/test/resources/dashboard/update_dashboard.json
@@ -1,0 +1,58 @@
+{
+  "id": "f1OijtLnf8a",
+  "name": "test",
+  "code": "",
+  "description": "",
+  "dashboardItems": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 20,
+      "h": 29,
+      "id": "YcpTnjbWwsR",
+      "type": "TEXT",
+      "position": null,
+      "text": "TEXT_ITEM_WITH_NO_CONTENT",
+      "i": "YcpTnjbWwsR",
+      "minH": 4,
+      "width": 20,
+      "height": 29
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 20,
+      "h": 29,
+      "id": "KnmKNIFiAwC",
+      "type": "VISUALIZATION",
+      "position": null,
+      "visualization": {
+        "id": "gyYXi0rXAIc",
+        "name": "ANC: 1-3 dropout rate Yearly"
+      },
+      "i": "KnmKNIFiAwC",
+      "minH": 4,
+      "width": 20,
+      "height": 29
+    }
+  ],
+  "allowedFilters": [],
+  "restrictFilters": false,
+  "layout": {
+    "columns": []
+  },
+  "itemConfig": {
+    "insertPosition": "END"
+  },
+  "sharing": {
+    "public": "--------",
+    "external" : false,
+    "owner" : "M5zQapPyTZI",
+    "users" : {
+      "XThzKnyzeYW": {
+        "id" : "XThzKnyzeYW",
+        "access" : "rw------"
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14404

- In 2.39 and older versions, we added a loop hole to allow user to update a `Dashboard` even if that user doesn't have READ access to all `DashboardItem` associate objects such as `Visualization` or `Report`. https://github.com/dhis2/dhis2-core/pull/12453

- In 2.40 we don't allow that, instead this PR will throw an error for same use case.  So in order to update a `Dashboard` user need READ access to all objects associate with all `DashboardItem`.

### Test

1. Login with SuperUser.
2. Create a new UserA, user should not have `ALL` authority, but can read/update Dashboard.
3. Create a new dashboard `DashboardA`, add one Visualization to it.
4. In Visualization app, update sharing settings of Visualization in step 2 to make user UserA doesn't have METADATA_READ access to it.
5. Share `DashboardA` to UserA with METADATA_READ_WRITE permission.
6. Login with UserA.
7.  In Dashboard app, edit `DashboardA` , add one more Visualization to it.
8. Expect: an error is returned from server.