### PR TITLE
fix: Scheduled events missing when using fixed monthly periods [DHIS2…

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -1511,7 +1511,7 @@ public class DataQueryParams
         for ( int i = datesRange.size() - 1; i > 0; i-- )
         {
             boolean diffAboveOneDay = DateUtils.daysBetween( datesRange.get( i - 1 ).getEndDate(),
-                    datesRange.get( i ).getStartDate() ) > 1;
+                datesRange.get( i ).getStartDate() ) > 1;
 
             if ( diffAboveOneDay )
             {
@@ -1999,8 +1999,7 @@ public class DataQueryParams
      * @param itemType the data dimension type, or all types if null.
      * @param options the data dimension options.
      */
-    private void setDataDimensionOptions( @Nullable
-    DataDimensionItemType itemType,
+    private void setDataDimensionOptions( @Nullable DataDimensionItemType itemType,
         List<? extends DimensionalItemObject> options )
     {
         List<DimensionalItemObject> existing = getDimensionOptions( DATA_X_DIM_ID );
@@ -2373,7 +2372,6 @@ public class DataQueryParams
     {
         return endDate;
     }
-
 
     public SortOrder getOrder()
     {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -29,7 +29,9 @@ package org.hisp.dhis.analytics;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.analytics.OrgUnitField.DEFAULT_ORG_UNIT_FIELD;
 import static org.hisp.dhis.analytics.TimeField.DEFAULT_TIME_FIELDS;
 import static org.hisp.dhis.common.DimensionType.CATEGORY;
@@ -368,11 +370,6 @@ public class DataQueryParams
     protected Date endDate;
 
     /**
-     * The date range for the period dimension, can be empty.
-     */
-    protected List<DateRange> dateRangeList = new ArrayList<>();
-
-    /**
      * The order in which the data values has to be sorted, can be null.
      */
     protected SortOrder order;
@@ -601,7 +598,6 @@ public class DataQueryParams
         params.duplicatesOnly = this.duplicatesOnly;
         params.approvalLevel = this.approvalLevel;
         params.startDate = this.startDate;
-        params.dateRangeList = this.dateRangeList;
         params.endDate = this.endDate;
         params.order = this.order;
         params.timeField = this.timeField;
@@ -691,8 +687,6 @@ public class DataQueryParams
             .add( "approvalLevel", approvalLevel )
             .add( "startDate", startDate )
             .add( "endDate", endDate )
-            .add( "dateRangeList", dateRangeList.stream()
-                .map( DateRange::toString ).collect( Collectors.joining( ":" ) ) )
             .add( "order", order )
             .add( "timeField", timeField )
             .add( "orgUnitField", orgUnitField )
@@ -709,7 +703,7 @@ public class DataQueryParams
                 .collect( Collectors.joining( ":" ) );
         }
 
-        return StringUtils.EMPTY;
+        return EMPTY;
     }
 
     // -------------------------------------------------------------------------
@@ -778,7 +772,7 @@ public class DataQueryParams
     public Period getLatestPeriod()
     {
         return getAllPeriods().stream()
-            .map( obj -> (Period) obj )
+            .map( Period.class::cast )
             .min( DescendingPeriodComparator.INSTANCE )
             .orElse( null );
     }
@@ -869,7 +863,7 @@ public class DataQueryParams
     public List<Period> getTypedFilterPeriods()
     {
         return getFilterPeriods().stream()
-            .map( p -> (Period) p )
+            .map( Period.class::cast )
             .collect( Collectors.toList() );
     }
 
@@ -1499,34 +1493,25 @@ public class DataQueryParams
     }
 
     /**
-     * Indicates whether this query has a nonempty dateRangeList.
+     * Indicates whether this query has a continuous list of dates range or is
+     * empty. It assumes that the datesRange IS SORTED.
      */
-    public boolean hasDateRangeList()
+    public boolean hasContinuousRange( List<DateRange> datesRange )
     {
-        return isNotEmpty( dateRangeList );
-    }
-
-    /**
-     * Indicates whether this query has a continuous or EMPTY dateRangeList. It
-     * assumes that the dateRangeList is sorted. It should happen in the
-     * EventQueryParam::replacePeriodsWithDates method.
-     */
-    public boolean hasContinuousDateRangeList()
-    {
-        if ( !hasDateRangeList() )
+        if ( isEmpty( datesRange ) )
         {
             return true;
         }
 
-        if ( dateRangeList.size() == 1 )
+        if ( datesRange.size() == 1 )
         {
             return true;
         }
 
-        for ( int i = dateRangeList.size() - 1; i > 0; i-- )
+        for ( int i = datesRange.size() - 1; i > 0; i-- )
         {
-            boolean diffAboveOneDay = DateUtils.daysBetween( dateRangeList.get( i - 1 ).getEndDate(),
-                dateRangeList.get( i ).getStartDate() ) > 1;
+            boolean diffAboveOneDay = DateUtils.daysBetween( datesRange.get( i - 1 ).getEndDate(),
+                    datesRange.get( i ).getStartDate() ) > 1;
 
             if ( diffAboveOneDay )
             {
@@ -1535,15 +1520,6 @@ public class DataQueryParams
         }
 
         return true;
-    }
-
-    /**
-     * Indicates whether any start date is after the end date, which is invalid.
-     */
-    public boolean startDatesAfterEndDates()
-    {
-        return hasDateRangeList() && dateRangeList.stream()
-            .anyMatch( drl -> drl.getStartDate().after( drl.getEndDate() ) );
     }
 
     /**
@@ -1675,7 +1651,7 @@ public class DataQueryParams
         List<DimensionalItemObject> items = AnalyticsUtils
             .getByDataDimensionItemType( DataDimensionItemType.PROGRAM_INDICATOR, dimension.getItems() );
 
-        return items.size() > 0;
+        return isNotEmpty( items );
     }
 
     /**
@@ -2023,7 +1999,8 @@ public class DataQueryParams
      * @param itemType the data dimension type, or all types if null.
      * @param options the data dimension options.
      */
-    private void setDataDimensionOptions( @Nullable DataDimensionItemType itemType,
+    private void setDataDimensionOptions( @Nullable
+    DataDimensionItemType itemType,
         List<? extends DimensionalItemObject> options )
     {
         List<DimensionalItemObject> existing = getDimensionOptions( DATA_X_DIM_ID );
@@ -2129,7 +2106,7 @@ public class DataQueryParams
             List<String> keys = Lists.newArrayList( key.split( DIMENSION_SEP ) );
 
             // Org unit group always at last index, org unit potentially at
-            // first
+            // first.
 
             int ougInx = keys.size() - 1;
 
@@ -2159,7 +2136,7 @@ public class DataQueryParams
             return null;
         }
 
-        Map<MeasureFilter, Double> map = new HashMap<>();
+        Map<MeasureFilter, Double> map = new java.util.EnumMap<>( MeasureFilter.class );
 
         String[] criteria = param.split( DimensionalObject.OPTION_SEP );
 
@@ -2397,10 +2374,6 @@ public class DataQueryParams
         return endDate;
     }
 
-    public List<DateRange> getDateRangeList()
-    {
-        return dateRangeList;
-    }
 
     public SortOrder getOrder()
     {
@@ -2686,12 +2659,12 @@ public class DataQueryParams
         final Set<IdentifiableObject> programs = new HashSet<>();
 
         getAllProgramAttributes().stream()
-            .map( a -> (ProgramTrackedEntityAttributeDimensionItem) a )
+            .map( ProgramTrackedEntityAttributeDimensionItem.class::cast )
             .filter( a -> a.getProgram() != null )
             .forEach( a -> programs.add( a.getProgram() ) );
 
         getAllProgramDataElements().stream()
-            .map( d -> (ProgramDataElementDimensionItem) d )
+            .map( ProgramDataElementDimensionItem.class::cast )
             .filter( d -> d.getProgram() != null )
             .forEach( d -> programs.add( d.getProgram() ) );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -56,6 +56,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import lombok.Getter;
+
 import org.apache.commons.collections4.MapUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
@@ -99,8 +101,6 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
-
-import lombok.Getter;
 
 /**
  * Class representing query parameters for retrieving event data from the event

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/EventQueryParams.java
@@ -28,7 +28,10 @@
 package org.hisp.dhis.analytics.event;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.hisp.dhis.analytics.OrgUnitFieldType.ATTRIBUTE;
+import static org.hisp.dhis.analytics.SortOrder.ASC;
+import static org.hisp.dhis.analytics.SortOrder.DESC;
 import static org.hisp.dhis.common.DimensionalObject.DATA_X_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
@@ -42,20 +45,18 @@ import static org.hisp.dhis.common.FallbackCoordinateFieldType.TEI_GEOMETRY;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import lombok.Getter;
-
+import org.apache.commons.collections4.MapUtils;
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.analytics.AnalyticsAggregationType;
 import org.hisp.dhis.analytics.DataQueryParams;
@@ -99,6 +100,8 @@ import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 
+import lombok.Getter;
+
 /**
  * Class representing query parameters for retrieving event data from the event
  * analytics service. Example instantiation:
@@ -136,8 +139,9 @@ public class EventQueryParams
      */
     private List<QueryItem> itemFilters = new ArrayList<>();
 
-    /**
-     * TODO Change to List? TODO Add Javadoc
+    /*
+     * The headers to be returned. Does not make sense to be repeated and should
+     * keep ordering, hence a {@link LinkedHashSet}.
      */
     protected Set<String> headers = new LinkedHashSet<>();
 
@@ -284,14 +288,12 @@ public class EventQueryParams
     protected IdScheme dataIdScheme;
 
     /**
-     * a map holding for each time field a range of dates
+     * A map that holds time fields({@link TimeField}) and their respective
+     * range of dates({@link DateRange}).
      */
     @Getter
-    protected Map<AnalyticsDateFilter, DateRange> dateRangeByDateFilter = new HashMap<>();
+    protected Map<TimeField, List<DateRange>> timeDateRanges = new EnumMap<>( TimeField.class );
 
-    /**
-     * flag to enable enhanced OR conditions
-     */
     @Getter
     protected boolean enhancedCondition = false;
 
@@ -321,7 +323,6 @@ public class EventQueryParams
         params.skipRounding = this.skipRounding;
         params.startDate = this.startDate;
         params.endDate = this.endDate;
-        params.dateRangeList = this.dateRangeList;
         params.timeField = this.timeField;
         params.orgUnitField = this.orgUnitField;
         params.apiVersion = this.apiVersion;
@@ -365,7 +366,7 @@ public class EventQueryParams
         params.dataIdScheme = this.dataIdScheme;
         params.periodType = this.periodType;
         params.explainOrderId = this.explainOrderId;
-        params.dateRangeByDateFilter = this.dateRangeByDateFilter;
+        params.timeDateRanges = this.timeDateRanges;
         params.skipPartitioning = this.skipPartitioning;
         params.enhancedCondition = this.enhancedCondition;
         params.endpointItem = this.endpointItem;
@@ -487,81 +488,79 @@ public class EventQueryParams
      * from the periods as start date and the latest end date from the periods
      * as end date. Before removing the period dimension or filter, DateRange
      * list is created. This saves the complete date information from PE
-     * Dimension prior removal of dimension
+     * Dimension prior removal of dimension.
      *
      * When heterogeneous date fields are specified, set a specific start/date
-     * pair for each of them
+     * pair for each of them.
      */
-    private void replacePeriodsWithDates()
+    void replacePeriodsWithDates()
     {
         List<Period> periods = asTypedList( getDimensionOrFilterItems( PERIOD_DIM_ID ) );
 
         for ( Period period : periods )
         {
-            DateRange dateRange = new DateRange( period.getStartDate(), period.getEndDate() );
+            Date start = period.getStartDate();
+            Date end = period.getEndDate();
+            DateRange dateRange = new DateRange( start, end );
 
-            dateRangeList.add( dateRange );
+            // The "dateField" can be: SCHEDULED_DATE, INCIDENT_DATE, etc. See
+            // {@link org.hisp.dhis.analytics.TimeField}
+            boolean blankDateField = isBlank( period.getDateField() );
 
-            if ( Objects.isNull( period.getDateField() ) )
+            if ( blankDateField )
             {
-                Date start = period.getStartDate();
-
-                Date end = period.getEndDate();
-
-                if ( startDate == null || (start != null && start.before( startDate )) )
-                {
-                    startDate = start;
-                }
-                if ( endDate == null || (end != null && end.after( endDate )) )
-                {
-                    endDate = end;
-                }
+                // Needed because of some internal flows.
+                setDates( start, end );
             }
             else
             {
-                Optional<AnalyticsDateFilter> dateFilter = AnalyticsDateFilter.of( period.getDateField() );
-                if ( dateFilter.isPresent() )
+                Optional<AnalyticsDateFilter> optDateFilter = AnalyticsDateFilter.of( period.getDateField() );
+
+                if ( optDateFilter.isPresent() )
                 {
-                    updateStartForDateFilterIfNecessary( dateFilter.get(), period.getStartDate() );
-                    updateEndForDateFilterIfNecessary( dateFilter.get(), period.getEndDate() );
+                    TimeField timeField = optDateFilter.get().getTimeField();
+
+                    if ( timeDateRanges.containsKey( timeField ) )
+                    {
+                        List<DateRange> dateRanges = timeDateRanges.get( timeField );
+                        dateRanges.add( dateRange );
+                        timeDateRanges.replace( timeField, dateRanges );
+                    }
+                    else
+                    {
+                        List<DateRange> dateRanges = new ArrayList<>();
+                        dateRanges.add( dateRange );
+                        timeDateRanges.put( timeField, dateRanges );
+                    }
                 }
             }
         }
-        // Sorting the date range list
-        dateRangeList.sort( Comparator.comparing( DateRange::getStartDate ) );
+
+        // Sorting lists of data ranges.
+        for ( List<DateRange> ranges : timeDateRanges.values() )
+        {
+            ranges.sort( Comparator.comparing( DateRange::getStartDate ) );
+        }
 
         removeDimensionOrFilter( PERIOD_DIM_ID );
     }
 
-    private void updateStartForDateFilterIfNecessary( AnalyticsDateFilter dateFilter, Date start )
+    /**
+     * Ensures the older start date and the newer end date.
+     *
+     * @param start {@link Date}
+     * @param end {@link Date}
+     */
+    private void setDates( Date start, Date end )
     {
-        if ( dateRangeByDateFilter.get( dateFilter ) != null )
+        if ( startDate == null || (start != null && start.before( startDate )) )
         {
-            Date startDateInMap = dateRangeByDateFilter.get( dateFilter ).getStartDate();
-            if ( startDateInMap == null || (start != null && start.before( startDateInMap )) )
-            {
-                dateRangeByDateFilter.get( dateFilter ).setStartDate( start );
-            }
+            startDate = start;
         }
-        else
-        {
-            dateRangeByDateFilter.put( dateFilter, new DateRange( start, null ) );
-        }
-    }
 
-    private void updateEndForDateFilterIfNecessary( AnalyticsDateFilter dateFilter, Date end )
-    {
-        if ( dateRangeByDateFilter.get( dateFilter ) != null )
+        if ( endDate == null || (end != null && end.after( endDate )) )
         {
-            Date endDateInMap = dateRangeByDateFilter.get( dateFilter ).getEndDate();
-            if ( endDateInMap == null || (end != null && end.after( endDateInMap )) )
-            {
-                dateRangeByDateFilter.get( dateFilter ).setEndDate( end );
-            }
-        }
-        else
-        {
-            dateRangeByDateFilter.put( dateFilter, new DateRange( null, end ) );
+            endDate = end;
         }
     }
 
@@ -571,7 +570,7 @@ public class EventQueryParams
      */
     public boolean useStartEndDates()
     {
-        return hasStartEndDate() || !getDateRangeByDateFilter().isEmpty();
+        return hasStartEndDate();
     }
 
     /**
@@ -625,7 +624,7 @@ public class EventQueryParams
         return getItemsAndItemFilters().stream()
             .filter( QueryItem::hasLegendSet )
             .map( i -> i.getLegendSet().getLegends() )
-            .flatMap( i -> i.stream() )
+            .flatMap( Set::stream )
             .collect( Collectors.toSet() );
     }
 
@@ -637,7 +636,7 @@ public class EventQueryParams
         return getItemsAndItemFilters().stream()
             .filter( QueryItem::hasOptionSet )
             .map( q -> q.getOptionSet().getOptions() )
-            .flatMap( q -> q.stream() )
+            .flatMap( List::stream )
             .collect( Collectors.toSet() );
     }
 
@@ -690,11 +689,10 @@ public class EventQueryParams
             return validateProgramHasOrgUnitField( program );
         }
 
-        if ( !itemProgramIndicators.isEmpty() )
+        if ( isNotEmpty( itemProgramIndicators ) )
         {
             // Fail validation if at least one program indicator is invalid
-
-            return !itemProgramIndicators.stream().anyMatch( pi -> !validateProgramHasOrgUnitField( pi.getProgram() ) );
+            return itemProgramIndicators.stream().allMatch( pi -> validateProgramHasOrgUnitField( pi.getProgram() ) );
         }
 
         return false;
@@ -877,6 +875,11 @@ public class EventQueryParams
         return isNotEmpty( getEventStatus() );
     }
 
+    public boolean hasTimeDateRanges()
+    {
+        return MapUtils.isNotEmpty( getTimeDateRanges() );
+    }
+
     /**
      * Checks if a value dimension exists.
      *
@@ -948,7 +951,7 @@ public class EventQueryParams
      */
     public boolean hasFilterPeriods()
     {
-        return getFilterPeriods().size() > 0;
+        return isNotEmpty( getFilterPeriods() );
     }
 
     public boolean hasHeaders()
@@ -991,7 +994,12 @@ public class EventQueryParams
      */
     public int getSortOrderAsInt()
     {
-        return SortOrder.ASC.equals( sortOrder ) ? -1 : SortOrder.DESC.equals( sortOrder ) ? 1 : 0;
+        if ( ASC == sortOrder )
+        {
+            return -1;
+        }
+
+        return DESC == sortOrder ? 1 : 0;
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EnrollmentTimeFieldSqlRenderer.java
@@ -46,6 +46,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.TimeField;
@@ -57,9 +60,6 @@ import org.hisp.dhis.program.AnalyticsPeriodBoundary;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
@@ -48,6 +48,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -55,9 +58,6 @@ import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.period.Period;
 import org.springframework.stereotype.Component;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/EventTimeFieldSqlRenderer.java
@@ -27,8 +27,8 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static java.util.Arrays.asList;
 import static org.hisp.dhis.analytics.EventOutputType.ENROLLMENT;
+import static org.hisp.dhis.analytics.TimeField.ENROLLMENT_DATE;
 import static org.hisp.dhis.analytics.TimeField.EVENT_DATE;
 import static org.hisp.dhis.analytics.TimeField.LAST_UPDATED;
 import static org.hisp.dhis.analytics.TimeField.SCHEDULED_DATE;
@@ -43,14 +43,10 @@ import static org.hisp.dhis.commons.util.TextUtils.getQuotedCommaDelimitedString
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 import static org.hisp.dhis.util.DateUtils.plusOneDay;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.TimeField;
@@ -60,6 +56,9 @@ import org.hisp.dhis.jdbc.StatementBuilder;
 import org.hisp.dhis.period.Period;
 import org.springframework.stereotype.Component;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 @Component
 @RequiredArgsConstructor
 class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
@@ -67,10 +66,10 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     private final StatementBuilder statementBuilder;
 
     @Getter
-    private final Collection<TimeField> allowedTimeFields = new HashSet<>( asList( LAST_UPDATED, SCHEDULED_DATE ) );
+    private final Set<TimeField> allowedTimeFields = Set.of( LAST_UPDATED, SCHEDULED_DATE );
 
     @Override
-    protected String getSqlConditionForPeriods( final EventQueryParams params )
+    protected String getAggregatedConditionForPeriods( final EventQueryParams params )
     {
         final List<DimensionalItemObject> periods = params.getDimensionOrFilterItems( PERIOD_DIM_ID );
 
@@ -99,13 +98,13 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
     }
 
     @Override
-    protected String getColumnName( EventQueryParams params )
+    protected String getColumnName( Optional<TimeField> timeField, EventOutputType outputType )
     {
-        return getTimeCol( params.getOutputType(), getTimeField( params ) );
+        return getTimeCol( timeField, outputType );
     }
 
     @Override
-    protected String getSqlConditionForNonDefaultBoundaries( EventQueryParams params )
+    protected String getConditionForNonDefaultBoundaries( EventQueryParams params )
     {
         return params.getProgramIndicator().getAnalyticsPeriodBoundaries().stream()
             .map( analyticsPeriodBoundary -> statementBuilder.getBoundaryCondition( analyticsPeriodBoundary,
@@ -114,17 +113,21 @@ class EventTimeFieldSqlRenderer extends TimeFieldSqlRenderer
             .collect( Collectors.joining( " and " ) );
     }
 
-    private String getTimeCol( EventOutputType outputType, Optional<TimeField> timeField )
+    private String getTimeCol( Optional<TimeField> timeField, EventOutputType outputType )
     {
-        if ( ENROLLMENT.equals( outputType ) )
+        if ( timeField.isPresent() )
         {
-            return quoteAlias( TimeField.ENROLLMENT_DATE.getField() );
+            return quoteAlias( timeField.get().getField() );
         }
-        // EVENTS
-        return quoteAlias(
-            timeField
-                .map( TimeField::getField )
-                .orElse( EVENT_DATE.getField() ) );
+        else if ( ENROLLMENT == outputType )
+        {
+            return quoteAlias( ENROLLMENT_DATE.getField() );
+        }
+        else
+        {
+            // EVENTS
+            return quoteAlias( EVENT_DATE.getField() );
+        }
     }
 
     private String toSqlCondition( Period period, TimeField timeField )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -44,6 +44,8 @@ import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import java.util.Date;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
@@ -77,8 +79,6 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Markus Bekken

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEnrollmentAnalyticsManager.java
@@ -44,8 +44,6 @@ import static org.hisp.dhis.commons.util.TextUtils.removeLastOr;
 import java.util.Date;
 import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.analytics.analyze.ExecutionPlanStore;
 import org.hisp.dhis.analytics.event.EnrollmentAnalyticsManager;
@@ -79,6 +77,8 @@ import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Markus Bekken
@@ -233,7 +233,7 @@ public class JdbcEnrollmentAnalyticsManager
         // Periods
         // ---------------------------------------------------------------------
 
-        sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderTimeFieldSql( params );
+        sql += hlp.whereAnd() + " " + timeFieldSqlRenderer.renderPeriodTimeFieldSql( params );
 
         // ---------------------------------------------------------------------
         // Organisation units

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -56,6 +56,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Precision;
 import org.hisp.dhis.analytics.AggregationType;
@@ -97,8 +99,6 @@ import org.springframework.util.Assert;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * TODO could use row_number() and filtering for paging. TODO introduce

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/JdbcEventAnalyticsManager.java
@@ -56,8 +56,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.util.Precision;
 import org.hisp.dhis.analytics.AggregationType;
@@ -99,6 +97,8 @@ import org.springframework.util.Assert;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * TODO could use row_number() and filtering for paging. TODO introduce
@@ -422,7 +422,7 @@ public class JdbcEventAnalyticsManager
         // ---------------------------------------------------------------------
 
         sql += hlp.whereAnd() + " "
-            + timeFieldSqlRenderer.renderTimeFieldSql( params );
+            + timeFieldSqlRenderer.renderPeriodTimeFieldSql( params );
 
         // ---------------------------------------------------------------------
         // Organisation units

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -36,13 +36,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import lombok.Builder;
+import lombok.Data;
+
 import org.hisp.dhis.analytics.EventOutputType;
 import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.common.DateRange;
-
-import lombok.Builder;
-import lombok.Data;
 
 /**
  * Provides methods targeting the generation of SQL statements for periods and
@@ -107,19 +107,20 @@ public abstract class TimeFieldSqlRenderer
         params.getTimeDateRanges().forEach( ( timeField, dateRanges ) -> {
             if ( params.hasContinuousRange( dateRanges ) )
             {
-                // Picks the start date of the first range and end date of the last range.
+                // Picks the start date of the first range and end date of the
+                // last range.
                 DateRange dateRange = new DateRange( dateRanges.get( 0 ).getStartDate(),
-                        dateRanges.get( dateRanges.size() - 1 ).getEndDate() );
+                    dateRanges.get( dateRanges.size() - 1 ).getEndDate() );
 
                 ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
-                        getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
+                    getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
                 orConditions.add( getDateRangeCondition( columnWithDateRange ) );
             }
             else
             {
                 dateRanges.forEach( dateRange -> {
                     ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
-                            getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
+                        getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
                     orConditions.add( getDateRangeCondition( columnWithDateRange ) );
                 } );
             }
@@ -138,14 +139,14 @@ public abstract class TimeFieldSqlRenderer
     private String getDateRangeCondition( ColumnWithDateRange dateRangeColumn )
     {
         return "(" +
-                dateRangeColumn.getColumn() +
-                " >= '" +
-                getMediumDateString( dateRangeColumn.getDateRange().getStartDate() ) +
-                "' and " +
-                dateRangeColumn.getColumn() +
-                " < '" +
-                getMediumDateString( dateRangeColumn.getDateRange().getEndDatePlusOneDay() ) +
-                "')";
+            dateRangeColumn.getColumn() +
+            " >= '" +
+            getMediumDateString( dateRangeColumn.getDateRange().getStartDate() ) +
+            "' and " +
+            dateRangeColumn.getColumn() +
+            " < '" +
+            getMediumDateString( dateRangeColumn.getDateRange().getEndDatePlusOneDay() ) +
+            "')";
     }
 
     /**
@@ -157,9 +158,9 @@ public abstract class TimeFieldSqlRenderer
     private void addStartEndDateToCondition( EventQueryParams params, List<String> conditions )
     {
         ColumnWithDateRange defaultDateRangeColumn = ColumnWithDateRange.builder()
-                .column( getColumnName( getTimeField( params ), params.getOutputType() ) )
-                .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
-                .build();
+            .column( getColumnName( getTimeField( params ), params.getOutputType() ) )
+            .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
+            .build();
 
         conditions.add( getDateRangeCondition( defaultDateRangeColumn ) );
     }
@@ -188,9 +189,9 @@ public abstract class TimeFieldSqlRenderer
         static ColumnWithDateRange of( String column, DateRange dateRange )
         {
             return ColumnWithDateRange.builder()
-                    .column( column )
-                    .dateRange( dateRange )
-                    .build();
+                .column( column )
+                .dateRange( dateRange )
+                .build();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRenderer.java
@@ -27,54 +27,154 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
-import static org.hisp.dhis.analytics.util.AnalyticsSqlUtils.quoteAlias;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hisp.dhis.util.DateUtils.getMediumDateString;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Set;
+
+import org.hisp.dhis.analytics.EventOutputType;
+import org.hisp.dhis.analytics.TimeField;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.common.DateRange;
 
 import lombok.Builder;
 import lombok.Data;
 
-import org.hisp.dhis.analytics.TimeField;
-import org.hisp.dhis.analytics.event.EventQueryParams;
-import org.hisp.dhis.common.AnalyticsDateFilter;
-import org.hisp.dhis.common.DateRange;
-
+/**
+ * Provides methods targeting the generation of SQL statements for periods and
+ * time fields.
+ */
 public abstract class TimeFieldSqlRenderer
 {
-    public String renderTimeFieldSql( EventQueryParams params )
+    /**
+     * Generates a SQL statement for periods or time field based on the given
+     * params.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    public String renderPeriodTimeFieldSql( EventQueryParams params )
     {
         StringBuilder sql = new StringBuilder();
 
         if ( params.hasNonDefaultBoundaries() )
         {
-            sql.append( getSqlConditionForNonDefaultBoundaries( params ) );
+            sql.append( getConditionForNonDefaultBoundaries( params ) );
         }
-        // When multiple periods are set
-        // and date range list is no continuous
-        else if ( !params.hasContinuousDateRangeList() )
+        else if ( params.useStartEndDates() || params.hasTimeDateRanges() )
         {
-            sql.append( getSqlConditionHasDateRangeList( params ) );
+            sql.append( getDateRangeCondition( params ) );
         }
-        // otherwise
-        else if ( params.useStartEndDates() || !params.getDateRangeByDateFilter().isEmpty() )
+        else // Periods condition only for pivot table (aggregated).
         {
-            sql.append( getSqlConditionHasStartEndDate( params ) );
-        }
-        // Periods should not go here when line list, only pivot table
-        else
-        {
-            sql.append( getSqlConditionForPeriods( params ) );
+            sql.append( getAggregatedConditionForPeriods( params ) );
         }
 
         return sql.toString();
+    }
+
+    /**
+     * Checks if the given time field is allowed in time/date queries.
+     *
+     * @param timeField the {@link TimeField}
+     * @return true if the time field is allowed, false otherwise
+     */
+    private boolean isAllowed( TimeField timeField )
+    {
+        return getAllowedTimeFields().contains( timeField );
+    }
+
+    /**
+     * Returns a SQL statement based on start/end dates and all time/date ranges
+     * defined, if any.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    private String getDateRangeCondition( EventQueryParams params )
+    {
+        List<String> orConditions = new ArrayList<>();
+
+        if ( params.hasStartEndDate() )
+        {
+            addStartEndDateToCondition( params, orConditions );
+        }
+
+        params.getTimeDateRanges().forEach( ( timeField, dateRanges ) -> {
+            if ( params.hasContinuousRange( dateRanges ) )
+            {
+                // Picks the start date of the first range and end date of the last range.
+                DateRange dateRange = new DateRange( dateRanges.get( 0 ).getStartDate(),
+                        dateRanges.get( dateRanges.size() - 1 ).getEndDate() );
+
+                ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
+                        getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
+                orConditions.add( getDateRangeCondition( columnWithDateRange ) );
+            }
+            else
+            {
+                dateRanges.forEach( dateRange -> {
+                    ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.of(
+                            getColumnName( Optional.of( timeField ), params.getOutputType() ), dateRange );
+                    orConditions.add( getDateRangeCondition( columnWithDateRange ) );
+                } );
+            }
+        } );
+
+        return isNotEmpty( orConditions ) ? String.join( " or ", orConditions ) : EMPTY;
+    }
+
+    /**
+     * Returns a string representing the SQL condition for the given
+     * {@link ColumnWithDateRange}.
+     *
+     * @param dateRangeColumn
+     * @return the SQL statement
+     */
+    private String getDateRangeCondition( ColumnWithDateRange dateRangeColumn )
+    {
+        return "(" +
+                dateRangeColumn.getColumn() +
+                " >= '" +
+                getMediumDateString( dateRangeColumn.getDateRange().getStartDate() ) +
+                "' and " +
+                dateRangeColumn.getColumn() +
+                " < '" +
+                getMediumDateString( dateRangeColumn.getDateRange().getEndDatePlusOneDay() ) +
+                "')";
+    }
+
+    /**
+     * Adds the default data range condition into the given list of conditions.
+     *
+     * @param params the {@link EventQueryParams}
+     * @param conditions a list of SQL conditions
+     */
+    private void addStartEndDateToCondition( EventQueryParams params, List<String> conditions )
+    {
+        ColumnWithDateRange defaultDateRangeColumn = ColumnWithDateRange.builder()
+                .column( getColumnName( getTimeField( params ), params.getOutputType() ) )
+                .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
+                .build();
+
+        conditions.add( getDateRangeCondition( defaultDateRangeColumn ) );
+    }
+
+    /**
+     * Returns the time field {@link TimeField} set in the given params
+     * {@link EventQueryParams}. It also checks if the time field set is
+     * allowed. Case negative, it returns an empty optional.
+     *
+     * @param params the {@link EventQueryParams}
+     * @return and optional {@link TimeField}
+     */
+    protected Optional<TimeField> getTimeField( EventQueryParams params )
+    {
+        return TimeField.of( params.getTimeField() ).filter( this::isAllowed );
     }
 
     @Data
@@ -85,83 +185,49 @@ public abstract class TimeFieldSqlRenderer
 
         private final DateRange dateRange;
 
-        static ColumnWithDateRange of( Map.Entry<AnalyticsDateFilter, DateRange> entry )
+        static ColumnWithDateRange of( String column, DateRange dateRange )
         {
             return ColumnWithDateRange.builder()
-                .column( quoteAlias( entry.getKey().getTimeField().getField() ) )
-                .dateRange( entry.getValue() )
-                .build();
+                    .column( column )
+                    .dateRange( dateRange )
+                    .build();
         }
     }
-
-    protected Optional<TimeField> getTimeField( EventQueryParams params )
-    {
-        return TimeField.of( params.getTimeField() )
-            .filter( this::isAllowed );
-    }
-
-    private boolean isAllowed( TimeField timeField )
-    {
-        return getAllowedTimeFields().contains( timeField );
-    }
-
-    protected abstract String getSqlConditionForPeriods( EventQueryParams params );
 
     /**
-     * renders all periods, which are now organized by dateFilter, into SQL
+     * It generates a period SQL statement for aggregated queries based on the
+     * given params.
+     *
+     * @param params {@link EventQueryParams}
+     * @return the SQL statement
      */
-    protected String getSqlConditionHasStartEndDate( EventQueryParams params )
-    {
+    protected abstract String getAggregatedConditionForPeriods( EventQueryParams params );
 
-        ColumnWithDateRange defaultColumn = params.hasStartEndDate() ? ColumnWithDateRange.builder()
-            .column( getColumnName( params ) )
-            .dateRange( new DateRange( params.getStartDate(), params.getEndDate() ) )
-            .build() : null;
+    /**
+     * Returns the field/column associated with the given {@link TimeField}. If
+     * the time field is empty, it will return a default one. The
+     * {@link EventOutputType} might be used to decided which field/column will
+     * be the default.
+     *
+     * @param timeField the optional {@link TimeField}
+     * @param outputType the {@link EventOutputType}
+     * @return the field/column of the given time field
+     */
+    protected abstract String getColumnName( Optional<TimeField> timeField, EventOutputType outputType );
 
-        return Stream.concat(
-            Stream.of( defaultColumn ),
-            params.getDateRangeByDateFilter().entrySet().stream().map( ColumnWithDateRange::of ) )
-            .filter( Objects::nonNull )
-            .map( columnWithDateRange -> new StringBuilder()
-                .append( columnWithDateRange.getColumn() )
-                .append( " >= '" )
-                .append( getMediumDateString( columnWithDateRange.getDateRange().getStartDate() ) )
-                .append( "' and " )
-                .append( columnWithDateRange.getColumn() )
-                .append( " < '" )
-                .append( getMediumDateString( columnWithDateRange.getDateRange().getEndDatePlusOneDay() ) )
-                .append( "' " )
-                .toString() )
-            .collect( Collectors.joining( " and " ) );
-    }
+    /**
+     * Generates a SQL statement based on program indicators boundaries.
+     *
+     * @param params {@link EventQueryParams}
+     * @return the SQL statement
+     */
+    protected abstract String getConditionForNonDefaultBoundaries( EventQueryParams params );
 
-    protected String getSqlConditionHasDateRangeList( EventQueryParams params )
-    {
-        List<String> orConditions = new ArrayList<>();
-        for ( DateRange dateRange : params.getDateRangeList() )
-        {
-            ColumnWithDateRange columnWithDateRange = ColumnWithDateRange.builder()
-                .column( getColumnName( params ) )
-                .dateRange( dateRange )
-                .build();
-
-            orConditions.add(
-                columnWithDateRange.getColumn() +
-                    " >= '" +
-                    getMediumDateString( columnWithDateRange.getDateRange().getStartDate() ) +
-                    "' and " +
-                    columnWithDateRange.getColumn() +
-                    " < '" +
-                    getMediumDateString( columnWithDateRange.getDateRange().getEndDatePlusOneDay() ) +
-                    "' " );
-        }
-
-        return "(" + String.join( " or ", orConditions ) + ")";
-    }
-
-    protected abstract String getColumnName( EventQueryParams params );
-
-    protected abstract String getSqlConditionForNonDefaultBoundaries( EventQueryParams params );
-
-    protected abstract Collection<TimeField> getAllowedTimeFields();
+    /**
+     * Simply returns a collection of {@link TimeField} allowed for the
+     * respective implementation.
+     *
+     * @return the collection of {@link TimeField}
+     */
+    protected abstract Set<TimeField> getAllowedTimeFields();
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/DataQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/DataQueryParamsTest.java
@@ -52,7 +52,6 @@ import java.util.Set;
 import org.hamcrest.Matchers;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.hisp.dhis.DhisConvenienceTest;
-import org.hisp.dhis.analytics.event.EventQueryParams;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
@@ -73,16 +72,12 @@ import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorType;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.period.DailyPeriodType;
-import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.period.PeriodType;
-import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramDataElementDimensionItem;
 import org.hisp.dhis.program.ProgramTrackedEntityAttributeDimensionItem;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -673,81 +668,5 @@ class DataQueryParamsTest extends DhisConvenienceTest
             IsIterableContainingInAnyOrder.containsInAnyOrder(
                 hasProperty( "isoDate", Matchers.is( peC.getIsoDate() ) ),
                 hasProperty( "isoDate", Matchers.is( peC.getIsoDate() ) ) ) );
-    }
-
-    @Test
-    void testContinuousDateRangeListForThisWeeklyAndDailyPeriods()
-    {
-        // Given
-        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD,
-                Lists.newArrayList( weeklyPeriod, todayPeriod ) ) )
-            .build();
-
-        // When
-        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
-
-        // Then
-        assertEquals( 2, params.getDateRangeList().size() );
-        assertEquals( weeklyPeriod.getStartDate(), params.getDateRangeList().get( 0 ).getStartDate() );
-        assertEquals( weeklyPeriod.getEndDate(), params.getDateRangeList().get( 0 ).getEndDate() );
-        assertEquals( todayPeriod.getStartDate(), params.getDateRangeList().get( 1 ).getStartDate() );
-        assertEquals( todayPeriod.getEndDate(), params.getDateRangeList().get( 1 ).getEndDate() );
-        assertTrue( params.hasContinuousDateRangeList() );
-    }
-
-    @Test
-    void testContinuousDateRangeListForThisWeeklyDailyAndMonthlyPeriods()
-    {
-        // Given
-        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period monthlyPeriod = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD,
-                Lists.newArrayList( weeklyPeriod, todayPeriod, monthlyPeriod ) ) )
-            .build();
-
-        // When
-        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
-
-        // Then
-        assertEquals( 3, params.getDateRangeList().size() );
-        assertEquals( weeklyPeriod.getStartDate(), params.getDateRangeList().get( 0 ).getStartDate() );
-        assertEquals( weeklyPeriod.getEndDate(), params.getDateRangeList().get( 0 ).getEndDate() );
-        assertEquals( todayPeriod.getStartDate(), params.getDateRangeList().get( 1 ).getStartDate() );
-        assertEquals( todayPeriod.getEndDate(), params.getDateRangeList().get( 1 ).getEndDate() );
-        assertEquals( monthlyPeriod.getStartDate(), params.getDateRangeList().get( 2 ).getStartDate() );
-        assertEquals( monthlyPeriod.getEndDate(), params.getDateRangeList().get( 2 ).getEndDate() );
-        assertTrue( params.hasContinuousDateRangeList() );
-    }
-
-    @Test
-    void testNotContinuousDateRangeListForWeeklyDailyAndMonthly()
-    {
-        // Given
-        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
-        // due to sorting monthly period will be first one
-        Period monthlyPeriod = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 1, 1, 0, 0 ).toDate() );
-        EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension( new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD,
-                Lists.newArrayList( weeklyPeriod, todayPeriod, monthlyPeriod ) ) )
-            .build();
-
-        // When
-        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
-
-        // Then
-        assertEquals( 3, params.getDateRangeList().size() );
-        assertEquals( monthlyPeriod.getStartDate(), params.getDateRangeList().get( 0 ).getStartDate() );
-        assertEquals( monthlyPeriod.getEndDate(), params.getDateRangeList().get( 0 ).getEndDate() );
-        assertEquals( weeklyPeriod.getStartDate(), params.getDateRangeList().get( 1 ).getStartDate() );
-        assertEquals( weeklyPeriod.getEndDate(), params.getDateRangeList().get( 1 ).getEndDate() );
-        assertEquals( todayPeriod.getStartDate(), params.getDateRangeList().get( 2 ).getStartDate() );
-        assertEquals( todayPeriod.getEndDate(), params.getDateRangeList().get( 2 ).getEndDate() );
-        assertFalse( params.hasContinuousDateRangeList() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
@@ -27,8 +27,9 @@
  */
 package org.hisp.dhis.analytics.event;
 
-import static org.hisp.dhis.common.DimensionalObject.ORGUNIT_DIM_ID;
-import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
+import static org.hisp.dhis.analytics.TimeField.SCHEDULED_DATE;
+import static org.hisp.dhis.common.DimensionType.PERIOD;
+import static org.hisp.dhis.period.PeriodTypeEnum.MONTHLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -36,16 +37,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Collections;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.OrgUnitField;
-import org.hisp.dhis.analytics.TimeField;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.common.BaseDimensionalObject;
-import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DateRange;
 import org.hisp.dhis.common.QueryItem;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
@@ -54,8 +55,10 @@ import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.Option;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
+import org.hisp.dhis.period.DailyPeriodType;
 import org.hisp.dhis.period.MonthlyPeriodType;
 import org.hisp.dhis.period.Period;
+import org.hisp.dhis.period.WeeklyPeriodType;
 import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramIndicator;
 import org.hisp.dhis.program.ProgramStage;
@@ -65,15 +68,11 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
 /**
  * @author Lars Helge Overland
  */
 class EventQueryParamsTest extends DhisConvenienceTest
 {
-
     private Option opA;
 
     private Option opB;
@@ -150,13 +149,13 @@ class EventQueryParamsTest extends DhisConvenienceTest
         psB.addDataElement( deB, 1 );
         // Program Stage C
         psC.addDataElement( deA, 0 );
-        prA = createProgram( 'A', Sets.newHashSet( psA ), ouA );
-        prB = createProgram( 'B', Sets.newHashSet( psB ), ouA );
-        prC = createProgram( 'C', Sets.newHashSet( psC ), ouA );
+        prA = createProgram( 'A', Set.of( psA ), ouA );
+        prB = createProgram( 'B', Set.of( psB ), ouA );
+        prC = createProgram( 'C', Set.of( psC ), ouA );
         TrackedEntityAttribute teA = createTrackedEntityAttribute( 'A', ValueType.ORGANISATION_UNIT );
         teA.setUid( deD.getUid() );
         ProgramTrackedEntityAttribute pteA = createProgramTrackedEntityAttribute( prC, teA );
-        prC.setProgramAttributes( Collections.singletonList( pteA ) );
+        prC.setProgramAttributes( List.of( pteA ) );
         peA = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 4, 1, 0, 0 ).toDate() );
         peB = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
         peC = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 6, 1, 0, 0 ).toDate() );
