### PR TITLE
fix: Scheduler - reliably remove jobs from schedule [DHIS2-14316]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -335,7 +335,7 @@ public enum ErrorCode
     E7000( "Job of same type already scheduled with cron expression: `{0}`" ),
     E7003( "Only interval property can be configured for non configurable job type: `{0}`" ),
     E7004( "Cron expression must be not null for job with scheduling type CRON: `{0}`" ),
-    E7005( "Cron expression is invalid for job: `{0}` " ),
+    E7005( "Cron expression is invalid: `{0}`" ),
     E7006( "Failed to execute job: `{0}`" ),
     E7007( "Delay must be not null for job with scheduling type FIXED_DELAY: `{0}`" ),
     E7010( "Failed to validate job runtime: `{0}`" ),

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 import org.hisp.dhis.scheduling.parameters.jackson.JobConfigurationSanitizer;
@@ -340,7 +341,8 @@ public class JobConfiguration
         @JsonSubTypes.Type( value = DisableInactiveUsersJobParameters.class, name = "DISABLE_INACTIVE_USERS" ),
         @JsonSubTypes.Type( value = TrackerTrigramIndexJobParameters.class, name = "TRACKER_SEARCH_OPTIMIZATION" ),
         @JsonSubTypes.Type( value = DataIntegrityJobParameters.class, name = "DATA_INTEGRITY" ),
-        @JsonSubTypes.Type( value = AggregateDataExchangeJobParameters.class, name = "AGGREGATE_DATA_EXCHANGE" )
+        @JsonSubTypes.Type( value = AggregateDataExchangeJobParameters.class, name = "AGGREGATE_DATA_EXCHANGE" ),
+        @JsonSubTypes.Type( value = TestJobParameters.class, name = "TEST" )
     } )
     public JobParameters getJobParameters()
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -42,6 +42,7 @@ import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 
@@ -117,6 +118,7 @@ public enum JobType
     SYSTEM_VERSION_UPDATE_CHECK( false ),
 
     // Testing purposes
+    TEST( true, SchedulingType.CRON, TestJobParameters.class, null ),
     MOCK( false, SchedulingType.CRON, MockJobParameters.class, null ),
 
     // Deprecated, present to satisfy code using the old enumeration

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -93,8 +93,13 @@ public interface SchedulingManager
     void scheduleWithStartTime( JobConfiguration configuration, Date startTime );
 
     /**
-     * Stops the currently running task with the same {@link JobType} as the
-     * provided configuration.
+     * Removes any existing schedule for the given {@link JobConfiguration}.
+     *
+     * If the configuration does not have an ID nor a name this operation has no
+     * effect.
+     *
+     * This will not interrupt and abort a currently running job. To abort
+     * execution use {@link #cancel(JobType)}.
      */
     void stop( JobConfiguration configuration );
 
@@ -105,14 +110,20 @@ public interface SchedulingManager
      * running.
      *
      * @param configuration The configuration of the job to be executed
