### PR TITLE
feat: MAX_SUM_ORG_UNIT/MIN_SUM_ORG_UNIT [DHIS2-14430]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/AggregationType.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/analytics/AggregationType.java
@@ -52,6 +52,8 @@ public enum AggregationType
     VARIANCE( "variance", true ),
     MIN( "min", true ),
     MAX( "max", true ),
+    MIN_SUM_ORG_UNIT( "min_sum_org_unit", true ),
+    MAX_SUM_ORG_UNIT( "max_sum_org_unit", true ),
     NONE( "none", true ), // Aggregatable for text only
     CUSTOM( "custom", false ),
     DEFAULT( "default", false );

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/program/ProgramIndicator.java
@@ -159,6 +159,8 @@ public class ProgramIndicator
         case FIRST:
         case LAST:
         case LAST_IN_PERIOD:
+        case MAX_SUM_ORG_UNIT:
+        case MIN_SUM_ORG_UNIT:
             return AggregationType.SUM;
         case FIRST_AVERAGE_ORG_UNIT:
         case LAST_AVERAGE_ORG_UNIT:

--- a/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/test/java/org/hisp/dhis/dataintegrity/DataIntegrityServiceTest.java
@@ -541,6 +541,12 @@ class DataIntegrityServiceTest
         programIndicator.setAggregationType( AggregationType.AVERAGE_SUM_ORG_UNIT );
         assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
 
+        programIndicator.setAggregationType( AggregationType.MAX_SUM_ORG_UNIT );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
+        programIndicator.setAggregationType( AggregationType.MIN_SUM_ORG_UNIT );
+        assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
+
         programIndicator.setAggregationType( AggregationType.LAST_IN_PERIOD );
         assertEquals( AggregationType.SUM, programIndicator.getAggregationTypeFallback() );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsAggregationType.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/AnalyticsAggregationType.java
@@ -161,6 +161,12 @@ public class AnalyticsAggregationType
         case FIRST_FIRST_ORG_UNIT:
             analyticsAggregationType = new AnalyticsAggregationType( AggregationType.FIRST, AggregationType.FIRST );
             break;
+        case MAX_SUM_ORG_UNIT:
+            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.MAX );
+            break;
+        case MIN_SUM_ORG_UNIT:
+            analyticsAggregationType = new AnalyticsAggregationType( AggregationType.SUM, AggregationType.MIN );
+            break;
         default:
             analyticsAggregationType = new AnalyticsAggregationType( aggregationType, aggregationType );
         }
@@ -202,6 +208,12 @@ public class AnalyticsAggregationType
     public boolean isFirstOrLastOrLastInPeriodAggregationType()
     {
         return isFirstPeriodAggregationType() || isLastPeriodAggregationType() || isLastInPeriodAggregationType();
+    }
+
+    public boolean isMinOrMaxInPeriodAggregationType()
+    {
+        return periodAggregationType != aggregationType &&
+            (AggregationType.MIN == periodAggregationType || AggregationType.MAX == periodAggregationType);
     }
 
     public boolean isNumericDataType()

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManager.java
@@ -27,7 +27,9 @@
  */
 package org.hisp.dhis.analytics.data;
 
+import static java.lang.String.join;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.collections4.CollectionUtils.union;
 import static org.apache.commons.lang3.time.DateUtils.addYears;
 import static org.hisp.dhis.analytics.AggregationType.AVERAGE;
 import static org.hisp.dhis.analytics.AggregationType.COUNT;
@@ -43,9 +45,12 @@ import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.ANALYTICS_TBL_ALIAS
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quote;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
 import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAliasCommaSeparate;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteWithFunction;
+import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quotedListOf;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 import static org.hisp.dhis.common.DimensionalObject.DIMENSION_SEP;
 import static org.hisp.dhis.common.IdentifiableObjectUtils.getUids;
+import static org.hisp.dhis.commons.collection.CollectionUtils.concat;
 import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString;
 import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
@@ -58,7 +63,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -73,7 +77,6 @@ import org.hisp.dhis.analytics.MeasureFilter;
 import org.hisp.dhis.analytics.QueryPlanner;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.table.PartitionUtils;
-import org.hisp.dhis.analytics.util.AnalyticsSqlUtils;
 import org.hisp.dhis.analytics.util.AnalyticsUtils;
 import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemObject;
