### PR TITLE
fix: Scheduled events missing when using fixed monthly periods [DHIS2-14442]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -28,7 +28,9 @@
 package org.hisp.dhis.analytics;
 
 import static java.util.Collections.emptyList;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.OrgUnitField.DEFAULT_ORG_UNIT_FIELD;
 import static org.hisp.dhis.analytics.TimeField.DEFAULT_TIME_FIELDS;
 import static org.hisp.dhis.common.DimensionType.CATEGORY;
@@ -52,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -684,7 +687,6 @@ public class DataQueryParams
             .add( "approvalLevel", approvalLevel )
             .add( "startDate", startDate )
             .add( "endDate", endDate )
-            // TODO: Maikel: add cache key for multiple periods
             .add( "order", order )
             .add( "timeField", timeField )
             .add( "orgUnitField", orgUnitField )
@@ -701,7 +703,7 @@ public class DataQueryParams
                 .collect( Collectors.joining( ":" ) );
         }
 
-        return StringUtils.EMPTY;
+        return EMPTY;
     }
 
     // -------------------------------------------------------------------------
@@ -770,7 +772,7 @@ public class DataQueryParams
     public Period getLatestPeriod()
     {
         return getAllPeriods().stream()
-            .map( obj -> (Period) obj )
+            .map( Period.class::cast )
             .min( DescendingPeriodComparator.INSTANCE )
             .orElse( null );
     }
@@ -861,7 +863,7 @@ public class DataQueryParams
     public List<Period> getTypedFilterPeriods()
     {
         return getFilterPeriods().stream()
-            .map( p -> (Period) p )
+            .map( Period.class::cast )
             .collect( Collectors.toList() );
     }
 
@@ -1473,28 +1475,33 @@ public class DataQueryParams
     }
 
     /**
-     * Indicates whether this query has a continuous a list of dates has
-     * continuous range. It assumes that the datesRange IS SORTED.
+     * Indicates whether this query has a continuous list of dates range or is
+     * empty. It assumes that the datesRange IS SORTED.
      */