@@ -166,9 +165,9 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testHasDimensionValue()
     {
         EventQueryParams paramsA = new EventQueryParams.Builder()
-            .withOrganisationUnits( List.of( ouA, ouB ) )
-            .withValue( deA )
-            .build();
+                .withOrganisationUnits( List.of( ouA, ouB ) )
+                .withValue( deA )
+                .build();
 
         assertTrue( paramsA.hasValueDimension() );
     }
@@ -177,14 +176,14 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testHasNumericDimensionValue()
     {
         EventQueryParams paramsA = new EventQueryParams.Builder()
-            .withOrganisationUnits( List.of( ouA, ouB ) )
-            .withValue( deA )
-            .build();
+                .withOrganisationUnits( List.of( ouA, ouB ) )
+                .withValue( deA )
+                .build();
 
         EventQueryParams paramsB = new EventQueryParams.Builder()
-            .withOrganisationUnits( List.of( ouA, ouB ) )
-            .withValue( deC )
-            .build();
+                .withOrganisationUnits( List.of( ouA, ouB ) )
+                .withValue( deC )
+                .build();
 
         assertTrue( paramsA.hasNumericValueDimension() );
         assertFalse( paramsB.hasNumericValueDimension() );
@@ -194,14 +193,14 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testHasTextDimensionValue()
     {
         EventQueryParams paramsA = new EventQueryParams.Builder()
-            .withOrganisationUnits( List.of( ouA, ouB ) )
-            .withValue( deE )
-            .build();
+                .withOrganisationUnits( List.of( ouA, ouB ) )
+                .withValue( deE )
+                .build();
 
         EventQueryParams paramsB = new EventQueryParams.Builder()
-            .withOrganisationUnits( List.of( ouA, ouB ) )
-            .withValue( deA )
-            .build();
+                .withOrganisationUnits( List.of( ouA, ouB ) )
+                .withValue( deA )
+                .build();
 
         assertTrue( paramsA.hasTextValueDimension() );
         assertFalse( paramsB.hasTextValueDimension() );
@@ -213,17 +212,16 @@ class EventQueryParamsTest extends DhisConvenienceTest
         QueryItem qiA = new QueryItem( deA, null, deA.getValueType(), deA.getAggregationType(), osA );
         QueryItem qiB = new QueryItem( deB, null, deB.getValueType(), deB.getAggregationType(), osB );
         EventQueryParams paramsA = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peB, peC ) ) )
