### PR TITLE
fix: data value validation - compare date ranges as dates not timestamps [DHIS2-14591]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataInputPeriod.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataInputPeriod.java
@@ -97,8 +97,7 @@ public class DataInputPeriod implements EmbeddedObject
      */
     public boolean isDateWithinOpenCloseDates( Date date )
     {
-        return (openingDate == null || date.after( openingDate ))
-            && (closingDate == null || date.before( closingDate ));
+        return Period.isDateInTimeFrame( openingDate, closingDate, date );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataset/DataSet.java
@@ -555,10 +555,11 @@ public class DataSet
             return false;
         }
 
-        DateTime date = now != null ? new DateTime( now ) : new DateTime();
+        Date date = now != null ? now : new Date();
 
-        return expiryDays != DataSet.NO_EXPIRY &&
-            new DateTime( period.getEndDate() ).plusDays( expiryDays ).isBefore( date );
+        return expiryDays != DataSet.NO_EXPIRY
+            && !Period.isDateInTimeFrame( null, new DateTime( period.getEndDate() ).plusDays( expiryDays ).toDate(),
+                date );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -27,9 +27,6 @@
  */
 package org.hisp.dhis.period;
 
-import static org.hisp.dhis.util.DateUtils.atEndOfDay;
-import static org.hisp.dhis.util.DateUtils.atStartOfDay;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
@@ -108,8 +105,8 @@ public class Period
         this.isoPeriod = isoRelativePeriod.toString();
         this.name = isoRelativePeriod.toString();
         this.code = isoRelativePeriod.toString();
-        this.setStartDate( atStartOfDay( new Date() ) );
-        this.setEndDate( atEndOfDay( new Date() ) );
+        this.setStartDate( new Date() );
+        this.setEndDate( new Date() );
     }
 
     public Period( Period period )
@@ -427,5 +424,11 @@ public class Period
     public boolean isDefault()
     {
         return Objects.isNull( dateField );
+    }
+
+    private Date atEndOfDay( Date date )
+    {
+        long offset = 999L + 59 * 1000 + 59 * 60 * 1000 + 23 * 60 * 60 * 1000;
+        return new Date( date.getTime() + offset );
     }
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -28,8 +28,12 @@
 package org.hisp.dhis.period;
 
 import java.text.SimpleDateFormat;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Objects;
+import java.util.function.Function;
 
 import javax.annotation.CheckForNull;
 
@@ -77,9 +81,12 @@ public class Period
         {
             return false;
         }
-        DateTime from = start == null ? null : new DateTime( start ).withTimeAtStartOfDay();
-        DateTime to = end == null ? null : new DateTime( end ).withTimeAtStartOfDay();
-        DateTime sample = new DateTime( checked ).withTimeAtStartOfDay();
+        ZoneId zoneId = ZoneId.systemDefault();
+        Function<Date, ZonedDateTime> toZonedDate = date -> ZonedDateTime.ofInstant( date.toInstant(), zoneId )
+            .with( LocalTime.MIN );
+        ZonedDateTime from = start == null ? null : toZonedDate.apply( start );
+        ZonedDateTime to = end == null ? null : toZonedDate.apply( end );
+        ZonedDateTime sample = toZonedDate.apply( checked );
         return (from == null || !sample.isBefore( from )) && (to == null || !sample.isAfter( to ));
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/period/Period.java
@@ -27,6 +27,9 @@
  */
 package org.hisp.dhis.period;
 
+import static org.hisp.dhis.util.DateUtils.atEndOfDay;
+import static org.hisp.dhis.util.DateUtils.atStartOfDay;
+
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
@@ -105,8 +108,8 @@ public class Period
         this.isoPeriod = isoRelativePeriod.toString();
         this.name = isoRelativePeriod.toString();
         this.code = isoRelativePeriod.toString();
-        this.setStartDate( new Date() );
-        this.setEndDate( new Date() );
+        this.setStartDate( atStartOfDay( new Date() ) );
+        this.setEndDate( atEndOfDay( new Date() ) );
     }
 
     public Period( Period period )
@@ -114,7 +117,7 @@ public class Period
         this.id = period.getId();
         this.periodType = period.getPeriodType();
         this.startDate = period.getStartDate();
-        this.endDate = period.getEndDate();
+        this.endDate = atEndOfDay( period.getEndDate() );
         this.name = period.getName();
         this.isoPeriod = period.getIsoDate();
         this.dateField = period.getDateField();
@@ -124,14 +127,14 @@ public class Period
     {
         this.periodType = periodType;
         this.startDate = startDate;
-        this.endDate = endDate;
+        this.endDate = atEndOfDay( endDate );
     }
 
     protected Period( PeriodType periodType, Date startDate, Date endDate, String isoPeriod )
     {
         this.periodType = periodType;
         this.startDate = startDate;
-        this.endDate = endDate;
+        this.endDate = atEndOfDay( endDate );
         this.isoPeriod = isoPeriod;
     }
 
