### PR TITLE
fix: Predictor with integer P.I.s DHIS2-14499

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcher.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcher.java
@@ -197,6 +197,11 @@ public class PredictionAnalyticsDataFetcher
             String ao = hasAttributeOptions ? (String) row.get( aoInx ) : null;
             Object vl = row.get( vlInx );
 
+            if ( vl instanceof Number && !(vl instanceof Double) )
+            {
+                vl = ((Number) vl).doubleValue();
+            }
+
             Period period = periodLookup.get( pe );
             DimensionalItemObject item = analyticsItemsLookup.get( dx );
             OrganisationUnit orgUnit = orgUnitLookup.get( ou );

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -179,7 +179,7 @@ class PredictionAnalyticsDataFetcherTest
             .addValue( programIndicatorB.getUid() )
             .addValue( orgUnitA.getUid() )
             .addValue( aocC.getUid() )
-            .addValue( 20 ); // Note: boxed as Long, not Double
+            .addValue( 20L ); // Note: boxed as Long, not Double
 
         aocGrid.addRow()
             .addValue( periodB.getIsoDate() )

--- a/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/test/java/org/hisp/dhis/predictor/PredictionAnalyticsDataFetcherTest.java
@@ -179,7 +179,7 @@ class PredictionAnalyticsDataFetcherTest
             .addValue( programIndicatorB.getUid() )
             .addValue( orgUnitA.getUid() )
             .addValue( aocC.getUid() )
-            .addValue( 20.0 );
+            .addValue( 20 ); // Note: boxed as Long, not Double
 
         aocGrid.addRow()
             .addValue( periodB.getIsoDate() )


### PR DESCRIPTION
See [DHIS2-14499](https://dhis2.atlassian.net/browse/DHIS2-14499). Some analytics objects such as some program indicators now return `Long` instead of `Double`. The expression parser expects all numeric values to be `Double`, so predictors were breaking.

The fix is to make sure all analytics values are processed in predictor expressions as `Double`.

[DHIS2-14499]: https://dhis2.atlassian.net/browse/DHIS2-14499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