### PR TITLE
feat: data integrity check results with start time

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityDetails.java
@@ -56,6 +56,9 @@ public class DataIntegrityDetails implements Serializable
     private final DataIntegrityCheck check;
 
     @JsonProperty
+    private final Date startTime;
+
+    @JsonProperty
     private final Date finishedTime;
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegritySummary.java
@@ -49,6 +49,9 @@ public class DataIntegritySummary implements Serializable
     private final DataIntegrityCheck check;
 
     @JsonProperty
+    private final Date startTime;
+
+    @JsonProperty
     private final Date finishedTime;
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -860,8 +860,8 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity summary checks", expandChecks( checks ), progress, summaryCache,
             check -> check.getRunSummaryCheck().apply( check ),
-            ( check, startTime, ex ) -> new DataIntegritySummary( check, startTime, new Date(), ex.getMessage(), -1,
-                null ) );
+            ( check, startTime, ex ) -> new DataIntegritySummary( check, startTime, new Date(),
+                errorMessage( check, ex ), -1, null ) );
     }
 
     @Override
@@ -877,8 +877,15 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity details checks", expandChecks( checks ), progress, detailsCache,
             check -> check.getRunDetailsCheck().apply( check ),
-            ( check, startTime, ex ) -> new DataIntegrityDetails( check, startTime, new Date(), ex.getMessage(),
-                List.of() ) );
+            ( check, startTime, ex ) -> new DataIntegrityDetails( check, startTime, new Date(),
+                errorMessage( check, ex ), List.of() ) );
+    }
+
+    private static String errorMessage( DataIntegrityCheck check, RuntimeException ex )
+    {
+        String message = "Check failed because an exception was thrown: " + ex.getMessage();
+        log.error( "Check " + check.getName() + " failed because an exception was thrown", ex );
+        return message;
     }
 
     private <T> Map<String, T> getCached( Set<String> checks, long timeout, Cache<T> cache )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -57,7 +57,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -545,8 +544,16 @@ public class DefaultDataIntegrityService
                 .introduction( info.apply( "introduction", null ) )
                 .recommendation( info.apply( "recommendation", null ) )
                 .issuesIdType( issueIdTypeName )
-                .runDetailsCheck( c -> new DataIntegrityDetails( c, new Date(), null, check.get() ) )
-                .runSummaryCheck( c -> new DataIntegritySummary( c, new Date(), null, check.get().size(), null ) )
+                .runDetailsCheck( c -> {
+                    Date startTime = new Date();
+                    List<DataIntegrityIssue> issues = check.get();
+                    return new DataIntegrityDetails( c, startTime, new Date(), null, issues );
+                } )
+                .runSummaryCheck( c -> {
+                    Date startTime = new Date();
+                    List<DataIntegrityIssue> issues = check.get();
+                    return new DataIntegritySummary( c, startTime, new Date(), null, issues.size(), null );
+                } )
                 .build() );
         }
         catch ( Exception ex )
@@ -853,7 +860,8 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity summary checks", expandChecks( checks ), progress, summaryCache,
             check -> check.getRunSummaryCheck().apply( check ),
-            ( check, ex ) -> new DataIntegritySummary( check, new Date(), ex.getMessage(), -1, null ) );
+            ( check, startTime, ex ) -> new DataIntegritySummary( check, startTime, new Date(), ex.getMessage(), -1,
+                null ) );
     }
 
     @Override
@@ -869,7 +877,8 @@ public class DefaultDataIntegrityService
     {
         runDataIntegrityChecks( "Data Integrity details checks", expandChecks( checks ), progress, detailsCache,
             check -> check.getRunDetailsCheck().apply( check ),
-            ( check, ex ) -> new DataIntegrityDetails( check, new Date(), ex.getMessage(), List.of() ) );
+            ( check, startTime, ex ) -> new DataIntegrityDetails( check, startTime, new Date(), ex.getMessage(),
+                List.of() ) );
     }
 
     private <T> Map<String, T> getCached( Set<String> checks, long timeout, Cache<T> cache )
@@ -905,23 +914,30 @@ public class DefaultDataIntegrityService
         return resByName;
     }
 
