### PR TITLE
fix: Add missing mock dependency to fix 4 failing tests

### DIFF
--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/enrollment/AttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/enrollment/AttributeValidatorTest.java
@@ -54,6 +54,7 @@ import org.hisp.dhis.tracker.domain.MetadataIdentifier;
 import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
+import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,6 +86,9 @@ class AttributeValidatorTest
 
     @Mock
     private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Mock
+    private TrackedAttributeValidationService teAttrService;
 
     private TrackerBundle bundle;
 

--- a/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/trackedentity/AttributeValidatorTest.java
+++ b/dhis-2/dhis-services/dhis-service-tracker/src/test/java/org/hisp/dhis/tracker/validation/validator/trackedentity/AttributeValidatorTest.java
@@ -57,6 +57,7 @@ import org.hisp.dhis.tracker.preheat.TrackerPreheat;
 import org.hisp.dhis.tracker.util.Constant;
 import org.hisp.dhis.tracker.validation.Reporter;
 import org.hisp.dhis.tracker.validation.ValidationCode;
+import org.hisp.dhis.tracker.validation.service.attribute.TrackedAttributeValidationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +83,9 @@ class AttributeValidatorTest
 
     @Mock
     private DhisConfigurationProvider dhisConfigurationProvider;
+
+    @Mock
+    private TrackedAttributeValidationService teAttrService;
 
     @Mock
     private TrackedEntityAttribute trackedEntityAttribute;


### PR DESCRIPTION
- I pulled the latest master branch and tried building the project
- The build failed at the dhis-service-tracker module step
- I investigated this module's failing tests and it seems that 2 test classes (4 tests) were missing a mock dependency (NPEs being thrown as class member not initialised)
- dhis-service-tracker module back passing now :)