-            .addDimension( new BaseDimensionalObject( ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT,
-                Lists.newArrayList( ouA, ouB ) ) )
-            .addItem( qiA ).addItem( qiB ).build();
+                .withPeriods( List.of( peA, peB, peC ), MONTHLY.getName() )
+                .withOrganisationUnits( List.of( ouA, ouB ) )
+                .addItem( qiA ).addItem( qiB )
+                .withLocale( Locale.FRENCH )
+                .build();
         EventQueryParams paramsB = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peB ) ) )
-            .addDimension( new BaseDimensionalObject( ORGUNIT_DIM_ID, DimensionType.ORGANISATION_UNIT,
-                Lists.newArrayList( ouA ) ) )
-            .addItem( qiA ).addItem( qiB ).withGeometryOnly( true ).build();
+                .withPeriods( List.of( peA, peB ), MONTHLY.getName() )
+                .withOrganisationUnits( List.of( ouA ) )
+                .addItem( qiA ).addItem( qiB ).withGeometryOnly( true )
+                .build();
         assertNotNull( paramsA.getKey() );
         assertEquals( 40, paramsA.getKey().length() );
         assertNotNull( paramsB.getKey() );
@@ -232,17 +230,233 @@ class EventQueryParamsTest extends DhisConvenienceTest
     }
 
     @Test
