### PR TITLE
fix: lazy exception when load attributes in getMetadataWithDependencies

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/DefaultMetadataExportService.java
@@ -110,6 +110,7 @@ import org.hisp.dhis.user.User;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.visualization.Visualization;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -144,6 +145,7 @@ public class DefaultMetadataExportService implements MetadataExportService
 
     @Override
     @SuppressWarnings( "unchecked" )
+    @Transactional( readOnly = true )
     public Map<Class<? extends IdentifiableObject>, List<? extends IdentifiableObject>> getMetadata(
         MetadataExportParams params )
     {
@@ -205,6 +207,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ObjectNode getMetadataAsObjectNode( MetadataExportParams params )
     {
         ObjectNode rootNode = fieldFilterService.createObjectNode();
@@ -240,6 +243,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void getMetadataAsObjectNodeStream( MetadataExportParams params, OutputStream outputStream )
         throws IOException
     {
@@ -292,6 +296,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void getMetadataWithDependenciesAsNodeStream( IdentifiableObject object,
         @Nonnull MetadataExportParams params, OutputStream outputStream )
         throws IOException
@@ -338,6 +343,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public ObjectNode getMetadataWithDependenciesAsNode( IdentifiableObject object,
         @Nonnull MetadataExportParams params )
     {
@@ -369,6 +375,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public void validate( MetadataExportParams params )
     {
         if ( params.getUser() == null )
@@ -395,6 +402,7 @@ public class DefaultMetadataExportService implements MetadataExportService
 
     @Override
     @SuppressWarnings( "unchecked" )
+    @Transactional( readOnly = true )
     public MetadataExportParams getParamsFromMap( Map<String, List<String>> parameters )
     {
         MetadataExportParams params = new MetadataExportParams();
@@ -522,6 +530,7 @@ public class DefaultMetadataExportService implements MetadataExportService
     }
 
     @Override
+    @Transactional( readOnly = true )
     public SetMap<Class<? extends IdentifiableObject>, IdentifiableObject> getMetadataWithDependencies(
         IdentifiableObject object )
     {


### PR DESCRIPTION

- All methods in `DefaultMetadataExportService` are missing `@Transactional` annotation. 
- So we got below error when the service need to load Attribute from cache 
```java
    @Override
    @Transactional( readOnly = true )
    public Attribute getAttribute( String uid )
    {
        return attributeCache.get( uid, attr -> attributeStore.getByUid( uid ) );
    }
```

```
{"httpStatus":"Internal Server Error","httpStatusCode":500,"status":"ERROR","message":"could not initialize proxy [org.hisp.dhis.option.OptionSet#1505799] - no Session"}
```

### Test
- Using same test case as in jira issue https://dhis2.atlassian.net/browse/DHIS2-11846

### Screenshot of loading program metadata with dependencies 

<img width="1014" alt="Screen Shot 2023-01-09 at 12 33 44 PM" src="https://user-images.githubusercontent.com/766102/211270198-d731d9d5-79a4-4b15-aeb8-d73d126c1320.png">