@@ -113,7 +116,31 @@ import com.google.common.collect.Maps;
 public class JdbcAnalyticsManager
     implements AnalyticsManager
 {
-    private static final String COL_APPROVALLEVEL = "approvallevel";
+    private static final String DX = "dx";
+
+    private static final String OU = "ou";
+
+    private static final String CO = "co";
+
+    private static final String AO = "ao";
+
+    private static final String PESTARTDATE = "pestartdate";
+
+    private static final String PEENDDATE = "peenddate";
+
+    private static final String OULEVEL = "oulevel";
+
+    private static final String DAYSXVALUE = "daysxvalue";
+
+    private static final String DAYSNO = "daysno";
+
+    private static final String YEAR = "year";
+
+    private static final String VALUE = "value";
+
+    private static final String TEXTVALUE = "textvalue";
+
+    private static final String APPROVALLEVEL = "approvallevel";
 
     private static final int LAST_VALUE_YEARS_OFFSET = -10;
 
@@ -366,6 +393,10 @@ public class JdbcAnalyticsManager
         {
             sql += getFirstOrLastValueSubquerySql( params, params.getEarliestStartDate() );
         }
+        else if ( params.getAggregationType().isMinOrMaxInPeriodAggregationType() )
+        {
+            sql += getMinOrMaxValueSubquerySql( params );
+        }
         else if ( params.hasPreAggregateMeasureCriteria() && params.isDataType( DataType.NUMERIC ) )
         {
             sql += getPreMeasureCriteriaSubquerySql( params );
@@ -481,7 +512,7 @@ public class JdbcAnalyticsManager
                 Integer level = params.getDataApprovalLevels().get( unit );
 
                 sql += "(" + ouCol + " = '" + unit.getUid() + "' and " +
-                    quoteAlias( COL_APPROVALLEVEL ) + " <= " + level + ") or ";
+                    quoteAlias( APPROVALLEVEL ) + " <= " + level + ") or ";
             }
 
             sql = removeLastOr( sql ) + ") ";
@@ -512,13 +543,13 @@ public class JdbcAnalyticsManager
         if ( tableType.hasPeriodDimension() && params.hasStartDate() )
         {
             sql += sqlHelper.whereAnd() + " " +
-                quoteAlias( "pestartdate" ) + "  >= '" + getMediumDateString( params.getStartDate() ) + "' ";
+                quoteAlias( PESTARTDATE ) + "  >= '" + getMediumDateString( params.getStartDate() ) + "' ";
         }
 
         if ( tableType.hasPeriodDimension() && params.hasEndDate() )
         {
             sql += sqlHelper.whereAnd() + " " +
-                quoteAlias( "peenddate" ) + " <= '" + getMediumDateString( params.getEndDate() ) + "' ";
+                quoteAlias( PEENDDATE ) + " <= '" + getMediumDateString( params.getEndDate() ) + "' ";
         }
 
         if ( params.isTimely() )
@@ -567,6 +598,63 @@ public class JdbcAnalyticsManager
     }
 
     /**
+     * Generates a sub query which finds the minimum or maximum value of data
+     * over periods within each organisation unit. This is useful when the main
+     * query uses a different aggregation type across organisation units.
+     *
+     * @param params the {@link DataQueryParams}.
+     * @return a SQL minimum or maximum value sub query.
+     */
+    private String getMinOrMaxValueSubquerySql( DataQueryParams params )
+    {
+        String dimensionColumns = getMinOrMaxValueSubqueryDimensionColumns( params );
+        String valueColumns = getMinOrMaxValueSubqueryValueColumns( params );
+        String fromSourceClause = getFromSourceClause( params ) + " as " + ANALYTICS_TBL_ALIAS;
+        Date earliestDate = params.getEarliestStartDate();
+        Date latestDate = params.getLatestEndDate();
+
+        return "(select " + dimensionColumns + "," + valueColumns + " " +
+            "from " + fromSourceClause + " " +
+            "where " + quoteAlias( PESTARTDATE ) + " >= '" + getMediumDateString( earliestDate ) + "' " +
+            "and " + quoteAlias( PEENDDATE ) + " <= '" + getMediumDateString( latestDate ) + "' " +
+            "and (" + quoteAlias( VALUE ) + " is not null or " + quoteAlias( TEXTVALUE ) + " is not null) " +
+            "group by " + dimensionColumns + ") ";
+    }
+
+    /**
+     * Gets a string with the dimension columns for a min or max value subquery,
+     * quoted and separated with commas.
+     *
+     * @param params the {@link DataQueryParams}.
+     * @return the dimension columns string.
+     */
+    private String getMinOrMaxValueSubqueryDimensionColumns( DataQueryParams params )
+    {
+        // Note that the non-fixed subquery dimension columns may or may not
+        // duplicate the DX column that is specified, so a Set union is used.
+        return join( ",", union( quotedListOf( DX, OU, CO, AO, OULEVEL, YEAR ),
+            getParamsDependentSubqueryDimensionColumns( params, false ) ) );
+    }
+
+    /**
+     * Gets a string with the value columns for a min or max value subquery,
+     * quoted and separated with commas. Each of the value columns will be
+     * aggregated by either min() or max().
+     *
+     * @param params the {@link DataQueryParams}.
+     * @return the value columns string.
+     */
+    private String getMinOrMaxValueSubqueryValueColumns( DataQueryParams params )
+    {
+        AggregationType periodAggregationType = params.getAggregationType().getPeriodAggregationType();
+        Assert.isTrue( MIN == periodAggregationType || MAX == periodAggregationType,
+            "periodAggregationType must be MIN or MAX, not " + periodAggregationType );
+
+        String function = periodAggregationType.name().toLowerCase();
+        return quoteWithFunction( function, DAYSXVALUE, DAYSNO, VALUE, TEXTVALUE );
+    }
+
+    /**
      * Generates a sub query which provides a view of the data where each row is
      * ranked by the start date, then end date of the data value period, latest
      * first. The data is partitioned by data element, org unit, category option
@@ -580,28 +668,19 @@ public class JdbcAnalyticsManager
      */
     private String getFirstOrLastValueSubquerySql( DataQueryParams params, Date earliestDate )
     {
-        Date latest = params.getLatestEndDate();
-        List<String> columns = getFirstOrLastValueSubqueryQuotedColumns( params );
+        Date latestDate = params.getLatestEndDate();
+        String columns = getFirstOrLastValueSubqueryColumns( params );
         String partitionColumns = getFirstOrLastValuePartitionColumns( params );
         String order = params.getAggregationType().isFirstPeriodAggregationType() ? "asc" : "desc";
         String fromSourceClause = getFromSourceClause( params ) + " as " + ANALYTICS_TBL_ALIAS;
 
-        String sql = "(select ";
-
-        for ( String col : columns )
-        {
-            sql += col + ",";
-        }
-
-        sql += "row_number() over (" +
+        return "(select " + columns + ",row_number() over (" +
             "partition by " + partitionColumns + " " +
             "order by peenddate " + order + ", pestartdate " + order + ") as pe_rank " +
             "from " + fromSourceClause + " " +
-            "where " + quoteAlias( "pestartdate" ) + " >= '" + getMediumDateString( earliestDate ) + "' " +
-            "and " + quoteAlias( "pestartdate" ) + " <= '" + getMediumDateString( latest ) + "' " +
-            "and (" + quoteAlias( "value" ) + " is not null or " + quoteAlias( "textvalue" ) + " is not null))";
-
-        return sql;
+            "where " + quoteAlias( PESTARTDATE ) + " >= '" + getMediumDateString( earliestDate ) + "' " +
+            "and " + quoteAlias( PEENDDATE ) + " <= '" + getMediumDateString( latestDate ) + "' " +
+            "and (" + quoteAlias( VALUE ) + " is not null or " + quoteAlias( TEXTVALUE ) + " is not null))";
     }
 
     /**
@@ -629,31 +708,45 @@ public class JdbcAnalyticsManager
         }
         else
         {
-            return quoteAliasCommaSeparate( List.of( "dx", "ou", "co", "ao" ) );
+            return quoteAliasCommaSeparate( List.of( DX, OU, CO, AO ) );
         }
     }
 
     /**
      * Returns quoted names of columns for the {@link AggregationType#LAST} sub
      * query. It is assumed that {@link AggregationType#LAST} type only applies
-     * to aggregate data analytics. The period dimension is replaced by the name
-     * of the single period in the given query.
+     * to aggregate data analytics.
      *
      * @param params the {@link DataQueryParams}.
-     * @return a SQL clause with quoted columns for a first or last value query.
+     * @return comma separated list of columns
      */