-    void testReplacePeriodsWithStartEndDates()
+    void testWithStartEndDatesForPeriodsForScheduledMonthlyWithDateField()
     {
+        // Given
+        Period periodMay = MonthlyPeriodType.getPeriodFromIsoString( "202305" );
+        periodMay.setDateField( SCHEDULED_DATE.name() );
+
+        Period periodMarch = MonthlyPeriodType.getPeriodFromIsoString( "202303" );
+        periodMarch.setDateField( SCHEDULED_DATE.name() );
+
+        Period periodFebruary = MonthlyPeriodType.getPeriodFromIsoString( "202302" );
+        periodFebruary.setDateField( SCHEDULED_DATE.name() );
+
+        // When
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peB, peC ) ) )
-            .build();
+                .withPeriods( List.of( periodMay, periodMarch, periodFebruary ), MONTHLY.getName() )
+                .withStartEndDatesForPeriods()
+                .build();
+
+        // Then
         assertNull( params.getStartDate() );
         assertNull( params.getEndDate() );
-        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
-        assertEquals( new DateTime( 2014, 4, 1, 0, 0 ).toDate(), params.getStartDate() );
-        assertEquals( new DateTime( 2014, 6, 30, 0, 0 ).toDate(), params.getEndDate() );
+        assertEquals( 1, params.getTimeDateRanges().size() );
+        assertTrue( params.getTimeDateRanges().containsKey( SCHEDULED_DATE ) );
+
+        List<DateRange> ranges = params.getTimeDateRanges().get( SCHEDULED_DATE );
+        assertEquals( 3, ranges.size() );
+
+        LocalDate febDate = toLocalDate( ranges.get( 0 ).getStartDate() );
+        assertEquals( 2023, febDate.getYear() );
+        assertEquals( 2, febDate.getMonthValue() );
+        assertEquals( 1, febDate.getDayOfMonth() );
+
+        LocalDate marchDate = toLocalDate( ranges.get( 1 ).getStartDate() );
+        assertEquals( 2023, marchDate.getYear() );
+        assertEquals( 3, marchDate.getMonthValue() );
+        assertEquals( 1, marchDate.getDayOfMonth() );
+
+        LocalDate mayDate = toLocalDate( ranges.get( 2 ).getStartDate() );
+        assertEquals( 2023, mayDate.getYear() );
+        assertEquals( 5, mayDate.getMonthValue() );
+        assertEquals( 1, mayDate.getDayOfMonth() );
+    }
+
+    @Test
+    void testReplacePeriodsWithDatesWithDifferentPeriodTypesWithDateField()
+    {
+        // Given
+        Period weeklyPeriod = WeeklyPeriodType.getPeriodFromIsoString( "2023W5" );
+        weeklyPeriod.setDateField( SCHEDULED_DATE.name() );
+
+        Period monthlyPeriod = MonthlyPeriodType.getPeriodFromIsoString( "202303" );
+        monthlyPeriod.setDateField( SCHEDULED_DATE.name() );
+
+        Period dailyPeriod = DailyPeriodType.getPeriodFromIsoString( "20230105" );
+        dailyPeriod.setDateField( SCHEDULED_DATE.name() );
+
+        List<Period> periods = List.of( weeklyPeriod, monthlyPeriod, dailyPeriod );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withStartEndDatesForPeriods()
+                .build();
+        params.getDimensions().add( new BaseDimensionalObject( "pe", PERIOD, periods ) );
+
+        // When
+        params.replacePeriodsWithDates();
+
+        // Then
+        assertNull( params.getStartDate() );
+        assertNull( params.getEndDate() );
+        assertEquals( 1, params.getTimeDateRanges().size() );
+        assertTrue( params.getTimeDateRanges().containsKey( SCHEDULED_DATE ) );
+        assertEquals( 3, params.getTimeDateRanges().get( SCHEDULED_DATE ).size() );
+    }
+
+    @Test
+    void testReplacePeriodsWithDatesWithDifferentPeriodTypesWithoutDateField()
+    {
+        // Given
+        Period weeklyPeriod = WeeklyPeriodType.getPeriodFromIsoString( "2023W5" );
+        Period monthlyPeriod = MonthlyPeriodType.getPeriodFromIsoString( "202303" );
+        Period dailyPeriod = DailyPeriodType.getPeriodFromIsoString( "20230105" );
+
+        List<Period> periods = List.of( weeklyPeriod, monthlyPeriod, dailyPeriod );
+
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withStartEndDatesForPeriods()
+                .build();
+        params.getDimensions().add( new BaseDimensionalObject( "pe", PERIOD, periods ) );
+
+        // When
+        params.replacePeriodsWithDates();
+
+        // Then
+        assertNotNull( params.getStartDate() );
+        assertNotNull( params.getEndDate() );
+        assertEquals( 0, params.getTimeDateRanges().size() );
+        assertFalse( params.getTimeDateRanges().containsKey( SCHEDULED_DATE ) );
+        assertNull( params.getTimeDateRanges().get( SCHEDULED_DATE ) );
+    }
+
+    @Test
+    void testHasContinuousRangeDateRangeIsFalseWithDateField()
+    {
+        // Given
+        Period weeklyPeriod = WeeklyPeriodType.getPeriodFromIsoString( "2023W5" );
+        DateRange weeklyRange = new DateRange( weeklyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period monthlyPeriod = MonthlyPeriodType.getPeriodFromIsoString( "202303" );
+        DateRange monthlyRange = new DateRange( monthlyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period dailyPeriod = DailyPeriodType.getPeriodFromIsoString( "20230105" );
+        DateRange dailyRange = new DateRange( dailyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        EventQueryParams params = new EventQueryParams.Builder().build();
+
+        // When
+        boolean hasContinuousRange = params.hasContinuousRange( List.of( weeklyRange, monthlyRange, dailyRange ) );
+
+        // Then
+        assertFalse( hasContinuousRange );
+    }
+
+    @Test
+    void testHasContinuousRangeDateRangeIsFalse()
+    {
+        // Given
+        Period weeklyPeriod = WeeklyPeriodType.getPeriodFromIsoString( "2023W5" );
+        DateRange weeklyRange = new DateRange( weeklyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period monthlyPeriod = MonthlyPeriodType.getPeriodFromIsoString( "202303" );
+        DateRange monthlyRange = new DateRange( monthlyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period dailyPeriod = DailyPeriodType.getPeriodFromIsoString( "20230105" );
+        DateRange dailyRange = new DateRange( dailyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        EventQueryParams params = new EventQueryParams.Builder().build();
+
+        // When
+        boolean hasContinuousRange = params.hasContinuousRange( List.of( weeklyRange, monthlyRange, dailyRange ) );
+
+        // Then
+        assertFalse( hasContinuousRange );
+    }
+
+    @Test
+    void testHasContinuousRangeDateRangeIsTrue()
+    {
+        // Given
+        Period jan = WeeklyPeriodType.getPeriodFromIsoString( "202301" );
+        DateRange janRange = new DateRange( jan.getStartDate(), jan.getEndDate() );
+
+        Period feb = MonthlyPeriodType.getPeriodFromIsoString( "202302" );
+        DateRange febRange = new DateRange( feb.getStartDate(), feb.getEndDate() );
+
+        Period mar = DailyPeriodType.getPeriodFromIsoString( "20230103" );
+        DateRange marRange = new DateRange( mar.getStartDate(), mar.getEndDate() );
+
+        EventQueryParams params = new EventQueryParams.Builder().build();
+
+        // When
+        boolean hasContinuousRange = params.hasContinuousRange( List.of( janRange, febRange, marRange ) );
+
+        // Then
+        assertTrue( hasContinuousRange );
+    }
+
+    @Test
+    void testHasContinuousRangeDateRangeForThisWeeklyAndDailyPeriods()
+    {
+        // Given
+        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange weeklyRange = new DateRange( weeklyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange todayRange = new DateRange( todayPeriod.getStartDate(), todayPeriod.getEndDate() );
+
+        EventQueryParams params = new EventQueryParams.Builder().build();
+
+        // When
+        boolean hasContinuousRange = params.hasContinuousRange( List.of( weeklyRange, todayRange ) );
+
+        // Then
+        assertTrue( hasContinuousRange );
+    }
+
+    @Test
+    void testHasContinuousRangeDateRangeForThisWeeklyDailyAndMonthlyPeriods()
+    {
+        // Given
+        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange weeklyRange = new DateRange( weeklyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange todayRange = new DateRange( todayPeriod.getStartDate(), todayPeriod.getEndDate() );
+
+        Period monthlyPeriod = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange monthlyRange = new DateRange( monthlyPeriod.getStartDate(), monthlyPeriod.getEndDate() );
+
+        EventQueryParams params = new EventQueryParams.Builder().build();
+
+        // When
+        boolean hasContinuousRange = params.hasContinuousRange( List.of( weeklyRange, todayRange, monthlyRange ) );
+
+        // Then
+        assertTrue( hasContinuousRange );
+    }
+
+    @Test
+    void testHasContinuousRangeDateRangeForWeeklyDailyAndMonthlyIsFalse()
+    {
+        // Given
+        Period monthlyPeriod = new MonthlyPeriodType().createPeriod( new DateTime( 2014, 1, 1, 0, 0 ).toDate() );
+        DateRange monthlyRange = new DateRange( monthlyPeriod.getStartDate(), monthlyPeriod.getEndDate() );
+
+        Period weeklyPeriod = new WeeklyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange weeklyRange = new DateRange( weeklyPeriod.getStartDate(), weeklyPeriod.getEndDate() );
+
+        Period todayPeriod = new DailyPeriodType().createPeriod( new DateTime( 2014, 5, 1, 0, 0 ).toDate() );
+        DateRange todayRange = new DateRange( todayPeriod.getStartDate(), todayPeriod.getEndDate() );
+
+        EventQueryParams params = new EventQueryParams.Builder().build();
+
+        // When
+        boolean hasContinuousRange = params.hasContinuousRange( List.of( monthlyRange, weeklyRange, todayRange ) );
+
+        // Then
+        assertFalse( hasContinuousRange );
     }
 
     @Test
@@ -252,8 +466,10 @@ class EventQueryParamsTest extends DhisConvenienceTest
         Legend leB = createLegend( 'B', 1d, 2d );
         LegendSet lsA = createLegendSet( 'A', leA, leB );
         QueryItem qiA = new QueryItem( deA, lsA, deA.getValueType(), deA.getAggregationType(), null );
-        EventQueryParams params = new EventQueryParams.Builder().addItem( qiA ).build();
-        Set<Legend> expected = Sets.newHashSet( leA, leB );
+        EventQueryParams params = new EventQueryParams.Builder()
+                .addItem( qiA )
+                .build();
+        Set<Legend> expected = Set.of( leA, leB );
         assertEquals( expected, params.getItemLegends() );
     }
 
@@ -262,8 +478,11 @@ class EventQueryParamsTest extends DhisConvenienceTest
     {
         QueryItem qiA = new QueryItem( deA, null, deA.getValueType(), deA.getAggregationType(), osA );
         QueryItem qiB = new QueryItem( deB, null, deB.getValueType(), deB.getAggregationType(), osB );
-        EventQueryParams params = new EventQueryParams.Builder().addItem( qiA ).addItem( qiB ).build();
-        Set<Option> expected = Sets.newHashSet( opA, opB, opC, opD );
+        EventQueryParams params = new EventQueryParams.Builder()
+                .addItem( qiA )
+                .addItem( qiB )
+                .build();
+        Set<Option> expected = Set.of( opA, opB, opC, opD );
         assertEquals( expected, params.getItemOptions() );
     }
 
@@ -274,8 +493,12 @@ class EventQueryParamsTest extends DhisConvenienceTest
         QueryItem iB = new QueryItem( createDataElement( 'B', new CategoryCombo() ) );
         QueryItem iC = new QueryItem( createDataElement( 'B', new CategoryCombo() ) );
         QueryItem iD = new QueryItem( createDataElement( 'D', new CategoryCombo() ) );
-        EventQueryParams params = new EventQueryParams.Builder().addItem( iA ).addItem( iB ).addItem( iC ).addItem( iD )
-            .build();
+        EventQueryParams params = new EventQueryParams.Builder()
+                .addItem( iA )
+                .addItem( iB )
+                .addItem( iC )
+                .addItem( iD )
+                .build();
         List<QueryItem> duplicates = params.getDuplicateQueryItems();
         assertEquals( 1, duplicates.size() );
         assertTrue( duplicates.contains( iC ) );
@@ -285,14 +508,21 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testIsTimeFieldValid()
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
-        EventQueryParams params = new EventQueryParams.Builder().withProgram( prA ).withTimeField( deC.getUid() )
-            .addItem( iA ).build();
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( prA )
+                .withTimeField( deC.getUid() )
+                .addItem( iA ).build();
         assertTrue( params.timeFieldIsValid() );
-        params = new EventQueryParams.Builder().withProgram( prA ).withTimeField( TimeField.SCHEDULED_DATE.name() )
-            .addItem( iA ).build();
+        params = new EventQueryParams.Builder()
+                .withProgram( prA )
+                .withTimeField( SCHEDULED_DATE.name() )
+                .addItem( iA ).build();
         assertTrue( params.timeFieldIsValid() );
-        params = new EventQueryParams.Builder().withProgram( prA ).withTimeField( "someInvalidTimeField" ).addItem( iA )
-            .build();
+        params = new EventQueryParams.Builder()
+                .withProgram( prA )
+                .withTimeField( "someInvalidTimeField" )
+                .addItem( iA )
+                .build();
         assertFalse( params.timeFieldIsValid() );
     }
 
@@ -300,11 +530,14 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testIsOrgUnitFieldValid()
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
-        EventQueryParams params = new EventQueryParams.Builder().withProgram( prA )
-            .withOrgUnitField( new OrgUnitField( deD.getUid() ) ).addItem( iA ).build();
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( prA )
+                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+                .addItem( iA )
+                .build();
         assertTrue( params.orgUnitFieldIsValid() );
         params = new EventQueryParams.Builder().withProgram( prA )
-            .withOrgUnitField( new OrgUnitField( "someInvalidOrgUnitField" ) ).addItem( iA ).build();
+                .withOrgUnitField( new OrgUnitField( "someInvalidOrgUnitField" ) ).addItem( iA ).build();
         assertFalse( params.orgUnitFieldIsValid() );
     }
 
@@ -313,9 +546,12 @@ class EventQueryParamsTest extends DhisConvenienceTest
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', prA, "", "" );
-        EventQueryParams params = new EventQueryParams.Builder().withProgram( null )
-            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-            .addItem( iA ).addItemProgramIndicator( programIndicatorA ).build();
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( null )
+                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+                .addItem( iA )
+                .addItemProgramIndicator( programIndicatorA )
+                .build();
         assertTrue( params.orgUnitFieldIsValid() );
     }
 
@@ -324,12 +560,15 @@ class EventQueryParamsTest extends DhisConvenienceTest
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', prA, "", "" );
-        // this PI has 0 Data Element of type OrgUnit -> test should fail
+        // This PI has 0 Data Element of type OrgUnit -> test should fail.
         ProgramIndicator programIndicatorB = createProgramIndicator( 'B', prB, "", "" );
-        EventQueryParams params = new EventQueryParams.Builder().withProgram( null )
-            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-            .addItem( iA ).addItemProgramIndicator( programIndicatorA ).addItemProgramIndicator( programIndicatorB )
-            .build();
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( null )
+                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+                .addItem( iA )
+                .addItemProgramIndicator( programIndicatorA )
+                .addItemProgramIndicator( programIndicatorB )
+                .build();
         assertFalse( params.orgUnitFieldIsValid() );
     }
 
@@ -337,12 +576,14 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testIsOrgUnitFieldValidWithMultipleProgramIndicator2()
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
-        // This PI has a Program that has a Tracked Entity Attribute of type Org
-        // Unit
+        // This PI has a Program that has a Tracked Entity Attribute of type Org Unit.
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', prC, "", "" );
-        EventQueryParams params = new EventQueryParams.Builder().withProgram( null )
-            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-            .addItem( iA ).addItemProgramIndicator( programIndicatorA ).build();
+        EventQueryParams params = new EventQueryParams.Builder()
+                .withProgram( null )
+                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+                .addItem( iA )
+                .addItemProgramIndicator( programIndicatorA )
+                .build();
         assertTrue( params.orgUnitFieldIsValid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/EventQueryParamsTest.java
@@ -165,9 +165,9 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testHasDimensionValue()
     {
         EventQueryParams paramsA = new EventQueryParams.Builder()
-                .withOrganisationUnits( List.of( ouA, ouB ) )
-                .withValue( deA )
-                .build();
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deA )
+            .build();
 
         assertTrue( paramsA.hasValueDimension() );
     }
@@ -176,14 +176,14 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testHasNumericDimensionValue()
     {
         EventQueryParams paramsA = new EventQueryParams.Builder()
-                .withOrganisationUnits( List.of( ouA, ouB ) )
-                .withValue( deA )
-                .build();
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deA )
+            .build();
 
         EventQueryParams paramsB = new EventQueryParams.Builder()
-                .withOrganisationUnits( List.of( ouA, ouB ) )
-                .withValue( deC )
-                .build();
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deC )
+            .build();
 
         assertTrue( paramsA.hasNumericValueDimension() );
         assertFalse( paramsB.hasNumericValueDimension() );
@@ -193,14 +193,14 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testHasTextDimensionValue()
     {
         EventQueryParams paramsA = new EventQueryParams.Builder()
-                .withOrganisationUnits( List.of( ouA, ouB ) )
-                .withValue( deE )
-                .build();
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deE )
+            .build();
 
         EventQueryParams paramsB = new EventQueryParams.Builder()
-                .withOrganisationUnits( List.of( ouA, ouB ) )
-                .withValue( deA )
-                .build();
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .withValue( deA )
+            .build();
 
         assertTrue( paramsA.hasTextValueDimension() );
         assertFalse( paramsB.hasTextValueDimension() );
@@ -212,16 +212,16 @@ class EventQueryParamsTest extends DhisConvenienceTest
         QueryItem qiA = new QueryItem( deA, null, deA.getValueType(), deA.getAggregationType(), osA );
         QueryItem qiB = new QueryItem( deB, null, deB.getValueType(), deB.getAggregationType(), osB );
         EventQueryParams paramsA = new EventQueryParams.Builder()
-                .withPeriods( List.of( peA, peB, peC ), MONTHLY.getName() )
-                .withOrganisationUnits( List.of( ouA, ouB ) )
-                .addItem( qiA ).addItem( qiB )
-                .withLocale( Locale.FRENCH )
-                .build();
+            .withPeriods( List.of( peA, peB, peC ), MONTHLY.getName() )
+            .withOrganisationUnits( List.of( ouA, ouB ) )
+            .addItem( qiA ).addItem( qiB )
+            .withLocale( Locale.FRENCH )
+            .build();
         EventQueryParams paramsB = new EventQueryParams.Builder()
-                .withPeriods( List.of( peA, peB ), MONTHLY.getName() )
-                .withOrganisationUnits( List.of( ouA ) )
-                .addItem( qiA ).addItem( qiB ).withGeometryOnly( true )
-                .build();
+            .withPeriods( List.of( peA, peB ), MONTHLY.getName() )
+            .withOrganisationUnits( List.of( ouA ) )
+            .addItem( qiA ).addItem( qiB ).withGeometryOnly( true )
+            .build();
         assertNotNull( paramsA.getKey() );
         assertEquals( 40, paramsA.getKey().length() );
         assertNotNull( paramsB.getKey() );
@@ -244,9 +244,9 @@ class EventQueryParamsTest extends DhisConvenienceTest
 
         // When
         EventQueryParams params = new EventQueryParams.Builder()
-                .withPeriods( List.of( periodMay, periodMarch, periodFebruary ), MONTHLY.getName() )
-                .withStartEndDatesForPeriods()
-                .build();
+            .withPeriods( List.of( periodMay, periodMarch, periodFebruary ), MONTHLY.getName() )
+            .withStartEndDatesForPeriods()
+            .build();
 
         // Then
         assertNull( params.getStartDate() );
@@ -289,8 +289,8 @@ class EventQueryParamsTest extends DhisConvenienceTest
         List<Period> periods = List.of( weeklyPeriod, monthlyPeriod, dailyPeriod );
 
         EventQueryParams params = new EventQueryParams.Builder()
-                .withStartEndDatesForPeriods()
-                .build();
+            .withStartEndDatesForPeriods()
+            .build();
         params.getDimensions().add( new BaseDimensionalObject( "pe", PERIOD, periods ) );
 
         // When
@@ -315,8 +315,8 @@ class EventQueryParamsTest extends DhisConvenienceTest
         List<Period> periods = List.of( weeklyPeriod, monthlyPeriod, dailyPeriod );
 
         EventQueryParams params = new EventQueryParams.Builder()
-                .withStartEndDatesForPeriods()
-                .build();
+            .withStartEndDatesForPeriods()
+            .build();
         params.getDimensions().add( new BaseDimensionalObject( "pe", PERIOD, periods ) );
 
         // When
@@ -467,8 +467,8 @@ class EventQueryParamsTest extends DhisConvenienceTest
         LegendSet lsA = createLegendSet( 'A', leA, leB );
         QueryItem qiA = new QueryItem( deA, lsA, deA.getValueType(), deA.getAggregationType(), null );
         EventQueryParams params = new EventQueryParams.Builder()
-                .addItem( qiA )
-                .build();
+            .addItem( qiA )
+            .build();
         Set<Legend> expected = Set.of( leA, leB );
         assertEquals( expected, params.getItemLegends() );
     }
@@ -479,9 +479,9 @@ class EventQueryParamsTest extends DhisConvenienceTest
         QueryItem qiA = new QueryItem( deA, null, deA.getValueType(), deA.getAggregationType(), osA );
         QueryItem qiB = new QueryItem( deB, null, deB.getValueType(), deB.getAggregationType(), osB );
         EventQueryParams params = new EventQueryParams.Builder()
-                .addItem( qiA )
-                .addItem( qiB )
-                .build();
+            .addItem( qiA )
+            .addItem( qiB )
+            .build();
         Set<Option> expected = Set.of( opA, opB, opC, opD );
         assertEquals( expected, params.getItemOptions() );
     }
