### PR TITLE
fix: Analytics event query validation in filter [DHIS2-14561]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/QueryOperator.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.common;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.replaceOnce;
 
 import java.util.Set;
@@ -77,7 +78,7 @@ public enum QueryOperator
 
     public static QueryOperator fromString( String string )
     {
-        if ( string == null || string.isEmpty() )
+        if ( isBlank( string ) )
         {
             return null;
         }
@@ -98,5 +99,10 @@ public enum QueryOperator
     public boolean isLike()
     {
         return LIKE_OPERATORS.contains( this );
+    }
+
+    public boolean isIn()
+    {
+        return IN == this;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -249,7 +249,7 @@ public class DefaultEventQueryValidator
     /**
      * Some filter values may require some conversion, so they can be correctly
      * evaluated and properly validated. This method will provide the conversion
-     * needed for each {@link ValueType} applicable.
+     * needed for each {@link ValueType} if applicable.
      *
      * @param valueType the {@link ValueType}.
      * @param filterValue the value to be converted.

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -27,11 +27,17 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.replace;
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static org.hisp.dhis.analytics.QueryKey.NV;
+import static org.hisp.dhis.common.QueryOperator.IN;
+import static org.hisp.dhis.feedback.ErrorCode.E7229;
+import static org.hisp.dhis.feedback.ErrorCode.E7234;
+import static org.hisp.dhis.system.util.ValidationUtils.valueIsComparable;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.List;
+import java.util.Set;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +47,8 @@ import org.hisp.dhis.analytics.event.EventQueryValidator;
 import org.hisp.dhis.common.IllegalQueryException;
 import org.hisp.dhis.common.QueryFilter;
 import org.hisp.dhis.common.QueryItem;
+import org.hisp.dhis.common.QueryOperator;
+import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.feedback.ErrorMessage;
 import org.hisp.dhis.setting.SettingKey;
@@ -161,13 +169,11 @@ public class DefaultEventQueryValidator
 
             for ( QueryFilter filter : item.getFilters() )
             {
-                if ( !filter.getOperator().isNullAllowed() && filter.getFilter().contains( NV ) )
+                error = validateQueryFilter( filter, item.getValueType() );
+
+                if ( error != null )
                 {
-                    error = new ErrorMessage( ErrorCode.E7229, filter.getOperator().getValue() );
-                }
-                else if ( isNotEmpty( ValidationUtils.valueIsValid( filter.getFilter(), item.getValueType() ) ) )
-                {
-                    error = new ErrorMessage( ErrorCode.E7234, filter.getFilter(), item.getValueType() );
+                    return error;
                 }
             }
         }
@@ -175,6 +181,111 @@ public class DefaultEventQueryValidator
         // TODO validate coordinate field
 
         return error;
+    }
+
+    /**
+     * Validates the full {@link QueryFilter} based on the associated item's
+     * {@link ValueType}.
+     *
+     * @param filter the {@link QueryFilter}.
+     * @param valueType the {@link ValueType}.
+     *
+     * @return the validation {@link ErrorMessage}, or null if no error is
+     *         found.
+     */
+    private ErrorMessage validateQueryFilter( QueryFilter filter, ValueType valueType )
+    {
+        String filterValue = trimToEmpty( filter.getFilter() );
+        ErrorMessage errorMessage = null;
+
+        if ( filter.getOperator().isIn() )
+        {
+            // A filter value may contain multiple options, ie.: 1;0;NV.
+            Set<String> filterValues = Set.of( filterValue.split( ";" ) );
+
+            for ( String f : filterValues )
+            {
+                errorMessage = validateFilterValue( IN, valueType, f );
+                if ( errorMessage != null )
+                {
+                    return errorMessage;
+                }
+            }
+        }
+        else
+        {
+            errorMessage = validateFilterValue( filter.getOperator(), valueType, filterValue );
+        }
+
+        return errorMessage;
+    }
+
+    /**
+     * Validates a single filter value based on its {@link ValueType} and
+     * {@link QueryOperator}.
+     *
+     * @param operator the {@link QueryOperator}.
+     * @param valueType the {@link ValueType}.
+     * @param filterValue the filter value.
+     *
+     * @return the validation{@link ErrorMessage}, or null if no error is found.
+     */
+    private ErrorMessage validateFilterValue( QueryOperator operator, ValueType valueType, String filterValue )
+    {
+        if ( !operator.isNullAllowed() && filterValue.contains( NV ) )
+        {
+            return new ErrorMessage( E7229, operator.getValue() );
+        }
+        else if ( !filterValue.contains( NV )
+            && !valueIsComparable( convertFilterValue( valueType, filterValue ), valueType ) )
+        {
+            return new ErrorMessage( E7234, filterValue, valueType );
+        }
+
+        return null;
+    }
+
+    /**
+     * Some filter values may require some conversion, so they can be correctly
+     * evaluated and properly validated. This method will provide the conversion
+     * needed for each {@link ValueType} applicable.
+     *
+     * @param valueType the {@link ValueType}.
+     * @param filterValue the value to be converted.
+     *
+     * @return the converted value or else the filter value provided.
+     */
+    private String convertFilterValue( ValueType valueType, String filterValue )
+    {
+        switch ( valueType )
+        {
+        case TIME:
+        case DATETIME:
+            return replaceDateTimeSeparators( filterValue );
+        default:
+            return filterValue;
+        }
+    }
+
+    /**
+     * Based on the given input, this method will replace the first two ".", by
+     * ":". ie:
+     *
+     * "12.02" -> "12:02"
+     *
+     * "2023-12-25T12.02.00" -> "2023-12-25T12:02:00"
+     *
+     * This is required because of the URL params uses "." as separator, so it
+     * does not clash with the character ":", used by dimensions. But
+     * internally, the date/time masks requires the separator ":".
+     *
+     * @param dateTime time, or date/time
+     *
+     * @return the value with the correct separators.
+     */
+    private String replaceDateTimeSeparators( String dateTime )
+    {
+        return replace( dateTime, ".", ":", 2 );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/DefaultEventQueryValidator.java
@@ -228,7 +228,8 @@ public class DefaultEventQueryValidator
      * @param valueType the {@link ValueType}.
      * @param filterValue the filter value.
      *
-     * @return the validation{@link ErrorMessage}, or null if no error is found.
+     * @return the validation {@link ErrorMessage}, or null if no error is
+     *         found.
      */
     private ErrorMessage validateFilterValue( QueryOperator operator, ValueType valueType, String filterValue )
     {
@@ -271,15 +272,13 @@ public class DefaultEventQueryValidator
      * Based on the given input, this method will replace the first two ".", by
      * ":". ie:
      *
-     * "12.02" -> "12:02"
-     *
-     * "2023-12-25T12.02.00" -> "2023-12-25T12:02:00"
+     * "12.02" -> "12:02", "2023-12-25T12.02.00" -> "2023-12-25T12:02:00"
      *
      * This is required because of the URL params uses "." as separator, so it
      * does not clash with the character ":", used by dimensions. But
      * internally, the date/time masks requires the separator ":".
      *
-     * @param dateTime time, or date/time
+     * @param dateTime time, or date/time.
      *
      * @return the value with the correct separators.
      */

--- a/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/main/java/org/hisp/dhis/system/util/ValidationUtils.java
@@ -27,35 +27,51 @@
  */
 package org.hisp.dhis.system.util;
 
-import static org.apache.commons.lang3.StringUtils.trimToEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.lowerCase;
+import static org.apache.commons.lang3.StringUtils.trim;
+import static org.hisp.dhis.common.CodeGenerator.isValidUid;
+import static org.hisp.dhis.common.ValueType.MULTI_TEXT;
+import static org.hisp.dhis.datavalue.DataValue.FALSE;
+import static org.hisp.dhis.datavalue.DataValue.TRUE;
+import static org.hisp.dhis.system.util.MathUtils.isBool;
+import static org.hisp.dhis.system.util.MathUtils.isCoordinate;
+import static org.hisp.dhis.system.util.MathUtils.isInteger;
+import static org.hisp.dhis.system.util.MathUtils.isNegativeInteger;
+import static org.hisp.dhis.system.util.MathUtils.isNumeric;
+import static org.hisp.dhis.system.util.MathUtils.isPercentage;
+import static org.hisp.dhis.system.util.MathUtils.isPositiveInteger;
+import static org.hisp.dhis.system.util.MathUtils.isUnitInterval;
+import static org.hisp.dhis.system.util.MathUtils.isValidDouble;
+import static org.hisp.dhis.system.util.MathUtils.isZeroOrPositiveInteger;
 import static org.hisp.dhis.system.util.MathUtils.parseDouble;
+import static org.hisp.dhis.util.DateUtils.dateIsValid;
+import static org.hisp.dhis.util.DateUtils.dateTimeIsValid;
 
 import java.awt.geom.Point2D;
 import java.util.Date;
-import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.validator.routines.DateValidator;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.hisp.dhis.analytics.AggregationType;
-import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.common.FileTypeValueOptions;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.common.ValueTypeOptions;
 import org.hisp.dhis.commons.util.TextUtils;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.datavalue.DataValue;
 import org.hisp.dhis.fileresource.FileResource;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.render.ObjectValueTypeRenderingOption;
 import org.hisp.dhis.render.StaticRenderingConfiguration;
 import org.hisp.dhis.render.type.ValueTypeRenderingType;
-import org.hisp.dhis.util.DateUtils;
 
 import com.google.common.collect.Sets;
 
@@ -113,6 +129,12 @@ public class ValidationUtils
 
     private static final Pattern GENERIC_PHONE_NUMBER = Pattern.compile( "^[0-9+\\(\\)#\\.\\s\\/ext-]{6,50}$" );
 
+    private static final Map<String, String> BOOLEAN_VALUES = Map.of(
+        "true", TRUE,
+        "false", FALSE,
+        "0", FALSE,
+        "1", TRUE );
+
     /**
      * Validates whether a filter expression contains malicious code such as SQL
      * injection attempts.
@@ -156,31 +178,6 @@ public class ValidationUtils
     public static boolean emailIsValid( String email )
     {
         return EmailValidator.getInstance().isValid( email );
-    }
-
-    /**
-     * Validates whether a date string is valid for the given Locale.
-     *
-     * @param date the date string.
-     * @param locale the Locale
-     *
-     * @return true if the date string is valid, false otherwise.
-     */
-    public static boolean dateIsValid( String date, Locale locale )
-    {
-        return DateValidator.getInstance().isValid( date, locale );
-    }
-
-    /**
-     * Validates whether a date string is valid for the default Locale.
-     *
-     * @param date the date string.
-     *
-     * @return true if the date string is valid, false otherwise.
-     */
-    public static boolean dateIsValid( String date )
-    {
-        return dateIsValid( date, null );
     }
 
     /**
@@ -523,7 +520,7 @@ public class ValidationUtils
 
         OptionSet options = dataElement.getOptionSet();
 
-        boolean isMultiText = valueType == ValueType.MULTI_TEXT;
+        boolean isMultiText = valueType == MULTI_TEXT;
 
         if ( isMultiText && options == null )
         {
@@ -578,36 +575,91 @@ public class ValidationUtils
         case LETTER:
             return !isValidLetter( value ) ? "value_not_valid_letter" : null;
         case NUMBER:
-            return !MathUtils.isNumeric( value ) ? "value_not_numeric" : null;
+            return !isNumeric( value ) ? "value_not_numeric" : null;
         case UNIT_INTERVAL:
-            return !MathUtils.isUnitInterval( value ) ? "value_not_unit_interval" : null;
+            return !isUnitInterval( value ) ? "value_not_unit_interval" : null;
         case PERCENTAGE:
-            return !MathUtils.isPercentage( value ) ? "value_not_percentage" : null;
+            return !isPercentage( value ) ? "value_not_percentage" : null;
         case INTEGER:
-            return !MathUtils.isInteger( value ) ? "value_not_integer" : null;
+            return !isInteger( value ) ? "value_not_integer" : null;
         case INTEGER_POSITIVE:
-            return !MathUtils.isPositiveInteger( value ) ? "value_not_positive_integer" : null;
+            return !isPositiveInteger( value ) ? "value_not_positive_integer" : null;
         case INTEGER_NEGATIVE:
-            return !MathUtils.isNegativeInteger( value ) ? "value_not_negative_integer" : null;
+            return !isNegativeInteger( value ) ? "value_not_negative_integer" : null;
         case INTEGER_ZERO_OR_POSITIVE:
-            return !MathUtils.isZeroOrPositiveInteger( value ) ? "value_not_zero_or_positive_integer" : null;
+            return !isZeroOrPositiveInteger( value ) ? "value_not_zero_or_positive_integer" : null;
         case BOOLEAN:
-            return !MathUtils.isBool( trimToEmpty( value ).toLowerCase() ) ? "value_not_bool" : null;
+            return !isBool( value.toLowerCase() ) ? "value_not_bool" : null;
         case TRUE_ONLY:
-            return !DataValue.TRUE.equalsIgnoreCase( trimToEmpty( value ) ) ? "value_not_true_only" : null;
+            return !TRUE.equalsIgnoreCase( value ) ? "value_not_true_only" : null;
         case DATE:
-            return !DateUtils.dateIsValid( value ) ? "value_not_valid_date" : null;
+            return !dateIsValid( value ) ? "value_not_valid_date" : null;
         case DATETIME:
-            return !DateUtils.dateTimeIsValid( value ) ? "value_not_valid_datetime" : null;
+            return !dateTimeIsValid( value ) ? "value_not_valid_datetime" : null;
         case COORDINATE:
-            return !MathUtils.isCoordinate( value ) ? "value_not_coordinate" : null;
+            return !isCoordinate( value ) ? "value_not_coordinate" : null;
         case URL:
             return !urlIsValid( value ) ? "value_not_url" : null;
         case FILE_RESOURCE:
         case IMAGE:
-            return !CodeGenerator.isValidUid( value ) ? "value_not_valid_file_resource_uid" : null;
+            return !isValidUid( value ) ? "value_not_valid_file_resource_uid" : null;
         default:
             return null;
+        }
+    }
+
+    /**
+     * Indicates whether the given "value" is comparable in relation to the
+     * given {@link ValueType}. Empty/null values are always considered NOT
+     * comparable.
+     *
+     * @param value the value.
+     * @param valueType the {@link ValueType}.
+     *
+     * @return true if the value is comparable, false otherwise.
+     */
+    public static boolean valueIsComparable( String value, ValueType valueType )
+    {
+        if ( isEmpty( value ) || value.length() > VALUE_MAX_LENGTH || valueType == null )
+        {
+            return false;
+        }
+
+        // Value type grouped checks.
+        switch ( valueType )
+        {
+        case INTEGER:
+        case INTEGER_POSITIVE:
+        case INTEGER_NEGATIVE:
+        case INTEGER_ZERO_OR_POSITIVE:
+            return isInteger( trim( value ) );
+        case NUMBER:
+        case UNIT_INTERVAL:
+        case PERCENTAGE:
+            return isValidDouble( parseDouble( trim( value ) ) );
+        case BOOLEAN:
+        case TRUE_ONLY:
+            return isBool( defaultIfBlank( BOOLEAN_VALUES.get( lowerCase( trim( value ) ) ), EMPTY ) );
+        case DATE:
+            return dateIsValid( trim( value ) );
+        case TIME:
+            return timeIsValid( trim( value ) );
+        case DATETIME:
+            return dateTimeIsValid( trim( value ) );
+        case LONG_TEXT:
+        case MULTI_TEXT:
+        case PHONE_NUMBER:
+        case EMAIL:
+        case TEXT:
+        case LETTER:
+        case COORDINATE:
+        case URL:
+        case FILE_RESOURCE:
+        case IMAGE:
+        case USERNAME:
+        case GEOJSON:
+        default:
+            return true;
         }
     }
 
@@ -741,11 +793,11 @@ public class ValidationUtils
         {
             if ( BOOL_FALSE_VARIANTS.contains( bool ) && valueType != ValueType.TRUE_ONLY )
             {
-                return DataValue.FALSE;
+                return FALSE;
             }
             else if ( BOOL_TRUE_VARIANTS.contains( bool ) )
             {
-                return DataValue.TRUE;
+                return TRUE;
             }
         }
 

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -27,6 +27,30 @@
  */
 package org.hisp.dhis.system.util;
 
+import static org.hisp.dhis.common.ValueType.BOOLEAN;
+import static org.hisp.dhis.common.ValueType.COORDINATE;
+import static org.hisp.dhis.common.ValueType.DATE;
+import static org.hisp.dhis.common.ValueType.DATETIME;
+import static org.hisp.dhis.common.ValueType.EMAIL;
+import static org.hisp.dhis.common.ValueType.FILE_RESOURCE;
+import static org.hisp.dhis.common.ValueType.GEOJSON;
+import static org.hisp.dhis.common.ValueType.IMAGE;
+import static org.hisp.dhis.common.ValueType.INTEGER;
+import static org.hisp.dhis.common.ValueType.INTEGER_NEGATIVE;
+import static org.hisp.dhis.common.ValueType.INTEGER_POSITIVE;
+import static org.hisp.dhis.common.ValueType.INTEGER_ZERO_OR_POSITIVE;
+import static org.hisp.dhis.common.ValueType.LETTER;
+import static org.hisp.dhis.common.ValueType.LONG_TEXT;
+import static org.hisp.dhis.common.ValueType.MULTI_TEXT;
+import static org.hisp.dhis.common.ValueType.NUMBER;
+import static org.hisp.dhis.common.ValueType.PERCENTAGE;
+import static org.hisp.dhis.common.ValueType.PHONE_NUMBER;
+import static org.hisp.dhis.common.ValueType.TEXT;
+import static org.hisp.dhis.common.ValueType.TIME;
+import static org.hisp.dhis.common.ValueType.TRUE_ONLY;
+import static org.hisp.dhis.common.ValueType.UNIT_INTERVAL;
+import static org.hisp.dhis.common.ValueType.URL;
+import static org.hisp.dhis.common.ValueType.USERNAME;
 import static org.hisp.dhis.system.util.ValidationUtils.bboxIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.coordinateIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.dataValueIsZeroAndInsignificant;
@@ -41,6 +65,7 @@ import static org.hisp.dhis.system.util.ValidationUtils.normalizeBoolean;
 import static org.hisp.dhis.system.util.ValidationUtils.passwordIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.usernameIsValid;
 import static org.hisp.dhis.system.util.ValidationUtils.uuidIsValid;
+import static org.hisp.dhis.system.util.ValidationUtils.valueIsComparable;
 import static org.hisp.dhis.system.util.ValidationUtils.valueIsValid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -62,11 +87,12 @@ import org.hisp.dhis.fileresource.FileResourceDomain;
 import org.junit.jupiter.api.Test;
 
 /**
+ * Unit tests for {@link ValidationUtils}.
+ *
  * @author Lars Helge Overland
  */
 class ValidationUtilsTest
 {
-
     @Test
     void testCoordinateIsValid()
     {
@@ -186,50 +212,313 @@ class ValidationUtilsTest
     void testDataValueIsZeroAndInsignificant()
     {
         DataElement de = new DataElement( "DEA" );
-        de.setValueType( ValueType.INTEGER );
+
+        de.setValueType( INTEGER );
         de.setAggregationType( AggregationType.SUM );
         assertTrue( dataValueIsZeroAndInsignificant( "0", de ) );
+
         de.setAggregationType( AggregationType.AVERAGE_SUM_ORG_UNIT );
         assertFalse( dataValueIsZeroAndInsignificant( "0", de ) );
     }
 
     @Test
-    void testDataValueIsValid()
+    void testValueIsComparable()
+    {
+        testIntegerTypes();
+        testDoubleTypes();
+        testBooleanTypes();
+        testDateTimeTypes();
+        testStringTypes();
+    }
+
+    private void testIntegerTypes()
+    {
+        ValueType valueType = INTEGER;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = INTEGER_POSITIVE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = INTEGER_NEGATIVE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = INTEGER_ZERO_OR_POSITIVE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "-1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+    }
+
+    private void testDoubleTypes()
+    {
+        ValueType valueType;
+        valueType = NUMBER;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = UNIT_INTERVAL;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = PERCENTAGE;
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45", valueType ) );
+        assertTrue( valueIsComparable( "-2.45 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+    }
+
+    private void testBooleanTypes()
+    {
+        ValueType valueType;
+        valueType = BOOLEAN;
+        assertTrue( valueIsComparable( "true", valueType ) );
+        assertTrue( valueIsComparable( "false", valueType ) );
+        assertTrue( valueIsComparable( "false ", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = TRUE_ONLY;
+        assertTrue( valueIsComparable( "true", valueType ) );
+        assertTrue( valueIsComparable( "false", valueType ) );
+        assertTrue( valueIsComparable( "false ", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "1 ", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+    }
+
+    private void testDateTimeTypes()
+    {
+        ValueType valueType;
+        valueType = DATE;
+        assertTrue( valueIsComparable( "2013-04-01", valueType ) );
+        assertFalse( valueIsComparable( "2013/04/01", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = TIME;
+        assertTrue( valueIsComparable( "12:30", valueType ) );
+        assertFalse( valueIsComparable( "12.30", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+        assertFalse( valueIsComparable( "a", valueType ) );
+
+        valueType = DATETIME;
+        assertTrue( valueIsComparable( "2021-08-30T13:53:33.767412Z", valueType ) );
+        assertTrue( valueIsComparable( "2021-08-30T13:53:33.767412", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:05.5417Z", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:05.5417", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:02.541Z", valueType ) );
+        assertTrue( valueIsComparable( "2021-08-30T13:53:33.741", valueType ) );
+        assertTrue( valueIsComparable( "2013-04-01T11:12:00", valueType ) );
+        assertFalse( valueIsComparable( "2021-08-30T13.53.33.767412Z", valueType ) );
+        assertFalse( valueIsComparable( "2021-08-30T13.53.33.767412", valueType ) );
+        assertFalse( valueIsComparable( "2013-04-01T11.12.05.5417Z", valueType ) );
+        assertFalse( valueIsComparable( "2021-08-30T13.53.33.741", valueType ) );
+        assertFalse( valueIsComparable( "2013-04-01T11.12.00", valueType ) );
+        assertFalse( valueIsComparable( "2013-04-01", valueType ) );
+        assertFalse( valueIsComparable( "abcd", valueType ) );
+        assertFalse( valueIsComparable( "-", valueType ) );
+    }
+
+    private void testStringTypes()
+    {
+        ValueType valueType;
+        valueType = LONG_TEXT;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = MULTI_TEXT;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( " ", valueType ) );
+
+        valueType = PHONE_NUMBER;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "(+355)", valueType ) );
+        assertTrue( valueIsComparable( "5-1234-5", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = EMAIL;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "5_1234_5", valueType ) );
+        assertTrue( valueIsComparable( "5-1234-5", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = TEXT;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( " ", valueType ) );
+
+        valueType = LETTER;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( " ", valueType ) );
+
+        valueType = COORDINATE;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = URL;
+        assertTrue( valueIsComparable( "http", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = FILE_RESOURCE;
+        assertTrue( valueIsComparable( "file://", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = IMAGE;
+        assertTrue( valueIsComparable( "file://", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+        assertTrue( valueIsComparable( ":", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+
+        valueType = USERNAME;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "@", valueType ) );
+
+        valueType = GEOJSON;
+        assertTrue( valueIsComparable( "a", valueType ) );
+        assertTrue( valueIsComparable( "abc", valueType ) );
+        assertTrue( valueIsComparable( "1", valueType ) );
+        assertTrue( valueIsComparable( "0", valueType ) );
+        assertTrue( valueIsComparable( "-1", valueType ) );
+        assertTrue( valueIsComparable( "[", valueType ) );
+        assertTrue( valueIsComparable( ".", valueType ) );
+        assertTrue( valueIsComparable( " ", valueType ) );
+
+        // Applicable for all value types.
+        assertFalse( valueIsComparable( "", valueType ) );
+        assertFalse( valueIsComparable( null, valueType ) );
+    }
+
+    @Test
+    void testValueIsValid()
     {
         DataElement de = new DataElement( "DEA" );
-        de.setValueType( ValueType.INTEGER );
+
+        de.setValueType( INTEGER );
         assertNull( valueIsValid( null, de ) );
         assertNull( valueIsValid( "", de ) );
         assertNull( valueIsValid( "34", de ) );
         assertNotNull( valueIsValid( "Yes", de ) );
-        de.setValueType( ValueType.NUMBER );
+
+        de.setValueType( NUMBER );
         assertNull( valueIsValid( "3.7", de ) );
         assertNotNull( valueIsValid( "No", de ) );
-        de.setValueType( ValueType.INTEGER_POSITIVE );
+
+        de.setValueType( INTEGER_POSITIVE );
         assertNull( valueIsValid( "3", de ) );
         assertNotNull( valueIsValid( "-4", de ) );
-        de.setValueType( ValueType.INTEGER_ZERO_OR_POSITIVE );
+
+        de.setValueType( INTEGER_ZERO_OR_POSITIVE );
         assertNull( valueIsValid( "3", de ) );
         assertNotNull( valueIsValid( "-4", de ) );
-        de.setValueType( ValueType.INTEGER_NEGATIVE );
+
+        de.setValueType( INTEGER_NEGATIVE );
         assertNull( valueIsValid( "-3", de ) );
         assertNotNull( valueIsValid( "4", de ) );
-        de.setValueType( ValueType.TEXT );
+
+        de.setValueType( TEXT );
         assertNull( valueIsValid( "0", de ) );
-        de.setValueType( ValueType.BOOLEAN );
+
+        de.setValueType( BOOLEAN );
         assertNull( valueIsValid( "true", de ) );
         assertNull( valueIsValid( "false", de ) );
         assertNull( valueIsValid( "FALSE", de ) );
         assertNotNull( valueIsValid( "yes", de ) );
-        de.setValueType( ValueType.TRUE_ONLY );
+
+        de.setValueType( TRUE_ONLY );
         assertNull( valueIsValid( "true", de ) );
         assertNull( valueIsValid( "TRUE", de ) );
         assertNotNull( valueIsValid( "false", de ) );
-        de.setValueType( ValueType.DATE );
+
+        de.setValueType( DATE );
         assertNull( valueIsValid( "2013-04-01", de ) );
         assertNotNull( valueIsValid( "2012304-01", de ) );
         assertNotNull( valueIsValid( "Date", de ) );
-        de.setValueType( ValueType.DATETIME );
+
+        de.setValueType( DATETIME );
         assertNull( valueIsValid( "2021-08-30T13:53:33.767412Z", de ) );
         assertNull( valueIsValid( "2021-08-30T13:53:33.767412", de ) );
         assertNull( valueIsValid( "2013-04-01T11:12:05.5417Z", de ) );
@@ -292,17 +581,17 @@ class ValidationUtilsTest
     @Test
     void testNormalizeBoolean()
     {
-        assertEquals( "true", normalizeBoolean( "1", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "T", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "true", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "TRUE", ValueType.BOOLEAN ) );
-        assertEquals( "true", normalizeBoolean( "t", ValueType.BOOLEAN ) );
-        assertEquals( "test", normalizeBoolean( "test", ValueType.TEXT ) );
-        assertEquals( "false", normalizeBoolean( "0", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "f", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "False", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "FALSE", ValueType.BOOLEAN ) );
-        assertEquals( "false", normalizeBoolean( "F", ValueType.BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "1", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "T", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "true", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "TRUE", BOOLEAN ) );
+        assertEquals( "true", normalizeBoolean( "t", BOOLEAN ) );
+        assertEquals( "test", normalizeBoolean( "test", TEXT ) );
+        assertEquals( "false", normalizeBoolean( "0", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "f", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "False", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "FALSE", BOOLEAN ) );
+        assertEquals( "false", normalizeBoolean( "F", BOOLEAN ) );
     }
 
     @Test
@@ -310,15 +599,19 @@ class ValidationUtilsTest
         throws IOException
     {
         long oneHundredMegaBytes = 1024 * (1024 * 100L);
-        ValueType valueType = ValueType.FILE_RESOURCE;
+        ValueType valueType = FILE_RESOURCE;
+
         FileTypeValueOptions options = new FileTypeValueOptions();
         options.setMaxFileSize( oneHundredMegaBytes );
         options.setAllowedContentTypes( Set.of( "jpg", "pdf" ) );
+
         FileResource fileResource = new FileResource( "name", "jpg", oneHundredMegaBytes, "md5sum",
             FileResourceDomain.DOCUMENT );
         assertNull( valueIsValid( fileResource, valueType, options ) );
+
         fileResource = new FileResource( "name", "jpg", 1024 * (1024 * 101L), "md5sum", FileResourceDomain.DOCUMENT );
         assertEquals( "not_valid_file_size_too_big", valueIsValid( fileResource, valueType, options ) );
+
         fileResource = new FileResource( "name", "exe", oneHundredMegaBytes, "md5sum", FileResourceDomain.DOCUMENT );
         assertEquals( "not_valid_file_content_type", valueIsValid( fileResource, valueType, options ) );
     }

--- a/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-system/src/test/java/org/hisp/dhis/system/util/ValidationUtilsTest.java
@@ -222,16 +222,7 @@ class ValidationUtilsTest
     }
 
     @Test
-    void testValueIsComparable()
-    {
-        testIntegerTypes();
-        testDoubleTypes();
-        testBooleanTypes();
-        testDateTimeTypes();
-        testStringTypes();
-    }
-
-    private void testIntegerTypes()
+    void testValueIsComparableForIntegerTypes()
     {
         ValueType valueType = INTEGER;
         assertTrue( valueIsComparable( "0", valueType ) );
@@ -266,7 +257,8 @@ class ValidationUtilsTest
         assertFalse( valueIsComparable( "a", valueType ) );
     }
 
-    private void testDoubleTypes()
+    @Test
+    void testValueIsComparableForDoubleTypes()
     {
         ValueType valueType;
         valueType = NUMBER;
@@ -300,7 +292,8 @@ class ValidationUtilsTest
         assertFalse( valueIsComparable( "a", valueType ) );
     }
 
-    private void testBooleanTypes()
+    @Test
+    void testValueIsComparableForBooleanTypes()
     {
         ValueType valueType;
         valueType = BOOLEAN;
@@ -324,7 +317,8 @@ class ValidationUtilsTest
         assertFalse( valueIsComparable( "a", valueType ) );
     }
 
-    private void testDateTimeTypes()
+    @Test
+    void testValueIsComparableForDateTimeTypes()
     {
         ValueType valueType;
         valueType = DATE;
@@ -357,7 +351,8 @@ class ValidationUtilsTest
         assertFalse( valueIsComparable( "-", valueType ) );
     }
 
-    private void testStringTypes()
+    @Test
+    void testValueIsComparableForStringTypes()
     {
         ValueType valueType;
         valueType = LONG_TEXT;


### PR DESCRIPTION
Fixes related to the event query filter param.
Recently, we introduced a validation for the filters based on the related `ValueType`.

This was too restrictive as clients might want to use operators like `!=`,  `like`, `not like`, `not null`, etc. We started to face validation errors for common filters that had valid comparisons.

This PR aims to make the validation more "relaxed", so filters that are comparable are always permitted. This will allow a broader set of possible comparisons and at the same time disallow invalid comparisons for the most restrictive types.
The idea is to have a more balanced validation.

I also took some time for small code improvements/clean-up.