-    private List<String> getFirstOrLastValueSubqueryQuotedColumns( DataQueryParams params )
+    private String getFirstOrLastValueSubqueryColumns( DataQueryParams params )
+    {
+        return join( ",", concat(
+            quotedListOf( YEAR, PESTARTDATE, PEENDDATE, OULEVEL, DAYSXVALUE, DAYSNO, VALUE, TEXTVALUE ),
+            getParamsDependentSubqueryDimensionColumns( params, true ) ) );
+    }
+
+    /**
+     * Returns quoted names of all dimension columns for a period subquery (e.g.
+     * first, last, min, max) that depend on the parameters.
+     * <p>
+     * If requested, the period dimension is replaced by the name of the latest
+     * period in the given query.
+     *
+     * @param params the {@link DataQueryParams}.
+     * @param replacePeriod if the query is for first or last value.
+     * @return a {@link List} of columns
+     */
+    private List<String> getParamsDependentSubqueryDimensionColumns( DataQueryParams params, boolean replacePeriod )
     {
         Period period = params.getLatestPeriod();
 
-        List<String> cols = Lists.newArrayList( "year", "pestartdate", "peenddate", "oulevel", "daysxvalue", "daysno",
-            "value", "textvalue" );
-
-        cols = cols.stream().map( AnalyticsSqlUtils::quote ).collect( Collectors.toList() );
+        List<String> cols = Lists.newArrayList();
 
         if ( params.isDataApproval() )
         {
-            cols.add( quote( COL_APPROVALLEVEL ) );
+            cols.add( quote( APPROVALLEVEL ) );
 
             for ( OrganisationUnit unit : params.getDataApprovalLevels().keySet() )
             {
@@ -663,7 +756,7 @@ public class JdbcAnalyticsManager
 
         for ( DimensionalObject dim : params.getDimensionsAndFilters() )
         {
-            if ( DimensionType.PERIOD == dim.getDimensionType() && period != null )
+            if ( DimensionType.PERIOD == dim.getDimensionType() && period != null && replacePeriod )
             {
                 String alias = quote( dim.getDimensionName() );
                 String col = "cast('" + period.getDimensionItem() + "' as text) as " + alias;
@@ -793,7 +886,7 @@ public class JdbcAnalyticsManager
      * dimensions where each dimension name is quoted. Dimensions which are
      * considered fixed will be excluded.
      *
-     * @param dimensions the collection of {@link Dimension}.
+     * @param dimensions the collection of {@link DimensionalObject}.
      * @return a comma-delimited string of quoted dimension names.
      */
     private String getCommaDelimitedQuotedColumns( Collection<DimensionalObject> dimensions )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtils.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.analytics.util;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -72,6 +75,11 @@ public class AnalyticsSqlUtils
         String rel = relation.replaceAll( QUOTE, (QUOTE + QUOTE) );
 
         return QUOTE + rel + QUOTE;
+    }
+
+    public static List<String> quotedListOf( String... relation )
+    {
+        return Arrays.asList( relation ).stream().map( AnalyticsSqlUtils::quote ).collect( toList() );
     }
 
     /**
@@ -124,6 +132,13 @@ public class AnalyticsSqlUtils
     {
         return items.stream()
             .map( AnalyticsSqlUtils::quoteAlias )
+            .collect( Collectors.joining( "," ) );
+    }
+
+    public static String quoteWithFunction( String function, String... items )
+    {
+        return Arrays.asList( items ).stream()
+            .map( item -> String.format( "%s(%s) as %s", function, quote( item ), quote( item ) ) )
             .collect( Collectors.joining( "," ) );
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/AnalyticsAggregationTypeTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/AnalyticsAggregationTypeTest.java
@@ -37,6 +37,10 @@ import static org.hisp.dhis.analytics.AggregationType.LAST_AVERAGE_ORG_UNIT;
 import static org.hisp.dhis.analytics.AggregationType.LAST_IN_PERIOD;
 import static org.hisp.dhis.analytics.AggregationType.LAST_IN_PERIOD_AVERAGE_ORG_UNIT;
 import static org.hisp.dhis.analytics.AggregationType.LAST_LAST_ORG_UNIT;
+import static org.hisp.dhis.analytics.AggregationType.MAX;
+import static org.hisp.dhis.analytics.AggregationType.MAX_SUM_ORG_UNIT;
+import static org.hisp.dhis.analytics.AggregationType.MIN;
+import static org.hisp.dhis.analytics.AggregationType.MIN_SUM_ORG_UNIT;
 import static org.hisp.dhis.analytics.AggregationType.SUM;
 import static org.hisp.dhis.analytics.AnalyticsAggregationType.fromAggregationType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,6 +56,8 @@ class AnalyticsAggregationTypeTest
     void verifyFromAggregationType()
     {
         assertAggregationType( fromAggregationType( AVERAGE_SUM_ORG_UNIT ), SUM, AVERAGE );
+        assertAggregationType( fromAggregationType( MAX_SUM_ORG_UNIT ), SUM, MAX );
+        assertAggregationType( fromAggregationType( MIN_SUM_ORG_UNIT ), SUM, MIN );
         assertAggregationType( fromAggregationType( LAST ), SUM, LAST );
         assertAggregationType( fromAggregationType( LAST_AVERAGE_ORG_UNIT ), AVERAGE, LAST );
         assertAggregationType( fromAggregationType( LAST_LAST_ORG_UNIT ), LAST, LAST );

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/data/JdbcAnalyticsManagerTest.java
@@ -134,7 +134,7 @@ class JdbcAnalyticsManagerTest
         String subquery = "(select \"year\",\"pestartdate\",\"peenddate\",\"oulevel\",\"daysxvalue\",\"daysno\"," +
             "\"value\",\"textvalue\",\"dx\",cast('201501' as text) as \"pe\",\"ou\"," +
             "row_number() over (partition by ax.\"dx\" order by peenddate desc, pestartdate desc) as pe_rank " +
-            "from analytics as ax where ax.\"pestartdate\" >= '2005-01-31' and ax.\"pestartdate\" <= '2015-01-31' " +
+            "from analytics as ax where ax.\"pestartdate\" >= '2005-01-31' and ax.\"peenddate\" <= '2015-01-31' " +
             "and (ax.\"value\" is not null or ax.\"textvalue\" is not null))";
 
         assertThat( sql.getValue(), containsString( subquery ) );
@@ -159,6 +159,30 @@ class JdbcAnalyticsManagerTest
 
         assertExpectedLastInPeriodSql( "desc" );
     }
+
+    @Test
+    void verifyQueryGeneratedWhenDataElementHasMaxSumOrgUnitAggregationType()
+    {
+        DataQueryParams params = createParams( AggregationType.MAX_SUM_ORG_UNIT );
+
+        subject.getAggregatedDataValues( params, AnalyticsTableType.DATA_VALUE, 20000 );
+
+        assertExpectedMaxMinSumOrgUnitSql( "max" );
+    }
+
+    @Test
+    void verifyQueryGeneratedWhenDataElementHasMinSumOrgUnitAggregationType()
+    {
+        DataQueryParams params = createParams( AggregationType.MIN_SUM_ORG_UNIT );
+
+        subject.getAggregatedDataValues( params, AnalyticsTableType.DATA_VALUE, 20000 );
+
+        assertExpectedMaxMinSumOrgUnitSql( "min" );
+    }
+
+    // -------------------------------------------------------------------------
+    // Supportive methods
+    // -------------------------------------------------------------------------
 
     private void mockRowSet()
     {
@@ -187,7 +211,7 @@ class JdbcAnalyticsManagerTest
             + "\"daysno\",\"value\",\"textvalue\",\"dx\",cast('201501' as text) as \"pe\",\"ou\","
             + "row_number() over (partition by ax.\"dx\",ax.\"ou\",ax.\"co\",ax.\"ao\" order by peenddate " +
             sortOrder + ", pestartdate " + sortOrder + ") as pe_rank "
-            + "from analytics as ax where ax.\"pestartdate\" >= '2005-01-31' and ax.\"pestartdate\" <= '2015-01-31' "
+            + "from analytics as ax where ax.\"pestartdate\" >= '2005-01-31' and ax.\"peenddate\" <= '2015-01-31' "
             + "and (ax.\"value\" is not null or ax.\"textvalue\" is not null))";
 
         assertThat( sql.getValue(), containsString( lastAggregationTypeSql ) );
@@ -199,9 +223,21 @@ class JdbcAnalyticsManagerTest
             + "\"daysno\",\"value\",\"textvalue\",\"dx\",cast('201501' as text) as \"pe\",\"ou\","
             + "row_number() over (partition by ax.\"dx\",ax.\"ou\",ax.\"co\",ax.\"ao\" order by peenddate " +
             sortOrder + ", pestartdate " + sortOrder + ") as pe_rank "
-            + "from analytics as ax where ax.\"pestartdate\" >= '2015-01-01' and ax.\"pestartdate\" <= '2015-01-31' "
+            + "from analytics as ax where ax.\"pestartdate\" >= '2015-01-01' and ax.\"peenddate\" <= '2015-01-31' "
             + "and (ax.\"value\" is not null or ax.\"textvalue\" is not null))";
 
         assertThat( sql.getValue(), containsString( lastAggregationTypeSql ) );
+    }
+
+    private void assertExpectedMaxMinSumOrgUnitSql( String maxOrMin )
+    {
+        String maxMinTypeSql = "(select \"ao\",\"oulevel\",\"co\",\"pe\",\"ou\",\"dx\",\"year\","
+            + maxOrMin + "(\"daysxvalue\") as \"daysxvalue\"," + maxOrMin + "(\"daysno\") as \"daysno\","
+            + maxOrMin + "(\"value\") as \"value\"," + maxOrMin + "(\"textvalue\") as \"textvalue\" "
+            + "from analytics as ax where ax.\"pestartdate\" >= '2015-01-01' and ax.\"peenddate\" <= '2015-01-31' "
+            + "and (ax.\"value\" is not null or ax.\"textvalue\" is not null) "
+            + "group by \"ao\",\"oulevel\",\"co\",\"pe\",\"ou\",\"dx\",\"year\")";
+
+        assertThat( sql.getValue(), containsString( maxMinTypeSql ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/util/AnalyticsSqlUtilsTest.java
@@ -46,6 +46,15 @@ class AnalyticsSqlUtilsTest
     }
 
     @Test
+    void testQuotedListOf()
+    {
+        assertEquals( List.of( "\"a\"\"b\"\"c\"", "\"d\"\"e\"\"f\"" ),
+            AnalyticsSqlUtils.quotedListOf( "a\"b\"c", "d\"e\"f" ) );
+
+        assertEquals( List.of( "\"ab\"", "\"cd\"", "\"ef\"" ), AnalyticsSqlUtils.quotedListOf( "ab", "cd", "ef" ) );
+    }
+
+    @Test
     void testQuoteWithAlias()
     {
         assertEquals( "ougs.\"Short name\"", AnalyticsSqlUtils.quote( "ougs", "Short name" ) );
@@ -59,6 +68,16 @@ class AnalyticsSqlUtilsTest
             AnalyticsSqlUtils.quoteAliasCommaSeparate( List.of( "de", "pe", "ou" ) ) );
         assertEquals( "ax.\"gender\",ax.\"date of \"\"birth\"\"\"",
             AnalyticsSqlUtils.quoteAliasCommaSeparate( List.of( "gender", "date of \"birth\"" ) ) );
+    }
+
+    @Test
+    void testQuoteWithFunction()
+    {
+        assertEquals( "min(\"value\") as \"value\",min(\"textvalue\") as \"textvalue\"",
+            AnalyticsSqlUtils.quoteWithFunction( "min", "value", "textvalue" ) );
+
+        assertEquals( "max(\"daysxvalue\") as \"daysxvalue\",max(\"daysno\") as \"daysno\"",
+            AnalyticsSqlUtils.quoteWithFunction( "max", "daysxvalue", "daysno" ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.commons.collection;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -104,7 +107,7 @@ public class CollectionUtils
     {
         return collection.stream()
             .map( mapper )
-            .collect( Collectors.toList() );
+            .collect( toList() );
     }
 
     /**
@@ -153,6 +156,22 @@ public class CollectionUtils
         List<A> list = new ArrayList<>( collection1 );
         list.removeAll( collection2 );
         return Collections.unmodifiableList( list );
+    }
+
+    /**
+     * Returns a list that contains all the members of one or more collections.
+     * No check for duplicates is made.
+     *
+     * @param <T>
+     * @param collections the collections to be concatenated.
+     * @return the concatenated collections.
+     */
+    @SafeVarargs
+    public static <T> List<T> concat( Collection<T>... collections )
+    {
+        return Arrays.stream( collections )
+            .flatMap( Collection::stream )
+            .collect( toList() );
     }
 
     /**

--- a/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/CollectionUtilsTest.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/test/java/org/hisp/dhis/commons/util/CollectionUtilsTest.java
@@ -129,6 +129,16 @@ class CollectionUtilsTest
     }
 
     @Test
+    void testConcat()
+    {
+        List<String> collection1 = List.of( "a", "b", "c" );
+        List<String> collection2 = List.of( "c", "d", "e" );
+        List<String> concat = CollectionUtils.concat( collection1, collection2 );
+
+        assertEquals( List.of( "a", "b", "c", "c", "d", "e" ), concat );
+    }
+
+    @Test
     void testMapToList()
     {
         List<String> collection = Lists.newArrayList( "1", "2", "3" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/AnalyticsServiceTest.java
@@ -620,6 +620,38 @@ class AnalyticsServiceTest
     }
 
     @Test
+    void testMaxAndMinSumOrgUnit()
+    {
+        withIndicator( inA, "#{" + deA.getUid() + "}.aggregationType(MAX_SUM_ORG_UNIT)" );
+        withIndicator( inB, "#{" + deA.getUid() + "}.aggregationType(MIN_SUM_ORG_UNIT)" );
+
+        // Find max and min values inside periods within each orgUnit:
+        assertDataValues(
+            Map.of( "indicatorAA-ouabcdefghD-2017Q1", 233.0,
+                "indicatorBB-ouabcdefghD-2017Q1", 66.0,
+                "indicatorAA-ouabcdefghE-2017Q1", 1.0,
+                "indicatorBB-ouabcdefghE-2017Q1", 1.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnits( List.of( ouD, ouE ) )
+                .withIndicators( List.of( inA, inB ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriod( quarter )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+
+        // Sum the max/min values across different orgUnits:
+        // (Note: orgUnit B is parent of D and E and also has value 1.)
+        assertDataValues(
+            Map.of( "indicatorAA-ouabcdefghB-2017Q1", 235.0,
+                "indicatorBB-ouabcdefghB-2017Q1", 68.0 ),
+            DataQueryParams.newBuilder()
+                .withOrganisationUnit( ouB )
+                .withIndicators( List.of( inA, inB ) )
+                .withAggregationType( AnalyticsAggregationType.SUM )
+                .withPeriod( quarter )
+                .withOutputFormat( OutputFormat.ANALYTICS ).build() );
+    }
+
+    @Test
     void test_de_avg_2017_03()
     {
         List<DataElement> dataElements = List.of( deA, deB, deC, deD, deE );


### PR DESCRIPTION
See [DHIS2-14430](https://dhis2.atlassian.net/browse/DHIS2-14430). This adds two new data element aggregation types `MAX_SUM_ORG_UNIT` and `MIN_SUM_ORG_UNIT`.

The main logic for this is in `JdbcAnalyticsManager.getMinOrMaxValueSubquerySql` and supporting methods which creates a subquery for these types so the min or max value can be found in the subquery before summing across orgUnits. This is patterned after `getFirstOrLastValueSubquerySql` which also creates a subquery for the purpose of finding the first or last value before summing over orgUnits. The main difference is that MinOrMax uses `group by` to find the min or the max, whereas FirstOrLast uses `partition` and `row_number()`.

`getFirstOrLastValueSubquerySql` was modified to share some common code with `getMinOrMaxValueSubquerySql` and to present a similar look and feel. Also the logic was fixed where it compared the period start date against the latest end date, instead of comparing the period end date against the latest end date (likely a copy/paste/no-edit error). I believe this didn't result in wrong behaviour because it correctly identified the last period of that type that started before the end date; the next period would start after the end date. But it was fixed to conform to the logic used elsewhere.

A bunch of private string constants for column names were added in the beginning of `JdbcAnalyticsManager` to avoid SonarLint complaints about duplicate literals, which this PR would have otherwise made worse. To avoid wordiness and inconsistency a `_COL` suffix was not added to these literals and was removed from `APPROVALLEVEL_COL`.

[DHIS2-14430]: https://dhis2.atlassian.net/browse/DHIS2-14430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