@@ -494,11 +494,11 @@ class EventQueryParamsTest extends DhisConvenienceTest
         QueryItem iC = new QueryItem( createDataElement( 'B', new CategoryCombo() ) );
         QueryItem iD = new QueryItem( createDataElement( 'D', new CategoryCombo() ) );
         EventQueryParams params = new EventQueryParams.Builder()
-                .addItem( iA )
-                .addItem( iB )
-                .addItem( iC )
-                .addItem( iD )
-                .build();
+            .addItem( iA )
+            .addItem( iB )
+            .addItem( iC )
+            .addItem( iD )
+            .build();
         List<QueryItem> duplicates = params.getDuplicateQueryItems();
         assertEquals( 1, duplicates.size() );
         assertTrue( duplicates.contains( iC ) );
@@ -509,20 +509,20 @@ class EventQueryParamsTest extends DhisConvenienceTest
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
         EventQueryParams params = new EventQueryParams.Builder()
-                .withProgram( prA )
-                .withTimeField( deC.getUid() )
-                .addItem( iA ).build();
+            .withProgram( prA )
+            .withTimeField( deC.getUid() )
+            .addItem( iA ).build();
         assertTrue( params.timeFieldIsValid() );
         params = new EventQueryParams.Builder()
-                .withProgram( prA )
-                .withTimeField( SCHEDULED_DATE.name() )
-                .addItem( iA ).build();
+            .withProgram( prA )
+            .withTimeField( SCHEDULED_DATE.name() )
+            .addItem( iA ).build();
         assertTrue( params.timeFieldIsValid() );
         params = new EventQueryParams.Builder()
