### PR TITLE
fix: Flags paging and skipPaging for enrollments API [DHIS2-14476]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapter.java
@@ -28,11 +28,11 @@
 package org.hisp.dhis.webapi.controller.event.webrequest;
 
 import static java.util.stream.Collectors.partitioningBy;
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -54,7 +54,6 @@ import org.apache.commons.collections4.CollectionUtils;
 @NoArgsConstructor( access = AccessLevel.PROTECTED )
 public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria, SortingCriteria
 {
-
     /**
      * Page number to return.
      */
@@ -100,13 +99,12 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
 
     public boolean isPagingRequest()
     {
-        return !isSkipPaging();
+        return !toBooleanDefaultIfNull( isSkipPaging(), false );
     }
 
-    public boolean isSkipPaging()
+    public Boolean isSkipPaging()
     {
-        return Optional.ofNullable( skipPaging )
-            .orElse( false );
+        return skipPaging;
     }
 
     @Override
@@ -147,5 +145,4 @@ public abstract class PagingAndSortingCriteriaAdapter implements PagingCriteria,
     {
         String getEntityName();
     }
-
 }

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapterTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/webapi/controller/event/webrequest/PagingAndSortingCriteriaAdapterTest.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.event.webrequest;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -83,7 +84,7 @@ public class PagingAndSortingCriteriaAdapterTest
         {
         };
 
-        assertFalse( pagingAndSortingCriteriaAdapter.isSkipPaging() );
+        assertFalse( toBooleanDefaultIfNull( pagingAndSortingCriteriaAdapter.isSkipPaging(), false ) );
         assertTrue( pagingAndSortingCriteriaAdapter.isPagingRequest() );
     }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/hibernate/HibernateProgramInstanceStore.java
@@ -132,7 +132,7 @@ public class HibernateProgramInstanceStore
         }
 
         // When the clients choose to not show the total of pages.
