### PR TITLE
fix: Remove data values with null value from rule engine context [DHIS2-13979]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEntityMapperServiceTest.java
@@ -47,7 +47,6 @@ import org.hisp.dhis.commons.collection.ListUtils;
 import org.hisp.dhis.constant.Constant;
 import org.hisp.dhis.constant.ConstantService;
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.dataelement.DataElementService;
 import org.hisp.dhis.eventdatavalue.EventDataValue;
 import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.i18n.I18nManager;
@@ -162,16 +161,13 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Mock
     private I18n i18n;
 
-    @Mock
-    private DataElementService dataElementService;
-
     private DefaultProgramRuleEntityMapperService subject;
 
     @BeforeEach
     public void initTest()
     {
         subject = new DefaultProgramRuleEntityMapperService( programRuleService, programRuleVariableService,
-            dataElementService, constantService, i18nManager );
+            constantService, i18nManager );
 
         setUpProgramRules();
     }
@@ -250,20 +246,8 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     }
 
     @Test
-    void testExceptionIfDataElementIsNull()
-    {
-        when( dataElementService.getDataElement( anyString() ) ).thenReturn( null );
-
-        assertThrows( RuntimeException.class, () -> subject.toMappedRuleEvent( programStageInstanceA ),
-            "Required DataElement(" + dataElement.getUid() + ") was not found." );
-
-    }
-
-    @Test
     void testMappedRuleEvent()
     {
-        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
-
         RuleEvent ruleEvent = subject.toMappedRuleEvent( programStageInstanceA );
 
         assertEquals( ruleEvent.event(), programStageInstanceA.getUid() );
@@ -284,8 +268,6 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     void testMappedRuleEventsWithFilter()
     {
-        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
-
         List<RuleEvent> ruleEvents = subject.toMappedRuleEvents(
             Sets.newHashSet( programStageInstanceA, programStageInstanceB ), programStageInstanceA );
 
@@ -310,8 +292,6 @@ class ProgramRuleEntityMapperServiceTest extends DhisConvenienceTest
     @Test
     void testMappedRuleEvents()
     {
-        when( dataElementService.getDataElement( anyString() ) ).thenReturn( dataElement );
-
         List<RuleEvent> ruleEvents = subject
             .toMappedRuleEvents( Sets.newHashSet( programStageInstanceA, programStageInstanceB ), null );
 

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/programrule/ProgramRuleTest.java
@@ -329,6 +329,45 @@ class ProgramRuleTest extends TrackerTest
         assertNoErrorsAndNoWarnings( importReport );
     }
 
+    @Test
+    void shouldNotImportWithWhenDataElementHasValue()
+        throws IOException
+    {
+        showErrorWhenVariableHasValueRule();
+        TrackerImportParams params = fromJson(
+            "tracker/programrule/tei_completed_enrollment_event.json" );
+
+        ImportReport importReport = trackerImportService.importTracker( params );
+
+        assertHasOnlyErrors( importReport, E1300 );
+    }
+
+    @Test
+    void shouldImportWithNoWarningsWhenDataElementHasNoValue()
+        throws IOException
+    {
+        showErrorWhenVariableHasValueRule();
+        TrackerImportParams params = fromJson(
+            "tracker/programrule/tei_enrollment_event_with_no_data_value.json" );
+
+        ImportReport importReport = trackerImportService.importTracker( params );
+
+        assertNoErrorsAndNoWarnings( importReport );
+    }
+
+    @Test
+    void shouldImportWithNoWarningsWhenDataElementHasNullValue()
+        throws IOException
+    {
+        showErrorWhenVariableHasValueRule();
+        TrackerImportParams params = fromJson(
+            "tracker/programrule/tei_enrollment_event_with_null_data_value.json" );
+
+        ImportReport importReport = trackerImportService.importTracker( params );
+
+        assertNoErrorsAndNoWarnings( importReport );
+    }
+
     private void alwaysTrueErrorProgramRule()
     {
         storeProgramRule( 'A', program, ProgramRuleActionType.SHOWERROR );
@@ -379,6 +418,17 @@ class ProgramRuleTest extends TrackerTest
         ProgramRule programRule = createProgramRule( 'J', program, programStageOnComplete, "true" );
         programRuleService.addProgramRule( programRule );
         ProgramRuleAction programRuleAction = createProgramRuleAction( programRule, SHOWWARNING, dataElement1, null );
+        programRuleActionService.addProgramRuleAction( programRuleAction );
+        programRule.getProgramRuleActions().add( programRuleAction );
+        programRuleService.updateProgramRule( programRule );
+    }
+
+    private void showErrorWhenVariableHasValueRule()
+    {
+        ProgramRule programRule = createProgramRule( 'K', program, programStageOnInsert,
+            "d2:hasValue(#{ProgramRuleVariableA})" );
+        programRuleService.addProgramRule( programRule );
+        ProgramRuleAction programRuleAction = createProgramRuleAction( programRule, SHOWERROR, null, null );
         programRuleActionService.addProgramRuleAction( programRuleAction );
         programRule.getProgramRuleActions().add( programRuleAction );
         programRuleService.updateProgramRule( programRule );

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_enrollment_event_with_no_data_value.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_enrollment_event_with_no_data_value.json
@@ -1,0 +1,116 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "status": "COMPLETED",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    }
+  ],
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "status": "ACTIVE",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
+      "attributeCategoryOptions": [],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "dataValues": [],
+      "notes": []
+    }
+  ],
+  "relationships": [],
+  "username": "system-process"
+}

