### PR TITLE
ci: Use latest tag instead of master in canary pipeline [skip ci]

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -25,7 +25,7 @@ pipeline {
             steps {
                 echo "Publishing docker image to dhis2/core-canary"
                 script {
-                    def branch="${GIT_BRANCH}"
+                    def branch="${env.GIT_BRANCH == 'master' ? 'latest' : env.GIT_BRANCH}"
                     def today = new Date()
                     def formatted = "${today.format('yyyyMMdd')}"
                     def source = "dhis2/core-dev:${branch}"


### PR DESCRIPTION
As we no longer publish a `master` tag, but instead changed to a `latest` one (since https://github.com/dhis2/dhis2-core/pull/12046), the canary pipeline was "silently" still using an old `master` image.