-        if ( !params.isTotalPages() )
+        if ( !params.isTotalPages() && !params.isSkipPaging() )
         {
             // Get pageSize + 1, so we are able to know if there is another
             // page available. It adds one additional element into the list,

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.events.enrollment;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
+import static org.hisp.dhis.common.Pager.DEFAULT_PAGE_SIZE;
 import static org.hisp.dhis.common.SlimPager.FIRST_PAGE;
 import static org.hisp.dhis.system.notification.NotificationLevel.ERROR;
 import static org.hisp.dhis.trackedentity.TrackedEntityAttributeService.TEA_VALUE_MAX_LENGTH;
@@ -197,23 +198,23 @@ public abstract class AbstractEnrollmentService
     @Override
     public Enrollments getEnrollments( ProgramInstanceQueryParams params )
     {
-        final Enrollments enrollments = new Enrollments();
-        final List<ProgramInstance> programInstances = new ArrayList<>();
+        Enrollments enrollments = new Enrollments();
+        List<ProgramInstance> programInstances = new ArrayList<>();
 
         if ( !params.isPaging() && !params.isSkipPaging() )
         {
             params.setDefaultPaging();
         }
 
-        if ( params.isPaging() )
+        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
+
+        if ( !params.isSkipPaging() )
         {
-            final Pager pager;
+            Pager pager;
 
             if ( params.isTotalPages() )
             {
-                programInstances.addAll( programInstanceService.getProgramInstances( params ) );
-
-                final int count = programInstanceService.countProgramInstances( params );
+                int count = programInstanceService.countProgramInstances( params );
                 pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
             }
             else
@@ -243,14 +244,11 @@ public abstract class AbstractEnrollmentService
      * @param programInstances the reference to the list of ProgramInstance
      * @return the populated SlimPager instance
      */
-    private Pager handleLastPageFlag( final ProgramInstanceQueryParams params,
-        final List<ProgramInstance> programInstances )
+    private Pager handleLastPageFlag( ProgramInstanceQueryParams params, List<ProgramInstance> programInstances )
     {
-        final int originalPage = params.getPage();
-        final int originalPageSize = params.getPageSize();
+        Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
         boolean isLastPage = false;
-
-        programInstances.addAll( programInstanceService.getProgramInstances( params ) );
 
         if ( isNotEmpty( programInstances ) )
         {

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/AbstractEventService.java
@@ -308,18 +308,17 @@ public abstract class AbstractEventService implements EventService
             return events;
         }
 
-        final Pager pager;
+        Pager pager;
+        eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
 
         if ( params.isTotalPages() )
         {
-            eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
-
             int count = eventStore.getEventCount( params, organisationUnits );
             pager = new Pager( params.getPageWithDefault(), count, params.getPageSizeWithDefault() );
         }
         else
         {
-            pager = handleLastPageFlag( params, eventList, organisationUnits );
+            pager = handleLastPageFlag( params, eventList );
         }
 
         events.setPager( pager );
@@ -455,14 +454,11 @@ public abstract class AbstractEventService implements EventService
      * @param eventList the reference to the list of Event
      * @return the populated SlimPager instance
      */
-    private Pager handleLastPageFlag( final EventSearchParams params,
-        final List<Event> eventList, final List<OrganisationUnit> organisationUnits )
+    private Pager handleLastPageFlag( final EventSearchParams params, List<Event> eventList )
     {
-        final Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
-        final Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
+        Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
         boolean isLastPage = false;
-
-        eventList.addAll( eventStore.getEvents( params, organisationUnits, emptyMap() ) );
 
         if ( isNotEmpty( eventList ) )
         {
@@ -493,10 +489,10 @@ public abstract class AbstractEventService implements EventService
      * @param grid the populated Grid object
      * @return the populated SlimPager instance
      */
-    private Pager handleLastPageFlag( final EventSearchParams params, final Grid grid )
+    private Pager handleLastPageFlag( EventSearchParams params, Grid grid )
     {
-        final int originalPage = params.getPage();
-        final int originalPageSize = params.getPageSize();
+        Integer originalPage = defaultIfNull( params.getPage(), FIRST_PAGE );
+        Integer originalPageSize = defaultIfNull( params.getPageSize(), DEFAULT_PAGE_SIZE );
         boolean isLastPage = false;
 
         if ( isNotEmpty( grid.getRows() ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/EnrollmentCriteriaMapper.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller.event.mapper;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
 
 import java.util.Date;
@@ -198,7 +199,7 @@ public class EnrollmentCriteriaMapper
             trackerEnrollmentCriteria.getPage(),
             trackerEnrollmentCriteria.getPageSize(),
             trackerEnrollmentCriteria.isTotalPages(),
-            trackerEnrollmentCriteria.isSkipPaging(),
+            toBooleanDefaultIfNull( trackerEnrollmentCriteria.isSkipPaging(), false ),
             trackerEnrollmentCriteria.isIncludeDeleted(),
             trackerEnrollmentCriteria.getOrder() );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/RequestToSearchParamsMapper.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.webapi.controller.event.mapper;
 
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -340,7 +342,7 @@ public class RequestToSearchParamsMapper
             eventCriteria.getPage(),
             eventCriteria.getPageSize(),
             eventCriteria.isTotalPages(),
-            eventCriteria.isSkipPaging(),
+            toBooleanDefaultIfNull( eventCriteria.isSkipPaging(), false ),
             getOrderParams( eventCriteria.getOrder() ),
             getGridOrderParams( eventCriteria.getOrder(), dataElementOrders ),
             false,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/mapper/TrackedEntityCriteriaMapper.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.webapi.controller.event.mapper;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.lang3.BooleanUtils.toBooleanDefaultIfNull;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams.OrderColumn.findColumn;
 import static org.hisp.dhis.webapi.controller.event.mapper.OrderParamsHelper.toOrderParams;
@@ -200,7 +201,7 @@ public class TrackedEntityCriteriaMapper
             .setPage( criteria.getPage() )
             .setPageSize( criteria.getPageSize() )
             .setTotalPages( criteria.isTotalPages() )
-            .setSkipPaging( criteria.isSkipPaging() )
+            .setSkipPaging( toBooleanDefaultIfNull( criteria.isSkipPaging(), false ) )
             .setIncludeDeleted( criteria.isIncludeDeleted() )
             .setIncludeAllAttributes( criteria.isIncludeAllAttributes() )
             .setUser( user )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/RelationshipCriteria.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/webrequest/RelationshipCriteria.java
@@ -47,7 +47,7 @@ public class RelationshipCriteria extends PagingAndSortingCriteriaAdapter
      * TODO Add Pager
      */
     @Override
-    public boolean isSkipPaging()
+    public Boolean isSkipPaging()
     {
         return true;
     }


### PR DESCRIPTION
**_[Backport from master/2.40]_**

The URL param flags `paging` and `skipPaging` are not working for the API `/api/enrollments`.

This fix will address that problem.
Not that I changed the `skipPaging` flag to `Boolean`. This was needed because of the method `PageUtils.isSkipPaging`. It works on top of `Boolean` objects.
Some methods were still assuming `boolean` types. For those cases, if the `skipPaging` flag is null, they become `false` by default, so we keep the existing behaviour.
