### PR TITLE
fix: Predictor skipTest with no data DHIS2-14422

### DIFF
--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/predictor/DefaultPredictionService.java
@@ -408,7 +408,8 @@ public class DefaultPredictionService
         for ( Period p : allSamplePeriods )
         {
             if ( aocData.get( p ) != null &&
-                (Boolean) expressionService.getExpressionValue( baseExParams.toBuilder()
+            // Note: getExpressionValue could return null if no data is found
+                Boolean.TRUE == expressionService.getExpressionValue( baseExParams.toBuilder()
                     .expression( skipTest.getExpression() )
                     .parseType( PREDICTOR_SKIP_TEST )
                     .valueMap( aocData.get( p ) )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/predictor/PredictionServiceTest.java
@@ -557,6 +557,26 @@ class PredictionServiceTest extends IntegrationTestBase
     }
 
     @Test
+    void testPredictWithSkipTest()
+    {
+        useDataValue( dataElementA, makeMonth( 2023, 1 ), sourceA, 10 );
+        useDataValue( dataElementA, makeMonth( 2023, 2 ), sourceA, 20 );
+        useDataValue( dataElementA, makeMonth( 2023, 3 ), sourceA, 40 );
+
+        useDataValue( dataElementB, makeMonth( 2023, 2 ), sourceA, 10 );
+        dataValueBatchHandler.flush();
+
+        Expression expression = new Expression( "sum(#{" + dataElementA.getUid() + "})", "expression" );
+        Expression skipTest = new Expression( "#{" + dataElementB.getUid() + "} == 10", "skipTest" );
+        Predictor p = createPredictor( dataElementX, defaultCombo, "PredictWithSkip", expression, skipTest,
+            periodTypeMonthly, orgUnitLevel1, 3, 0, 0 );
+
+        predictionService.predict( p, monthStart( 2023, 4 ), monthStart( 2023, 5 ), summary );
+        assertEquals( "Pred 1 Ins 1 Upd 0 Del 0 Unch 0", shortSummary( summary ) );
+        assertEquals( "50.0", getDataValue( dataElementX, defaultCombo, sourceA, makeMonth( 2023, 4 ) ) );
+    }
+
+    @Test
     void testPredictSequentialStddevPop()
     {
         setupTestData();


### PR DESCRIPTION
See [DHIS2-14422](https://dhis2.atlassian.net/browse/DHIS2-14422). When the prediction service was testing the result of a skip test, it was assuming the expression evaluation result was boolean. However if the data referenced by the skip test was missing, the expression would return null. The fix is to explicitly see if the value returned is `Boolean.TRUE`.

A unit test has been added that fails without the fix and succeeds with it.

[DHIS2-14422]: https://dhis2.atlassian.net/browse/DHIS2-14422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