### PR TITLE
fix: Missing assertion on CSV tests 

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerTrackedEntitiesExportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerTrackedEntitiesExportControllerTest.java
@@ -308,9 +308,9 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
 
         assertEquals( HttpStatus.OK, response.status() );
 
-        assertAll( () -> response.header( "content-type" ).contains( ContextUtils.CONTENT_TYPE_TEXT_CSV ),
-            () -> response.header( "content-disposition" ).contains( "filename=\"trackedEntities.csv\"" ),
-            () -> response.content().toString().contains( "trackedEntity,trackedEntityType" ) );
+        assertAll( () -> assertTrue( response.header( "content-type" ).contains( ContextUtils.CONTENT_TYPE_CSV ) ),
+            () -> assertTrue( response.header( "content-disposition" ).contains( "filename=\"trackedEntities.csv\"" ) ),
+            () -> assertTrue( response.content().toString().contains( "trackedEntity,trackedEntityType" ) ) );
     }
 
     @Test
@@ -322,8 +322,9 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
 
         assertEquals( HttpStatus.OK, response.status() );
 
-        assertAll( () -> response.header( "content-type" ).contains( ContextUtils.CONTENT_TYPE_CSV_ZIP ),
-            () -> response.header( "content-disposition" ).contains( "filename=\"trackedEntities.csv.zip\"" ) );
+        assertAll( () -> assertTrue( response.header( "content-type" ).contains( ContextUtils.CONTENT_TYPE_CSV_ZIP ) ),
+            () -> assertTrue(
+                response.header( "content-disposition" ).contains( "filename=\"trackedEntities.csv.zip\"" ) ) );
     }
 
     @Test
@@ -335,8 +336,9 @@ class TrackerTrackedEntitiesExportControllerTest extends DhisControllerConvenien
 
         assertEquals( HttpStatus.OK, response.status() );
 
-        assertAll( () -> response.header( "content-type" ).contains( ContextUtils.CONTENT_TYPE_CSV_GZIP ),
-            () -> response.header( "content-disposition" ).contains( "filename=\"trackedEntities.csv.gz\"" ) );
+        assertAll( () -> assertTrue( response.header( "content-type" ).contains( ContextUtils.CONTENT_TYPE_CSV_GZIP ) ),
+            () -> assertTrue(
+                response.header( "content-disposition" ).contains( "filename=\"trackedEntities.csv.gz\"" ) ) );
     }
 
     @Test


### PR DESCRIPTION
CSV Tests in `TrackerTrackedEntitiesExportControllerTest` were missing assertions 