-    public boolean hasContinuousDateRangeList( List<DateRange> datesRange )
+    public boolean hasContinuousRange( List<DateRange> datesRange )
     {
-        if ( isNotEmpty( datesRange ) )
+        if ( isEmpty( datesRange ) )
         {
-            for ( int i = datesRange.size() - 1; i > 0; i-- )
-            {
-                boolean diffAboveOneDay = DateUtils.daysBetween( datesRange.get( i - 1 ).getEndDate(),
-                    datesRange.get( i ).getStartDate() ) > 1;
-
-                if ( diffAboveOneDay )
-                {
-                    return false;
-                }
-            }
-
             return true;
         }
 
-        return false;
+        if ( datesRange.size() == 1 )
+        {
+            return true;
+        }
+
+        for ( int i = datesRange.size() - 1; i > 0; i-- )
+        {
+            boolean diffAboveOneDay = DateUtils.daysBetween( datesRange.get( i - 1 ).getEndDate(),
+                datesRange.get( i ).getStartDate() ) > 1;
+
+            if ( diffAboveOneDay )
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -1643,7 +1650,7 @@ public class DataQueryParams
         List<DimensionalItemObject> items = AnalyticsUtils
             .getByDataDimensionItemType( DataDimensionItemType.PROGRAM_INDICATOR, dimension.getItems() );
 
-        return items.size() > 0;
+        return isNotEmpty( items );
     }
 
     /**
@@ -2097,10 +2104,8 @@ public class DataQueryParams
             List<String> keys = Lists.newArrayList( key.split( DIMENSION_SEP ) );
 
             // Org unit group always at last index, org unit potentially at
-            // first
-
+            // first.
             int ougInx = keys.size() - 1;
-
             String oug = keys.get( ougInx );
 
             ListUtils.removeAll( keys, ougInx );
@@ -2127,7 +2132,7 @@ public class DataQueryParams
             return null;
         }
 
-        Map<MeasureFilter, Double> map = new HashMap<>();
+        Map<MeasureFilter, Double> map = new EnumMap<>( MeasureFilter.class );
 
         String[] criteria = param.split( DimensionalObject.OPTION_SEP );
 
@@ -2649,12 +2654,12 @@ public class DataQueryParams
         Set<IdentifiableObject> programs = new HashSet<>();
 
         getAllProgramAttributes().stream()
-            .map( a -> (ProgramTrackedEntityAttributeDimensionItem) a )
+            .map( ProgramTrackedEntityAttributeDimensionItem.class::cast )
             .filter( a -> a.getProgram() != null )
             .forEach( a -> programs.add( a.getProgram() ) );
 
         getAllProgramDataElements().stream()
-            .map( d -> (ProgramDataElementDimensionItem) d )
+            .map( ProgramDataElementDimensionItem.class::cast )
             .filter( d -> d.getProgram() != null )
             .forEach( d -> programs.add( d.getProgram() ) );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static java.util.Collections.singleton;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
@@ -39,7 +38,6 @@ import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import static org.hisp.dhis.util.DateUtils.plusOneDay;
 
 import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -70,10 +68,10 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     private final StatementBuilder statementBuilder;
 
     @Getter
-    private final Collection<TimeField> allowedTimeFields = singleton( TimeField.LAST_UPDATED );
+    private final Set<TimeField> allowedTimeFields = Set.of( TimeField.LAST_UPDATED );
 
     @Override
-    protected String getSqlConditionForPeriods( EventQueryParams params )
+    protected String getAggregatedConditionForPeriods( EventQueryParams params )
     {
         List<DimensionalItemObject> periods = params.getDimensionOrFilterItems( PERIOD_DIM_ID );
 
@@ -107,7 +105,7 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     }
 
     @Override
-    protected String getSqlConditionForNonDefaultBoundaries( EventQueryParams params )
+    protected String getConditionForNonDefaultBoundaries( EventQueryParams params )
     {
         String sql = params.getProgramIndicator().getAnalyticsPeriodBoundaries().stream()
             .filter(

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -33,6 +33,7 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
+import static org.hisp.dhis.commons.util.TextUtils.EMPTY;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import static org.hisp.dhis.util.DateUtils.plusOneDay;
@@ -51,6 +52,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -99,15 +101,14 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     }
 
     @Override
-    protected String getColumnName( EventQueryParams params )
+    protected String getColumnName( Optional<TimeField> timeField, EventOutputType outputType )
     {
-        return getTimeField( params ).orElse( TimeField.ENROLLMENT_DATE ).getField();
+        return timeField.orElse( TimeField.ENROLLMENT_DATE ).getField();
     }
 
     @Override
     protected String getSqlConditionForNonDefaultBoundaries( EventQueryParams params )
     {
-
         String sql = params.getProgramIndicator().getAnalyticsPeriodBoundaries().stream()
             .filter(
                 boundary -> boundary.isCohortDateBoundary() && !boundary.isEnrollmentHavingEventDateCohortBoundary() )
@@ -119,7 +120,7 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
         String sqlEventCohortBoundary = params.getProgramIndicator().hasEventDateCohortBoundary()
             ? getProgramIndicatorEventInProgramStageSql( params.getProgramIndicator(), params.getEarliestStartDate(),
                 params.getLatestEndDate() )
-            : "";
+            : EMPTY;
 
         return Stream.of( sql, sqlEventCohortBoundary )
             .filter( StringUtils::isNotBlank )
@@ -137,7 +138,7 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
         SimpleDateFormat format = new SimpleDateFormat();
         format.applyPattern( Period.DEFAULT_DATE_FORMAT );
 
-        String sql = "";
+        String sql = EMPTY;
         for ( String programStage : map.keySet() )
         {
             Set<AnalyticsPeriodBoundary> boundaries = map.get( programStage );
@@ -166,5 +167,4 @@ class EnrollmentTimeFieldSqlRenderer extends TimeFieldSqlRenderer
         return "( " + timeCol + " >= '" + getMediumDateString( period.getStartDate() ) + "' and " + timeCol + " < '"
             + getMediumDateString( plusOneDay( period.getEndDate() ) ) + "') ";
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.analytics.event.data;
 
 import static java.util.Arrays.asList;
 import static org.hisp.dhis.analytics.EventOutputType.ENROLLMENT;
+import static org.hisp.dhis.analytics.TimeField.ENROLLMENT_DATE;
 import static org.hisp.dhis.analytics.TimeField.EVENT_DATE;
 import static org.hisp.dhis.analytics.TimeField.LAST_UPDATED;
 import static org.hisp.dhis.analytics.TimeField.SCHEDULED_DATE;
@@ -99,9 +100,9 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     }
 
     @Override
-    protected String getColumnName( EventQueryParams params )
+    protected String getColumnName( Optional<TimeField> timeField, EventOutputType outputType )
     {
-        return getTimeCol( params.getOutputType(), getTimeField( params ) );
+        return getTimeCol( outputType, timeField );
     }
 
     @Override
@@ -116,15 +117,19 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
 
     private String getTimeCol( EventOutputType outputType, Optional<TimeField> timeField )
     {
-        if ( ENROLLMENT.equals( outputType ) )
+        if ( timeField.isPresent() )
         {
-            return quoteAlias( TimeField.ENROLLMENT_DATE.getField() );
+            return quoteAlias( timeField.get().getField() );
         }
-        // EVENTS
-        return quoteAlias(
-            timeField
-                .map( TimeField::getField )
-                .orElse( EVENT_DATE.getField() ) );
+        else if ( ENROLLMENT == outputType )
+        {
+            return quoteAlias( ENROLLMENT_DATE.getField() );
+        }
+        else
+        {
+            // EVENTS
+            return quoteAlias( EVENT_DATE.getField() );
+        }
     }
 
     private String toSqlCondition( Period period, TimeField timeField )
@@ -138,5 +143,4 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     {
         return params.hasTimeField() ? DATE_PERIOD_STRUCT_ALIAS : ANALYTICS_TBL_ALIAS;
     }
-
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
@@ -27,7 +27,6 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static java.util.Arrays.asList;
 import static org.hisp.dhis.analytics.EventOutputType.ENROLLMENT;
 import static org.hisp.dhis.analytics.TimeField.ENROLLMENT_DATE;
 import static org.hisp.dhis.analytics.TimeField.EVENT_DATE;
@@ -44,10 +43,9 @@ import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import static org.hisp.dhis.util.DateUtils.plusOneDay;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
@@ -68,10 +66,10 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     private final StatementBuilder statementBuilder;
 
     @Getter
-    private final Collection<TimeField> allowedTimeFields = new HashSet<>( asList( LAST_UPDATED, SCHEDULED_DATE ) );
+    private final Set<TimeField> allowedTimeFields = Set.of( LAST_UPDATED, SCHEDULED_DATE );
 
     @Override
-    protected String getSqlConditionForPeriods( EventQueryParams params )
+    protected String getAggregatedConditionForPeriods( EventQueryParams params )
     {
         List<DimensionalItemObject> periods = params.getDimensionOrFilterItems( PERIOD_DIM_ID );
 
@@ -102,11 +100,11 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     @Override
     protected String getColumnName( Optional<TimeField> timeField, EventOutputType outputType )
     {
-        return getTimeCol( outputType, timeField );
+        return getTimeCol( timeField, outputType );
     }
 
     @Override
-    protected String getSqlConditionForNonDefaultBoundaries( EventQueryParams params )
+    protected String getConditionForNonDefaultBoundaries( EventQueryParams params )
     {
         return params.getProgramIndicator().getAnalyticsPeriodBoundaries().stream()
             .map( analyticsPeriodBoundary -> statementBuilder.getBoundaryCondition( analyticsPeriodBoundary,
@@ -115,7 +113,7 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
             .collect( Collectors.joining( " and " ) );
     }
 
-    private String getTimeCol( EventOutputType outputType, Optional<TimeField> timeField )
+    private String getTimeCol( Optional<TimeField> timeField, EventOutputType outputType )
     {
         if ( timeField.isPresent() )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -235,7 +235,7 @@ public class JdbcEnrollmentAnalyticsManager
         // Periods
         // ---------------------------------------------------------------------
 
-        sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderTimeFieldSql( params );
+        sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderPeriodTimeFieldSql( params );
 
         // ---------------------------------------------------------------------
         // Organisation units

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -412,7 +412,7 @@ public class JdbcEventAnalyticsManager
         // ---------------------------------------------------------------------
 
         sql += hlp.whereAnd() + " "
-            + timeFieldSqlRenderer.renderTimeFieldSql( params );
+            + timeFieldSqlRenderer.renderPeriodTimeFieldSql( params );
 
         // ---------------------------------------------------------------------
         // Organisation units

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -32,9 +32,9 @@ import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import lombok.Builder;
 import lombok.Data;
@@ -44,27 +44,164 @@ import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.DateRange;
 
+/**
+ * Provides methods targeting the generation of SQL statements for periods and
+ * time fields.
+ */
 public abstract class TimeFieldSqlRenderer
 {
-    public String renderTimeFieldSql( EventQueryParams params )
+    /**
+     * Generates a SQL statement for periods or time field based on the given
+     * params.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    public String renderPeriodTimeFieldSql( EventQueryParams params )
     {
         StringBuilder sql = new StringBuilder();
 
         if ( params.hasNonDefaultBoundaries() )
         {
-            sql.append( getSqlConditionForNonDefaultBoundaries( params ) );
+            sql.append( getConditionForNonDefaultBoundaries( params ) );
         }
-        else if ( params.useStartEndDates() )
+        else if ( !params.hasContinuousRange( params.getPeriodDateRanges() ) )
         {
-            sql.append( getSqlDateRangeCondition( params ) );
+            sql.append( getPeriodsCondition( params ) );
         }
-        // Periods condition only for pivot table.
-        else
+        else if ( params.useStartEndDates() || params.hasTimeDateRanges() )
         {
-            sql.append( getSqlConditionForPeriods( params ) );
+            sql.append( getDateRangeCondition( params ) );
+        }
+        else // Periods condition only for pivot table (aggregated).
+        {
+            sql.append( getAggregatedConditionForPeriods( params ) );
         }
 
         return sql.toString();
+    }
+
+    /**
+     * Checks if the given time field is allowed in time/date queries.
+     *
+     * @param timeField the {@link TimeField}
+     * @return true if the time field is allowed, false otherwise
+     */
+    private boolean isAllowed( TimeField timeField )
+    {
+        return getAllowedTimeFields().contains( timeField );
+    }
+
+    /**
+     * Generates a SQL statement for based on a range of periods.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    private String getPeriodsCondition( EventQueryParams params )
+    {
+        List<String> orConditions = new ArrayList<>();
+
+        params.getPeriodDateRanges().forEach( dateRange -> {
+            ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.builder()
+                .column( getColumnName( Optional.empty(), params.getOutputType() ) )
+                .dateRange( dateRange )
+                .build();
+
+            orConditions.add( getDateRangeCondition( columnWithDateRange ) );
+        } );
+
+        return isNotEmpty( orConditions ) ? String.join( " or ", orConditions ) : EMPTY;
+    }
+
+    /**
+     * Returns a SQL statement based on start/end dates and all time/date ranges
+     * defined, if any.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    private String getDateRangeCondition( EventQueryParams params )
+    {
+        List<String> orConditions = new ArrayList<>();
+
+        if ( params.hasStartEndDate() )
+        {
+            addDefaultDateToConditions( params, orConditions );
+        }
+
+        params.getTimeDateRanges().forEach( ( timeField, dateRanges ) -> {
+            if ( params.hasContinuousRange( dateRanges ) )
+            {
+                // Picks the start date of the first range and end date of the last range.
+                DateRange dateRange = new DateRange( dateRanges.get( 0 ).getStartDate(),
+                    dateRanges.get( dateRanges.size() - 1 ).getEndDate() );
+
+                ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
+                    getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
+                orConditions.add( getDateRangeCondition( columnWithDateRange ) );
+            }
+            else
+            {
+                dateRanges.forEach( dateRange -> {
+                    ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
+                        getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
+                    orConditions.add( getDateRangeCondition( columnWithDateRange ) );
+                } );
+            }
+        } );
+
+        return isNotEmpty( orConditions ) ? String.join( " or ", orConditions ) : EMPTY;
+    }
+
+    /**
+     * Returns a string representing the SQL condition for the given
+     * {@link ColumnWithDateRange}.
+     *
+     * @param dateRangeColumn
+     * @return the SQL statement
+     */
+    private String getDateRangeCondition( ColumnWithDateRange dateRangeColumn )
+    {
+        return "(" +
+            dateRangeColumn.getColumn() +
+            " >= '" +
+            getMediumDateString( dateRangeColumn.getDateRange().getStartDate() ) +
+            "' and " +
+            dateRangeColumn.getColumn() +
+            " < '" +
+            getMediumDateString( dateRangeColumn.getDateRange().getEndDatePlusOneDay() ) +
+            "')";
+    }
+
+    /**
+     * Adds the default data range condition into the given list of conditions.
+     *
+     * @param params the {@link EventQueryParams}
+     * @param conditions a list of SQL conditions
+     */
+    private void addDefaultDateToConditions( EventQueryParams params, List<String> conditions )
+    {
+        ColumnWithDateRange defaultDateRangeColumn = ColumnWithDateRange.builder()
+            .column( getColumnName( TimeField.of( params.getTimeField() ), params.getOutputType() ) )
+            .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
+            .build();
+
+        conditions.add( getDateRangeCondition( defaultDateRangeColumn ) );
+    }
+
+    /**
+     * Returns the time field {@link TimeField} set in the given params
+     * {@link EventQueryParams}. It also checks if the time field set is
+     * allowed. Case negative, it returns an empty optional.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return and optional {@link TimeField}
+     */
+    protected Optional<TimeField> getTimeField( EventQueryParams params )
+    {
+        return TimeField.of( params.getTimeField() )
+            .filter( this::isAllowed );
     }
 
     @Data
@@ -84,81 +221,40 @@ public abstract class TimeFieldSqlRenderer
         }
     }
 
