### PR TITLE
fix: only add lock exceptions for org units in data capture hierarchy [DHIS2-13908]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/LockExceptionControllerTest.java
@@ -65,6 +65,16 @@ class LockExceptionControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testAddLockException_UnauthorizedUser()
+    {
+        switchToNewUser( "guest", "F_DATASET_PUBLIC_ADD" );
+
+        assertWebMessage( "Forbidden", 403, "ERROR",
+            "You can only add a lock exceptions to your data capture organisation units.",
+            POST( "/lockExceptions/?ou={ou}&pe=2021-01&ds={ds}", ouId, dsId ).content( HttpStatus.FORBIDDEN ) );
+    }
+
+    @Test
     void testAddLockException_DataSetNotLinked()
     {
         String dsId2 = assertStatus( HttpStatus.CREATED,


### PR DESCRIPTION
### Summary
Limits adding lock exceptions to users that have the affected organisation unit in their data capture organisation unit hierarchy.

### Automatic Testing
Added a controller test for the validation failed scenario.

### Manual Testing
Error Scenario
* Create a user with only the `F_DATASET_PUBLIC_ADD` authority
* switch to new user
* try to add a lock exception for an existing data set and some existing organisation unit
* check a 403, forbidden status us returned with a descriptive error message

Success Scenario
* add the target organisation unit or any of its parents to the test user's data capture set (the "normal organisation unit" set of the user)
* rerun the test scenario above and check the exception can now be added