### PR TITLE
refactor: ExpressionParams.expressionInfo TECH-1497

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expression/ExpressionParams.java
@@ -207,7 +207,7 @@ public class ExpressionParams
      * {@see ExpressionInfo} instance.
      */
     @Builder.Default
-    private ExpressionInfo expressionInfo = new ExpressionInfo();
+    private final ExpressionInfo expressionInfo = new ExpressionInfo();
 
     // -------------------------------------------------------------------------
     // Logic


### PR DESCRIPTION
See [TECH-1497](https://dhis2.atlassian.net/browse/TECH-1497). All `ExpressionParams` fields are immutable and should be marked `final`.

[TECH-1497]: https://dhis2.atlassian.net/browse/TECH-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