-    protected Optional<TimeField> getTimeField( EventQueryParams params )
-    {
-        return TimeField.of( params.getTimeField() )
-            .filter( this::isAllowed );
-    }
-
-    private boolean isAllowed( TimeField timeField )
-    {
-        return getAllowedTimeFields().contains( timeField );
-    }
-
-    protected abstract String getSqlConditionForPeriods( EventQueryParams params );
+    /**
+     * It generates a period SQL statement for aggregated queries based on the
+     * given params.
+     *
+     * @param params {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    protected abstract String getAggregatedConditionForPeriods( EventQueryParams params );
 
     /**
-     * Renders all periods, which are now organized by dateFilter, into SQL
+     * Returns the field/column associated with the given {@link TimeField}. If
+     * the time field is empty, it will return a default one. The
+     * {@link EventOutputType} might be used to decided which field/column will
+     * be the default.
+     *
+     * @param timeField the optional {@link TimeField}
+     * @param outputType the {@link EventOutputType}
+     * @return the field/column of the given time field
      */
-    protected String getSqlDateRangeCondition( EventQueryParams params )
-    {
-        List<String> orConditions = new ArrayList<>();
-
-        if ( params.hasStartEndDate() )
-        {
-            addDefaultDateToConditions( params, orConditions );
-        }
-
-        params.getTimeDateRanges().forEach( ( timeField, dateRanges ) -> {
-            if ( params.hasContinuousDateRangeList( dateRanges ) )
-            {
-                // Picks the start date of the first range and end date of the last range.
-                DateRange dateRange = new DateRange( dateRanges.get( 0 ).getStartDate(),
-                    dateRanges.get( dateRanges.size() - 1 ).getEndDate() );
-
-                ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
-                    getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
-                orConditions.add( getDateRangeCondition( columnWithDateRange ) );
-            }
-            else
-            {
-                dateRanges.forEach( ( dateRange ) -> {
-                    ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
-                        getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
-                    orConditions.add( getDateRangeCondition( columnWithDateRange ) );
-                } );
-            }
-        } );
-
-        return isNotEmpty( orConditions ) ? "(" + String.join( " or ", orConditions ) + ")" : EMPTY;
-    }
-
-    private void addDefaultDateToConditions( EventQueryParams params, List<String> conditions )
-    {
-        ColumnWithDateRange defaultDateRangeColumn = ColumnWithDateRange.builder()
-            .column( getColumnName( TimeField.of( params.getTimeField() ), params.getOutputType() ) )
-            .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
-            .build();
-
-        conditions.add( getDateRangeCondition( defaultDateRangeColumn ) );
-    }
-
-    private String getDateRangeCondition( ColumnWithDateRange defaultDateRangeColumn )
-    {
-        return "(" +
-            defaultDateRangeColumn.getColumn() +
-            " >= '" +
-            getMediumDateString( defaultDateRangeColumn.getDateRange().getStartDate() ) +
-            "' and " +
-            defaultDateRangeColumn.getColumn() +
-            " < '" +
-            getMediumDateString( defaultDateRangeColumn.getDateRange().getEndDatePlusOneDay() ) +
-            "')";
-    }
-
     protected abstract String getColumnName( Optional<TimeField> timeField, EventOutputType outputType );
 
