### PR TITLE
feat: data integrity - list of running and completed checks [DHIS2-14488]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityService.java
@@ -69,4 +69,13 @@ public interface DataIntegrityService
     void runSummaryChecks( Set<String> checks, JobProgress progress );
 
     void runDetailsChecks( Set<String> checks, JobProgress progress );
+
+    Set<String> getRunningSummaryChecks();
+
+    Set<String> getRunningDetailsChecks();
+
+    Set<String> getCompletedSummaryChecks();
+
+    Set<String> getCompletedDetailsChecks();
+
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
@@ -93,6 +93,7 @@ class DataIntegrityDetailsControllerTest extends AbstractDataIntegrityController
         postDetails( "categories-no-options" );
         JsonDataIntegrityDetails details = GET( "/dataIntegrity/categories-no-options/details?timeout=1000" )
             .content().as( JsonDataIntegrityDetails.class );
+        assertNotNull( details );
 
         assertEquals( List.of( "categories_no_options" ),
             GET( "/dataIntegrity/details/completed" ).content().stringValues() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.web.HttpStatus;
@@ -80,5 +82,19 @@ class DataIntegrityDetailsControllerTest extends AbstractDataIntegrityController
         assertEquals( uid, issues.get( 0 ).getId() );
         assertEquals( "CatDog", issues.get( 0 ).getName() );
         assertEquals( "categories", details.getIssuesIdType() );
+    }
+
+    @Test
+    void testCompletedChecks()
+    {
+        String uid = assertStatus( HttpStatus.CREATED,
+            POST( "/categories", "{'name': 'CatDog', 'shortName': 'CD', 'dataDimensionType': 'ATTRIBUTE'}" ) );
+
+        postDetails( "categories-no-options" );
+        JsonDataIntegrityDetails details = GET( "/dataIntegrity/categories-no-options/details?timeout=1000" )
+            .content().as( JsonDataIntegrityDetails.class );
+
+        assertEquals( List.of( "categories_no_options" ),
+            GET( "/dataIntegrity/details/completed" ).content().stringValues() );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
@@ -86,6 +86,7 @@ class DataIntegritySummaryControllerTest extends AbstractDataIntegrityController
         postSummary( "categories-no-options" );
         JsonDataIntegritySummary summary = GET( "/dataIntegrity/categories-no-options/summary" ).content()
             .as( JsonDataIntegritySummary.class );
+        assertNotNull( summary );
 
         assertEquals( List.of( "categories_no_options" ),
             GET( "/dataIntegrity/summary/completed" ).content().stringValues() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
@@ -33,6 +33,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
+
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
@@ -73,5 +75,19 @@ class DataIntegritySummaryControllerTest extends AbstractDataIntegrityController
         assertEquals( 50, summary.getPercentage().intValue() );
         assertNotNull( summary.getStartTime() );
         assertFalse( summary.getStartTime().isAfter( summary.getFinishedTime() ) );
+    }
+
+    @Test
+    void testCompletedChecks()
+    {
+        assertStatus( HttpStatus.CREATED,
+            POST( "/categories", "{'name': 'CatDog', 'shortName': 'CD', 'dataDimensionType': 'ATTRIBUTE'}" ) );
+
+        postSummary( "categories-no-options" );
+        JsonDataIntegritySummary summary = GET( "/dataIntegrity/categories-no-options/summary" ).content()
+            .as( JsonDataIntegritySummary.class );
+
+        assertEquals( List.of( "categories_no_options" ),
+            GET( "/dataIntegrity/summary/completed" ).content().stringValues() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataIntegrityController.java
@@ -122,6 +122,20 @@ public class DataIntegrityController
             : matches.stream().filter( check -> section.equals( check.getSection() ) ).collect( toList() );
     }
 
+    @GetMapping( "/summary/running" )
+    @ResponseBody
+    public Set<String> getRunningSummaryChecks()
+    {
+        return dataIntegrityService.getRunningSummaryChecks();
+    }
+
+    @GetMapping( "/summary/completed" )
+    @ResponseBody
+    public Set<String> getCompletedSummaryChecks()
+    {
+        return dataIntegrityService.getCompletedSummaryChecks();
+    }
+
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )
     @GetMapping( "/summary" )
     @ResponseBody
@@ -141,6 +155,20 @@ public class DataIntegrityController
     {
         return runDataIntegrityAsync( checks, currentUser, "runSummariesCheck", DataIntegrityReportType.SUMMARY )
             .setLocation( "/dataIntegrity/summary?checks=" + toChecksList( checks ) );
+    }
+
+    @GetMapping( "/details/running" )
+    @ResponseBody
+    public Set<String> getRunningDetailsChecks()
+    {
+        return dataIntegrityService.getRunningDetailsChecks();
+    }
+
+    @GetMapping( "/details/completed" )
+    @ResponseBody
+    public Set<String> getCompletedDetailsChecks()
+    {
+        return dataIntegrityService.getCompletedDetailsChecks();
     }
 
     @PreAuthorize( "hasRole('ALL') or hasRole('F_PERFORM_MAINTENANCE')" )


### PR DESCRIPTION
### Summary
Another small addition to the data integrity API to support app development with two new functions:

* list checks by name that are currently running
* list checks by name that have results available

These have to be distinguished by details and summary so in total this makes 4 combinations.

### Automatic Testing
Added a test for each of the two completed checks endpoints.
Testing the running checks is to timing sensitive to successfully test without doing the actual check on larger database.
This needs manual testing.