-     * @return true, if the job was executed successful. If the execution is
-     *         asynchronous true is returned if the job was accepted for
-     *         execution.
+     * @return true, if the job was accepted for execution. This means no job of
+     *         the same type was running but the another job might still manage
+     *         to reach the {@link Job#execute(JobConfiguration, JobProgress)}
+     *         method first in which case this execution is aborted.
      */
     boolean executeNow( JobConfiguration configuration );
 
     /**
-     * Request cancellation for job of given type potentially running currently
+     * Request cancellation for job of given type. If no job of that type is
+     * currently running the operation has no effect.
+     *
+     * Cancellation is cooperative abort. The job will abort at the next
+     * possible "safe-point". This is the next step or item in the overall
+     * process which checks for cancellation.
      *
      * @param type job type to cancel
      */

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -71,8 +71,7 @@ public interface SchedulingManager
     /**
      * Schedules a job with the given job configuration.
      *
-     * This stops running jobs of the same {@link JobType} is necessary and
-     * replaces existing scheduled tasks in the future.
+     * This removes previously issued scheduling for the configuration.
      *
      * The job will be scheduled based on the
      * {@link JobConfiguration#getCronExpression()} property.
@@ -84,8 +83,7 @@ public interface SchedulingManager
     /**
      * Schedule a job with the given start time.
      *
-     * This stops running jobs of the same {@link JobType} is necessary and
-     * replaces existing scheduled tasks in the future.
+     * This removes previously issued scheduling for the configuration.
      *
      * @param configuration The configuration with job details to be scheduled
      * @param startTime The time at which the job should start
@@ -102,6 +100,19 @@ public interface SchedulingManager
      * execution use {@link #cancel(JobType)}.
      */
     void stop( JobConfiguration configuration );
+
+    /**
+     * Check if a configuration is already scheduled for execution(s) in the
+     * future.
+     *
+     * @param configuration the configuration to check
+     * @return true, if the configuration will execute in the future, false if
+     *         it has not been scheduled
+     */
+    default boolean isScheduled( JobConfiguration configuration )
+    {
+        return false; // overridden by implementations supporting scheduling
+    }
 
     /**
      * Ad-hoc execution of a {@link JobConfiguration}.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling.parameters;
+
+import java.util.Optional;
+
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.scheduling.JobParameters;
+import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+@JacksonXmlRootElement( localName = "jobParameters", namespace = DxfNamespaces.DXF_2_0 )
+public class TestJobParameters implements JobParameters
+{
+    /**
+     * Initial waiting time in millis (as there is no actual "work" done)
+     */
+    private Long waitMillis;
+
+    /**
+     * Number of stages in the job, zero if {@code null}
+     */
+    private Integer stages;
+
+    /**
+     * Stage number at which an item fails, none of {@code null}
+     */
+    private Integer failAtStage;
+
+    /**
+     * Number of items in each stage, none if {@code null}
+     */
+    private Integer items;
+
+    /**
+     * Item number in the failing stage at which the failure occurs, none if
+     * {@code null}
+     */
+    private Integer failAtItem;
+
+    /**
+     * Duration each item takes in millis, zero if {@code null}
+     */
+    private Long itemDuration;
+
+    /**
+     * The message used when failing the item
+     */
+    private String failWithMessage;
+
+    /**
+     * When true, an exception is used to fail, otherwise the progress tracking
+     * api is used
+     */
+    private boolean failWithException;
+
+    /**
+     * Stage failure policy to use, when {@code null} it is the default policy
+     */
+    private FailurePolicy failWithPolicy;
+
+    private boolean runStagesParallel;
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Long getWaitMillis()
+    {
+        return waitMillis;
+    }
+
+    public void setWaitMillis( Long waitMillis )
+    {
+        this.waitMillis = waitMillis;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getStages()
+    {
+        return stages;
+    }
+
+    public void setStages( Integer stages )
+    {
+        this.stages = stages;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getFailAtStage()
+    {
+        return failAtStage;
+    }
+
+    public void setFailAtStage( Integer failAtStage )
+    {
+        this.failAtStage = failAtStage;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getItems()
+    {
+        return items;
+    }
+
+    public void setItems( Integer items )
+    {
+        this.items = items;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getFailAtItem()
+    {
+        return failAtItem;
+    }
+
+    public void setFailAtItem( Integer failAtItem )
+    {
+        this.failAtItem = failAtItem;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Long getItemDuration()
+    {
+        return itemDuration;
+    }
+
+    public void setItemDuration( Long itemDuration )
+    {
+        this.itemDuration = itemDuration;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getFailWithMessage()
+    {
+        return failWithMessage;
+    }
+
+    public void setFailWithMessage( String failWithMessage )
+    {
+        this.failWithMessage = failWithMessage;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isFailWithException()
+    {
+        return failWithException;
+    }
+
+    public void setFailWithException( boolean failWithException )
+    {
+        this.failWithException = failWithException;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public FailurePolicy getFailWithPolicy()
+    {
+        return failWithPolicy;
+    }
+
+    public void setFailWithPolicy( FailurePolicy failWithPolicy )
+    {
+        this.failWithPolicy = failWithPolicy;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isRunStagesParallel()
+    {
+        return runStagesParallel;
+    }
+
+    public void setRunStagesParallel( boolean runStagesParallel )
+    {
+        this.runStagesParallel = runStagesParallel;
+    }
+
+    @Override
+    public Optional<ErrorReport> validate()
+    {
+        return Optional.empty();
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/TestJobParametersDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/TestJobParametersDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling.parameters.jackson;
+
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+public class TestJobParametersDeserializer extends AbstractJobParametersDeserializer<TestJobParameters>
+{
+    public TestJobParametersDeserializer()
+    {
+        super( TestJobParameters.class, CustomJobParameters.class );
+    }
+
+    @JsonDeserialize
+    public static class CustomJobParameters extends TestJobParameters
+    {
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -226,11 +226,12 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
      * Runs a job queue sequence.
      *
      * @param name name of the queue to run
+     * @param startPosition first position in the queue to run
      * @return true, if the entire sequence ran successful, otherwise false
      */
-    protected final boolean executeQueue( String name )
+    protected final boolean executeQueue( String name, int startPosition )
     {
-        int position = 0;
+        int position = startPosition;
         while ( true )
         {
             // OBS! intentionally the sequence is reloaded every time to allow for changes of the sequence

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobQueueService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultJobQueueService.java
@@ -47,6 +47,7 @@ import org.hisp.dhis.common.IdentifiableObjectStore;
 import org.hisp.dhis.feedback.ConflictException;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -96,6 +97,7 @@ public class DefaultJobQueueService implements JobQueueService
             throw new ConflictException( ErrorCode.E7021, name );
         }
         Map<String, JobConfiguration> queueJobs = getQueueJobsByIds( sequence );
+        validateCronExpression( cronExpression );
         validateQueue( name, queueJobs.values() );
         addSequenceToQueue( name, cronExpression, sequence, queueJobs );
     }
@@ -112,6 +114,7 @@ public class DefaultJobQueueService implements JobQueueService
             throw new NotFoundException( ErrorCode.E7020, name );
         }
         Map<String, JobConfiguration> newQueueJobs = getQueueJobsByIds( newSequence );
+        validateCronExpression( newCronExpression );
         validateQueue( name, newQueueJobs.values() );
         addSequenceToQueue( name, newCronExpression, newSequence, newQueueJobs );
         oldQueueJobs.entrySet().stream()
@@ -157,6 +160,19 @@ public class DefaultJobQueueService implements JobQueueService
         {
             JobConfiguration config = systemJob.get();
             throw new ConflictException( ErrorCode.E7023, config.getUid() );
+        }
+    }
+
+    private void validateCronExpression( String cronExpression )
+        throws ConflictException
+    {
+        try
+        {
+            CronExpression.parse( cronExpression );
+        }
+        catch ( IllegalArgumentException ex )
+        {
+            throw new ConflictException( ErrorCode.E7005, ex.getMessage() );
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
@@ -36,7 +36,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.function.Function;
@@ -72,9 +71,20 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
 {
     private static final int DEFAULT_INITIAL_DELAY_S = 10;
 
-    private final Map<JobType, Future<?>> scheduled = new ConcurrentHashMap<>();
-
-    private final Map<JobType, Future<?>> running = new ConcurrentHashMap<>();
+    /**
+     * When a job is scheduled using an executor that will then invoke the job
+     * at specific times in the future a {@link Future} is added to the map
+     * which can be used to stop the job to continue to run in the future. It is
+     * essentially removed from the executor.
+     *
+     * The key is the UID of the {@link JobConfiguration}. Should the UID be
+     * {@code null} the {@link JobConfiguration#getName()} is used as key.
+     *
+     * This means any {@link JobConfiguration} only aborts itself from further
+     * runs in the future. Other configurations for the same {@link JobType}
+     * might exist and continue to run if there have been scheduled to do so.
+     */
+    private final Map<String, Future<?>> removeFromScheduleByIdOrName = new ConcurrentHashMap<>();
 
     private final TaskScheduler jobScheduler;
 
@@ -101,64 +111,66 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
     }
 
     @Override
-    public void schedule( JobConfiguration configuration )
+    public void schedule( JobConfiguration conf )
     {
-        boolean isCronTriggered = configuration.getJobType().getSchedulingType() == SchedulingType.CRON;
-        if ( isCronTriggered && isNullOrEmpty( configuration.getCronExpression() ) )
+        boolean isCronTriggered = conf.getJobType().getSchedulingType() == SchedulingType.CRON;
+        if ( isCronTriggered && isNullOrEmpty( conf.getCronExpression() ) )
         {
-            log.info( "Ignoring CRON schedule for {} as it is not ready to run.", configuration.getJobType() );
+            log.warn( "Job {} of type {} cannot be scheduled as it has no CRON expression.", conf.getUid(),
+                conf.getJobType() );
             return;
         }
-        log.info( "Scheduling job: {}", configuration );
+        log.info( "Scheduling job: {}", conf );
 
-        scheduleTask( configuration, task -> isCronTriggered
-            ? scheduleCronBased( configuration, task )
-            : scheduleFixedDelayBased( configuration, task ) );
-
-        log.info( "Scheduled job: {}", configuration );
+        if ( scheduleTask( conf, task -> isCronTriggered
+            ? scheduleCronBased( conf, task )
+            : scheduleFixedDelayBased( conf, task ) ) )
+        {
+            log.info( "Scheduled job: {}", conf );
+        }
     }
 
     @Override
-    public void scheduleWithStartTime( JobConfiguration configuration, Date startTime )
+    public void scheduleWithStartTime( JobConfiguration conf, Date startTime )
     {
-        scheduleTask( configuration, task -> scheduleTimeBased( startTime, task ) );
-
-        log.info( "Scheduled job: {} with start time: {}", configuration, getMediumDateString( startTime ) );
+        if ( scheduleTask( conf, task -> scheduleTimeBased( startTime, task ) ) )
+        {
+            log.info( "Scheduled job: {} with start time: {}", conf, getMediumDateString( startTime ) );
+        }
     }
 
-    private void scheduleTask( JobConfiguration configuration, Function<Runnable, Future<?>> scheduler )
+    private boolean scheduleTask( JobConfiguration conf, Function<Runnable, Future<?>> schedule )
     {
-        String jobId = configuration.getUid();
-        JobType type = configuration.getJobType();
-        CompletableFuture<Future<?>> cancellation = new CompletableFuture<>();
-        Runnable task = configuration.isInMemoryJob()
-            ? () -> execute( configuration )
-            : !isNullOrEmpty( configuration.getQueueName() )
-                ? () -> executeQueue( configuration.getQueueName() )
+        String jobId = conf.getUid();
+        if ( isNullOrEmpty( jobId ) && isNullOrEmpty( conf.getName() ) )
+        {
+            log.warn( "Aborted scheduling of job of type {} as no UID or name was given", conf.getJobType() );
+            return false;
+        }
+        Runnable task = conf.isInMemoryJob()
+            ? () -> execute( conf )
+            : !isNullOrEmpty( conf.getQueueName() )
+                ? () -> executeQueue( conf.getQueueName() )
                 : () -> execute( jobId );
-        Future<?> cancelable = scheduler.apply( runIfPossible( configuration, cancellation, task ) );
-        Future<?> scheduledBefore = scheduled.put( type, cancelable );
-        if ( scheduledBefore != null && !scheduledBefore.cancel( true ) )
-        {
-            cancellation.cancel( false );
-        }
-        else
-        {
-            cancellation.complete( cancelable );
-        }
+        Future<?> removeFromSchedule = schedule.apply( task );
+        String key = getKey( conf );
+        Future<?> removeScheduledBefore = removeFromScheduleByIdOrName.put( key, removeFromSchedule );
+        removeFromSchedule( conf, key, removeScheduledBefore );
+        log.info( "Job {} of type {} has been added to the schedule", key, conf.getJobType() );
+        return true;
     }
 
-    private Future<?> scheduleFixedDelayBased( JobConfiguration configuration, Runnable task )
+    private Future<?> scheduleFixedDelayBased( JobConfiguration conf, Runnable task )
     {
         return jobScheduler.scheduleWithFixedDelay( task,
             Instant.now().plusSeconds( DEFAULT_INITIAL_DELAY_S ),
-            Duration.of( configuration.getDelay(), ChronoUnit.SECONDS ) );
+            Duration.of( conf.getDelay(), ChronoUnit.SECONDS ) );
     }
 
-    private Future<?> scheduleCronBased( JobConfiguration configuration, Runnable task )
+    private Future<?> scheduleCronBased( JobConfiguration conf, Runnable task )
     {
         return jobScheduler.schedule( task,
-            new CronTrigger( configuration.getCronExpression() ) );
+            new CronTrigger( conf.getCronExpression() ) );
     }
 
     private Future<?> scheduleTimeBased( Date startTime, Runnable task )
@@ -167,99 +179,46 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
     }
 
     @Override
-    public void stop( JobConfiguration configuration )
+    public boolean executeNow( JobConfiguration conf )
     {
-        JobType type = configuration.getJobType();
-        if ( type != null && isRunningLocally( type ) )
-        {
-            stoppedSuccessful( type );
-        }
-    }
-
-    @Override
-    public boolean executeNow( JobConfiguration configuration )
-    {
-        if ( configuration == null )
+        if ( conf == null || conf.getJobType() == null || isRunning( conf.getJobType() ) )
         {
             return false;
         }
-        JobType type = configuration.getJobType();
-        if ( type == null || isRunning( type ) )
-        {
-            return false;
-        }
-        log.info( "Scheduler initiated execution of job: {}", configuration );
-        CompletableFuture<Future<?>> cancellation = new CompletableFuture<>();
-        Runnable task = runIfPossible( configuration, cancellation, () -> execute( configuration ) );
-        cancellation.complete( taskExecutor.executeTaskWithCancelation( task ) );
+        log.info( "Scheduler initiated execution of job: {}", conf );
+        taskExecutor.executeTaskWithCancelation( () -> execute( conf ) );
         return true;
     }
 
-    /**
-     * Wraps the original task in order to manage cancellation state correctly
-     * as part of running the task so that transitions occur when the task
-     * actually executes.
-     */
-    private Runnable runIfPossible( JobConfiguration configuration, Future<Future<?>> cancellation, Runnable task )
+    @Override
+    public void stop( JobConfiguration conf )
     {
-        JobType type = configuration.getJobType();
-        return () -> {
-            Future<?> cancelable = getOrThrow( cancellation );
-            if ( cancelable == null )
-            {
-                log.warn( "Job {} aborted as no cancellation was provided", type );
-                return;
-            }
-            scheduled.remove( type, cancelable );
-            if ( type == null || isRunningLocally( type ) && !stoppedSuccessful( type ) || isRunningRemotely( type ) )
-            {
-                return;
-            }
-            running.put( type, cancelable );
-            try
-            {
-                task.run();
-            }
-            finally
-            {
-                JobStatus lastExecutedStatus = configuration.getLastExecutedStatus();
-                if ( cancelable.isCancelled()
-                    && (lastExecutedStatus == JobStatus.RUNNING || lastExecutedStatus == JobStatus.COMPLETED) )
-                {
-                    configuration.setLastExecutedStatus( JobStatus.STOPPED );
-                }
-                running.remove( type, cancelable );
-            }
-        };
-    }
-
-    private Future<?> getOrThrow( Future<Future<?>> cancelProvider )
-    {
-        try
+        String key = getKey( conf );
+        if ( isNullOrEmpty( key ) )
         {
-            return cancelProvider.get();
-        }
-        catch ( InterruptedException ex )
-        {
-            Thread.currentThread().interrupt();
-            return null;
-        }
-        catch ( Exception ex )
-        {
-            throw ex instanceof RuntimeException ? (RuntimeException) ex : new RuntimeException( ex );
+            removeFromSchedule( conf, key, removeFromScheduleByIdOrName.get( key ) );
         }
     }
 
-    private boolean stoppedSuccessful( JobType type )
+    private void removeFromSchedule( JobConfiguration conf, String key, Future<?> removeFromSchedule )
     {
-        Future<?> cancelable = running.get( type );
-        if ( cancelable == null )
+        JobType type = conf.getJobType();
+        if ( removeFromSchedule == null )
         {
-            log.info( "Tried to stop job of type '{}' but no job was found", type );
-            return true;
+            log.info( "Tried to remove job '{}' of type '{}' from schedule but it was not scheduled.", key, type );
+            return;
         }
-        boolean success = cancelable.isDone() || cancelable.cancel( true );
-        log.info( "Stopped job of type: '{}' with successful result: '{}'", type, success );
-        return success;
+        if ( removeFromSchedule.isDone() )
+        {
+            log.info( "Tried to remove job '{}' of type '{}' from schedule but it was already removed.", key, type );
+            return;
+        }
+        boolean accepted = removeFromSchedule.cancel( false );
+        log.info( "Job '{}' of type: '{}' was removed from schedule: '{}'", key, type, accepted );
+    }
+
+    private static String getKey( JobConfiguration conf )
+    {
+        return isNullOrEmpty( conf.getUid() ) ? conf.getName() : conf.getUid();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/TestJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/TestJob.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling;
+
+import static java.lang.String.format;
+
+import java.util.stream.IntStream;
+
+import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
+import org.springframework.stereotype.Component;
+
+/**
+ * A job for testing purposes that allows to fail in a controlled way.
+ *
+ * @author Jan Bernitt
+ */
+@Component
+public class TestJob implements Job
+{
+    @Override
+    public JobType getJobType()
+    {
+        return JobType.TEST;
+    }
+
+    @Override
+    @SuppressWarnings( "java:S3776" ) // better keeping all processing in one loop
+    public void execute( JobConfiguration conf, JobProgress progress )
+    {
+        TestJobParameters params = (TestJobParameters) conf.getJobParameters();
+        progress.startingProcess( "Test job" );
+
+        // initial wait stage
+        long waitTime = params.getWaitMillis() == null ? 0L : params.getWaitMillis();
+        progress.startingStage( format( "Waiting for %dms", waitTime ) );
+        simulateWorkForDuration( waitTime );
+        progress.completedStage( format( "waited for %dms", waitTime ) );
+
+        // additional stages (potentially with items)
+        int stages = params.getStages() == null ? 1 : params.getStages();
+        int items = params.getItems() == null ? 0 : params.getItems();
+        int failAtStage = params.getFailAtStage() == null ? -1 : params.getFailAtStage();
+        int failAtItemDefault = items > 0 && failAtStage >= 0 ? 0 : -1;
+        int failAtItem = params.getFailAtItem() == null ? failAtItemDefault : params.getFailAtItem();
+        String msg = params.getFailWithMessage() == null ? "Simulated error" : params.getFailWithMessage();
+        FailurePolicy policy = params.getFailWithPolicy() == null
+            ? FailurePolicy.PARENT
+            : params.getFailWithPolicy();
+        if ( stages > 0 )
+        {
+            for ( int stage = 0; stage < stages; stage++ )
+            {
+                progress.startingStage( format( "Stage %d", stage ), items, policy );
+                if ( items > 0 )
+                {
+                    if ( params.isFailWithException() )
+                    {
+                        progress.runStage( IntStream.range( 0, items ).boxed(), item -> "Item " + item, item -> {
+                            simulateWorkForDuration( params.getItemDuration() );
+                            if ( item == failAtItem )
+                                throw new RuntimeException( msg );
+                        } );
+                    }
+                    else
+                    {
+                        for ( int item = 0; item < items; item++ )
+                        {
+                            progress.startingWorkItem( item );
+                            simulateWorkForDuration( params.getItemDuration() );
+                            if ( item == failAtItem )
+                            {
+                                progress.failedWorkItem( msg );
+                            }
+                            else
+                            {
+                                progress.completedWorkItem( null );
+                            }
+                        }
+                    }
+                }
+                else if ( failAtStage == stage )
+                {
+                    if ( params.isFailWithException() )
+                        throw new RuntimeException( msg );
+                    progress.failedStage( msg );
+                }
+                else
+                {
+                    progress.completedStage( format( "Stage %d complete", stage ) );
+                }
+            }
+        }
+        progress.completedProcess( null );
+    }
+
+    private void simulateWorkForDuration( Long waitTime )
+    {
+        if ( waitTime == null || waitTime == 0L )
+        {
+            return;
+        }
+        try
+        {
+            Thread.sleep( waitTime );
+        }
+        catch ( InterruptedException ex )
+        {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -39,13 +39,16 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
@@ -92,14 +95,14 @@ class SchedulingManagerTest
 
     private final ApplicationContext applicationContext = mock( ApplicationContext.class );
 
-    private final Job job = mock( Job.class );
-
     private DefaultSchedulingManager schedulingManager;
+
+    private final Map<String, Job> jobBeans = new LinkedHashMap<>();
 
     @BeforeEach
     void setUp()
     {
-        when( applicationContext.getBeansOfType( any() ) ).thenReturn( Collections.singletonMap( "test", job ) );
+        when( applicationContext.getBeansOfType( Job.class ) ).thenReturn( jobBeans );
 
         CacheProvider cacheProvider = mock( CacheProvider.class );
         when( cacheProvider.createJobCancelRequestedCache() ).thenReturn( new TestCache<>() );
@@ -114,143 +117,211 @@ class SchedulingManagerTest
     @TestFactory
     Stream<DynamicTest> testScheduleRunCronJob()
     {
-        JobConfiguration configuration = createCronJonConfiguration();
-        when( job.getJobType() ).thenReturn( configuration.getJobType() );
-        when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
+        JobConfiguration conf = createCronJobConfiguration();
+        when( jobConfigurationService.getJobConfigurationByUid( conf.getUid() ) ).thenReturn( conf );
         ArgumentCaptor<Runnable> cronTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.schedule( cronTask.capture(), any( Trigger.class ) ) ).thenReturn( new MockFuture<>() );
-        schedulingManager.schedule( configuration );
-        return assertScheduledJob( configuration, SchedulingManagerTest::createCronJonConfiguration,
-            cronTask.getValue() );
+        schedulingManager.schedule( conf );
+        return createTestCases( conf, this::createCronJobConfiguration, cronTask.getValue() );
     }
 
     @TestFactory
     Stream<DynamicTest> testScheduleRunFixedDelayJob()
     {
-        JobConfiguration configuration = createFixedDelayJobConfiguration();
-        when( job.getJobType() ).thenReturn( configuration.getJobType() );
-        when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
+        JobConfiguration conf = createFixedDelayJobConfiguration();
+        when( jobConfigurationService.getJobConfigurationByUid( conf.getUid() ) ).thenReturn( conf );
         ArgumentCaptor<Runnable> delayTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.scheduleWithFixedDelay( delayTask.capture(), any( Instant.class ), any( Duration.class ) ) )
             .thenReturn( new MockFuture<>() );
-        schedulingManager.schedule( configuration );
-        return assertScheduledJob( configuration, SchedulingManagerTest::createFixedDelayJobConfiguration,
-            delayTask.getValue() );
+        schedulingManager.schedule( conf );
+        return createTestCases( conf, this::createFixedDelayJobConfiguration, delayTask.getValue() );
     }
 
     @TestFactory
     Stream<DynamicTest> testScheduleRunWithStartTimeJob()
     {
-        JobConfiguration configuration = createStartTimeJobConfiguration();
-        when( job.getJobType() ).thenReturn( configuration.getJobType() );
-        when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
+        JobConfiguration conf = createStartTimeJobConfiguration();
+        when( jobConfigurationService.getJobConfigurationByUid( conf.getUid() ) ).thenReturn( conf );
         ArgumentCaptor<Runnable> startTimeTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.schedule( startTimeTask.capture(), any( Date.class ) ) ).thenReturn( new MockFuture<>() );
-        schedulingManager.scheduleWithStartTime( configuration, new Date() );
-        return assertScheduledJob( configuration, SchedulingManagerTest::createStartTimeJobConfiguration,
-            startTimeTask.getValue() );
+        schedulingManager.scheduleWithStartTime( conf, new Date() );
+        return createTestCases( conf, this::createStartTimeJobConfiguration, startTimeTask.getValue() );
     }
 
-    private static JobConfiguration createCronJonConfiguration()
+    @TestFactory
+    Stream<DynamicTest> testScheduleRunWithQueue()
     {
-        JobConfiguration configuration = new JobConfiguration( "cron", JobType.ANALYTICS_TABLE,
+        JobConfiguration conf = createCronJobConfiguration();
+        conf.setQueueName( "test" );
+        conf.setQueuePosition( 0 );
+        List<JobConfiguration> queue = List.of( conf,
+            createQueueJobConfiguration( JobType.SEND_SCHEDULED_MESSAGE, 1 ),
+            createQueueJobConfiguration( JobType.PROGRAM_NOTIFICATIONS, 2 ) );
+        when( jobConfigurationService.getAllJobConfigurations() ).thenReturn( queue );
+        queue.forEach( config -> when( jobConfigurationService.getJobConfigurationByUid( config.getUid() ) )
+            .thenReturn( config ) );
+        ArgumentCaptor<Runnable> queueStart = ArgumentCaptor.forClass( Runnable.class );
+        when( taskScheduler.schedule( queueStart.capture(), any( Trigger.class ) ) ).thenReturn( new MockFuture<>() );
+        schedulingManager.schedule( conf );
+        return createTestCases( conf, this::createCronJobConfiguration, queueStart.getValue() );
+    }
+
+    private JobConfiguration createQueueJobConfiguration( JobType type, int position )
+    {
+        JobConfiguration conf = new JobConfiguration();
+        conf.setName( "queue" + position );
+        conf.setUid( generateUid() );
+        conf.setJobType( type );
+        conf.setCronExpression( null );
+        conf.setQueueName( "test" );
+        conf.setQueuePosition( position );
+        addJob( conf );
+        return conf;
+    }
+
+    private JobConfiguration createCronJobConfiguration()
+    {
+        JobConfiguration conf = new JobConfiguration( "cron", JobType.ANALYTICS_TABLE,
             getDailyCronExpression( 0, 0 ), new AnalyticsJobParameters() );
         // only jobs with ID get scheduled
-        configuration.setUid( generateUid() );
-        return configuration;
+        conf.setUid( generateUid() );
+        addJob( conf );
+        return conf;
     }
 
-    private static JobConfiguration createFixedDelayJobConfiguration()
+    private JobConfiguration createFixedDelayJobConfiguration()
     {
-        JobConfiguration configuration = new JobConfiguration( "delay", JobType.CONTINUOUS_ANALYTICS_TABLE,
+        JobConfiguration conf = new JobConfiguration( "delay", JobType.CONTINUOUS_ANALYTICS_TABLE,
             getDailyCronExpression( 0, 0 ), new ContinuousAnalyticsJobParameters() );
         // only jobs with ID get scheduled
-        configuration.setUid( generateUid() );
-        configuration.setDelay( 1 );
-        return configuration;
+        conf.setUid( generateUid() );
+        conf.setDelay( 1 );
+        addJob( conf );
+        return conf;
     }
 
-    private static JobConfiguration createStartTimeJobConfiguration()
+    private JobConfiguration createStartTimeJobConfiguration()
     {
-        return new JobConfiguration( "CLUSTER_LEADER_RENEWAL", JobType.LEADER_RENEWAL, null, true );
+        JobConfiguration conf = new JobConfiguration( "CLUSTER_LEADER_RENEWAL",
+            JobType.LEADER_RENEWAL, null, true );
+        addJob( conf );
+        return conf;
     }
 
-    private Stream<DynamicTest> assertScheduledJob( JobConfiguration configuration, Supplier<JobConfiguration> copy,
+    private void addJob( JobConfiguration conf )
+    {
+        Job job = mock( Job.class );
+        when( job.getJobType() ).thenReturn( conf.getJobType() );
+        jobBeans.put( jobBeans.size() + "", job );
+    }
+
+    private Stream<DynamicTest> createTestCases( JobConfiguration configuration, Supplier<JobConfiguration> copy,
         Runnable task )
     {
         assertNotNull( task, "job was not scheduled" );
         return Stream.of(
-            dynamicTest( "assertScheduledJobCompletes",
-                () -> assertScheduledJobCompletes( configuration, task ) ),
-            dynamicTest( "assertScheduledJobDoesNotStartWhenAlreadyRunning",
-                () -> assertScheduledJobDoesNotStartWhenAlreadyRunning( configuration, task ) ),
-            dynamicTest( "assertScheduledJobCancelsToStopped",
-                () -> assertScheduledJobCancelsToStopped( configuration, task ) ),
-            dynamicTest( "assertScheduledJobStopWhenInterrupted",
-                () -> assertScheduledJobStopWhenInterrupted( configuration, task ) ),
+            //OBS! the order here is important because these are not isolated from each other
+            dynamicTest( "assertScheduledJobCompletesSuccessful",
+                () -> assertScheduledJobCompletesSuccessful( configuration, task ) ),
+            dynamicTest( "assertJobDoesNotStartWhenAlreadyRunning",
+                () -> assertJobDoesNotStartWhenAlreadyRunning( configuration, task ) ),
+            dynamicTest( "assertScheduledJobCanBeCancelled",
+                () -> assertScheduledJobCanBeCancelled( configuration, task ) ),
+            dynamicTest( "assertScheduledJobFailsGracefulWhenInterrupted",
+                () -> assertScheduledJobFailsGracefulWhenInterrupted( configuration, task ) ),
             dynamicTest( "assertScheduledJobFailsGraceful",
                 () -> assertScheduledJobFailsGraceful( configuration, task ) ),
+            dynamicTest( "assertStopRemovesJobFromSchedule",
+                () -> assertStopRemovesJobFromSchedule( configuration, task ) ),
             dynamicTest( "assertScheduledJobStaysDisabled",
                 () -> assertScheduledJobStaysDisabled( configuration, copy, task ) ) );
     }
 
-    private void assertScheduledJobCompletes( JobConfiguration configuration, Runnable task )
+    private void assertScheduledJobCompletesSuccessful( JobConfiguration conf, Runnable task )
     {
+        assertTrue( schedulingManager.isScheduled( conf ), "job is scheduled before it runs" );
+
         setUpJobExecute( this::assertIsRunning );
         // synchronously
         task.run();
         verify( applicationContext, atLeastOnce() ).getBeansOfType( any() );
-        if ( !configuration.isInMemoryJob() )
+        if ( !conf.isInMemoryJob() )
         {
-            assertEquals( JobStatus.COMPLETED, configuration.getLastExecutedStatus() );
-            assertNotNull( configuration.getLastExecuted(), "job did not complete" );
+            assertEquals( JobStatus.COMPLETED, conf.getLastExecutedStatus() );
+            assertNotNull( conf.getLastExecuted(), "job did not complete" );
         }
-        assertFalse( schedulingManager.isRunning( configuration.getJobType() ),
+        assertFalse( schedulingManager.isRunning( conf.getJobType() ),
             "job is still considered running when it is actually finished" );
+        assertTrue( schedulingManager.isScheduled( conf ), "job is still scheduled after it ran" );
+        // all jobs involved in the test should have been executed once
+        jobBeans.values().forEach( job -> verify( job, times( 1 ) ).execute( any(), any() ) );
     }
 
-    private void assertIsRunning( JobConfiguration configuration )
+    private void assertIsRunning( JobConfiguration conf )
     {
-        assertTrue( schedulingManager.isRunning( configuration.getJobType() ) );
-        assertEquals( JobStatus.RUNNING, configuration.getJobStatus() );
+        assertTrue( schedulingManager.isRunning( conf.getJobType() ) );
+        assertEquals( JobStatus.RUNNING, conf.getJobStatus() );
     }
 
-    private void assertScheduledJobDoesNotStartWhenAlreadyRunning( JobConfiguration configuration, Runnable task )
+    private void assertJobDoesNotStartWhenAlreadyRunning( JobConfiguration configuration, Runnable task )
     {
-        setUpJobExecute( jobConfiguration -> assertFalse( schedulingManager.executeNow( configuration ) ) );
+        setUpJobExecute( conf -> assertFalse( schedulingManager.executeNow( configuration ) ) );
         // synchronously
         task.run();
+
+        // but now it can run as the scheduled one is not running
         assertTrue( schedulingManager.executeNow( configuration ) );
     }
 
-    private void assertScheduledJobCancelsToStopped( JobConfiguration configuration, Runnable task )
+    private void assertScheduledJobCanBeCancelled( JobConfiguration configuration, Runnable task )
     {
-        // once running the job stops itself
-        setUpJobExecute( jobConfiguration -> schedulingManager.cancel( jobConfiguration.getJobType() ) );
+        // once running the job cancels itself
+        setUpJobExecute( conf -> schedulingManager.cancel( conf.getJobType() ) );
         // synchronously
         task.run();
+
         assertEquals( JobStatus.STOPPED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
     }
 
-    private void assertScheduledJobStopWhenInterrupted( JobConfiguration configuration, Runnable task )
+    private void assertStopRemovesJobFromSchedule( JobConfiguration configuration, Runnable task )
     {
-        setUpJobExecute( jobConfiguration -> Thread.currentThread().interrupt() );
+        // once running the job stops itself
+        setUpJobExecute( schedulingManager::stop );
         // synchronously
         task.run();
+
+        // stop does not interrupt or abort a running job
+        assertEquals( JobStatus.COMPLETED, configuration.getLastExecutedStatus() );
+        // but removes it from being scheduled anymore
+        assertFalse( schedulingManager.isScheduled( configuration ) );
+
+        // also it should be valid to call stop again
+        schedulingManager.stop( configuration );
+    }
+
+    private void assertScheduledJobFailsGracefulWhenInterrupted( JobConfiguration configuration, Runnable task )
+    {
+        setUpJobExecute( conf -> Thread.currentThread().interrupt() );
+        // synchronously
+        task.run();
+
         assertEquals( JobStatus.FAILED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
+        assertTrue( schedulingManager.isScheduled( configuration ) );
     }
 
     private void assertScheduledJobFailsGraceful( JobConfiguration configuration, Runnable task )
     {
-        setUpJobExecute( jobConfiguration -> {
+        setUpJobExecute( conf -> {
             throw new IllegalStateException( "Something goes wrong while doing the work..." );
         } );
         // synchronously
         task.run();
+
         assertEquals( JobStatus.FAILED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
+        assertTrue( schedulingManager.isScheduled( configuration ) );
     }
 
     private void assertScheduledJobStaysDisabled( JobConfiguration configuration, Supplier<JobConfiguration> copy,
@@ -258,7 +329,7 @@ class SchedulingManagerTest
     {
         if ( !configuration.isInMemoryJob() )
         {
-            setUpJobExecute( jobConfiguration -> {
+            setUpJobExecute( conf -> {
                 // pretend the job has been disabled in database
                 JobConfiguration persistent = copy.get();
                 persistent.setJobStatus( JobStatus.DISABLED );
@@ -266,6 +337,7 @@ class SchedulingManagerTest
             } );
             // synchronously
             task.run();
+
             assertEquals( JobStatus.DISABLED, configuration.getJobStatus() );
             assertFalse( configuration.isEnabled() );
         }
@@ -273,12 +345,13 @@ class SchedulingManagerTest
 
     private void setUpJobExecute( Consumer<JobConfiguration> execute )
     {
+        Job tested = jobBeans.values().iterator().next();
         doAnswer( invocation -> {
             execute.accept( invocation.getArgument( 0, JobConfiguration.class ) );
             if ( Thread.currentThread().isInterrupted() )
                 throw new InterruptedException();
             return null;
-        } ).when( job ).execute( any( JobConfiguration.class ), any( JobProgress.class ) );
+        } ).when( tested ).execute( any( JobConfiguration.class ), any( JobProgress.class ) );
     }
 
     /**

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulerEntry.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/scheduling/SchedulerEntry.java
@@ -80,8 +80,11 @@ class SchedulerEntry
             List.of( SchedulerEntryJob.of( config ) ) );
     }
 
-    static SchedulerEntry of( List<JobConfiguration> queue )
+    static SchedulerEntry of( List<JobConfiguration> jobs )
     {
+        List<JobConfiguration> queue = jobs.stream()
+            .sorted( comparing( JobConfiguration::getQueuePosition ) )
+            .collect( toList() );
         JobConfiguration trigger = queue.get( 0 );
         if ( !trigger.isUsedInQueue() )
         {


### PR DESCRIPTION
### Summary
Main goal was to make the scheduler behave reasonable and consistent when removing previously scheduled jobs from the schedule. There are two aspects that need to come together consistent:

* the actual schedule managed in memory by an executor 
* the description and state of the jobs

The issues found were inconsistencies of the executor state and the state of the job descriptions.

The semantics chosen to make this reliable, predictable and consistent are as follows

* `SchedulingManager.stop`ing a `JobConfiguration` removes it from the schedule **but** will finish a run that already started
* `SchedulingManager.cancel`ing a `JobType` is the cooperative attempt to abort a running job of the type independent of the configuration that started it. This does **not** remove the job from the schedule but only aborts the current run.
* There can be multiple `JobConfiguration`s of the same `JobType` put on a schedule but only one of them will be able to run at the same time. If a job run is due to run while another of the same type already is in progress the attempt to run fails.

### Additional Improvements and Fixes
* fix: added CRON expression validation to the job queue create and update
* feat: added a `TEST` job which allows to test failing job scenarios
* feat: job configurations that are part of a queue can be executed ad-hoc using `executeNow`. This will start the queue from their position onward. This might come in handy when a queue fails at a certain points and the queue should be resumed from that point after the data has been adjusted manually
* fix: the `JobConfiguration.setLastExecuted` records the start time of the job run, not the finish time
* fix: the `STOPPED` status is persisted after a cancelled run (instead of `FAILED`)
* fix: `SchedulerEntry.of` reorders jobs in the queue by position

### Automatic Testing
New controller tests were added for the added job queue validation
New unit tests were added for `DefaultSchedulingManager` with job queues

### Manual Testing
Testing Job Queues

* create 2-3 jobs (ideally but not necessarily of different types)
* create a job queue with the jobs
* run the queue by waiting for the CRON trigger or run the first job in the queue manually (run now)
* check the job progress tracking for the jobs in the queue after the run. Compare the timestamps to verify they ran in the queue order

Testing Stop

* create a job that gives you some time to stop it while it is running (for example use TEST job with `waitMillis` or a slow job like analytics)
* start the run manually (or wait for the scheduled execution)
* while it is running stop the job by editing its configuration
* check the job ran did continue and finish
* redo steps so far except disable the job
* check the job ran did continue and finish
* check that job is no longer on schedule (ideally a CRON expression is used that allows to just wait a short time to verify it did indeed not run again, for example use ` 0/5 * * * *` for every 5 minutes)