-    protected abstract String getSqlConditionForNonDefaultBoundaries( EventQueryParams params );
+    /**
+     * Generates a SQL statement based on program indicators boundaries.
+     *
+     * @param params {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    protected abstract String getConditionForNonDefaultBoundaries( EventQueryParams params );
 
-    protected abstract Collection<TimeField> getAllowedTimeFields();
+    /**
+     * Simply returns a collection of {@link TimeField} allowed for the
+     * respective implementation.
+     *
+     * @return the collection of {@link TimeField}
+     */
+    protected abstract Set<TimeField> getAllowedTimeFields();
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/DataQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/DataQueryParamsTest.java
@@ -52,7 +52,6 @@ import java.util.Set;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
@@ -74,16 +73,12 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.DailyPeriodType;
-import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -159,6 +154,8 @@ class DataQueryParamsTest extends DhisConvenienceTest
     private OrganisationUnit ouA;
 
     private OrganisationUnit ouB;
+
+    //pe:202305:SCHEDULED_DATE;202303:SCHEDULED_DATE;202302:SCHEDULED_DATE
 
     @BeforeEach
     void setUpTest()
@@ -748,78 +745,5 @@ class DataQueryParamsTest extends DhisConvenienceTest
             IsIterableContainingInAnyOrder.containsInAnyOrder(
                 hasProperty( "isoDate", Matchers.is( peC.getIsoDate() ) ),
                 hasProperty( "isoDate", Matchers.is( peC.getIsoDate() ) ) ) );
