### PR TITLE
fix(valueType): move MULTI_TEXT valueType order

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/ValueType.java
@@ -53,6 +53,7 @@ public enum ValueType
 {
     TEXT( String.class, true ),
     LONG_TEXT( String.class, true ),
+    MULTI_TEXT( String.class, true ),
     LETTER( String.class, true ),
     PHONE_NUMBER( String.class, false ),
     EMAIL( String.class, false ),
@@ -77,8 +78,7 @@ public enum ValueType
     URL( String.class, false ),
     FILE_RESOURCE( String.class, true, FileTypeValueOptions.class ),
     IMAGE( String.class, false, FileTypeValueOptions.class ),
-    GEOJSON( String.class, false ),
-    MULTI_TEXT( String.class, true );
+    GEOJSON( String.class, false );
 
     /**
      * The character used to separate values in a multi-text value.


### PR DESCRIPTION
Most of the other constants are grouped "logically", eg. text and integers are next to each other in the list. Instead of creating a custom ordering in the client, I think it make sense to move `MULTI_TEXT` to be next to the other "text"-options.

