### PR TITLE
fix: Flags paging and skipPaging for enrollments API [DHIS2-14476]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event.webrequest;
 
 import static java.util.stream.Collectors.partitioningBy;
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,6 @@ import org.apache.commons.collections4.CollectionUtils;
 @NoArgsConstructor( access = AccessLevel.PROTECTED )
 public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria, SortingCriteria
 {
-
     /**
      * Page number to return.
      */
@@ -73,7 +73,7 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     /**
      * Indicates whether paging should be skipped.
      */
-    private boolean skipPaging;
+    private Boolean skipPaging;
 
     /**
      * order params
@@ -99,7 +99,7 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
 
     public boolean isPagingRequest()
     {
-        return !isSkipPaging();
+        return !toBooleanDefaultIfNull( isSkipPaging(), false );
     }
 
     @Override
@@ -136,9 +136,13 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
         return !CollectionUtils.emptyIfNull( getOrder() ).isEmpty();
     }
 
+    public Boolean isSkipPaging()
+    {
+        return skipPaging;
+    }
+
     public interface EntityNameSupplier
     {
         String getEntityName();
     }
-
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingCriteria.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingCriteria.java
@@ -59,7 +59,7 @@ public interface PagingCriteria
     /**
      * Indicates whether paging should be skipped.
      */
-    boolean isSkipPaging();
+    Boolean isSkipPaging();
 
     default Integer getFirstResult()
     {

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapterTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapterTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.event.webrequest;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -81,7 +82,7 @@ class PagingAndSortingCriteriaAdapterTest
         PagingAndSortingCriteriaAdapter pagingAndSortingCriteriaAdapter = new PagingAndSortingCriteriaAdapter()
         {
         };
-        assertFalse( pagingAndSortingCriteriaAdapter.isSkipPaging() );
+        assertFalse( toBooleanDefaultIfNull( pagingAndSortingCriteriaAdapter.isSkipPaging(), false ) );
         assertTrue( pagingAndSortingCriteriaAdapter.isPagingRequest() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -132,7 +132,7 @@ public class HibernateProgramInstanceStore
         }
 
         // When the clients choose to not show the total of pages.
-        if ( !params.isTotalPages() )
+        if ( !params.isTotalPages() && !params.isSkipPaging() )
         {
             // Get pageSize + 1, so we are able to know if there is another
             // page available. It adds one additional element into the list,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -200,23 +200,23 @@ public abstract class AbstractEnrollmentService
     @Override
     public Enrollments getEnrollments( ProgramInstanceQueryParams params )
     {
-        final Enrollments enrollments = new Enrollments();
-        final List<ProgramInstance> programInstances = new ArrayList<>();
+        Enrollments enrollments = new Enrollments();
+        List<ProgramInstance> programInstances = new ArrayList<>();
 
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
             params.setDefaultPaging();
         }
 
-        if ( params.isPaging() )
+        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
+
+        if ( !params.isSkipPaging() )
         {
-            final Pager pager;
+            Pager pager;
 
             if ( params.isTotalPages() )
             {
-                programInstances.addAll( programInstanceService.getProgramInstances( params ) );
-
-                final int count = programInstanceService.countProgramInstances( params );
+                int count = programInstanceService.countProgramInstances( params );
                 pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             }
             else
@@ -246,14 +246,12 @@ public abstract class AbstractEnrollmentService
      * @param programInstances the reference to the list of ProgramInstance
      * @return the populated SlimPager instance
      */
-    private Pager handleLastPageFlag( final ProgramInstanceQueryParams params,
-        final List<ProgramInstance> programInstances )
+    private Pager handleLastPageFlag( ProgramInstanceQueryParams params,
+        List<ProgramInstance> programInstances )
     {
-        final Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
-        final Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
+        Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
         boolean isLastPage = false;
-
-        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
 
         if ( isNotEmpty( programInstances ) )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -308,18 +308,17 @@ public abstract class AbstractEventService implements EventService
             return events;
         }
 
-        final Pager pager;
+        Pager pager;
+        eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
 
         if ( params.isTotalPages() )
         {
-            eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
-
             int count = eventStore.getEventCount( params, organisationUnits );
             pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
         }
         else
         {
-            pager = handleLastPageFlag( params, eventList, organisationUnits );
+            pager = handleLastPageFlag( params, eventList );
         }
 
         events.setPager( pager );
@@ -342,14 +341,11 @@ public abstract class AbstractEventService implements EventService
      * @param eventList the reference to the list of Event
      * @return the populated SlimPager instance
      */
-    private Pager handleLastPageFlag( final EventSearchParams params,
-        final List<Event> eventList, final List<OrganisationUnit> organisationUnits )
+    private Pager handleLastPageFlag( final EventSearchParams params, final List<Event> eventList )
     {
-        final Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
-        final Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
+        Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
         boolean isLastPage = false;
-
-        eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
 
         if ( isNotEmpty( eventList ) )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/EventRequestToSearchParamsMapper.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -332,7 +334,7 @@ class EventRequestToSearchParamsMapper
             eventCriteria.getPage(),
             eventCriteria.getPageSize(),
             eventCriteria.isTotalPages(),
-            eventCriteria.isSkipPaging(),
+            toBooleanDefaultIfNull( eventCriteria.isSkipPaging(), false ),
             getOrderParams( eventCriteria.getOrder() ),
             getGridOrderParams( eventCriteria.getOrder(), dataElementOrders ),
             false,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.event.mapper;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 
 import java.util.Date;
@@ -198,7 +199,7 @@ public class EnrollmentCriteriaMapper
             trackerEnrollmentCriteria.getPage(),
             trackerEnrollmentCriteria.getPageSize(),
             trackerEnrollmentCriteria.isTotalPages(),
-            trackerEnrollmentCriteria.isSkipPaging(),
+            toBooleanDefaultIfNull( trackerEnrollmentCriteria.isSkipPaging(), false ),
             trackerEnrollmentCriteria.isIncludeDeleted(),
             trackerEnrollmentCriteria.getOrder() );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event.mapper;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.findColumn;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
@@ -201,7 +202,7 @@ public class TrackedEntityCriteriaMapper
             .setPage( criteria.getPage() )
             .setPageSize( criteria.getPageSize() )
             .setTotalPages( criteria.isTotalPages() )
-            .setSkipPaging( criteria.isSkipPaging() )
+            .setSkipPaging( toBooleanDefaultIfNull( criteria.isSkipPaging(), false ) )
             .setIncludeDeleted( criteria.isIncludeDeleted() )
             .setIncludeAllAttributes( criteria.isIncludeAllAttributes() )
             .setUser( user )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/RelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/RelationshipCriteria.java
@@ -47,7 +47,7 @@ public class RelationshipCriteria extends PagingAndSortingCriteriaAdapter
      * TODO Add Pager
      */
     @Override
-    public boolean isSkipPaging()
+    public Boolean isSkipPaging()
     {
         return true;
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapper.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.export;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -209,7 +211,7 @@ class TrackerEventCriteriaMapper
             .setCategoryOptionCombo( attributeOptionCombo ).setIdSchemes( eventCriteria.getIdSchemes() )
             .setPage( eventCriteria.getPage() )
             .setPageSize( eventCriteria.getPageSize() ).setTotalPages( eventCriteria.isTotalPages() )
-            .setSkipPaging( eventCriteria.isSkipPaging() )
+            .setSkipPaging( toBooleanDefaultIfNull( eventCriteria.isSkipPaging(), false ) )
             .setSkipEventId( eventCriteria.getSkipEventId() ).setIncludeAttributes( false )
             .setIncludeAllDataElements( false ).addDataElements( dataElements )
             .addFilters( filters ).addFilterAttributes( filterAttributes )


### PR DESCRIPTION
[Backport from master/2.40]

The URL param flags `paging` and `skipPaging` are not working for the API `/api/enrollments`.

This fix will address that problem.
Not that I changed the `skipPaging` flag to `Boolean`. This was needed because of the method `PageUtils.isSkipPaging`. It works on top of `Boolean` objects.
Some methods were still assuming `boolean` types. For those cases, if the `skipPaging` flag is null, they become `false` by default, so we keep the existing behaviour.