-    }
-
-    @Test
-    void testContinuousDateRangeListForThisWeeklyAndDailyPeriods()
-    {
-        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD,
-                List.of( weeklyPeriod, todayPeriod ) ) )
-            .build();
-
-        params = new EventQueryParams.Builder( params )
-            .withStartEndDatesForPeriods()
-            .build();
-
-        assertEquals( 2, params.getDateRangeList().size() );
-        assertEquals( weeklyPeriod.getStartDate(), params.getDateRangeList().get( 0 ).getStartDate() );
-        assertEquals( weeklyPeriod.getEndDate(), params.getDateRangeList().get( 0 ).getEndDate() );
-        assertEquals( todayPeriod.getStartDate(), params.getDateRangeList().get( 1 ).getStartDate() );
-        assertEquals( todayPeriod.getEndDate(), params.getDateRangeList().get( 1 ).getEndDate() );
-        assertTrue( params.hasContinuousDateRangeList() );
-    }
-
-    @Test
-    void testContinuousDateRangeListForThisWeeklyDailyAndMonthlyPeriods()
-    {
-        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period monthlyPeriod = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD,
-                List.of( weeklyPeriod, todayPeriod, monthlyPeriod ) ) )
-            .build();
-
-        params = new EventQueryParams.Builder( params )
-            .withStartEndDatesForPeriods()
-            .build();
-
-        assertEquals( 3, params.getDateRangeList().size() );
-        assertEquals( weeklyPeriod.getStartDate(), params.getDateRangeList().get( 0 ).getStartDate() );
-        assertEquals( weeklyPeriod.getEndDate(), params.getDateRangeList().get( 0 ).getEndDate() );
-        assertEquals( todayPeriod.getStartDate(), params.getDateRangeList().get( 1 ).getStartDate() );
-        assertEquals( todayPeriod.getEndDate(), params.getDateRangeList().get( 1 ).getEndDate() );
-        assertEquals( monthlyPeriod.getStartDate(), params.getDateRangeList().get( 2 ).getStartDate() );
-        assertEquals( monthlyPeriod.getEndDate(), params.getDateRangeList().get( 2 ).getEndDate() );
-        assertTrue( params.hasContinuousDateRangeList() );
-    }
-
-    @Test
-    void testNotContinuousDateRangeListForWeeklyDailyAndMonthly()
-    {
-        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        // Due to sorting monthly period will be first one
-        Period monthlyPeriod = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 1, 1, 0, 0 ).toDate() );
-        EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD,
-                List.of( weeklyPeriod, todayPeriod, monthlyPeriod ) ) )
-            .build();
-
-        params = new EventQueryParams.Builder( params )
-            .withStartEndDatesForPeriods()
-            .build();
-
-        assertEquals( 3, params.getDateRangeList().size() );
-        assertEquals( monthlyPeriod.getStartDate(), params.getDateRangeList().get( 0 ).getStartDate() );
-        assertEquals( monthlyPeriod.getEndDate(), params.getDateRangeList().get( 0 ).getEndDate() );
-        assertEquals( weeklyPeriod.getStartDate(), params.getDateRangeList().get( 1 ).getStartDate() );
-        assertEquals( weeklyPeriod.getEndDate(), params.getDateRangeList().get( 1 ).getEndDate() );
-        assertEquals( todayPeriod.getStartDate(), params.getDateRangeList().get( 2 ).getStartDate() );
-        assertEquals( todayPeriod.getEndDate(), params.getDateRangeList().get( 2 ).getEndDate() );
-        assertFalse( params.hasContinuousDateRangeList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -145,7 +145,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
     }