-                .withProgram( prA )
-                .withTimeField( "someInvalidTimeField" )
-                .addItem( iA )
-                .build();
+            .withProgram( prA )
+            .withTimeField( "someInvalidTimeField" )
+            .addItem( iA )
+            .build();
         assertFalse( params.timeFieldIsValid() );
     }
 
@@ -531,13 +531,13 @@ class EventQueryParamsTest extends DhisConvenienceTest
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
         EventQueryParams params = new EventQueryParams.Builder()
-                .withProgram( prA )
-                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-                .addItem( iA )
-                .build();
+            .withProgram( prA )
+            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+            .addItem( iA )
+            .build();
         assertTrue( params.orgUnitFieldIsValid() );
         params = new EventQueryParams.Builder().withProgram( prA )
-                .withOrgUnitField( new OrgUnitField( "someInvalidOrgUnitField" ) ).addItem( iA ).build();
+            .withOrgUnitField( new OrgUnitField( "someInvalidOrgUnitField" ) ).addItem( iA ).build();
         assertFalse( params.orgUnitFieldIsValid() );
     }
 
@@ -547,11 +547,11 @@ class EventQueryParamsTest extends DhisConvenienceTest
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', prA, "", "" );
         EventQueryParams params = new EventQueryParams.Builder()
-                .withProgram( null )
-                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-                .addItem( iA )
-                .addItemProgramIndicator( programIndicatorA )
-                .build();
+            .withProgram( null )
+            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+            .addItem( iA )
+            .addItemProgramIndicator( programIndicatorA )
+            .build();
         assertTrue( params.orgUnitFieldIsValid() );
     }
 