+    @FunctionalInterface
+    private interface DataIntegrityCheckErrorHandler<T>
+    {
+        T createErrorReport( DataIntegrityCheck check, Date startTime, RuntimeException ex );
+    }
+
     private <T> void runDataIntegrityChecks( String stageDesc, Set<String> checks, JobProgress progress,
         Cache<T> cache, Function<DataIntegrityCheck, T> runCheck,
-        BiFunction<DataIntegrityCheck, RuntimeException, T> createErrorReport )
+        DataIntegrityCheckErrorHandler<T> createErrorReport )
     {
         progress.startingProcess( "Data Integrity check" );
         progress.startingStage( stageDesc, checks.size(), SKIP_ITEM );
         progress.runStage( checks.stream().map( checksByName::get ).filter( Objects::nonNull ),
             DataIntegrityCheck::getDescription,
             check -> {
-                T res = null;
+                Date startTime = new Date();
+                T res;
                 try
                 {
                     res = runCheck.apply( check );
                 }
                 catch ( RuntimeException ex )
                 {
-                    cache.put( check.getName(), createErrorReport.apply( check, ex ) );
+                    cache.put( check.getName(), createErrorReport.createErrorReport( check, startTime, ex ) );
                     throw ex;
                 }
                 if ( res != null )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/hibernate/HibernateDataIntegrityStore.java
@@ -59,9 +59,10 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
     @Transactional( readOnly = true )
     public DataIntegritySummary querySummary( DataIntegrityCheck check, String sql )
     {
+        Date startTime = new Date();
         Object summary = sessionFactory.getCurrentSession()
             .createNativeQuery( sql ).getSingleResult();
-        return new DataIntegritySummary( check, new Date(), null, parseCount( summary ),
+        return new DataIntegritySummary( check, startTime, new Date(), null, parseCount( summary ),
             parsePercentage( summary ) );
     }
 
@@ -69,10 +70,11 @@ public class HibernateDataIntegrityStore implements DataIntegrityStore
     @Transactional( readOnly = true )
     public DataIntegrityDetails queryDetails( DataIntegrityCheck check, String sql )
     {
+        Date startTime = new Date();
         @SuppressWarnings( "unchecked" )
         List<Object[]> rows = sessionFactory.getCurrentSession().createNativeQuery( sql )
             .getResultList();
-        return new DataIntegrityDetails( check, new Date(), null, rows.stream()
+        return new DataIntegrityDetails( check, startTime, new Date(), null, rows.stream()
             .map( row -> new DataIntegrityIssue(
                 getIndex( row, 0 ), getIndex( row, 1 ), getIndex( row, 2 ), getRefs( row, 3 ) ) )
             .collect( toUnmodifiableList() ) );

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReaderTest.java
@@ -51,8 +51,8 @@ class DataIntegrityYamlReaderTest
         List<DataIntegrityCheck> checks = new ArrayList<>();
         readDataIntegrityYaml( "data-integrity-checks.yaml", checks::add,
             ( property, defaultValue ) -> defaultValue,
-            sql -> check -> new DataIntegritySummary( check, new Date(), null, 1, 100d ),
-            sql -> check -> new DataIntegrityDetails( check, new Date(), null,
+            sql -> check -> new DataIntegritySummary( check, new Date(), new Date(), null, 1, 100d ),
+            sql -> check -> new DataIntegrityDetails( check, new Date(), new Date(), null,
                 List.of( new DataIntegrityIssue( "id", "name", sql, List.of() ) ) ) );
         assertEquals( 62, checks.size() );
         DataIntegrityCheck check = checks.get( 0 );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegrityDetails.java
@@ -49,6 +49,12 @@ public interface JsonDataIntegrityDetails extends JsonDataIntegrityCheck
         return get( "finishedTime", JsonDate.class ).date();
     }
 
+    @Expected
+    default LocalDateTime getStartTime()
+    {
+        return get( "startTime", JsonDate.class ).date();
+    }
+
     default String getError()
     {
         return getString( "error" ).string( null );

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/webapi/json/domain/JsonDataIntegritySummary.java
@@ -46,6 +46,12 @@ public interface JsonDataIntegritySummary extends JsonDataIntegrityCheck
         return get( "finishedTime", JsonDate.class ).date();
     }
 
+    @Expected
+    default LocalDateTime getStartTime()
+    {
+        return get( "startTime", JsonDate.class ).date();
+    }
+
     default String getError()
     {
         return getString( "error" ).string( null );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
@@ -70,6 +72,8 @@ class DataIntegrityDetailsControllerTest extends AbstractDataIntegrityController
 
         assertTrue( details.exists() );
         assertTrue( details.isObject() );
+        assertNotNull( details.getStartTime() );
+        assertFalse( details.getStartTime().isAfter( details.getFinishedTime() ) );
         JsonList<JsonDataIntegrityIssue> issues = details.getIssues();
         assertTrue( issues.exists() );
         assertEquals( 1, issues.size() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
@@ -29,6 +29,8 @@ package org.hisp.dhis.webapi.controller;
 
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
@@ -69,5 +71,7 @@ class DataIntegritySummaryControllerTest extends AbstractDataIntegrityController
         assertTrue( summary.isObject() );
         assertEquals( 1, summary.getCount() );
         assertEquals( 50, summary.getPercentage().intValue() );
+        assertNotNull( summary.getStartTime() );
+        assertFalse( summary.getStartTime().isAfter( summary.getFinishedTime() ) );
     }
 }


### PR DESCRIPTION
### Summary
* adds a `startTime` to check results (so a duration can be computed)
* fixes `finishedTime` to be actually after the check is performed in some of the paths
* fixes `error` to always hold a message even if the exception message was `null`
* logs any exceptions thrown by a check as error