--- a/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_enrollment_event_with_null_data_value.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/tracker/programrule/tei_enrollment_event_with_null_data_value.json
@@ -1,0 +1,128 @@
+{
+  "importMode": "COMMIT",
+  "idSchemes": {
+    "dataElementIdScheme": {
+      "idScheme": "UID"
+    },
+    "orgUnitIdScheme": {
+      "idScheme": "UID"
+    },
+    "programIdScheme": {
+      "idScheme": "UID"
+    },
+    "programStageIdScheme": {
+      "idScheme": "UID"
+    },
+    "idScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionComboIdScheme": {
+      "idScheme": "UID"
+    },
+    "categoryOptionIdScheme": {
+      "idScheme": "UID"
+    }
+  },
+  "importStrategy": "CREATE",
+  "atomicMode": "ALL",
+  "flushMode": "AUTO",
+  "validationMode": "FULL",
+  "skipPatternValidation": false,
+  "skipSideEffects": false,
+  "skipRuleEngine": false,
+  "trackedEntities": [
+    {
+      "trackedEntity": "IOR1AXXl24H",
+      "trackedEntityType": {
+        "idScheme": "UID",
+        "identifier": "ja8NY4PW7Xm"
+      },
+      "createdAt": "2020-02-20T12:09:21.844",
+      "updatedAt": "2020-02-20T12:09:21.844",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "inactive": false,
+      "deleted": false,
+      "potentialDuplicate": false,
+      "relationships": [],
+      "attributes": [],
+      "enrollments": []
+    }
+  ],
+  "enrollments": [
+    {
+      "enrollment": "TvctPPhpD8u",
+      "createdAtClient": "2017-01-26T13:48:13.363",
+      "trackedEntity": "IOR1AXXl24H",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "status": "COMPLETED",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "orgUnitName": "Mbokie CHP",
+      "enrolledAt": "2019-03-28T12:05:00.000",
+      "occurredAt": "2019-03-28T12:05:00.000",
+      "followUp": false,
+      "deleted": false,
+      "events": [],
+      "relationships": [],
+      "attributes": [],
+      "notes": []
+    }
+  ],
+  "events": [
+    {
+      "event": "D9PbzJY8bJO",
+      "status": "ACTIVE",
+      "program": {
+        "idScheme": "UID",
+        "identifier": "BFcipDERJnf"
+      },
+      "programStage": {
+        "idScheme": "UID",
+        "identifier": "NpsdDv6kKSO"
+      },
+      "enrollment": "TvctPPhpD8u",
+      "orgUnit": {
+        "idScheme": "UID",
+        "identifier": "h4w96yEMlzO"
+      },
+      "relationships": [],
+      "occurredAt": "2019-01-28T00:00:00.000",
+      "scheduledAt": "2019-01-28T12:10:38.100",
+      "storedBy": "admin",
+      "followup": false,
+      "deleted": false,
+      "createdAt": "2019-01-28T12:10:38.108",
+      "updatedAt": "2019-01-28T12:10:38.109",
+      "attributeOptionCombo": {
+        "idScheme": "UID"
+      },
+      "attributeCategoryOptions": [],
+      "completedBy": "admin",
+      "completedAt": "2019-01-28T00:00:00.000",
+      "dataValues": [
+        {
+          "createdAt": "2019-01-28T12:10:38.113",
+          "updatedAt": "2019-01-28T12:10:38.113",
+          "storedBy": "admin",
+          "providedElsewhere": false,
+          "dataElement": {
+            "idScheme": "UID",
+            "identifier": "DATAEL00002"
+          },
+          "value": null
+        }
+      ],
+      "notes": []
+    }
+  ],
+  "relationships": [],
+  "username": "system-process"
+}


### PR DESCRIPTION
When preparing the context for rule engine, null values for data values were replaced by default value.
This was introducing a bug as `d2:hasValue()` was not working properly for data elements with null value