@@ -164,7 +164,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where ((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where (lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
     }
@@ -388,7 +388,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -430,7 +430,7 @@ class EnrollmentAnalyticsManagerTest extends
             "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi )), double precision 'NaN')" + " as \""
             + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -502,7 +502,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -145,10 +145,9 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where ((enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
-
     }
 
     @Test
@@ -165,10 +164,9 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where lastupdated >= '2017-01-01' and lastupdated < '2018-01-01' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where ((lastupdated >= '2017-01-01' and lastupdated < '2018-01-01'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
-
     }
 
     @Test
@@ -390,7 +388,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -432,7 +430,7 @@ class EnrollmentAnalyticsManagerTest extends
             "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi )), double precision 'NaN')" + " as \""
             + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -504,7 +502,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where ((enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09'))and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.hisp.dhis.analytics.TimeField.INCIDENT_DATE;
+import static org.hisp.dhis.analytics.TimeField.LAST_UPDATED;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -63,7 +65,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     }
 
     @Test
-    void testRenderEventTimeFieldSqlWhenNonContinuousDateRangeList()
+    void testRenderEventTimeFieldSqlWhenNonContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .addDimension(
@@ -74,12 +76,12 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
         assertEquals(
-            "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-05-01' or ax.\"executiondate\" >= '2022-06-01'and ax.\"executiondate\" < '2022-07-01'))",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
+            "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-05-01') or (ax.\"executiondate\" >= '2022-06-01' and ax.\"executiondate\" < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
     @Test
-    void testRenderEventTimeFieldSqlWhenContinuousDateRangeList()
+    void testRenderEventTimeFieldSqlWhenContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .addDimension(
@@ -89,12 +91,12 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
+        assertEquals( "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
     @Test
-    void testRenderEnrollmentTimeFieldSqlWhenNonContinuousDateRangeList()
+    void testRenderEnrollmentTimeFieldSqlWhenNonContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .addDimension(
@@ -106,12 +108,12 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
         assertEquals(
-            "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-05-01' or enrollmentdate >= '2022-06-01'and enrollmentdate < '2022-07-01')",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
+            "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-05-01') or (enrollmentdate >= '2022-06-01' and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
     @Test
-    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeList()
+    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
             .addDimension(
@@ -122,7 +124,41 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
+        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
+    }
+
+    @Test
+    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldAllowed()
+    {
+        EventQueryParams params = new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .withTimeField( LAST_UPDATED.name() )
+            .build();
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
+            new PostgreSQLStatementBuilder() );
+
+        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
+
+        assertEquals( "(lastupdated >= '2022-04-01' and lastupdated < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
+    }
+
+    @Test
+    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldNotAllowed()
+    {
+        EventQueryParams params = new EventQueryParams.Builder()
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .withTimeField( INCIDENT_DATE.getField() )
+            .build();
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
+            new PostgreSQLStatementBuilder() );
+
+        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
+
+        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -74,8 +74,8 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
         assertEquals(
-            "(ax.\"executiondate\">='2022-04-01'andax.\"executiondate\"<'2022-05-01'orax.\"executiondate\">='2022-06-01'andax.\"executiondate\"<'2022-07-01')",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+            "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-05-01' or ax.\"executiondate\" >= '2022-06-01'and ax.\"executiondate\" < '2022-07-01'))",
+            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
     }
 
     @Test
@@ -89,8 +89,8 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "ax.\"executiondate\">='2022-04-01'andax.\"executiondate\"<'2022-07-01'",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+        assertEquals( "((ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01'))",
+            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
     }
 
     @Test
@@ -106,8 +106,8 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
         assertEquals(
-            "(enrollmentdate>='2022-04-01'andenrollmentdate<'2022-05-01'orenrollmentdate>='2022-06-01'andenrollmentdate<'2022-07-01')",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+            "((enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-05-01' or enrollmentdate >= '2022-06-01'and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
     }
 
     @Test
@@ -122,7 +122,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        assertEquals( "enrollmentdate>='2022-04-01'andenrollmentdate<'2022-07-01'",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+        assertEquals( "enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01'",
+            timeFieldSqlRenderer.renderTimeFieldSql( params ) );
     }
 }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -351,6 +353,18 @@ public abstract class DhisConvenienceTest
         dataTime = dataTime.withDayOfYear( day );
 
         return dataTime.toDate();
+    }
+
+    /**
+     * Converts a {@link Date} into a {@link LocalDate}.
+     *
+     * @param date the {@link Date}
+     * @return the {@link LocalDate} object
+     * @throws NullPointerException if the given date is null
+     */
+    public LocalDate toLocalDate( Date date )
+    {
+        return date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
     }
 
     /**


### PR DESCRIPTION
These changes should fix the problem regarding monthly periods. This was affecting analytics events and enrollments.

Before this fix, when we had more than one type of date specified (ie. `scheduled` and `execution date`), the final query considered was always and only the `execution date`.

Now, we will consider and allow different dates with different time ranges. During my tests, I also found out that the monthly periods were flattened, always taking the interval between the oldest and newest date. Now each monthly period is evaluated in isolation unless the range contains sequential months (in this case the code will consider only the oldest and newest date).

I also improved the related unit tests and included some basic clean-up + Javadoc.

As part of my manual tests, I tested the following scenarios (**_let me know if you think I should test some other case_**):

```
http://localhost:8080/dhis/api/40/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=202302,202305,202303&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/40/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=202305,202304,202303,202302&eventDate=202306,202307,202308&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/40/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=LAST_YEAR&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/40/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=202209,202210,202203&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/40/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate&totalPages=false&startDate=2023-01-01&endDate=2023-01-24&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/40/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/40/analytics/events/cluster/IpHINAT79UW?dimension=ou:USER_ORGUNIT&clusterSize=10&bbox=1,2,3,4&dimension=pe:LAST_12_MONTHS

http://localhost:8080/dhis/api/40/analytics/events/cluster/IpHINAT79UW?dimension=ou:USER_ORGUNIT&clusterSize=10&bbox=1,2,3,4&startDate=2022-01-01&endDate=2023-06-01

http://localhost:8080/dhis/api/40/analytics/events/query/eBAyeGv0exc?dimension=ou:lc3eMKXaEfw,tUdBD1JDxpn,gWxh7DiRmG7,x7PaHGvgWY2,hlPt8H4bUOQ,Y7hKDSuqEtH,oZg33kd9taw,GieVkTxp4HH-TBxGTceyzwy,HS8QXAJtuKV,vV9UWAZohSf-OrkEzxZEH4X&headers=eventdate,ouname,tUdBD1JDxpn,gWxh7DiRmG7,x7PaHGvgWY2,hlPt8H4bUOQ,Y7hKDSuqEtH,oZg33kd9taw,GieVkTxp4HH,HS8QXAJtuKV,vV9UWAZohSf&totalPages=false&eventDate=2023W5,20230105,202308,202304&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=Zj7UnCAulEk&asc=ouname

http://localhost:8080/dhis/api/29/analytics/events/aggregate/IpHINAT79UW.json?dimension=pe:202309;202306;2023S2;2023W2;LAST_12_MONTHS&dimension=A03MvHHogjR.cejWyOfXge6&dimension=A03MvHHogjR.wQLfBvPrXqq&dimension=ou:jUb8gELQApl;TEQlaapDQoK;eIQbndfxQMb;Vth0fbpFcsO;PMa2VCrupOd;O6uvpzGd5pu;bL4ooGhyHRQ;kJq2mPyFEHo;fdc6uOvgoji;at6UHUQatSo;lc3eMKXaEfw;qhqAxPSTUXp;jmIPBj66vD6&stage=A03MvHHogjR&displayProperty=NAME&totalPages=false&outputType=EVENT&programStatus=ACTIVE&eventStatus=ACTIVE

http://localhost:8080/dhis/api/40/analytics?dimension=dx:ReUHfIn0pTQ,ou:O6uvpzGd5pu;fdc6uOvgoji;lc3eMKXaEfw;jUb8gELQApl;PMa2VCrupOd;kJq2mPyFEHo;qhqAxPSTUXp;Vth0fbpFcsO;jmIPBj66vD6;TEQlaapDQoK;bL4ooGhyHRQ;eIQbndfxQMb;at6UHUQatSo&filter=pe:THIS_YEAR;202301;202302;202207;20230103;2023WedW6&displayProperty=NAME&includeNumDen=false&skipMeta=false&skipData=true&includeMetadataDetails=true
```
