### PR TITLE
fix: Scheduler - reliably remove jobs from schedule (2.38)

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -264,8 +264,8 @@ public enum ErrorCode
     E7000( "Job of same type already scheduled with cron expression: `{0}`" ),
     E7003( "Only interval property can be configured for non configurable job type: `{0}`" ),
     E7004( "Cron expression must be not null for job with scheduling type CRON: `{0}`" ),
-    E7005( "Cron expression is invalid for job: `{0}` " ),
-    E7006( "Failed to execute job: `{0}`." ),
+    E7005( "Cron expression is invalid: `{0}`" ),
+    E7006( "Failed to execute job: `{0}`" ),
     E7007( "Delay must be not null for job with scheduling type FIXED_DELAY: `{0}`" ),
     E7010( "Failed to validate job runtime: `{0}`" ),
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobConfiguration.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 import org.hisp.dhis.scheduling.parameters.jackson.JobConfigurationSanitizer;
@@ -334,7 +335,8 @@ public class JobConfiguration
         @JsonSubTypes.Type( value = DataSynchronizationJobParameters.class, name = "DATA_SYNC" ),
         @JsonSubTypes.Type( value = DisableInactiveUsersJobParameters.class, name = "DISABLE_INACTIVE_USERS" ),
         @JsonSubTypes.Type( value = TrackerTrigramIndexJobParameters.class, name = "TRACKER_SEARCH_OPTIMIZATION" ),