@@ -563,12 +563,12 @@ class EventQueryParamsTest extends DhisConvenienceTest
         // This PI has 0 Data Element of type OrgUnit -> test should fail.
         ProgramIndicator programIndicatorB = createProgramIndicator( 'B', prB, "", "" );
         EventQueryParams params = new EventQueryParams.Builder()
-                .withProgram( null )
-                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-                .addItem( iA )
-                .addItemProgramIndicator( programIndicatorA )
-                .addItemProgramIndicator( programIndicatorB )
-                .build();
+            .withProgram( null )
+            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+            .addItem( iA )
+            .addItemProgramIndicator( programIndicatorA )
+            .addItemProgramIndicator( programIndicatorB )
+            .build();
         assertFalse( params.orgUnitFieldIsValid() );
     }
 
@@ -576,14 +576,15 @@ class EventQueryParamsTest extends DhisConvenienceTest
     void testIsOrgUnitFieldValidWithMultipleProgramIndicator2()
     {
         QueryItem iA = new QueryItem( createDataElement( 'A', new CategoryCombo() ) );
-        // This PI has a Program that has a Tracked Entity Attribute of type Org Unit.
+        // This PI has a Program that has a Tracked Entity Attribute of type Org
+        // Unit.
         ProgramIndicator programIndicatorA = createProgramIndicator( 'A', prC, "", "" );
         EventQueryParams params = new EventQueryParams.Builder()
-                .withProgram( null )
-                .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
-                .addItem( iA )
-                .addItemProgramIndicator( programIndicatorA )
-                .build();
+            .withProgram( null )
+            .withOrgUnitField( new OrgUnitField( deD.getUid() ) )
+            .addItem( iA )
+            .addItemProgramIndicator( programIndicatorA )
+            .build();
         assertTrue( params.orgUnitFieldIsValid() );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -143,8 +143,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
-
+                + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
         assertSql( sql.getValue(), expected );
 
     }
@@ -162,7 +161,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-            + " as ax where lastupdated >= '2017-01-01' and lastupdated < '2018-01-01' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+                + " as ax where (lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
 
@@ -389,7 +388,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -430,7 +429,7 @@ class EnrollmentAnalyticsManagerTest extends
             "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi )), double precision 'NaN')" + " as \""
             + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }
@@ -501,7 +500,7 @@ class EnrollmentAnalyticsManagerTest extends
             + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
-            + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
+            + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
 
         assertSql( sql.getValue(), expected );
     }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -143,7 +143,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-                + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where (enrollmentdate >= '2017-01-01' and enrollmentdate < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
         assertSql( sql.getValue(), expected );
 
     }
@@ -161,7 +161,7 @@ class EnrollmentAnalyticsManagerTest extends
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
         String expected = "ax.\"monthly\",ax.\"ou\"  from " + getTable( programA.getUid() )
-                + " as ax where (lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
+            + " as ax where (lastupdated >= '2017-01-01' and lastupdated < '2018-01-01')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 10001";
 
         assertSql( sql.getValue(), expected );
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -27,8 +27,12 @@
  */
 package org.hisp.dhis.analytics.event.data;
 
+import static org.hisp.dhis.analytics.TimeField.INCIDENT_DATE;
+import static org.hisp.dhis.analytics.TimeField.LAST_UPDATED;
 import static org.hisp.dhis.common.DimensionalObject.PERIOD_DIM_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
 
 import org.hisp.dhis.DhisConvenienceTest;
 import org.hisp.dhis.analytics.event.EventQueryParams;
