### PR TITLE
fix: cannot add sharing userGroup using json patch api

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/SharingUtils.java
@@ -44,7 +44,7 @@ import com.google.common.collect.*;
 public class SharingUtils
 {
     private static final ImmutableList<String> LEGACY_SHARING_PROPERTIES = ImmutableList.<String> builder().add(
-        "userAccesses", "userGroupAccess", "publicAccess", "externalAccess" ).build();
+        "userAccesses", "userGroupAccesses", "publicAccess", "externalAccess" ).build();
 
     private static final ObjectMapper FROM_AND_TO_JSON = createMapper();
 


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14550
- A spelling error cause `sharing.userGroups` to be cleared before it goes into json patch process.
- This will be removed on 2.40 after this PR is merged https://github.com/dhis2/dhis2-core/pull/12814 but it still need to be backported down to 2.37
- Added a unit test.