### PR TITLE
fix: data integrity test setup so it is execution order independent

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegrityDetailsControllerTest.java
@@ -33,8 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
-
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
 import org.hisp.dhis.jsontree.JsonList;
 import org.hisp.dhis.web.HttpStatus;
@@ -95,7 +93,8 @@ class DataIntegrityDetailsControllerTest extends AbstractDataIntegrityController
             .content().as( JsonDataIntegrityDetails.class );
         assertNotNull( details );
 
-        assertEquals( List.of( "categories_no_options" ),
-            GET( "/dataIntegrity/details/completed" ).content().stringValues() );
+        //OBS! The result is based on application scoped map so there might be other values from other tests
+        assertTrue(
+            GET( "/dataIntegrity/details/completed" ).content().stringValues().contains( "categories_no_options" ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataIntegritySummaryControllerTest.java
@@ -33,8 +33,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.List;
-
 import org.hisp.dhis.dataintegrity.DataIntegrityCheckType;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.json.domain.JsonDataIntegritySummary;
@@ -88,7 +86,8 @@ class DataIntegritySummaryControllerTest extends AbstractDataIntegrityController
             .as( JsonDataIntegritySummary.class );
         assertNotNull( summary );
 
-        assertEquals( List.of( "categories_no_options" ),
-            GET( "/dataIntegrity/summary/completed" ).content().stringValues() );
+        //OBS! The result is based on application scoped map so there might be other values from other tests
+        assertTrue(
+            GET( "/dataIntegrity/summary/completed" ).content().stringValues().contains( "categories_no_options" ) );
     }
 }


### PR DESCRIPTION
The issue with the test setup is that the endpoint cannot be tested in isolation as long as the same spring application context is used for multiple tests. Therefore the expectation here needed to be relaxed to just check that at least the check that the setup did run must be in the completed set but there may be other checks from other tests too.