### PR TITLE
fix: Associate Visualization with ExpressionDimensionItem [2.40-DHIS2-14083-3]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.expressiondimensionitem;
 
 import org.hisp.dhis.common.BaseDataDimensionalItemObject;
+import org.hisp.dhis.common.DimensionItemType;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.expression.MissingValueStrategy;
@@ -216,8 +217,9 @@ public class ExpressionDimensionItem
         return slidingWindow;
     }
 
-    public void setSlidingWindow( Boolean slidingWindow )
+    @Override
+    public DimensionItemType getDimensionItemType()
     {
-        this.slidingWindow = slidingWindow;
+        return DimensionItemType.EXPRESSION_DIMENSION_ITEM;
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/expressiondimensionitem/ExpressionDimensionItem.java
@@ -217,6 +217,11 @@ public class ExpressionDimensionItem
         return slidingWindow;
     }
 
+    public void setSlidingWindow( Boolean slidingWindow )
+    {
+        this.slidingWindow = slidingWindow;
+    }
+
     @Override
     public DimensionItemType getDimensionItemType()
     {

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expression_dimensionitem.hibernate/ExpressionDimensionItem.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/expression_dimensionitem.hibernate/ExpressionDimensionItem.hbm.xml
@@ -18,6 +18,10 @@
 
         <property name="name" column="name" not-null="true" unique="true" length="230" />
 
+        <property name="shortName" type="text"/>
+
+        <property name="formName" type="text" />
+
         <property name="description" type="text" />
 
         <property name="translations" type="jblTranslations"/>


### PR DESCRIPTION
There is an issue with visualizations. The dimensionItemType for the EDI is not visible.