@@ -328,7 +331,7 @@ public class Period
      */
     public String getCacheKey()
     {
-        return periodType.getName() + "-" + startDate.toString() + "-" + endDate.toString();
+        return periodType.getName() + "-" + getStartDateString() + "-" + getEndDateString();
     }
 
     // -------------------------------------------------------------------------
@@ -403,7 +406,7 @@ public class Period
 
     public void setEndDate( Date endDate )
     {
-        this.endDate = endDate;
+        this.endDate = atEndOfDay( endDate );
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -31,7 +31,9 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
@@ -45,6 +47,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.CheckForNull;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.calendar.DateTimeUnit;
@@ -236,6 +240,38 @@ public class DateUtils
     public static Date minusOneDay( Date date )
     {
         return new Date( date.getTime() - MS_PER_DAY );
+    }
+
+    /**
+     * The provided date at the start of the day {@code 00:00:00}.
+     *
+     * @param date maybe null
+     * @return same date but with time component at the start of the day
+     */
+    public static @CheckForNull Date atStartOfDay( @CheckForNull Date date )
+    {
+        return date == null ? null : localDateTimeToDate( dateToLocalDateTime( date ).with( LocalTime.MIN ) );
+    }
+
+    /**
+     * The provided date at the end of the day {@code 23:59:59}.
+     *
+     * @param date maybe null
+     * @return same date but with time component at the end of the day
+     */
+    public static @CheckForNull Date atEndOfDay( @CheckForNull Date date )
+    {
+        return date == null ? null : localDateTimeToDate( dateToLocalDateTime( date ).with( LocalTime.MAX ) );
+    }
+
+    private static LocalDateTime dateToLocalDateTime( Date date )
+    {
+        return LocalDateTime.ofInstant( date.toInstant(), ZoneId.systemDefault() );
+    }
+
+    private static Date localDateTimeToDate( LocalDateTime localDateTime )
+    {
+        return Date.from( localDateTime.atZone( ZoneId.systemDefault() ).toInstant() );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -31,7 +31,6 @@ import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -46,8 +45,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.annotation.CheckForNull;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hisp.dhis.calendar.DateTimeUnit;
@@ -239,38 +236,6 @@ public class DateUtils
     public static Date minusOneDay( Date date )
     {
         return new Date( date.getTime() - MS_PER_DAY );
-    }
-
-    /**
-     * The provided date at the start of the day {@code 00:00:00}.
-     *
-     * @param date maybe null
-     * @return same date but with time component at the start of the day
-     */
-    public static @CheckForNull Date atStartOfDay( @CheckForNull Date date )
-    {
-        return date == null ? null : localDateTimeToDate( dateToLocalDateTime( date ).with( LocalTime.MIN ) );
-    }
-
-    /**
-     * The provided date at the end of the day {@code 23:59:59}.
-     *
-     * @param date maybe null
-     * @return same date but with time component at the end of the day
-     */
-    public static @CheckForNull Date atEndOfDay( @CheckForNull Date date )
-    {
-        return date == null ? null : localDateTimeToDate( dateToLocalDateTime( date ).with( LocalTime.MAX ) );
-    }
-
-    private static LocalDateTime dateToLocalDateTime( Date date )
-    {
-        return LocalDateTime.ofInstant( date.toInstant(), ZoneOffset.UTC );
-    }
-
-    private static Date localDateTimeToDate( LocalDateTime dateTime )
-    {
-        return Date.from( dateTime.atZone( ZoneOffset.UTC ).toInstant() );
     }
 
     /**

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/util/DateUtils.java
@@ -33,7 +33,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
@@ -266,12 +265,12 @@ public class DateUtils
 
     private static LocalDateTime dateToLocalDateTime( Date date )
     {
-        return LocalDateTime.ofInstant( date.toInstant(), ZoneId.systemDefault() );
+        return LocalDateTime.ofInstant( date.toInstant(), ZoneOffset.UTC );
     }
 
-    private static Date localDateTimeToDate( LocalDateTime localDateTime )
+    private static Date localDateTimeToDate( LocalDateTime dateTime )
     {
-        return Date.from( localDateTime.atZone( ZoneId.systemDefault() ).toInstant() );
+        return Date.from( dateTime.atZone( ZoneOffset.UTC ).toInstant() );
     }
 
     /**


### PR DESCRIPTION
Adjusting `endDate` to `23:59:59.999` did not work out. 100+ tests failed. Quick dive showed that there are many downstream implications to such a change. 

Therefore I took the more local approach to only fix the date comparison itself. 
When comparing dates without time one always has to decide in which time-zone the timestamp should be considered as date - means there is still room for semantic errors. I think the most reasonable is to compare the timestamps as dates in the system zone. 

This PR fixes the issues related to the data validation. There clearly are more but this at the moment causes test failures and needs fixing. 