### PR TITLE
fix: cannot patch user.userGroups using api/users endpoint

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/user/UserGroupService.java
@@ -66,7 +66,17 @@ public interface UserGroupService
 
     void updateUserGroups( User user, Collection<String> uids );
 
-    void updateUserGroups( User user, Collection<String> uids, User currentUser );
+    /**
+     * This method will check and perform add/remove given {@link User} from
+     * given {@link UserGroup} member list. The final result is that given
+     * {@link User} will only belong to given {@link UserGroup} list.
+     *
+     * @param user the {@link User} which will be added or removed from given
+     *        list of {@link UserGroup}
+     * @param userGroupIds List uid of {@link UserGroup}
+     * @param currentUser Current User.
+     */
+    void updateUserGroups( User user, Collection<String> userGroupIds, User currentUser );
 
     List<UserGroup> getAllUserGroups();
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/UserControllerTest.java
@@ -48,6 +48,7 @@ import org.hisp.dhis.outboundmessage.OutboundMessage;
 import org.hisp.dhis.security.RestoreType;
 import org.hisp.dhis.security.SecurityService;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.user.UserGroup;
 import org.hisp.dhis.user.UserRole;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
@@ -363,6 +364,30 @@ class UserControllerTest extends DhisControllerConvenienceTest
             "{'surname':'S.','firstName':'Harry', 'email':'test@example.com', 'username':'harrys', 'userRoles': [{'id': '"
                 + roleUid + "'}]}" )
                     .content( HttpStatus.CREATED ) );
+    }
+
+    @Test
+    void testPatchUserGroups()
+    {
+        UserGroup userGroupA = createUserGroup( 'A', Set.of() );
+        userGroupA.setUid( "GZSvMCVowAx" );
+        manager.save( userGroupA );
+
+        UserGroup userGroupB = createUserGroup( 'B', Set.of() );
+        userGroupB.setUid( "B6JNeAQ6akX" );
+        manager.save( userGroupB );
+
+        assertStatus( HttpStatus.OK, PATCH( "/users/{id}", peter.getUid() + "?importReportMode=ERRORS",
+            Body(
+                "[{'op': 'add', 'path': '/userGroups', 'value': [ { 'id': 'GZSvMCVowAx' }, { 'id': 'B6JNeAQ6akX' } ] } ]" ) ) );
+
+        JsonResponse response = GET( "/users/{id}?fields=userGroups", peter.getUid() ).content( HttpStatus.OK );
+        assertEquals( 2, response.getArray( "userGroups" ).size() );
+
+        assertStatus( HttpStatus.OK, PATCH( "/users/{id}", peter.getUid() + "?importReportMode=ERRORS",
+            Body( "[{'op': 'add', 'path': '/userGroups', 'value': [ { 'id': 'GZSvMCVowAx' } ] } ]" ) ) );
+        response = GET( "/users/{id}?fields=userGroups", peter.getUid() ).content( HttpStatus.OK );
+        assertEquals( 1, response.getArray( "userGroups" ).size() );
     }
 
     private String extractTokenFromEmailText( String message )


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14557

- I have added a hack to allow user to update `user.userGroups` list by sending a PATCH request to `api/users` endpoint.
- The hack is still in master but somehow has been removed in 2.39 branch.
- Note that currently the User App sends PATCH request with `op=add` when updating a User using User edit form. I think this is wrong and the correct `op` should be `replace`.  This will be fixed in 2.40. 