-        @JsonSubTypes.Type( value = DataIntegrityJobParameters.class, name = "DATA_INTEGRITY" )
+        @JsonSubTypes.Type( value = DataIntegrityJobParameters.class, name = "DATA_INTEGRITY" ),
+        @JsonSubTypes.Type( value = TestJobParameters.class, name = "TEST" )
     } )
     public JobParameters getJobParameters()
     {
@@ -466,4 +468,5 @@ public class JobConfiguration
     {
         this.userUid = userUid;
     }
+
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/JobType.java
@@ -41,6 +41,7 @@ import org.hisp.dhis.scheduling.parameters.MonitoringJobParameters;
 import org.hisp.dhis.scheduling.parameters.PredictorJobParameters;
 import org.hisp.dhis.scheduling.parameters.PushAnalysisJobParameters;
 import org.hisp.dhis.scheduling.parameters.SmsJobParameters;
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerProgramsDataSynchronizationJobParameters;
 import org.hisp.dhis.scheduling.parameters.TrackerTrigramIndexJobParameters;
 
@@ -113,6 +114,7 @@ public enum JobType
     SYSTEM_VERSION_UPDATE_CHECK( false ),
 
     // Testing purposes
+    TEST( true, SchedulingType.CRON, TestJobParameters.class, null ),
     MOCK( false, SchedulingType.CRON, MockJobParameters.class, null ),
 
     // Deprecated, present to satisfy code using the old enumeration

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/SchedulingManager.java
@@ -141,6 +141,14 @@ public interface SchedulingManager
     void cancel( JobType type );
 
     /**
+     * Check if this job configuration is currently running
+     *
+     * @param type type of job to check
+     * @return true/false
+     */
+    boolean isRunning( JobType type );
+
+    /**
      * @return a set of job types for which a job is running currently
      */
     Collection<JobType> getRunningTypes();

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling.parameters;
+
+import java.util.Optional;
+
+import org.hisp.dhis.common.DxfNamespaces;
+import org.hisp.dhis.feedback.ErrorReport;
+import org.hisp.dhis.scheduling.JobParameters;
+import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+
+@JacksonXmlRootElement( localName = "jobParameters", namespace = DxfNamespaces.DXF_2_0 )
+public class TestJobParameters implements JobParameters
+{
+    /**
+     * Initial waiting time in millis (as there is no actual "work" done)
+     */
+    private Long waitMillis;
+
+    /**
+     * Number of stages in the job, zero if {@code null}
+     */
+    private Integer stages;
+
+    /**
+     * Stage number at which an item fails, none of {@code null}
+     */
+    private Integer failAtStage;
+
+    /**
+     * Number of items in each stage, none if {@code null}
+     */
+    private Integer items;
+
+    /**
+     * Item number in the failing stage at which the failure occurs, none if
+     * {@code null}
+     */
+    private Integer failAtItem;
+
+    /**
+     * Duration each item takes in millis, zero if {@code null}
+     */
+    private Long itemDuration;
+
+    /**
+     * The message used when failing the item
+     */
+    private String failWithMessage;
+
+    /**
+     * When true, an exception is used to fail, otherwise the progress tracking
+     * api is used
+     */
+    private boolean failWithException;
+
+    /**
+     * Stage failure policy to use, when {@code null} it is the default policy
+     */
+    private FailurePolicy failWithPolicy;
+
+    private boolean runStagesParallel;
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Long getWaitMillis()
+    {
+        return waitMillis;
+    }
+
+    public void setWaitMillis( Long waitMillis )
+    {
+        this.waitMillis = waitMillis;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getStages()
+    {
+        return stages;
+    }
+
+    public void setStages( Integer stages )
+    {
+        this.stages = stages;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getFailAtStage()
+    {
+        return failAtStage;
+    }
+
+    public void setFailAtStage( Integer failAtStage )
+    {
+        this.failAtStage = failAtStage;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getItems()
+    {
+        return items;
+    }
+
+    public void setItems( Integer items )
+    {
+        this.items = items;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Integer getFailAtItem()
+    {
+        return failAtItem;
+    }
+
+    public void setFailAtItem( Integer failAtItem )
+    {
+        this.failAtItem = failAtItem;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public Long getItemDuration()
+    {
+        return itemDuration;
+    }
+
+    public void setItemDuration( Long itemDuration )
+    {
+        this.itemDuration = itemDuration;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public String getFailWithMessage()
+    {
+        return failWithMessage;
+    }
+
+    public void setFailWithMessage( String failWithMessage )
+    {
+        this.failWithMessage = failWithMessage;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isFailWithException()
+    {
+        return failWithException;
+    }
+
+    public void setFailWithException( boolean failWithException )
+    {
+        this.failWithException = failWithException;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public FailurePolicy getFailWithPolicy()
+    {
+        return failWithPolicy;
+    }
+
+    public void setFailWithPolicy( FailurePolicy failWithPolicy )
+    {
+        this.failWithPolicy = failWithPolicy;
+    }
+
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
+    public boolean isRunStagesParallel()
+    {
+        return runStagesParallel;
+    }
+
+    public void setRunStagesParallel( boolean runStagesParallel )
+    {
+        this.runStagesParallel = runStagesParallel;
+    }
+
+    @Override
+    public Optional<ErrorReport> validate()
+    {
+        return Optional.empty();
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/TestJobParameters.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import org.hisp.dhis.common.DxfNamespaces;
 import org.hisp.dhis.feedback.ErrorReport;
 import org.hisp.dhis.scheduling.JobParameters;
-import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
@@ -82,11 +81,6 @@ public class TestJobParameters implements JobParameters
      * api is used
      */
     private boolean failWithException;
-
-    /**
-     * Stage failure policy to use, when {@code null} it is the default policy
-     */
-    private FailurePolicy failWithPolicy;
 
     private boolean runStagesParallel;
 
@@ -184,18 +178,6 @@ public class TestJobParameters implements JobParameters
     public void setFailWithException( boolean failWithException )
     {
         this.failWithException = failWithException;
-    }
-
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    public FailurePolicy getFailWithPolicy()
-    {
-        return failWithPolicy;
-    }
-
-    public void setFailWithPolicy( FailurePolicy failWithPolicy )
-    {
-        this.failWithPolicy = failWithPolicy;
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/TestJobParametersDeserializer.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/scheduling/parameters/jackson/TestJobParametersDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling.parameters.jackson;
+
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+public class TestJobParametersDeserializer extends AbstractJobParametersDeserializer<TestJobParameters>
+{
+    public TestJobParametersDeserializer()
+    {
+        super( TestJobParameters.class, CustomJobParameters.class );
+    }
+
+    @JsonDeserialize
+    public static class CustomJobParameters extends TestJobParameters
+    {
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -320,7 +320,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         JobProgress tracker = configuration.getJobType().isUsingNotifications()
             ? new NotifierJobProgress( notifier, configuration )
             : NoopJobProgress.INSTANCE;
-        return new ControlledJobProgress( messageService, configuration, tracker, true );
+        return new ControlledJobProgress( configuration, tracker, true );
     }
 
     private void whenRunIsDone( JobConfiguration configuration, Clock clock )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/AbstractSchedulingManager.java
@@ -145,13 +145,8 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         }
     }
 
-    /**
-     * Check if this job configuration is currently running
-     *
-     * @param type type of job to check
-     * @return true/false
-     */
-    final boolean isRunning( JobType type )
+    @Override
+    public boolean isRunning( JobType type )
     {
         return isRunningLocally( type ) || isRunningRemotely( type );
     }
@@ -224,22 +219,35 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         }
     }
 
-    protected final void execute( String jobId )
+    /**
+     * Run a job potentially in the future.
+     *
+     * This is used for scheduled jobs to reload the job right before it is run
+     * so the most recent configuration is used.
+     *
+     * @param jobId ID of the job to run
+     * @return true when the job ran successful, otherwise false
+     */
+    protected final boolean execute( String jobId )
     {
-        execute( jobConfigurationService.getJobConfigurationByUid( jobId ) );
+        return execute( jobConfigurationService.getJobConfigurationByUid( jobId ) );
     }
 
-    protected final void execute( JobConfiguration configuration )
+    /**
+     * @param configuration the job to run now
+     * @return true when the job ran successful, otherwise false
+     */
+    protected final boolean execute( JobConfiguration configuration )
     {
         if ( !configuration.isEnabled() )
         {
-            return;
+            return false;
         }
         JobType type = configuration.getJobType();
         if ( configuration.isLeaderOnlyJob() && !leaderManager.isLeader() )
         {
             whenLeaderOnlyOnNonLeader( configuration );
-            return;
+            return false;
         }
         ControlledJobProgress progress = createJobProgress( configuration );
         // OBS: we cannot use computeIfAbsent since we have no way of
@@ -248,13 +256,13 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         if ( runningLocally.putIfAbsent( type, progress ) != null )
         {
             whenAlreadyRunning( configuration );
-            return;
+            return false;
         }
         if ( !runningRemotely.putIfAbsent( type.name(), progress.getProcesses() ) )
         {
             runningLocally.remove( type );
             whenAlreadyRunning( configuration );
-            return;
+            return false;
         }
 
         Clock clock = new Clock().startClock();
@@ -283,17 +291,20 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
                 // complected by calling completedProcess at the end of the job
                 progress.completedProcess( "(process completed implicitly)" );
             }
+            boolean wasSuccessfulRun = !progress.isCancellationRequested()
+                && progress.getProcesses().stream().allMatch( p -> p.getStatus() == JobProgress.Status.SUCCESS );
             if ( configuration.getLastExecutedStatus() == RUNNING )
             {
-                boolean wasSuccessfulRun = progress.getProcesses().stream()
-                    .allMatch( p -> p.getStatus() == JobProgress.Status.SUCCESS );
-                configuration.setLastExecutedStatus( wasSuccessfulRun ? JobStatus.COMPLETED : JobStatus.FAILED );
+                JobStatus errorStatus = progress.isCancellationRequested() ? JobStatus.STOPPED : JobStatus.FAILED;
+                configuration.setLastExecutedStatus( wasSuccessfulRun ? JobStatus.COMPLETED : errorStatus );
             }
+            return wasSuccessfulRun;
         }
         catch ( Exception ex )
         {
             progress.failedProcess( ex );
-            whenRunThrewException( configuration, ex );
+            whenRunThrewException( configuration, ex, progress );
+            return false;
         }
         finally
         {
@@ -309,7 +320,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         JobProgress tracker = configuration.getJobType().isUsingNotifications()
             ? new NotifierJobProgress( notifier, configuration )
             : NoopJobProgress.INSTANCE;
-        return new ControlledJobProgress( configuration, tracker, true );
+        return new ControlledJobProgress( messageService, configuration, tracker, true );
     }
 
     private void whenRunIsDone( JobConfiguration configuration, Clock clock )
@@ -319,16 +330,15 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         {
             log.debug( "Job executed successfully: '{}'. Time used: '{}'", configuration.getName(), duration );
         }
+        configuration.setJobStatus( JobStatus.SCHEDULED );
+        configuration.setNextExecutionTime( null );
+        configuration.setLastExecuted( new Date( clock.getStartTime() ) );
+        configuration.setLastRuntimeExecution( duration );
+
         if ( configuration.isInMemoryJob() )
         {
             return;
         }
-
-        configuration.setJobStatus( JobStatus.SCHEDULED );
-        configuration.setNextExecutionTime( null );
-        configuration.setLastExecuted( new Date() );
-        configuration.setLastRuntimeExecution( duration );
-
         JobConfiguration persistentConfiguration = jobConfigurationService
             .getJobConfigurationByUid( configuration.getUid() );
 
@@ -345,7 +355,7 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         }
     }
 
-    private void whenRunThrewException( JobConfiguration configuration, Exception ex )
+    private void whenRunThrewException( JobConfiguration configuration, Exception ex, ControlledJobProgress progress )
     {
         String message = String.format( "Job failed: '%s'", configuration.getName() );
         log.error( message, ex );
@@ -354,7 +364,8 @@ public abstract class AbstractSchedulingManager implements SchedulingManager
         {
             messageService.sendSystemErrorNotification( message, ex );
         }
-        configuration.setLastExecutedStatus( JobStatus.FAILED );
+        configuration
+            .setLastExecutedStatus( progress.isCancellationRequested() ? JobStatus.STOPPED : JobStatus.FAILED );
         if ( ex instanceof InterruptedException )
         {
             Thread.currentThread().interrupt();

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/DefaultSchedulingManager.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.scheduling;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.time.Duration;
@@ -35,7 +36,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.function.Function;
@@ -71,9 +71,20 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
 {
     private static final int DEFAULT_INITIAL_DELAY_S = 10;
 
-    private final Map<JobType, Future<?>> scheduled = new ConcurrentHashMap<>();
-
-    private final Map<JobType, Future<?>> running = new ConcurrentHashMap<>();
+    /**
+     * When a job is scheduled using an executor that will then invoke the job
+     * at specific times in the future a {@link Future} is added to the map
+     * which can be used to stop the job to continue to run in the future. It is
+     * essentially removed from the executor.
+     *
+     * The key is the UID of the {@link JobConfiguration}. Should the UID be
+     * {@code null} the {@link JobConfiguration#getName()} is used as key.
+     *
+     * This means any {@link JobConfiguration} only aborts itself from further
+     * runs in the future. Other configurations for the same {@link JobType}
+     * might exist and continue to run if there have been scheduled to do so.
+     */
+    private final Map<String, Future<?>> removeFromScheduleByIdOrName = new ConcurrentHashMap<>();
 
     private final TaskScheduler jobScheduler;
 
@@ -99,57 +110,71 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
     }
 
     @Override
-    public void schedule( JobConfiguration configuration )
+    public boolean isScheduled( JobConfiguration conf )
     {
-        log.info( String.format( "Scheduling job: %s", configuration ) );
-
-        scheduleTask( configuration, task -> configuration.getJobType().getSchedulingType() == SchedulingType.CRON
-            ? scheduleCronBased( configuration, task )
-            : scheduleFixedDelayBased( configuration, task ) );
-
-        log.info( String.format( "Scheduled job: %s", configuration ) );
+        Future<?> removeFromSchedule = removeFromScheduleByIdOrName.get( getKey( conf ) );
+        return removeFromSchedule != null && !removeFromSchedule.isDone();
     }
 
     @Override
-    public void scheduleWithStartTime( JobConfiguration configuration, Date startTime )
+    public void schedule( JobConfiguration conf )
     {
-        scheduleTask( configuration, task -> scheduleTimeBased( startTime, task ) );
+        boolean isCronTriggered = conf.getJobType().getSchedulingType() == SchedulingType.CRON;
+        if ( isCronTriggered && isNullOrEmpty( conf.getCronExpression() ) )
+        {
+            log.warn( "Job {} of type {} cannot be scheduled as it has no CRON expression.", conf.getUid(),
+                conf.getJobType() );
+            return;
+        }
+        log.info( "Scheduling job: {}", conf );
 
-        log.info( String.format( "Scheduled job: %s with start time: %s", configuration,
-            getMediumDateString( startTime ) ) );
+        if ( scheduleTask( conf, task -> isCronTriggered
+            ? scheduleCronBased( conf, task )
+            : scheduleFixedDelayBased( conf, task ) ) )
+        {
+            log.info( "Scheduled job: {}", conf );
+        }
     }
 
-    private void scheduleTask( JobConfiguration configuration, Function<Runnable, Future<?>> scheduler )
+    @Override
+    public void scheduleWithStartTime( JobConfiguration conf, Date startTime )
     {
-        String jobId = configuration.getUid();
-        JobType type = configuration.getJobType();
-        CompletableFuture<Future<?>> cancellation = new CompletableFuture<>();
-        Runnable task = configuration.isInMemoryJob()
-            ? () -> execute( configuration )
+        if ( scheduleTask( conf, task -> scheduleTimeBased( startTime, task ) ) )
+        {
+            log.info( "Scheduled job: {} with start time: {}", conf, getMediumDateString( startTime ) );
+        }
+    }
+
+    private boolean scheduleTask( JobConfiguration conf, Function<Runnable, Future<?>> schedule )
+    {
+        String jobId = conf.getUid();
+        if ( isNullOrEmpty( jobId ) && isNullOrEmpty( conf.getName() ) )
+        {
+            log.warn( "Job of type {} cannot be scheduled as it has no UID or name", conf.getJobType() );
+            return false;
+        }
+        Runnable task = conf.isInMemoryJob()
+            ? () -> execute( conf )
             : () -> execute( jobId );
-        Future<?> cancelable = scheduler.apply( runIfPossible( configuration, cancellation, task ) );
-        Future<?> scheduledBefore = scheduled.put( type, cancelable );
-        if ( scheduledBefore != null && !scheduledBefore.cancel( true ) )
-        {
-            cancellation.cancel( false );
-        }
-        else
-        {
-            cancellation.complete( cancelable );
-        }
+        Future<?> removeFromSchedule = schedule.apply( task );
+        String key = getKey( conf );
+        Future<?> removeScheduledBefore = removeFromScheduleByIdOrName.put( key, removeFromSchedule );
+        removeFromSchedule( conf, key, removeScheduledBefore );
+        log.info( "Job {} of type {} has been added to the schedule", key, conf.getJobType() );
+        return true;
     }
 
-    private Future<?> scheduleFixedDelayBased( JobConfiguration configuration, Runnable task )
+    private Future<?> scheduleFixedDelayBased( JobConfiguration conf, Runnable task )
     {
         return jobScheduler.scheduleWithFixedDelay( task,
             Instant.now().plusSeconds( DEFAULT_INITIAL_DELAY_S ),
-            Duration.of( configuration.getDelay(), ChronoUnit.SECONDS ) );
+            Duration.of( conf.getDelay(), ChronoUnit.SECONDS ) );
     }
 
-    private Future<?> scheduleCronBased( JobConfiguration configuration, Runnable task )
+    private Future<?> scheduleCronBased( JobConfiguration conf, Runnable task )
     {
         return jobScheduler.schedule( task,
-            new CronTrigger( configuration.getCronExpression() ) );
+            new CronTrigger( conf.getCronExpression() ) );
     }
 
     private Future<?> scheduleTimeBased( Date startTime, Runnable task )
@@ -158,99 +183,48 @@ public class DefaultSchedulingManager extends AbstractSchedulingManager
     }
 
     @Override
-    public void stop( JobConfiguration configuration )
+    public boolean executeNow( JobConfiguration conf )
     {
-        JobType type = configuration.getJobType();
-        if ( type != null && isRunningLocally( type ) )
-        {
-            stoppedSuccessful( type );
-        }
-    }
-
-    @Override
-    public boolean executeNow( JobConfiguration configuration )
-    {
-        if ( configuration == null )
+        if ( conf == null || conf.getJobType() == null || isRunning( conf.getJobType() ) )
         {
             return false;
         }
-        JobType type = configuration.getJobType();
-        if ( type == null || isRunning( type ) )
-        {
-            return false;
-        }
-        log.info( String.format( "Scheduler initiated execution of job: %s", configuration ) );
-        CompletableFuture<Future<?>> cancellation = new CompletableFuture<>();
-        Runnable task = runIfPossible( configuration, cancellation, () -> execute( configuration ) );
-        cancellation.complete( taskExecutor.executeTaskWithCancelation( task ) );
+        log.info( "Scheduler initiated execution of job: {}", conf );
+        Runnable task = () -> execute( conf );
+        taskExecutor.executeTaskWithCancelation( task );
         return true;
     }
 
-    /**
-     * Wraps the original task in order to manage cancellation state correctly
-     * as part of running the task so that transitions occur when the task
-     * actually executes.
-     */
-    private Runnable runIfPossible( JobConfiguration configuration, Future<Future<?>> cancellation, Runnable task )
+    @Override
+    public void stop( JobConfiguration conf )
     {
-        JobType type = configuration.getJobType();
-        return () -> {
-            Future<?> cancelable = getOrThrow( cancellation );
-            if ( cancelable == null )
-            {
-                log.warn( "Job {} aborted as no cancellation was provided", type );
-                return;
-            }
-            scheduled.remove( type, cancelable );
-            if ( type == null || isRunningLocally( type ) && !stoppedSuccessful( type ) || isRunningRemotely( type ) )
-            {
-                return;
-            }
-            running.put( type, cancelable );
-            try
-            {
-                task.run();
-            }
-            finally
-            {
-                JobStatus lastExecutedStatus = configuration.getLastExecutedStatus();
-                if ( cancelable.isCancelled()
-                    && (lastExecutedStatus == JobStatus.RUNNING || lastExecutedStatus == JobStatus.COMPLETED) )
-                {
-                    configuration.setLastExecutedStatus( JobStatus.STOPPED );
-                }
-                running.remove( type, cancelable );
-            }
-        };
-    }
-
-    private Future<?> getOrThrow( Future<Future<?>> cancelProvider )
-    {
-        try
+        String key = getKey( conf );
+        if ( !isNullOrEmpty( key ) )
         {
-            return cancelProvider.get();
-        }
-        catch ( InterruptedException ex )
-        {
-            Thread.currentThread().interrupt();
-            return null;
-        }
-        catch ( Exception ex )
-        {
-            throw ex instanceof RuntimeException ? (RuntimeException) ex : new RuntimeException( ex );
+            removeFromSchedule( conf, key, removeFromScheduleByIdOrName.remove( key ) );
         }
     }
 
-    private boolean stoppedSuccessful( JobType type )
+    private void removeFromSchedule( JobConfiguration conf, String key, Future<?> removeFromSchedule )
     {
-        Future<?> cancelable = running.get( type );
-        if ( cancelable == null )
+        JobType type = conf.getJobType();
+        if ( removeFromSchedule == null )
         {
-            log.info( "Tried to stop job of type '{}' but no job was found", type );
-            return true;
+            log.debug( "Job '{}' of type '{}' was not scheduled before.", key, type );
+            return;
         }
-        boolean success = cancelable.isDone() || cancelable.cancel( true );
-        log.info( String.format( "Stopped job of type: '%s' with successful result: '%b'", type, success ) );
-        return success;
+        if ( removeFromSchedule.isDone() )
+        {
+            log.info( "Removing job '{}' of type '{}' from schedule had no effect as no further runs were scheduled.",
+                key, type );
+            return;
+        }
+        boolean accepted = removeFromSchedule.cancel( false );
+        log.info( "Removed job '{}' of type: '{}' from schedule: '{}'", key, type, accepted );
+    }
+
+    private static String getKey( JobConfiguration conf )
+    {
+        return isNullOrEmpty( conf.getUid() ) ? conf.getName() : conf.getUid();
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/TestJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/TestJob.java
@@ -31,7 +31,6 @@ import static java.lang.String.format;
 
 import java.util.stream.IntStream;
 
-import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
 import org.hisp.dhis.scheduling.parameters.TestJobParameters;
 import org.springframework.stereotype.Component;
 
@@ -70,14 +69,11 @@ public class TestJob implements Job
         int failAtItemDefault = items > 0 && failAtStage >= 0 ? 0 : -1;
         int failAtItem = params.getFailAtItem() == null ? failAtItemDefault : params.getFailAtItem();
         String msg = params.getFailWithMessage() == null ? "Simulated error" : params.getFailWithMessage();
-        FailurePolicy policy = params.getFailWithPolicy() == null
-            ? FailurePolicy.PARENT
-            : params.getFailWithPolicy();
         if ( stages > 0 )
         {
             for ( int stage = 0; stage < stages; stage++ )
             {
-                progress.startingStage( format( "Stage %d", stage ), items, policy );
+                progress.startingStage( format( "Stage %d", stage ), items );
                 if ( items > 0 )
                 {
                     if ( params.isFailWithException() )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/TestJob.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/scheduling/TestJob.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.scheduling;
+
+import static java.lang.String.format;
+
+import java.util.stream.IntStream;
+
+import org.hisp.dhis.scheduling.JobProgress.FailurePolicy;
+import org.hisp.dhis.scheduling.parameters.TestJobParameters;
+import org.springframework.stereotype.Component;
+
+/**
+ * A job for testing purposes that allows to fail in a controlled way.
+ *
+ * @author Jan Bernitt
+ */
+@Component
+public class TestJob implements Job
+{
+    @Override
+    public JobType getJobType()
+    {
+        return JobType.TEST;
+    }
+
+    @Override
+    @SuppressWarnings( "java:S3776" ) // better keeping all processing in one
+                                      // loop
+    public void execute( JobConfiguration conf, JobProgress progress )
+    {
+        TestJobParameters params = (TestJobParameters) conf.getJobParameters();
+        progress.startingProcess( "Test job" );
+
+        // initial wait stage
+        long waitTime = params.getWaitMillis() == null ? 0L : params.getWaitMillis();
+        progress.startingStage( format( "Waiting for %dms", waitTime ) );
+        simulateWorkForDuration( waitTime );
+        progress.completedStage( format( "waited for %dms", waitTime ) );
+
+        // additional stages (potentially with items)
+        int stages = params.getStages() == null ? 1 : params.getStages();
+        int items = params.getItems() == null ? 0 : params.getItems();
+        int failAtStage = params.getFailAtStage() == null ? -1 : params.getFailAtStage();
+        int failAtItemDefault = items > 0 && failAtStage >= 0 ? 0 : -1;
+        int failAtItem = params.getFailAtItem() == null ? failAtItemDefault : params.getFailAtItem();
+        String msg = params.getFailWithMessage() == null ? "Simulated error" : params.getFailWithMessage();
+        FailurePolicy policy = params.getFailWithPolicy() == null
+            ? FailurePolicy.PARENT
+            : params.getFailWithPolicy();
+        if ( stages > 0 )
+        {
+            for ( int stage = 0; stage < stages; stage++ )
+            {
+                progress.startingStage( format( "Stage %d", stage ), items, policy );
+                if ( items > 0 )
+                {
+                    if ( params.isFailWithException() )
+                    {
+                        progress.runStage( IntStream.range( 0, items ).boxed(), item -> "Item " + item, item -> {
+                            simulateWorkForDuration( params.getItemDuration() );
+                            if ( item == failAtItem )
+                                throw new RuntimeException( msg );
+                        } );
+                    }
+                    else
+                    {
+                        for ( int item = 0; item < items; item++ )
+                        {
+                            progress.startingWorkItem( item );
+                            simulateWorkForDuration( params.getItemDuration() );
+                            if ( item == failAtItem )
+                            {
+                                progress.failedWorkItem( msg );
+                            }
+                            else
+                            {
+                                progress.completedWorkItem( null );
+                            }
+                        }
+                    }
+                }
+                else if ( failAtStage == stage )
+                {
+                    if ( params.isFailWithException() )
+                        throw new RuntimeException( msg );
+                    progress.failedStage( msg );
+                }
+                else
+                {
+                    progress.completedStage( format( "Stage %d complete", stage ) );
+                }
+            }
+        }
+        progress.completedProcess( null );
+    }
+
+    private void simulateWorkForDuration( Long waitTime )
+    {
+        if ( waitTime == null || waitTime == 0L )
+        {
+            return;
+        }
+        try
+        {
+            Thread.sleep( waitTime );
+        }
+        catch ( InterruptedException ex )
+        {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/scheduling/SchedulingManagerTest.java
@@ -33,24 +33,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Delayed;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.hisp.dhis.cache.CacheProvider;
 import org.hisp.dhis.cache.TestCache;
@@ -61,7 +65,8 @@ import org.hisp.dhis.scheduling.parameters.AnalyticsJobParameters;
 import org.hisp.dhis.scheduling.parameters.ContinuousAnalyticsJobParameters;
 import org.hisp.dhis.system.notification.Notifier;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.TaskScheduler;
@@ -76,7 +81,7 @@ import org.springframework.util.concurrent.SuccessCallback;
  * implementation this test focuses on testing the
  * {@link DefaultSchedulingManager} implementation.
  *
- * This does not run any actual {@link Job} but checks that the ceremony around
+ * This does not run any actual {@link Job}s but checks that the ceremony around
  * running them works.
  *
  * @author Jan Bernitt
@@ -89,14 +94,14 @@ class SchedulingManagerTest
 
     private final ApplicationContext applicationContext = mock( ApplicationContext.class );
 
-    private final Job job = mock( Job.class );
-
     private DefaultSchedulingManager schedulingManager;
+
+    private final Map<String, Job> jobBeans = new LinkedHashMap<>();
 
     @BeforeEach
     void setUp()
     {
-        when( applicationContext.getBeansOfType( any() ) ).thenReturn( Collections.singletonMap( "test", job ) );
+        when( applicationContext.getBeansOfType( Job.class ) ).thenReturn( jobBeans );
 
         CacheProvider cacheProvider = mock( CacheProvider.class );
         when( cacheProvider.createJobCancelRequestedCache() ).thenReturn( new TestCache<>() );
@@ -108,137 +113,184 @@ class SchedulingManagerTest
             mock( LeaderManager.class ), taskScheduler, mock( AsyncTaskExecutor.class ), cacheProvider );
     }
 
-    @Test
-    void testScheduleRunCronJob()
+    @TestFactory
+    Stream<DynamicTest> testScheduleRunCronJob()
     {
-        JobConfiguration configuration = createCronJonConfiguration();
-        when( job.getJobType() ).thenReturn( configuration.getJobType() );
-        when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
+        JobConfiguration conf = createCronJobConfiguration();
+        when( jobConfigurationService.getJobConfigurationByUid( conf.getUid() ) ).thenReturn( conf );
         ArgumentCaptor<Runnable> cronTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.schedule( cronTask.capture(), any( Trigger.class ) ) ).thenReturn( new MockFuture<>() );
-        schedulingManager.schedule( configuration );
-        assertScheduledJob( configuration, SchedulingManagerTest::createCronJonConfiguration, cronTask.getValue() );
+        schedulingManager.schedule( conf );
+        return createTestCases( conf, this::createCronJobConfiguration, cronTask.getValue() );
     }
 
-    @Test
-    void testScheduleRunFixedDelayJob()
+    @TestFactory
+    Stream<DynamicTest> testScheduleRunFixedDelayJob()
     {
-        JobConfiguration configuration = createFixedDelayJobConfiguration();
-        when( job.getJobType() ).thenReturn( configuration.getJobType() );
-        when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
+        JobConfiguration conf = createFixedDelayJobConfiguration();
+        when( jobConfigurationService.getJobConfigurationByUid( conf.getUid() ) ).thenReturn( conf );
         ArgumentCaptor<Runnable> delayTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.scheduleWithFixedDelay( delayTask.capture(), any( Instant.class ), any( Duration.class ) ) )
             .thenReturn( new MockFuture<>() );
-        schedulingManager.schedule( configuration );
-        assertScheduledJob( configuration, SchedulingManagerTest::createFixedDelayJobConfiguration,
-            delayTask.getValue() );
+        schedulingManager.schedule( conf );
+        return createTestCases( conf, this::createFixedDelayJobConfiguration, delayTask.getValue() );
     }
 
-    @Test
-    void testScheduleRunWithStartTimeJob()
+    @TestFactory
+    Stream<DynamicTest> testScheduleRunWithStartTimeJob()
     {
-        JobConfiguration configuration = createStartTimeJobConfiguration();
-        when( job.getJobType() ).thenReturn( configuration.getJobType() );
-        when( jobConfigurationService.getJobConfigurationByUid( configuration.getUid() ) ).thenReturn( configuration );
+        JobConfiguration conf = createStartTimeJobConfiguration();
+        when( jobConfigurationService.getJobConfigurationByUid( conf.getUid() ) ).thenReturn( conf );
         ArgumentCaptor<Runnable> startTimeTask = ArgumentCaptor.forClass( Runnable.class );
         when( taskScheduler.schedule( startTimeTask.capture(), any( Date.class ) ) ).thenReturn( new MockFuture<>() );
-        schedulingManager.scheduleWithStartTime( configuration, new Date() );
-        assertScheduledJob( configuration, SchedulingManagerTest::createStartTimeJobConfiguration,
-            startTimeTask.getValue() );
+        schedulingManager.scheduleWithStartTime( conf, new Date() );
+        return createTestCases( conf, this::createStartTimeJobConfiguration, startTimeTask.getValue() );
     }
 
-    private static JobConfiguration createCronJonConfiguration()
+    private JobConfiguration createCronJobConfiguration()
     {
-        JobConfiguration configuration = new JobConfiguration( "cron", JobType.ANALYTICS_TABLE,
+        JobConfiguration conf = new JobConfiguration( "cron", JobType.ANALYTICS_TABLE,
             getDailyCronExpression( 0, 0 ), new AnalyticsJobParameters() );
         // only jobs with ID get scheduled
-        configuration.setUid( generateUid() );
-        return configuration;
+        conf.setUid( generateUid() );
+        addJob( conf );
+        return conf;
     }
 
-    private static JobConfiguration createFixedDelayJobConfiguration()
+    private JobConfiguration createFixedDelayJobConfiguration()
     {
-        JobConfiguration configuration = new JobConfiguration( "delay", JobType.CONTINUOUS_ANALYTICS_TABLE,
+        JobConfiguration conf = new JobConfiguration( "delay", JobType.CONTINUOUS_ANALYTICS_TABLE,
             getDailyCronExpression( 0, 0 ), new ContinuousAnalyticsJobParameters() );
         // only jobs with ID get scheduled
-        configuration.setUid( generateUid() );
-        configuration.setDelay( 1 );
-        return configuration;
+        conf.setUid( generateUid() );
+        conf.setDelay( 1 );
+        addJob( conf );
+        return conf;
     }
 
-    private static JobConfiguration createStartTimeJobConfiguration()
+    private JobConfiguration createStartTimeJobConfiguration()
     {
-        return new JobConfiguration( "CLUSTER_LEADER_RENEWAL", JobType.LEADER_RENEWAL, null, true );
+        JobConfiguration conf = new JobConfiguration( "CLUSTER_LEADER_RENEWAL",
+            JobType.LEADER_RENEWAL, null, true );
+        addJob( conf );
+        return conf;
     }
 
-    private void assertScheduledJob( JobConfiguration configuration, Supplier<JobConfiguration> copy, Runnable task )
+    private void addJob( JobConfiguration conf )
+    {
+        Job job = mock( Job.class );
+        when( job.getJobType() ).thenReturn( conf.getJobType() );
+        jobBeans.put( jobBeans.size() + "", job );
+    }
+
+    private Stream<DynamicTest> createTestCases( JobConfiguration configuration, Supplier<JobConfiguration> copy,
+        Runnable task )
     {
         assertNotNull( task, "job was not scheduled" );
-        assertScheduledJobCompletes( configuration, task );
-        assertScheduledJobDoesNotStartWhenAlreadyRunning( configuration, task );
-        assertScheduledJobStops( configuration, task );
-        assertScheduledJobStopWhenInterrupted( configuration, task );
-        assertScheduledJobFailsGraceful( configuration, task );
-        assertScheduledJobStaysDisabled( configuration, copy, task );
+        return Stream.of(
+            // OBS! the order here is important because these are not isolated
+            // from each other
+            dynamicTest( "assertScheduledJobCompletesSuccessful",
+                () -> assertScheduledJobCompletesSuccessful( configuration, task ) ),
+            dynamicTest( "assertJobDoesNotStartWhenAlreadyRunning",
+                () -> assertJobDoesNotStartWhenAlreadyRunning( configuration, task ) ),
+            dynamicTest( "assertScheduledJobCanBeCancelled",
+                () -> assertScheduledJobCanBeCancelled( configuration, task ) ),
+            dynamicTest( "assertScheduledJobFailsGracefulWhenInterrupted",
+                () -> assertScheduledJobFailsGracefulWhenInterrupted( configuration, task ) ),
+            dynamicTest( "assertScheduledJobFailsGraceful",
+                () -> assertScheduledJobFailsGraceful( configuration, task ) ),
+            dynamicTest( "assertStopRemovesJobFromSchedule",
+                () -> assertStopRemovesJobFromSchedule( configuration, task ) ),
+            dynamicTest( "assertScheduledJobStaysDisabled",
+                () -> assertScheduledJobStaysDisabled( configuration, copy, task ) ) );
     }
 
-    private void assertScheduledJobCompletes( JobConfiguration configuration, Runnable task )
+    private void assertScheduledJobCompletesSuccessful( JobConfiguration conf, Runnable task )
     {
+        assertTrue( schedulingManager.isScheduled( conf ), "job is scheduled before it runs" );
+
         setUpJobExecute( this::assertIsRunning );
         // synchronously
         task.run();
         verify( applicationContext, atLeastOnce() ).getBeansOfType( any() );
-        if ( !configuration.isInMemoryJob() )
+        if ( !conf.isInMemoryJob() )
         {
-            assertEquals( JobStatus.COMPLETED, configuration.getLastExecutedStatus() );
-            assertNotNull( configuration.getLastExecuted(), "job did not complete" );
+            assertEquals( JobStatus.COMPLETED, conf.getLastExecutedStatus() );
+            assertNotNull( conf.getLastExecuted(), "job did not complete" );
         }
-        assertFalse( schedulingManager.isRunning( configuration.getJobType() ),
+        assertFalse( schedulingManager.isRunning( conf.getJobType() ),
             "job is still considered running when it is actually finished" );
+        assertTrue( schedulingManager.isScheduled( conf ), "job is still scheduled after it ran" );
+        // all jobs involved in the test should have been executed once
+        jobBeans.values().forEach( job -> verify( job, times( 1 ) ).execute( any(), any() ) );
     }
 
-    private void assertIsRunning( JobConfiguration configuration )
+    private void assertIsRunning( JobConfiguration conf )
     {
-        assertTrue( schedulingManager.isRunning( configuration.getJobType() ) );
-        assertEquals( JobStatus.RUNNING, configuration.getJobStatus() );
+        assertTrue( schedulingManager.isRunning( conf.getJobType() ) );
+        assertEquals( JobStatus.RUNNING, conf.getJobStatus() );
     }
 
-    private void assertScheduledJobDoesNotStartWhenAlreadyRunning( JobConfiguration configuration, Runnable task )
+    private void assertJobDoesNotStartWhenAlreadyRunning( JobConfiguration configuration, Runnable task )
     {
-        setUpJobExecute( jobConfiguration -> assertFalse( schedulingManager.executeNow( configuration ) ) );
+        setUpJobExecute( conf -> assertFalse( schedulingManager.executeNow( configuration ) ) );
         // synchronously
         task.run();
+
+        // but now it can run as the scheduled one is not running
         assertTrue( schedulingManager.executeNow( configuration ) );
     }
 
-    private void assertScheduledJobStops( JobConfiguration configuration, Runnable task )
+    private void assertScheduledJobCanBeCancelled( JobConfiguration configuration, Runnable task )
     {
-        // once running the job stops itself
-        setUpJobExecute( jobConfiguration -> schedulingManager.stop( jobConfiguration ) );
+        // once running the job cancels itself
+        setUpJobExecute( conf -> schedulingManager.cancel( conf.getJobType() ) );
         // synchronously
         task.run();
+
         assertEquals( JobStatus.STOPPED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
     }
 
-    private void assertScheduledJobStopWhenInterrupted( JobConfiguration configuration, Runnable task )
+    private void assertStopRemovesJobFromSchedule( JobConfiguration configuration, Runnable task )
     {
-        setUpJobExecute( jobConfiguration -> Thread.currentThread().interrupt() );
+        // once running the job stops itself
+        setUpJobExecute( schedulingManager::stop );
         // synchronously
         task.run();
-        assertEquals( JobStatus.STOPPED, configuration.getLastExecutedStatus() );
+
+        // stop does not interrupt or abort a running job
+        assertEquals( JobStatus.COMPLETED, configuration.getLastExecutedStatus() );
+        // but removes it from being scheduled anymore
+        assertFalse( schedulingManager.isScheduled( configuration ) );
+
+        // also it should be valid to call stop again
+        schedulingManager.stop( configuration );
+    }
+
+    private void assertScheduledJobFailsGracefulWhenInterrupted( JobConfiguration configuration, Runnable task )
+    {
+        setUpJobExecute( conf -> Thread.currentThread().interrupt() );
+        // synchronously
+        task.run();
+
+        assertEquals( JobStatus.FAILED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
+        assertTrue( schedulingManager.isScheduled( configuration ) );
     }
 
     private void assertScheduledJobFailsGraceful( JobConfiguration configuration, Runnable task )
     {
-        setUpJobExecute( jobConfiguration -> {
+        setUpJobExecute( conf -> {
             throw new IllegalStateException( "Something goes wrong while doing the work..." );
         } );
         // synchronously
         task.run();
+
         assertEquals( JobStatus.FAILED, configuration.getLastExecutedStatus() );
         assertFalse( schedulingManager.isRunning( configuration.getJobType() ) );
+        assertTrue( schedulingManager.isScheduled( configuration ) );
     }
 
     private void assertScheduledJobStaysDisabled( JobConfiguration configuration, Supplier<JobConfiguration> copy,
@@ -246,7 +298,7 @@ class SchedulingManagerTest
     {
         if ( !configuration.isInMemoryJob() )
         {
-            setUpJobExecute( jobConfiguration -> {
+            setUpJobExecute( conf -> {
                 // pretend the job has been disabled in database
                 JobConfiguration persistent = copy.get();
                 persistent.setJobStatus( JobStatus.DISABLED );
@@ -254,6 +306,7 @@ class SchedulingManagerTest
             } );
             // synchronously
             task.run();
+
             assertEquals( JobStatus.DISABLED, configuration.getJobStatus() );
             assertFalse( configuration.isEnabled() );
         }
@@ -261,10 +314,13 @@ class SchedulingManagerTest
 
     private void setUpJobExecute( Consumer<JobConfiguration> execute )
     {
+        Job tested = jobBeans.values().iterator().next();
         doAnswer( invocation -> {
             execute.accept( invocation.getArgument( 0, JobConfiguration.class ) );
+            if ( Thread.currentThread().isInterrupted() )
+                throw new InterruptedException();
             return null;
-        } ).when( job ).execute( any( JobConfiguration.class ), any( JobProgress.class ) );
+        } ).when( tested ).execute( any( JobConfiguration.class ), any( JobProgress.class ) );
     }
 
     /**


### PR DESCRIPTION
backport from cherry-pick #12805 with manual merge conflict resolve.

Apart from simple conflicts due to changes on similar lines in `ErrorCode` and `JobConfiguration` the main cause of conflict was that 2.38 does not have the most recent `JobProgress` API with `FailurePolicy`. We opted to not backport this as many files were changed on the usage site of that API. So I had to remove some code related to the `FailurePolicy`.