@@ -40,8 +44,6 @@ import org.hisp.dhis.period.Period;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import com.google.common.collect.Lists;
 
 /**
  * @author Dusan Bernat
@@ -63,78 +65,98 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     }
 
     @Test
-    void testRenderEventTimeFieldSqlWhenNonContinuousDateRangeList()
+    void testRenderEventTimeFieldSqlWhenNonContinuousDateRange()
     {
-        // Given
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peC ) ) )
-            .build();
+                .addDimension(
+                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
+                .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer( new PostgreSQLStatementBuilder() );
 
-        // When
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        // Then
-        assertEquals(
-            "(ax.\"executiondate\">='2022-04-01'andax.\"executiondate\"<'2022-05-01'orax.\"executiondate\">='2022-06-01'andax.\"executiondate\"<'2022-07-01')",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+        assertEquals( "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
     @Test
-    void testRenderEventTimeFieldSqlWhenContinuousDateRangeList()
+    void testRenderEventTimeFieldSqlWhenContinuousDateRange()
     {
-        // Given
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peB, peC ) ) )
-            .build();
+                .addDimension(
+                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+                .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer( new PostgreSQLStatementBuilder() );
 
-        // When
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        // Then
-        assertEquals( "ax.\"executiondate\">='2022-04-01'andax.\"executiondate\"<'2022-07-01'",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+        assertEquals( "(ax.\"executiondate\" >= '2022-04-01' and ax.\"executiondate\" < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
     @Test
-    void testRenderEnrollmentTimeFieldSqlWhenNonContinuousDateRangeList()
+    void testRenderEnrollmentTimeFieldSqlWhenNonContinuousDateRange()
     {
-        // Given
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peC ) ) )
-            .build();
+                .addDimension(
+                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
+                .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
-            new PostgreSQLStatementBuilder() );
+                new PostgreSQLStatementBuilder() );
 
-        // When
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        // Then
-        assertEquals(
-            "(enrollmentdate>='2022-04-01'andenrollmentdate<'2022-05-01'orenrollmentdate>='2022-06-01'andenrollmentdate<'2022-07-01')",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 
     @Test
-    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeList()
+    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRange()
     {
-        // Given
         EventQueryParams params = new EventQueryParams.Builder()
-            .addDimension(
-                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, Lists.newArrayList( peA, peB, peC ) ) )
-            .build();
+                .addDimension(
+                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+                .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
-            new PostgreSQLStatementBuilder() );
+                new PostgreSQLStatementBuilder() );
 
-        // When
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
-        // Then
-        assertEquals( "enrollmentdate>='2022-04-01'andenrollmentdate<'2022-07-01'",
-            timeFieldSqlRenderer.renderTimeFieldSql( params ).replace( " ", "" ) );
+        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
+    }
+
+    @Test
+    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldAllowed()
+    {
+        EventQueryParams params = new EventQueryParams.Builder()
+                .addDimension(
+                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+                .withTimeField( LAST_UPDATED.name() )
+                .build();
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
+                new PostgreSQLStatementBuilder() );
+
+        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
+
+        assertEquals( "(lastupdated >= '2022-04-01' and lastupdated < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
+    }
+
+    @Test
+    void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldNotAllowed()
+    {
+        EventQueryParams params = new EventQueryParams.Builder()
+                .addDimension(
+                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+                .withTimeField( INCIDENT_DATE.getField() )
+                .build();
+        TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
+                new PostgreSQLStatementBuilder() );
+
+        params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
+
+        assertEquals( "(enrollmentdate >= '2022-04-01' and enrollmentdate < '2022-07-01')",
+            timeFieldSqlRenderer.renderPeriodTimeFieldSql( params ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/TimeFieldSqlRendererTest.java
@@ -68,9 +68,9 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEventTimeFieldSqlWhenNonContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-                .addDimension(
-                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
-                .build();
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
+            .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer( new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
@@ -83,9 +83,9 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEventTimeFieldSqlWhenContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-                .addDimension(
-                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
-                .build();
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EventTimeFieldSqlRenderer( new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
@@ -98,11 +98,11 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenNonContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-                .addDimension(
-                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
-                .build();
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peC ) ) )
+            .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
-                new PostgreSQLStatementBuilder() );
+            new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
@@ -114,11 +114,11 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRange()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-                .addDimension(
-                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
-                .build();
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
-                new PostgreSQLStatementBuilder() );
+            new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
@@ -130,12 +130,12 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldAllowed()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-                .addDimension(
-                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
-                .withTimeField( LAST_UPDATED.name() )
-                .build();
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .withTimeField( LAST_UPDATED.name() )
+            .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
-                new PostgreSQLStatementBuilder() );
+            new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 
@@ -147,12 +147,12 @@ class TimeFieldSqlRendererTest extends DhisConvenienceTest
     void testRenderEnrollmentTimeFieldSqlWhenContinuousDateRangeWithTimeFieldNotAllowed()
     {
         EventQueryParams params = new EventQueryParams.Builder()
-                .addDimension(
-                        new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
-                .withTimeField( INCIDENT_DATE.getField() )
-                .build();
+            .addDimension(
+                new BaseDimensionalObject( PERIOD_DIM_ID, DimensionType.PERIOD, List.of( peA, peB, peC ) ) )
+            .withTimeField( INCIDENT_DATE.getField() )
+            .build();
         TimeFieldSqlRenderer timeFieldSqlRenderer = new EnrollmentTimeFieldSqlRenderer(
-                new PostgreSQLStatementBuilder() );
+            new PostgreSQLStatementBuilder() );
 
         params = new EventQueryParams.Builder( params ).withStartEndDatesForPeriods().build();
 

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -62,6 +62,8 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeValue;
@@ -217,8 +219,6 @@ import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 
-import lombok.extern.slf4j.Slf4j;
-
 /**
  * @author Lars Helge Overland
  */
@@ -361,7 +361,7 @@ public abstract class DhisConvenienceTest
      * @return the {@link LocalDate} object
      * @throws NullPointerException if the given date is null
      */
-    public LocalDate toLocalDate(Date date )
+    public LocalDate toLocalDate( Date date )
     {
         return date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
     }

--- a/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
+++ b/dhis-2/dhis-support/dhis-support-test/src/main/java/org/hisp/dhis/DhisConvenienceTest.java
@@ -40,6 +40,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -59,8 +61,6 @@ import javax.annotation.PostConstruct;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
-
-import lombok.extern.slf4j.Slf4j;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.attribute.Attribute;
@@ -217,6 +217,8 @@ import com.google.common.collect.Sets;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * @author Lars Helge Overland
  */
@@ -350,6 +352,18 @@ public abstract class DhisConvenienceTest
         dataTime = dataTime.withDayOfYear( day );
 
         return dataTime.toDate();
+    }
+
+    /**
+     * Converts a {@link Date} into a {@link LocalDate}.
+     *
+     * @param date the {@link Date}
+     * @return the {@link LocalDate} object
+     * @throws NullPointerException if the given date is null
+     */
+    public LocalDate toLocalDate(Date date )
+    {
+        return date.toInstant().atZone( ZoneId.systemDefault() ).toLocalDate();
     }
 
     /**


### PR DESCRIPTION
**_[Backport from master/2.40]_**

These changes should fix the problem regarding monthly periods. This was affecting analytics events and enrollments.

Before this fix, when we had more than one type of date specified (ie. `scheduled` and `execution date`), the final query considered was always and only the `execution date`.

Now, we will consider and allow different dates with different time ranges. During my tests, I also found out that the monthly periods were flattened, always taking the interval between the oldest and newest date. Now each monthly period is evaluated in isolation unless the range contains sequential months (in this case the code will consider only the oldest and newest date).

I also improved the related unit tests and included some basic clean-up + Javadoc.

As part of my manual tests, I tested the following scenarios (**_let me know if you think I should test some other case_**):

```
http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=202302,202305,202303&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=202305,202304,202303,202302&eventDate=202306,202307,202308&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=LAST_YEAR&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate,scheduleddate&totalPages=false&scheduledDate=202209,202210,202203&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate&totalPages=false&startDate=2023-01-01&endDate=2023-01-24&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/39/analytics/events/query/IpHINAT79UW?dimension=ou:USER_ORGUNIT,w75KJ2mc4zz,cejWyOfXge6&headers=ouname,w75KJ2mc4zz,cejWyOfXge6,eventdate&totalPages=false&eventDate=LAST_12_MONTHS&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=ZzYYXq4fJie

http://localhost:8080/dhis/api/39/analytics/events/cluster/IpHINAT79UW?dimension=ou:USER_ORGUNIT&clusterSize=10&bbox=1,2,3,4&dimension=pe:LAST_12_MONTHS

http://localhost:8080/dhis/api/39/analytics/events/cluster/IpHINAT79UW?dimension=ou:USER_ORGUNIT&clusterSize=10&bbox=1,2,3,4&startDate=2022-01-01&endDate=2023-06-01

http://localhost:8080/dhis/api/39/analytics/events/query/eBAyeGv0exc?dimension=ou:lc3eMKXaEfw,tUdBD1JDxpn,gWxh7DiRmG7,x7PaHGvgWY2,hlPt8H4bUOQ,Y7hKDSuqEtH,oZg33kd9taw,GieVkTxp4HH-TBxGTceyzwy,HS8QXAJtuKV,vV9UWAZohSf-OrkEzxZEH4X&headers=eventdate,ouname,tUdBD1JDxpn,gWxh7DiRmG7,x7PaHGvgWY2,hlPt8H4bUOQ,Y7hKDSuqEtH,oZg33kd9taw,GieVkTxp4HH,HS8QXAJtuKV,vV9UWAZohSf&totalPages=false&eventDate=2023W5,20230105,202308,202304&displayProperty=NAME&outputType=EVENT&pageSize=100&page=1&includeMetadataDetails=true&stage=Zj7UnCAulEk&asc=ouname

http://localhost:8080/dhis/api/39/analytics/events/aggregate/IpHINAT79UW.json?dimension=pe:202309;202306;2023S2;2023W2;LAST_12_MONTHS&dimension=A03MvHHogjR.cejWyOfXge6&dimension=A03MvHHogjR.wQLfBvPrXqq&dimension=ou:jUb8gELQApl;TEQlaapDQoK;eIQbndfxQMb;Vth0fbpFcsO;PMa2VCrupOd;O6uvpzGd5pu;bL4ooGhyHRQ;kJq2mPyFEHo;fdc6uOvgoji;at6UHUQatSo;lc3eMKXaEfw;qhqAxPSTUXp;jmIPBj66vD6&stage=A03MvHHogjR&displayProperty=NAME&totalPages=false&outputType=EVENT&programStatus=ACTIVE&eventStatus=ACTIVE

http://localhost:8080/dhis/api/39/analytics?dimension=dx:ReUHfIn0pTQ,ou:O6uvpzGd5pu;fdc6uOvgoji;lc3eMKXaEfw;jUb8gELQApl;PMa2VCrupOd;kJq2mPyFEHo;qhqAxPSTUXp;Vth0fbpFcsO;jmIPBj66vD6;TEQlaapDQoK;bL4ooGhyHRQ;eIQbndfxQMb;at6UHUQatSo&filter=pe:THIS_YEAR;202301;202302;202207;20230103;2023WedW6&displayProperty=NAME&includeNumDen=false&skipMeta=false&skipData=true&includeMetadataDetails=true
```
