### PR TITLE
feat: [DHIS2-14300] Inform client that breaking the glass is permitted

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerAccessManager.java
@@ -114,4 +114,13 @@ public interface TrackerAccessManager
      *         program context, otherwise return false
      */
     boolean canAccess( User user, Program program, OrganisationUnit orgUnit );
+
+    /**
+     * Checks if user has permission to break the glass
+     *
+     * @param entityInstance Tracked entity instance object
+     * @param program Program object
+     * @param user The user to check access for
+     */
+    boolean canGainAccess( TrackedEntityInstance entityInstance, Program program, User user );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/trackedentity/TrackerOwnershipManager.java
@@ -40,6 +40,8 @@ public interface TrackerOwnershipManager
 {
     String OWNERSHIP_ACCESS_DENIED = "OWNERSHIP_ACCESS_DENIED";
 
+    String OWNERSHIP_ACCESS_PARTIALLY_DENIED = "OWNERSHIP_ACCESS_PARTIALLY_DENIED";
+
     String PROGRAM_ACCESS_CLOSED = "PROGRAM_ACCESS_CLOSED";
 
     /**
@@ -75,6 +77,17 @@ public interface TrackerOwnershipManager
 
     boolean hasAccessUsingContext( User user, String trackedEntityInstanceUid, String programUid,
         EventContext eventContext );
+
+    /**
+     * Check whether the user may break the glass for the given
+     * tracked entity instance - program combination.
+     *
+     * @param user The user to check for breaking the glass permission.
+     * @param entityInstance The tracked entity instance.
+     * @param program The program.
+     * @return true if the user may break the glass, false otherwise.
+     */
+    boolean mayGainAccess( User user, TrackedEntityInstance entityInstance, Program program );
 
     /**
      * Grant temporary ownership for a user for a specific tei-program

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerAccessManager.java
@@ -808,6 +808,12 @@ public class DefaultTrackerAccessManager implements TrackerAccessManager
         return organisationUnitService.isInUserSearchHierarchy( user, orgUnit );
     }
 
+    @Override
+    public boolean canGainAccess( TrackedEntityInstance entityInstance, Program program, User user )
+    {
+        return ownershipAccessManager.mayGainAccess(user, entityInstance, program);
+    }
+
     private boolean isNull( ProgramStage programStage )
     {
         return programStage == null || programStage.getProgram() == null;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/DefaultTrackerOwnershipManager.java
@@ -324,6 +324,20 @@ public class DefaultTrackerOwnershipManager implements TrackerOwnershipManager
     }
 
     @Override
+    @Transactional( readOnly = true )
+    public boolean mayGainAccess( User user, TrackedEntityInstance entityInstance, Program program )
+    {
+        if ( canSkipOwnershipCheck( user, program ) || entityInstance == null )
+        {
+            return true;
+        }
+
+        OrganisationUnit ou = getOwner( entityInstance.getId(), program, entityInstance::getOrganisationUnit );
+
+        return organisationUnitService.isInUserSearchHierarchyCached( user, ou );
+    }
+
+    @Override
     public boolean canSkipOwnershipCheck( User user, Program program )
     {
         return program == null || canSkipOwnershipCheck( user, program.getProgramType() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
@@ -108,11 +108,21 @@ class TrackedEntitiesSupportService
 
             if ( !errors.isEmpty() )
             {
-                if ( program.getAccessLevel() == AccessLevel.CLOSED )
+                AccessLevel accessLevel = program.getAccessLevel();
+                if ( accessLevel == AccessLevel.CLOSED )
                 {
                     throw new WebMessageException(
                         unauthorized( TrackerOwnershipManager.PROGRAM_ACCESS_CLOSED ) );
                 }
+
+                if ( accessLevel == AccessLevel.PROTECTED && trackerAccessManager.canGainAccess(
+                    instanceService.getTrackedEntityInstance( trackedEntityInstance.getTrackedEntityInstance() ),
+                    program, user) )
+                {
+                    throw new WebMessageException(
+                        unauthorized( TrackerOwnershipManager.OWNERSHIP_ACCESS_PARTIALLY_DENIED ) );
+                }
+
                 throw new WebMessageException(
                     unauthorized( TrackerOwnershipManager.OWNERSHIP_ACCESS_DENIED ) );
             }


### PR DESCRIPTION
Makes `tracker/trackedEntities/<uid>?program=<uid>` emit a special error message when the specified program is protected AND `programOwner` lies in the user's {search scope} minus {capture scope}.

The reason for making this into a special case is that it helps clients figure out if breaking the glass is applicable or not.