### PR TITLE
feat: /dataApprovals/categoryOptionCombos args [DHIS2-14371]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalService.java
@@ -182,11 +182,14 @@ public interface DataApprovalService
      * @param workflow workflow to check for approval.
      * @param period Period we are getting the status for
      * @param orgUnit Organisation unit we are getting the status for
+     * @param orgUnitFilter Organisation unit filter for attribute option combos
      * @param attributeCombo attribute category combo to search within
+     * @param attributeOptionCombo Single attribute option combo to get for
      * @return list of statuses and permissions
      */
     List<DataApprovalStatus> getUserDataApprovalsAndPermissions( DataApprovalWorkflow workflow,
-        Period period, OrganisationUnit orgUnit, CategoryCombo attributeCombo );
+        Period period, OrganisationUnit orgUnit, OrganisationUnit orgUnitFilter, CategoryCombo attributeCombo,
+        CategoryOptionCombo attributeOptionCombo );
 
     /**
      * Deletes DataApprovals for the given organisation unit.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataapproval/DataApprovalStore.java
@@ -146,13 +146,13 @@ public interface DataApprovalStore
      * @param period Period to look within
      * @param orgUnits Organisation unit to look for (null means all)
      * @param orgUnitLevel level for all orgUnits specified (if any)
+     * @param orgUnitFilter Organisation unit filter for attribute option combos
      * @param attributeCombo Attribute category combo to look within
      * @param attributeOptionCombos Attribute option combos (null means all)
      * @return data approval status objects
      */
     List<DataApprovalStatus> getDataApprovalStatuses( DataApprovalWorkflow workflow,
-        Period period, Collection<OrganisationUnit> orgUnits, int orgUnitLevel,
-        CategoryCombo attributeCombo,
-        Set<CategoryOptionCombo> attributeOptionCombos, List<DataApprovalLevel> userApprovalLevels,
-        Map<Integer, DataApprovalLevel> levelMap );
+        Period period, Collection<OrganisationUnit> orgUnits, int orgUnitLevel, OrganisationUnit orgUnitFilter,
+        CategoryCombo attributeCombo, Set<CategoryOptionCombo> attributeOptionCombos,
+        List<DataApprovalLevel> userApprovalLevels, Map<Integer, DataApprovalLevel> levelMap );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DefaultDataApprovalService.java
@@ -492,7 +492,7 @@ public class DefaultDataApprovalService
         DataApprovalStatus status;
 
         List<DataApprovalStatus> statuses = dataApprovalStore.getDataApprovalStatuses( workflow, period,
-            Lists.newArrayList( organisationUnit ), organisationUnit.getHierarchyLevel(), null,
+            Lists.newArrayList( organisationUnit ), organisationUnit.getHierarchyLevel(), null, null,
             attributeOptionCombo == null ? null : Sets.newHashSet( attributeOptionCombo ),
             dataApprovalLevelService.getUserDataApprovalLevelsOrLowestLevel(
                 currentUserService.getCurrentUser(), workflow ),
@@ -542,12 +542,15 @@ public class DefaultDataApprovalService
     @Override
     @Transactional( readOnly = true )
     public List<DataApprovalStatus> getUserDataApprovalsAndPermissions( DataApprovalWorkflow workflow,
-        Period period, OrganisationUnit orgUnit, CategoryCombo attributeCombo )
+        Period period, OrganisationUnit orgUnit, OrganisationUnit orgUnitFilter, CategoryCombo attributeCombo,
+        CategoryOptionCombo attributeOptionCombo )
     {
         List<DataApprovalStatus> statusList = dataApprovalStore.getDataApprovalStatuses(
             workflow, period, orgUnit == null ? null : Lists.newArrayList( orgUnit ),
-            orgUnit == null ? 0 : orgUnit.getHierarchyLevel(), attributeCombo, null, dataApprovalLevelService
-                .getUserDataApprovalLevelsOrLowestLevel( currentUserService.getCurrentUser(), workflow ),
+            orgUnit == null ? 0 : orgUnit.getHierarchyLevel(), orgUnitFilter, attributeCombo,
+            attributeOptionCombo == null ? null : Set.of( attributeOptionCombo ),
+            dataApprovalLevelService.getUserDataApprovalLevelsOrLowestLevel( currentUserService.getCurrentUser(),
+                workflow ),
             dataApprovalLevelService.getDataApprovalLevelMap() );
 
         DataApprovalPermissionsEvaluator permissionsEvaluator = makePermissionsEvaluator();
@@ -666,7 +669,7 @@ public class DefaultDataApprovalService
             DataApproval da = dataApprovals.get( 0 );
 
             List<DataApprovalStatus> statuses = dataApprovalStore.getDataApprovalStatuses( da.getWorkflow(),
-                da.getPeriod(), orgUnits, da.getOrganisationUnit().getHierarchyLevel(), null,
+                da.getPeriod(), orgUnits, da.getOrganisationUnit().getHierarchyLevel(), null, null,
                 getCategoryOptionCombos( dataApprovals ), dataApprovalLevelService
                     .getUserDataApprovalLevelsOrLowestLevel( currentUserService.getCurrentUser(), da.getWorkflow() ),
                 dataApprovalLevelService.getDataApprovalLevelMap() );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/hibernate/HibernateDataApprovalStore.java
@@ -259,7 +259,7 @@ public class HibernateDataApprovalStore
 
     @Override
     public List<DataApprovalStatus> getDataApprovalStatuses( DataApprovalWorkflow workflow,
-        Period period, Collection<OrganisationUnit> orgUnits, int orgUnitLevel,
+        Period period, Collection<OrganisationUnit> orgUnits, int orgUnitLevel, OrganisationUnit orgUnitFilter,
         CategoryCombo attributeCombo, Set<CategoryOptionCombo> attributeOptionCombos,
         List<DataApprovalLevel> userApprovalLevels, Map<Integer, DataApprovalLevel> levelMap )
     {
@@ -416,7 +416,7 @@ public class HibernateDataApprovalStore
 
         String highestApprovedOrgUnitJoin = "";
         String highestApprovedOrgUnitCompare;
-        String orgUnitIds = "";
+        String orgUnitIds = null;
 
         if ( orgUnits != null )
         {
@@ -429,6 +429,11 @@ public class HibernateDataApprovalStore
             highestApprovedOrgUnitJoin = "join organisationunit dao on dao.organisationunitid = da.organisationunitid ";
 
             highestApprovedOrgUnitCompare = statementBuilder.position( "dao.uid", "o.path" ) + " <> 0 ";
+        }
+
+        if ( orgUnitFilter != null )
+        {
+            orgUnitIds = String.valueOf( orgUnitFilter.getId() );
         }
 
         String userApprovalLevelRestrictions = "";
@@ -544,12 +549,12 @@ public class HibernateDataApprovalStore
             approvedAboveSubquery + " as approved_above " +
             "from categoryoptioncombo coc " +
             "join organisationunit o on "
-            + (orgUnits != null ? "o.organisationunitid in (" + orgUnitIds + ") "
+            + (orgUnitIds != null ? "o.organisationunitid in (" + orgUnitIds + ") "
                 : "o.hierarchylevel = " + orgUnitLevel + userOrgUnitRestrictions + " ")
             +
             "where not exists ( " + // Exclude any attribute option combo (COC)
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     // that is linked (1 to many) to an
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     // unwanted attribute option (CO):
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       // that is linked (1 to many) to an
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       // unwanted attribute option (CO):
             "select 1 " +
             "from categoryoptioncombos_categoryoptions cocco " +
             "join dataelementcategoryoption co on co.categoryoptionid = cocco.categoryoptionid " +

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceCategoryOptionGroupTest.java
@@ -28,19 +28,18 @@
 package org.hisp.dhis.dataapproval;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static java.util.stream.Collectors.toList;
 import static org.hisp.dhis.dataapproval.DataApproval.AUTH_ACCEPT_LOWER_LEVELS;
 import static org.hisp.dhis.dataapproval.DataApproval.AUTH_APPROVE;
 import static org.hisp.dhis.dataapproval.DataApproval.AUTH_APPROVE_LOWER_LEVELS;
 import static org.hisp.dhis.dataapproval.DataApproval.AUTH_VIEW_UNAPPROVED_DATA;
 import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.hisp.dhis.utils.Assertions.assertContainsOnly;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -202,6 +201,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
 
     private CategoryOption indiaA1;
 
+    private CategoryOption worldwide;
+
     private org.hisp.dhis.category.Category mechanismCategory;
 
     private CategoryCombo mechanismCategoryCombo;
@@ -217,6 +218,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
     private CategoryOptionCombo chinaB2Combo;
 
     private CategoryOptionCombo indiaA1Combo;
+
+    private CategoryOptionCombo worldwideCombo;
 
     private CategoryOptionGroup agencyA;
 
@@ -304,9 +307,12 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         throws Exception
     {
         userService = _userService;
+
         // ---------------------------------------------------------------------
         // Add supporting data
         // ---------------------------------------------------------------------
+
+        // Organisation units
         global = createOrganisationUnit( "Global" );
         americas = createOrganisationUnit( "Americas", global );
         asia = createOrganisationUnit( "Asia", global );
@@ -319,6 +325,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         organisationUnitService.addOrganisationUnit( brazil );
         organisationUnitService.addOrganisationUnit( china );
         organisationUnitService.addOrganisationUnit( india );
+
+        // Users
         userA = makeUser( "A" );
         userService.addUser( userA );
         dateA = new Date();
@@ -350,6 +358,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         chinaPartner1User = createAndAddUser( "ChinaPartner1User", china, AUTH_APPROVE );
         chinaPartner2User = createAndAddUser( "ChinaPartner2User", china, AUTH_APPROVE );
         indiaPartner1User = createAndAddUser( "IndiaPartner1User", india, AUTH_APPROVE );
+
+        // User groups
         UserGroup globalUsers = getUserGroup( "GlobalUsers",
             userSet( globalUser, globalApproveOnly, globalAcceptOnly, globalConsultant, globalReadAll ) );
         UserGroup globalAgencyAUsers = getUserGroup( "GlobalAgencyAUsers", userSet( globalAgencyAUser ) );
@@ -367,24 +377,29 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         UserGroup chinaPartner1Users = getUserGroup( "ChinaPartner1Users", userSet( chinaPartner1User ) );
         UserGroup chinaPartner2Users = getUserGroup( "ChinaPartner2Users", userSet( chinaPartner2User ) );
         UserGroup indiaPartner1Users = getUserGroup( "IndiaPartner1Users", userSet( indiaPartner1User ) );
+
+        // Attribute category options (mechanisms)
         brazilA1 = new CategoryOption( "BrazilA1" );
         chinaA1_1 = new CategoryOption( "ChinaA1_1" );
         chinaA1_2 = new CategoryOption( "ChinaA1_2" );
         chinaA2 = new CategoryOption( "ChinaA2" );
         chinaB2 = new CategoryOption( "ChinaB2" );
         indiaA1 = new CategoryOption( "IndiaA1" );
+        worldwide = new CategoryOption( "worldwide" );
         brazilA1.setOrganisationUnits( Sets.newHashSet( brazil ) );
         chinaA1_1.setOrganisationUnits( Sets.newHashSet( china ) );
         chinaA1_2.setOrganisationUnits( Sets.newHashSet( china ) );
         chinaA2.setOrganisationUnits( Sets.newHashSet( china ) );
         chinaB2.setOrganisationUnits( Sets.newHashSet( china ) );
         indiaA1.setOrganisationUnits( Sets.newHashSet( india ) );
+        // worldwide mechanism, unlike the others, is not limited by orgUnit
         categoryService.addCategoryOption( brazilA1 );
         categoryService.addCategoryOption( chinaA1_1 );
         categoryService.addCategoryOption( chinaA1_2 );
         categoryService.addCategoryOption( chinaA2 );
         categoryService.addCategoryOption( chinaB2 );
         categoryService.addCategoryOption( indiaA1 );
+        categoryService.addCategoryOption( worldwide );
         setAccess( brazilA1, globalUsers, globalAgencyAUsers, brazilInteragencyUsers, brazilAgencyAUsers,
             brazilPartner1Users );
         setAccess( chinaA1_1, globalUsers, globalAgencyAUsers, chinaInteragencyUsers, chinaAgencyAUsers,
@@ -397,10 +412,17 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
             chinaPartner2Users );
         setAccess( indiaA1, globalUsers, globalAgencyAUsers, indiaInteragencyUsers, indiaAgencyAUsers,
             indiaPartner1Users );
-        mechanismCategory = createCategory( 'A', brazilA1, chinaA1_1, chinaA1_2, chinaA2, chinaB2, indiaA1 );
+        setAccess( worldwide, globalUsers, globalAgencyAUsers, brazilInteragencyUsers, chinaInteragencyUsers,
+            indiaInteragencyUsers );
+
+        // Mechanism category and category combination (only 1 category)
+        mechanismCategory = createCategory( 'A', brazilA1, chinaA1_1, chinaA1_2, chinaA2, chinaB2, indiaA1,
+            worldwide );
         categoryService.addCategory( mechanismCategory );
         mechanismCategoryCombo = createCategoryCombo( 'A', mechanismCategory );
         categoryService.addCategoryCombo( mechanismCategoryCombo );
+
+        // Constrain users by mechanism
         constrainByMechanism( globalAgencyAUser );
         constrainByMechanism( globalAgencyBUser );
         constrainByMechanism( brazilAgencyAUser );
@@ -425,25 +447,32 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         userService.updateUser( chinaPartner1User );
         userService.updateUser( chinaPartner2User );
         userService.updateUser( indiaPartner1User );
+
+        // Attribute option combos (one option per combo)
         brazilA1Combo = createCategoryOptionCombo( mechanismCategoryCombo, brazilA1 );
         chinaA1_1Combo = createCategoryOptionCombo( mechanismCategoryCombo, chinaA1_1 );
         chinaA1_2Combo = createCategoryOptionCombo( mechanismCategoryCombo, chinaA1_2 );
         chinaA2Combo = createCategoryOptionCombo( mechanismCategoryCombo, chinaA2 );
         chinaB2Combo = createCategoryOptionCombo( mechanismCategoryCombo, chinaB2 );
         indiaA1Combo = createCategoryOptionCombo( mechanismCategoryCombo, indiaA1 );
+        worldwideCombo = createCategoryOptionCombo( mechanismCategoryCombo, worldwide );
         categoryService.addCategoryOptionCombo( brazilA1Combo );
         categoryService.addCategoryOptionCombo( chinaA1_1Combo );
         categoryService.addCategoryOptionCombo( chinaA1_2Combo );
         categoryService.addCategoryOptionCombo( chinaA2Combo );
         categoryService.addCategoryOptionCombo( chinaB2Combo );
         categoryService.addCategoryOptionCombo( indiaA1Combo );
+        categoryService.addCategoryOptionCombo( worldwideCombo );
         mechanismCategoryCombo.getOptionCombos().add( brazilA1Combo );
         mechanismCategoryCombo.getOptionCombos().add( chinaA1_1Combo );
         mechanismCategoryCombo.getOptionCombos().add( chinaA1_2Combo );
         mechanismCategoryCombo.getOptionCombos().add( chinaA2Combo );
         mechanismCategoryCombo.getOptionCombos().add( chinaB2Combo );
         mechanismCategoryCombo.getOptionCombos().add( indiaA1Combo );
+        mechanismCategoryCombo.getOptionCombos().add( worldwideCombo );
         categoryService.updateCategoryCombo( mechanismCategoryCombo );
+
+        // Agency and partner category option groups
         agencyA = createCategoryOptionGroup( 'A', brazilA1, chinaA1_1, chinaA1_2, chinaA2, indiaA1 );
         agencyB = createCategoryOptionGroup( 'B', chinaB2 );
         partner1 = createCategoryOptionGroup( '1', brazilA1, chinaA1_1, chinaA1_2, indiaA1 );
@@ -459,6 +488,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
             brazilAgencyAUsers, chinaAgencyAUsers, indiaAgencyAUsers, brazilPartner1Users, chinaPartner1Users,
             indiaPartner1Users );
         setAccess( partner2, globalUsers, chinaInteragencyUsers, chinaAgencyAUsers, chinaPartner2Users );
+
+        // Agencies and partners category option group sets
         agencies = new CategoryOptionGroupSet( "Agencies" );
         partners = new CategoryOptionGroupSet( "Partners" );
         categoryService.saveCategoryOptionGroupSet( partners );
@@ -483,6 +514,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         categoryService.updateCategoryOptionGroup( agencyB );
         categoryService.updateCategoryOptionGroup( partner1 );
         categoryService.updateCategoryOptionGroup( partner2 );
+
+        // Data approval levels
         globalLevel1 = new DataApprovalLevel( "GlobalLevel1", 1, null );
         globalAgencyLevel2 = new DataApprovalLevel( "GlobalAgencyLevel2", 1, agencies );
         countryLevel3 = new DataApprovalLevel( "CountryLevel3", 3, null );
@@ -494,14 +527,20 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         dataApprovalLevelService.addDataApprovalLevel( agencyLevel4, 4 );
         dataApprovalLevelService.addDataApprovalLevel( partnerLevel5, 5 );
         periodType = periodService.reloadPeriodType( PeriodType.getPeriodTypeByName( "Monthly" ) );
+
+        // Period
         periodA = createPeriod( "201801" );
         periodService.addPeriod( periodA );
+
+        // Data approval workflows
         workflow1 = new DataApprovalWorkflow( "workflow1", periodType,
             newHashSet( globalLevel1, countryLevel3, agencyLevel4, partnerLevel5 ) );
         workflow2 = new DataApprovalWorkflow( "workflow2", periodType,
             newHashSet( globalLevel1, globalAgencyLevel2, agencyLevel4, partnerLevel5 ) );
         dataApprovalService.addWorkflow( workflow1 );
         dataApprovalService.addWorkflow( workflow2 );
+
+        // Data sets
         dataSetA = createDataSet( 'A', periodType, mechanismCategoryCombo );
         dataSetB = createDataSet( 'B', periodType, mechanismCategoryCombo );
         dataSetA.assignWorkflow( workflow1 );
@@ -520,6 +559,8 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         dataSetB.addOrganisationUnit( india );
         dataSetService.addDataSet( dataSetA );
         dataSetService.addDataSet( dataSetB );
+
+        // System settings
         systemSettingManager.saveSystemSetting( SettingKey.IGNORE_ANALYTICS_APPROVAL_YEAR_THRESHOLD, 0 );
         systemSettingManager.saveSystemSetting( SettingKey.ACCEPTANCE_REQUIRED_FOR_APPROVAL, true );
     }
@@ -535,6 +576,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
     // -------------------------------------------------------------------------
     // Test helper methods
     // -------------------------------------------------------------------------
+
     private void setUser( User user )
     {
         injectSecurityContext( user );
@@ -559,19 +601,22 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
                     + " read=" + (p.isMayReadData() ? "T" : "F"));
     }
 
-    private String[] getUserApprovalsAndPermissions( User mockUserService, DataApprovalWorkflow workflow,
+    private List<String> getUserApprovalsAndPermissions( User mockUserService, DataApprovalWorkflow workflow,
         Period period, OrganisationUnit orgUnit )
+    {
+        return getApprovalsExtended( mockUserService, workflow, period, orgUnit, null, null );
+    }
+
+    private List<String> getApprovalsExtended( User mockUserService, DataApprovalWorkflow workflow,
+        Period period, OrganisationUnit orgUnit, OrganisationUnit ouFilter, CategoryOptionCombo aoc )
     {
         setUser( mockUserService );
         List<DataApprovalStatus> approvals = dataApprovalService.getUserDataApprovalsAndPermissions( workflow, period,
-            orgUnit, mechanismCategoryCombo );
-        List<String> approvalStrings = new ArrayList<>();
-        for ( DataApprovalStatus status : approvals )
-        {
-            approvalStrings.add( getStatusString( status ) );
-        }
-        Collections.sort( approvalStrings );
-        return Arrays.copyOf( approvalStrings.toArray(), approvalStrings.size(), String[].class );
+            orgUnit, ouFilter, mechanismCategoryCombo, aoc );
+        return approvals.stream()
+            .map( status -> getStatusString( status ) )
+            .sorted()
+            .collect( toList() );
     }
 
     private String levels( User user, DataApprovalWorkflow workflow )
@@ -683,6 +728,7 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
     // -------------------------------------------------------------------------
     // Tests
     // -------------------------------------------------------------------------
+
     @Test
     void testGetUserDataApprovalLevels()
     {
@@ -740,119 +786,160 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         // ---------------------------------------------------------------------
         // Nothing approved yet
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
+            getApprovalsExtended( superUser, workflow1, periodA, null, china, null ) );
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
+            getApprovalsExtended( superUser, workflow1, periodA, null, null, chinaA1_1Combo ) );
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
+            getApprovalsExtended( superUser, workflow1, periodA, null, null, worldwideCombo ) );
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Approve ChinaA1_1 at level 5
         // ---------------------------------------------------------------------
