### PR TITLE
fix: Excel export numbers as number type [DHIS2-14434] (#12678)

### DIFF
--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/grid/GridUtils.java
@@ -64,6 +64,7 @@ import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.DataFormat;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -170,6 +171,8 @@ public class GridUtils
     private static final String ATTR_REF = "ref";
 
     private static final String ATTR_FIELD = "field";
+
+    private static final String DECIMAL_DIGITS_MASK = "#.##########";
 
     /**
      * Writes a PDF representation of the given Grid to the given OutputStream.
@@ -349,6 +352,8 @@ public class GridUtils
 
         rowNumber++;
 
+        CellStyle numberCellStyle = getNumberCellStyle( sheet );
+
         for ( List<Object> row : grid.getVisibleRows() )
         {
             Row xlsRow = sheet.createRow( rowNumber );
@@ -361,8 +366,9 @@ public class GridUtils
             {
                 if ( column != null && Number.class.isAssignableFrom( column.getClass() ) )
                 {
-                    xlsRow.createCell( columnIndex++, CellType.STRING )
-                        .setCellValue( String.valueOf( maybeFormat( column ) ) );
+                    Cell cell = xlsRow.createCell( columnIndex++, CellType.NUMERIC );
+                    cell.setCellStyle( numberCellStyle );
+                    cell.setCellValue( ((Number) column).doubleValue() );
                 }
                 else
                 {
@@ -373,6 +379,23 @@ public class GridUtils
 
             rowNumber++;
         }
+    }
+
+    /**
+     * Returns a {@CellStyle} object with a default number format/mask.
+     *
+     * @param sheet the {@link Sheet}
+     * @return the cell style object
+     */
+    private static CellStyle getNumberCellStyle( Sheet sheet )
+    {
+        Workbook wb = sheet.getWorkbook();
+        DataFormat format = wb.createDataFormat();
+
+        CellStyle cs = wb.createCellStyle();
+        cs.setDataFormat( format.getFormat( DECIMAL_DIGITS_MASK ) );
+
+        return cs;
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -212,7 +212,7 @@ class AnalyticsControllerTest
         assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 0 ).getStringCellValue(), is( "de1" ) );
         assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 1 ).getStringCellValue(), is( "ou2" ) );
         assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 2 ).getStringCellValue(), is( "pe1" ) );
-        assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 3 ).getStringCellValue(), is( "3" ) );
+        assertThat( book.getSheetAt( 0 ).getRow( 2 ).getCell( 3 ).getNumericCellValue(), is( 3.0 ) );
     }
 
     @Test


### PR DESCRIPTION
**_[Backport from master/2.40]_**

Currently, when users the Download feature (Excel format) in the Data Visualizer application, the numbers in the spreadsheet are exported as text types.

This change will make numbers be exported as a number type.
