### PR TITLE
fix: P.I. custom aggregation func desc DHIS2-14500

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -66,6 +66,8 @@ import org.hisp.dhis.program.Program;
 @Builder( toBuilder = true )
 public class ExpressionParams
 {
+    public static final ExpressionParams DEFAULT_EXPRESSION_PARAMS;
+
     /**
      * Dummy data for sample periods, so in the absence of real sampled data the
      * parser will still traverse the contents of aggregation functions once for
@@ -84,6 +86,7 @@ public class ExpressionParams
         period.setStartDate( genTheFirst99 );
         period.setEndDate( genTheFirst99 );
         SAMPLE_PERIODS = Collections.singletonList( period );
+        DEFAULT_EXPRESSION_PARAMS = builder().build();
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -30,10 +30,12 @@ package org.hisp.dhis.program;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castClass;
 import static org.hisp.dhis.antlr.AntlrParserUtils.castString;
+import static org.hisp.dhis.expression.ExpressionParams.DEFAULT_EXPRESSION_PARAMS;
 import static org.hisp.dhis.jdbc.StatementBuilder.ANALYTICS_TBL_ALIAS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_DESCRIPTIONS;
 import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
 import static org.hisp.dhis.parser.expression.ParserUtils.COMMON_EXPRESSION_ITEMS;
+import static org.hisp.dhis.parser.expression.ProgramExpressionParams.DEFAULT_PROGRAM_EXPRESSION_PARAMS;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.AVG;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.A_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.COUNT;
@@ -331,7 +333,8 @@ public class DefaultProgramIndicatorService
     @Transactional( readOnly = true )
     public void validate( String expression, Class<?> clazz, Map<String, String> itemDescriptions )
     {
-        CommonExpressionVisitor visitor = newVisitor( ITEM_GET_DESCRIPTIONS, null, null );
+        CommonExpressionVisitor visitor = newVisitor( ITEM_GET_DESCRIPTIONS, DEFAULT_EXPRESSION_PARAMS,
+            DEFAULT_PROGRAM_EXPRESSION_PARAMS );
 
         castClass( clazz, Parser.visit( expression, visitor ) );
 

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ProgramExpressionParams.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ProgramExpressionParams.java
@@ -44,6 +44,8 @@ import org.hisp.dhis.program.ProgramIndicator;
 @Builder
 public class ProgramExpressionParams
 {
+    public static final ProgramExpressionParams DEFAULT_PROGRAM_EXPRESSION_PARAMS = builder().build();
+
     /**
      * Program indicator
      */

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceTest.java
@@ -32,6 +32,7 @@ import static org.hisp.dhis.analytics.DataType.NUMERIC;
 import static org.hisp.dhis.program.ProgramIndicator.KEY_ATTRIBUTE;
 import static org.hisp.dhis.program.ProgramIndicator.KEY_DATAELEMENT;
 import static org.hisp.dhis.program.ProgramIndicator.KEY_PROGRAM_VARIABLE;
+import static org.hisp.dhis.utils.Assertions.assertMapEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -39,8 +40,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.hisp.dhis.common.ValueType;
@@ -478,6 +481,20 @@ class ProgramIndicatorServiceTest extends TransactionalIntegrationTest
             .filterIsValid( "d2:hasValue(#{" + psA.getUid() + "." + deGBoolean.getUid() + "})" ) );
         assertTrue(
             programIndicatorService.filterIsValid( "d2:hasValue(#{" + psA.getUid() + "." + deHDate.getUid() + "})" ) );
+    }
+
+    @Test
+    void testValidate()
+    {
+        Map<String, String> descriptions = new HashMap<>();
+        programIndicatorService.validate( "#{" + psA.getUid() + "." + deAInteger.getUid() + "}",
+            Double.class, descriptions );
+        assertMapEquals( Map.of( "#{ProgrmStagA.DataElmentA}", "StageA\\.DataElementA" ), descriptions );
+
+        descriptions = new HashMap<>();
+        programIndicatorService.validate( "sum(#{" + psA.getUid() + "." + deAInteger.getUid() + "})",
+            Double.class, descriptions );
+        assertMapEquals( Map.of( "#{ProgrmStagA.DataElmentA}", "StageA\\.DataElementA" ), descriptions );
     }
 
     @Test


### PR DESCRIPTION
See [DHIS2-14500](https://dhis2.atlassian.net/browse/DHIS2-14500). When using a custom aggregation function in a program indicator expression, the code that validates it was getting a NPE.

The fix is to use default parameters instead of `null` inside `DefaultProgramIndicatorService.validate`.

[DHIS2-14500]: https://dhis2.atlassian.net/browse/DHIS2-14500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