+
         assertTrue( approve( superUser, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unapprove( superUser, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( globalConsultant, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
@@ -876,122 +963,164 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertFalse( approve( chinaPartner2User, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertFalse( approve( indiaPartner1User, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( chinaPartner1User, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getApprovalsExtended( globalUser, workflow1, periodA, null, china, null ) );
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getApprovalsExtended( globalUser, workflow1, periodA, null, null, chinaA1_1Combo ) );
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getApprovalsExtended( globalUser, workflow1, periodA, null, null, worldwideCombo ) );
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaA1_2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Approve ChinaA1_2 at level 5
         // ---------------------------------------------------------------------
+
         // TODO: test approving at wrong levels
         assertTrue( approve( superUser, partnerLevel5, workflow1, periodA, china, chinaA1_2Combo ) );
         assertTrue( unapprove( superUser, partnerLevel5, workflow1, periodA, china, chinaA1_2Combo ) );
@@ -1016,124 +1145,163 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertFalse( approve( chinaPartner2User, partnerLevel5, workflow1, periodA, china, chinaA1_2Combo ) );
         assertFalse( approve( indiaPartner1User, partnerLevel5, workflow1, periodA, china, chinaA1_2Combo ) );
         assertTrue( approve( chinaPartner1User, partnerLevel5, workflow1, periodA, china, chinaA1_2Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is approved at level 5
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getApprovalsExtended( chinaInteragencyUser, workflow1, periodA, null, china, null ) );
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getApprovalsExtended( chinaInteragencyUser, workflow1, periodA, null, null, chinaA1_1Combo ) );
+        assertContainsOnly( List.of(
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getApprovalsExtended( chinaInteragencyUser, workflow1, periodA, null, null, worldwideCombo ) );
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Accept ChinaA1_1 at level 5
         // ---------------------------------------------------------------------
+
         assertTrue( accept( superUser, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unaccept( superUser, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( globalConsultant, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
@@ -1158,124 +1326,150 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( unaccept( chinaAgencyAUser, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertFalse( accept( chinaAgencyAApproveOnly, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( chinaAgencyAAcceptOnly, partnerLevel5, workflow1, periodA, china, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is accepted at level 5
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Approve ChinaA1_1 at level 4
         // ---------------------------------------------------------------------
+
         assertTrue( approve( superUser, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unapprove( superUser, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( globalConsultant, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
@@ -1300,125 +1494,151 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( unapprove( chinaAgencyAUser, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertFalse( approve( chinaAgencyAAcceptOnly, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( chinaAgencyAApproveOnly, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is approved at level 4
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
         // (Note: Level 4 user can't see the level 3 approval, etc.)
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Accept ChinaA1_1 at level 4
         // ---------------------------------------------------------------------
+
         assertTrue( accept( superUser, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unaccept( superUser, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( globalConsultant, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
@@ -1443,124 +1663,150 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( unaccept( chinaInteragencyUser, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertFalse( accept( chinaInteragencyApproveOnly, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( chinalInteragencyAcceptOnly, agencyLevel4, workflow1, periodA, china, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is accepted at level 4
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Approve ChinaA1_1 at level 3
         // ---------------------------------------------------------------------
+
         assertTrue( approve( superUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unapprove( superUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( globalConsultant, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
@@ -1585,124 +1831,150 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( unapprove( chinaInteragencyUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertFalse( approve( chinalInteragencyAcceptOnly, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( chinaInteragencyApproveOnly, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is approved at level 3
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Accept ChinaA1_1 at level 3
         // ---------------------------------------------------------------------
+
         assertTrue( accept( superUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unaccept( superUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( globalConsultant, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
@@ -1727,124 +1999,150 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( unaccept( globalUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertFalse( accept( globalApproveOnly, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( globalAcceptOnly, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is accepted at level 3
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Approve ChinaA1_1 at level 1
         // ---------------------------------------------------------------------
+
         // False because wrong org unit:
         assertFalse( approve( superUser, globalLevel1, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( approve( superUser, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
@@ -1867,118 +2165,146 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( unapprove( globalUser, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
         assertFalse( approve( globalAcceptOnly, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
         assertTrue( approve( globalApproveOnly, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
+
         // ---------------------------------------------------------------------
         // ChinaA1_1 is approved at level 1
         // ChinaA1_2 is approved at level 5
         // ---------------------------------------------------------------------
-        assertArrayEquals( new String[] {
+
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=1 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=1 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalConsultant, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=1 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=1 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA1_1 level=1 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( globalAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=1 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( globalReadAll, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaInteragencyApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinalInteragencyAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
+            getUserApprovalsAndPermissions( indiaInteragencyUser, workflow1, periodA, null ) );
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( brazilAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=F accept=F unaccept=F read=F",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAApproveOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA1_1 level=4 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
-            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+            "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyAAcceptOnly, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( chinaAgencyBUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=F unapprove=F accept=F unaccept=F read=F" ),
             getUserApprovalsAndPermissions( indiaAgencyAUser, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( brazilPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals(
-            new String[] {
-                "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
-                "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=China mechanism=ChinaA1_1 level=5 ACCEPTED_HERE approve=F unapprove=F accept=F unaccept=F read=T",
+            "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner1User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( chinaPartner2User, workflow1, periodA, null ) );
-        assertArrayEquals( new String[] {
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+        assertContainsOnly( List.of(
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( indiaPartner1User, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Unapprove ChinaA1_1 at level 1
         // ---------------------------------------------------------------------
+
         assertTrue( unapprove( superUser, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
         assertTrue( approve( superUser, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
         assertTrue( unapprove( globalConsultant, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
@@ -1999,17 +2325,22 @@ class DataApprovalServiceCategoryOptionGroupTest extends IntegrationTestBase
         assertTrue( approve( globalUser, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
         assertTrue( unapprove( globalApproveOnly, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
         assertFalse( unapprove( globalAcceptOnly, globalLevel1, workflow1, periodA, global, chinaA1_1Combo ) );
-        assertArrayEquals( new String[] {
+        assertContainsOnly( List.of(
             "ou=Brazil mechanism=BrazilA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=Brazil mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaA1_1 level=3 ACCEPTED_HERE approve=T unapprove=T accept=F unaccept=T read=T",
             "ou=China mechanism=ChinaA1_2 level=5 APPROVED_HERE approve=F unapprove=T accept=T unaccept=F read=T",
             "ou=China mechanism=ChinaA2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
             "ou=China mechanism=ChinaB2 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
-            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" },
+            "ou=China mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=IndiaA1 level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T",
+            "ou=India mechanism=worldwide level=5 UNAPPROVED_READY approve=T unapprove=F accept=F unaccept=F read=T" ),
             getUserApprovalsAndPermissions( superUser, workflow1, periodA, null ) );
+
         // ---------------------------------------------------------------------
         // Unaccept ChinaA1_1 at level 3
         // ---------------------------------------------------------------------
+
         assertTrue( unaccept( superUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( accept( superUser, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );
         assertTrue( unaccept( globalConsultant, countryLevel3, workflow1, periodA, china, chinaA1_1Combo ) );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalServiceTest.java
@@ -329,13 +329,13 @@ class DataApprovalServiceTest extends IntegrationTestBase
         //
         // Organisation unit hierarchy:
         //
-        // Level 1 A
+        // A - Level 1
         // |
-        // Level 2 B
-        // / \
-        // Level 3 C E
+        // B - Level 2
+        // |\
+        // C E - Level 3
         // | |
-        // Level 4 D F
+        // D F - Level 4
         //
         organisationUnitA = createOrganisationUnit( 'A' );
         organisationUnitB = createOrganisationUnit( 'B', organisationUnitA );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreIntegrationTest.java
@@ -282,14 +282,14 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
 
             Mockito.when( currentUserService.getCurrentUser() ).thenReturn( userA );
 
-            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodJan, null, 1, categoryComboA,
-                null, userApprovalLevels, null ).size() );
-            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodFeb, null, 1, categoryComboA,
-                null, userApprovalLevels, null ).size() );
-            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodMay, null, 1, categoryComboA,
-                null, userApprovalLevels, null ).size() );
-            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodJun, null, 1, categoryComboA,
-                null, userApprovalLevels, null ).size() );
+            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodJan, null, 1, null,
+                categoryComboA, null, userApprovalLevels, null ).size() );
+            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodFeb, null, 1, null,
+                categoryComboA, null, userApprovalLevels, null ).size() );
+            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodMay, null, 1, null,
+                categoryComboA, null, userApprovalLevels, null ).size() );
+            assertEquals( 1, dataApprovalStore.getDataApprovalStatuses( workflowA, periodJun, null, 1, null,
+                categoryComboA, null, userApprovalLevels, null ).size() );
 
             categoryOptionA.setStartDate( new DateTime( 2020, 1, 1, 0, 0 ).toDate() );
             categoryOptionA.setEndDate( new DateTime( 2020, 5, 30, 0, 0 ).toDate() );
@@ -304,34 +304,34 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
             return null;
         } );
 
-        assertEquals( 0, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodJan, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 0, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodJan, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
-        assertEquals( 1, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodFeb, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 1, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodFeb, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
-        assertEquals( 1, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodMay, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 1, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodMay, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
-        assertEquals( 0, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodJun, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 0, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodJun, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
 
         dataSetA.setOpenPeriodsAfterCoEndDate( 1 );
 
         dataSetService.updateDataSet( dataSetA );
 
-        assertEquals( 0, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodJan, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 0, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodJan, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
-        assertEquals( 1, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodFeb, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 1, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodFeb, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
-        assertEquals( 1, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodMay, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 1, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodMay, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
-        assertEquals( 1, dataApprovalStore
-            .getDataApprovalStatuses( workflowA, periodJun, null, 1, categoryComboA, null, userApprovalLevels, null )
+        assertEquals( 1, dataApprovalStore.getDataApprovalStatuses(
+            workflowA, periodJun, null, 1, null, categoryComboA, null, userApprovalLevels, null )
             .size() );
     }
 
@@ -432,7 +432,7 @@ class DataApprovalStoreIntegrationTest extends TransactionalIntegrationTest
         Mockito.when( currentUserService.getCurrentUser() ).thenReturn( userA );
 
         assertEquals( expectedApprovalCount,
-            dataApprovalStore.getDataApprovalStatuses( workflowA, periodFeb, null, 1, categoryComboA,
+            dataApprovalStore.getDataApprovalStatuses( workflowA, periodFeb, null, 1, null, categoryComboA,
                 null, userApprovalLevels, null ).size() );
 
         dbmsManager.clearSession();

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreUserTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dataapproval/DataApprovalStoreUserTest.java
@@ -161,8 +161,8 @@ class DataApprovalStoreUserTest extends IntegrationTestBase
         CategoryOptionCombo catOptionComboA = createCategoryOptionCombo( catComboA, catOptionA );
         categoryService.addCategoryOptionCombo( catOptionComboA );
         List<DataApprovalStatus> statuses = dataApprovalStore.getDataApprovalStatuses( workflowA, periodA,
-            Lists.newArrayList( orgUnitA ), orgUnitA.getHierarchyLevel(), catComboA, null, dataApprovalLevelService
-                .getUserDataApprovalLevelsOrLowestLevel( currentUser, workflowA ),
+            Lists.newArrayList( orgUnitA ), orgUnitA.getHierarchyLevel(), null, catComboA, null,
+            dataApprovalLevelService.getUserDataApprovalLevelsOrLowestLevel( currentUser, workflowA ),
             dataApprovalLevelService.getDataApprovalLevelMap() );
         assertEquals( 1, statuses.size() );
         DataApprovalStatus status = statuses.get( 0 );
@@ -171,8 +171,8 @@ class DataApprovalStoreUserTest extends IntegrationTestBase
         assertEquals( orgUnitA.getName(), status.getOrganisationUnitName() );
         assertEquals( catOptionComboA.getUid(), status.getAttributeOptionComboUid() );
         statuses = dataApprovalStore.getDataApprovalStatuses( workflowA, periodA, Lists.newArrayList( orgUnitB ),
-            orgUnitB.getHierarchyLevel(), catComboA, null, dataApprovalLevelService
-                .getUserDataApprovalLevelsOrLowestLevel( currentUser, workflowA ),
+            orgUnitB.getHierarchyLevel(), null, catComboA, null,
+            dataApprovalLevelService.getUserDataApprovalLevelsOrLowestLevel( currentUser, workflowA ),
             dataApprovalLevelService.getDataApprovalLevelMap() );
         assertEquals( 1, statuses.size() );
         status = statuses.get( 0 );
@@ -181,8 +181,8 @@ class DataApprovalStoreUserTest extends IntegrationTestBase
         assertEquals( orgUnitB.getName(), status.getOrganisationUnitName() );
         assertEquals( catOptionComboA.getUid(), status.getAttributeOptionComboUid() );
         statuses = dataApprovalStore.getDataApprovalStatuses( workflowA, periodA, Lists.newArrayList( orgUnitC ),
-            orgUnitC.getHierarchyLevel(), catComboA, null, dataApprovalLevelService
-                .getUserDataApprovalLevelsOrLowestLevel( currentUser, workflowA ),
+            orgUnitC.getHierarchyLevel(), null, catComboA, null,
+            dataApprovalLevelService.getUserDataApprovalLevelsOrLowestLevel( currentUser, workflowA ),
             dataApprovalLevelService.getDataApprovalLevelMap() );
         assertEquals( 1, statuses.size() );
         status = statuses.get( 0 );
@@ -191,7 +191,7 @@ class DataApprovalStoreUserTest extends IntegrationTestBase
         assertEquals( orgUnitC.getName(), status.getOrganisationUnitName() );
         assertEquals( catOptionComboA.getUid(), status.getAttributeOptionComboUid() );
         statuses = dataApprovalStore.getDataApprovalStatuses( workflowA, periodA, Lists.newArrayList( orgUnitD ),
-            orgUnitD.getHierarchyLevel(), catComboA, null, null, null );
+            orgUnitD.getHierarchyLevel(), null, catComboA, null, null, null );
         assertEquals( 0, statuses.size() );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataApprovalControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataApprovalControllerTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -59,6 +60,9 @@ class DataApprovalControllerTest extends DhisControllerConvenienceTest
 
     @Autowired
     private PeriodService periodService;
+
+    @Autowired
+    private CategoryService categoryService;
 
     @BeforeEach
     void setUp()
@@ -129,6 +133,18 @@ class DataApprovalControllerTest extends DhisControllerConvenienceTest
     {
         JsonArray statuses = GET( "/dataApprovals/categoryOptionCombos?ou={ou}&pe=202101&wf={wf}", ouId, wfId )
             .content( HttpStatus.OK );
+        assertTrue( statuses.isArray() );
+        assertEquals( 1, statuses.size() );
+
+        statuses = GET( "/dataApprovals/categoryOptionCombos?ou={ou}&pe=202101&wf={wf}&ouFilter={ou}", ouId, wfId,
+            ouId ).content( HttpStatus.OK );
+        assertTrue( statuses.isArray() );
+        assertEquals( 1, statuses.size() );
+
+        String aocId = categoryService.getDefaultCategoryOptionCombo().getUid();
+
+        statuses = GET( "/dataApprovals/categoryOptionCombos?ou={ou}&pe=202101&wf={wf}&aoc={ou}", ouId, wfId,
+            aocId ).content( HttpStatus.OK );
         assertTrue( statuses.isArray() );
         assertEquals( 1, statuses.size() );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -377,12 +377,16 @@ public class DataApprovalController
         @OpenApi.Param( { UID[].class, DataSet.class } ) @RequestParam( required = false ) Set<String> ds,
         @OpenApi.Param( { UID[].class, DataApprovalWorkflow.class } ) @RequestParam( required = false ) Set<String> wf,
         @OpenApi.Param( Period.class ) @RequestParam String pe,
-        @OpenApi.Param( { UID.class, OrganisationUnit.class } ) @RequestParam( required = false ) String ou )
+        @OpenApi.Param( { UID.class, OrganisationUnit.class } ) @RequestParam( required = false ) String ou,
+        @OpenApi.Param( { UID.class, OrganisationUnit.class } ) @RequestParam( required = false ) String ouFilter,
+        @OpenApi.Param( { UID.class, CategoryOptionCombo.class } ) @RequestParam( required = false ) String aoc )
         throws WebMessageException
     {
         Set<DataApprovalWorkflow> workflows = getAndValidateWorkflows( ds, wf );
         Period period = getAndValidatePeriod( pe );
         OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ou );
+        OrganisationUnit orgUnitFilter = organisationUnitService.getOrganisationUnit( ouFilter );
+        CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( ou );
 
         if ( orgUnit != null && orgUnit.isRoot() )
         {
@@ -403,7 +407,7 @@ public class DataApprovalController
             for ( CategoryCombo attributeCombo : attributeCombos )
             {
                 statusList.addAll( dataApprovalService.getUserDataApprovalsAndPermissions( workflow, period, orgUnit,
-                    attributeCombo ) );
+                    orgUnitFilter, attributeCombo, attributeOptionCombo ) );
             }
         }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DataApprovalController.java
@@ -386,7 +386,7 @@ public class DataApprovalController
         Period period = getAndValidatePeriod( pe );
         OrganisationUnit orgUnit = organisationUnitService.getOrganisationUnit( ou );
         OrganisationUnit orgUnitFilter = organisationUnitService.getOrganisationUnit( ouFilter );
-        CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( ou );
+        CategoryOptionCombo attributeOptionCombo = categoryService.getCategoryOptionCombo( aoc );
 
         if ( orgUnit != null && orgUnit.isRoot() )
         {


### PR DESCRIPTION
See [DHIS2-14371](https://dhis2.atlassian.net/browse/DHIS2-14371). This adds two optional parameters to the `/dataApprovals/categoryOptionCombos` endpoint needed by PEPFAR for performance and correct functioning of their custom data approvals app. Existing use of this endpoint is not affected in any way.

`DataApprovalServiceCategoryOptionGroupTest` does the testing of the new parameter logic, since this test duplicates the complexity of the PEPFAR approval environment. A `worldwide` mechanism (attribute option combo) was added to this test to model the PEPFAR deduplication and MOH alignment mechanisms, and to verify that a non-country mechanism is correctly returned by the new parameters. Also calls to `assertArrayEquals` were changed to `assertContainsOnly` because the former returned only the length difference between arrays if that was different, whereas the latter says exactly which entries do not match.

`DataApprovalControllerTest` merely tests that the new parameters are supported by the controller.

[DHIS2-14371]: https://dhis2.atlassian.net/browse/DHIS2-14371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