### PR TITLE
fix: Remove unnecessary ELSE in date range filter [DHIS2-14442]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -278,13 +278,6 @@ public class EventQueryParams
     protected Map<TimeField, List<DateRange>> timeDateRanges = new EnumMap<>( TimeField.class );
 
     /**
-     * A list that holds the range of dates({@link DateRange}) of each period
-     * (pe).
-     */
-    @Getter
-    protected List<DateRange> periodDateRanges = new ArrayList<>();
-
-    /**
      * Flag to enable enhanced OR conditions.
      */
     @Getter
@@ -359,7 +352,6 @@ public class EventQueryParams
         params.periodType = this.periodType;
         params.explainOrderId = this.explainOrderId;
         params.timeDateRanges = this.timeDateRanges;
-        params.periodDateRanges = this.periodDateRanges;
         params.skipPartitioning = this.skipPartitioning;
         params.enhancedCondition = this.enhancedCondition;
         params.endpointItem = this.endpointItem;
@@ -497,8 +489,6 @@ public class EventQueryParams
             // The "dateField" can be: SCHEDULED_DATE, INCIDENT_DATE, etc. See {@link org.hisp.dhis.analytics.TimeField}
             boolean blankDateField = isBlank( period.getDateField() );
 
-            periodDateRanges.add( dateRange );
-
             if ( blankDateField )
             {
                 // Needed because of some internal flows.
@@ -529,8 +519,6 @@ public class EventQueryParams
         }
 
         // Sorting lists of data ranges.
-        periodDateRanges.sort( Comparator.comparing( DateRange::getStartDate ) );
-
         for ( List<DateRange> ranges : timeDateRanges.values() )
         {
             ranges.sort( Comparator.comparing( DateRange::getStartDate ) );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -65,10 +65,6 @@ public abstract class TimeFieldSqlRenderer
         {
             sql.append( getConditionForNonDefaultBoundaries( params ) );
         }
-        else if ( !params.hasContinuousRange( params.getPeriodDateRanges() ) )
-        {
-            sql.append( getPeriodsCondition( params ) );
-        }
         else if ( params.useStartEndDates() || params.hasTimeDateRanges() )
         {
             sql.append( getDateRangeCondition( params ) );
@@ -90,28 +86,6 @@ public abstract class TimeFieldSqlRenderer
     private boolean isAllowed( TimeField timeField )
     {
         return getAllowedTimeFields().contains( timeField );
-    }
-
-    /**
-     * Generates a SQL statement for based on a range of periods.
-     *
-     * @param params the {@link EventQueryParams}
-     * @return the SQL statement
-     */
-    private String getPeriodsCondition( EventQueryParams params )
-    {
-        List<String> orConditions = new ArrayList<>();
-
-        params.getPeriodDateRanges().forEach( dateRange -> {
-            ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.builder()
-                .column( getColumnName( Optional.empty(), params.getOutputType() ) )
-                .dateRange( dateRange )
-                .build();
-
-            orConditions.add( getDateRangeCondition( columnWithDateRange ) );
-        } );
-
-        return isNotEmpty( orConditions ) ? String.join( " or ", orConditions ) : EMPTY;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -157,7 +157,7 @@ public abstract class TimeFieldSqlRenderer
     private void addDefaultDateToConditions( EventQueryParams params, List<String> conditions )
     {
         ColumnWithDateRange defaultDateRangeColumn = ColumnWithDateRange.builder()
-            .column( getColumnName( TimeField.of( params.getTimeField() ), params.getOutputType() ) )
+            .column( getColumnName( getTimeField( params ), params.getOutputType() ) )
             .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
             .build();
 
@@ -174,8 +174,7 @@ public abstract class TimeFieldSqlRenderer
      */
     protected Optional<TimeField> getTimeField( EventQueryParams params )
     {
-        return TimeField.of( params.getTimeField() )
-            .filter( this::isAllowed );
+        return TimeField.of( params.getTimeField() ).filter( this::isAllowed );
     }
 
     @Data

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -101,7 +101,7 @@ public abstract class TimeFieldSqlRenderer
 
         if ( params.hasStartEndDate() )
         {
-            addDefaultDateToConditions( params, orConditions );
+            addStartEndDateToCondition( params, orConditions );
         }
 
         params.getTimeDateRanges().forEach( ( timeField, dateRanges ) -> {
@@ -154,7 +154,7 @@ public abstract class TimeFieldSqlRenderer
      * @param params the {@link EventQueryParams}
      * @param conditions a list of SQL conditions
      */
-    private void addDefaultDateToConditions( EventQueryParams params, List<String> conditions )
+    private void addStartEndDateToCondition( EventQueryParams params, List<String> conditions )
     {
         ColumnWithDateRange defaultDateRangeColumn = ColumnWithDateRange.builder()
             .column( getColumnName( getTimeField( params ), params.getOutputType() ) )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -76,7 +76,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
         assertEquals(
-            "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-05-01') or (ax.\"executiondate\" >= '2022-06-01' and ax.\"executiondate\" < '2022-07-01')",
+            "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
@@ -108,7 +108,7 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
         assertEquals(
-            "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-05-01') or (enrollmentdate >= '2022-06-01' and enrollmentdate < '2022-07-01')",
+            "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
             timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 


### PR DESCRIPTION
Removes unnecessary check that was causing some data ranges to be evaluated in the wrong way.
I realized that the list of period date ranges is not in use and can be removed.
Also, I renamed a method name to make his intention clear.