### PR TITLE
fix: Avoid fetch non-attribute entity by attribute value [DHIS2-14598]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/BaseIdentifiableObject.java
@@ -376,6 +376,12 @@ public class BaseIdentifiableObject
         return cacheAttributeValues.get( attributeUid );
     }
 
+    public String getAttributeValueString( Attribute attribute )
+    {
+        AttributeValue attributeValue = getAttributeValue( attribute );
+        return attributeValue != null ? attributeValue.getValue() : null;
+    }
+
     @Gist( included = Include.FALSE )
     @Override
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdScheme.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdScheme.java
@@ -27,7 +27,10 @@
  */
 package org.hisp.dhis.common;
 
+import lombok.Getter;
+
 import org.apache.commons.lang3.StringUtils;
+import org.hisp.dhis.attribute.Attribute;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
@@ -35,6 +38,7 @@ import com.google.common.collect.ImmutableMap;
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
+@Getter
 public class IdScheme
 {
     public static final IdScheme NULL = new IdScheme( null );
@@ -56,7 +60,7 @@ public class IdScheme
 
     public static final String ATTR_ID_SCHEME_PREFIX = "ATTRIBUTE:";
 
-    private IdentifiableProperty identifiableProperty;
+    private final IdentifiableProperty identifiableProperty;
 
     private String attribute;
 
@@ -96,6 +100,11 @@ public class IdScheme
             : new IdScheme( property );
     }
 
+    public static IdScheme from( Attribute attribute )
+    {
+        return new IdScheme( IdentifiableProperty.ATTRIBUTE, attribute.getUid() );
+    }
+
     private IdScheme( IdentifiableProperty identifiableProperty )
     {
         this.identifiableProperty = identifiableProperty;
@@ -107,24 +116,9 @@ public class IdScheme
         this.attribute = attribute;
     }
 
-    public IdentifiableProperty getIdentifiableProperty()
-    {
-        return identifiableProperty;
-    }
-
     public String getIdentifiableString()
     {
         return identifiableProperty != null ? identifiableProperty.toString() : null;
-    }
-
-    public void setIdentifiableProperty( IdentifiableProperty identifiableProperty )
-    {
-        this.identifiableProperty = identifiableProperty;
-    }
-
-    public String getAttribute()
-    {
-        return attribute;
     }
 
     public void setAttribute( String attribute )

--- a/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/Schema.java
+++ b/dhis-2/dhis-services/dhis-service-schema/src/main/java/org/hisp/dhis/schema/Schema.java
@@ -720,6 +720,11 @@ public class Schema implements Ordered, Klass
         references = null;
     }
 
+    public boolean hasAttributeValues()
+    {
+        return havePersistedProperty( "attributeValues" );
+    }
+
     @JsonIgnore
     public Property getProperty( String name )
     {

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/data/DataQueryServiceTest.java
@@ -410,9 +410,10 @@ class DataQueryServiceTest extends SingleSetupIntegrationTestBase
     void testGetDimensionDataByAttribute()
     {
         List<DimensionalItemObject> items = List.of( deA, deB, deC );
-        List<String> itemAttributeValues = List.of( deA.getCode(), deB.getCode(), deC.getCode() );
+        List<String> itemAttributeValues = List.of( deA.getAttributeValueString( atA ),
+            deB.getAttributeValueString( atA ), deC.getAttributeValueString( atA ) );
         DimensionalObject actual = dataQueryService.getDimension( DimensionalObject.DATA_X_DIM_ID, itemAttributeValues,
-            (Date) null, null, false, IdScheme.CODE );
+            (Date) null, null, false, IdScheme.from( atA ) );
         assertEquals( DimensionalObject.DATA_X_DIM_ID, actual.getDimension() );
         assertEquals( DimensionType.DATA_X, actual.getDimensionType() );
         assertEquals( DataQueryParams.DISPLAY_NAME_DATA_X, actual.getDimensionDisplayName() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -42,6 +42,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.hibernate.SessionFactory;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeService;
+import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOption;
@@ -75,9 +78,12 @@ import com.google.common.collect.Sets;
  */
 class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
 {
+    private Attribute atA;
 
     @Autowired
     private SessionFactory sessionFactory;
+
+    private AttributeService attributeService;
 
     @Autowired
     private DataElementService dataElementService;
@@ -92,6 +98,11 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     protected void setUpTest()
         throws Exception
     {
+        atA = createAttribute( 'A' );
+        atA.setUnique( true );
+        atA.setDataElementAttribute( true );
+        attributeService.addAttribute( atA );
+
         this.userService = _userService;
     }
 
@@ -129,6 +140,32 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
             idObjectManager.getObject( dataElementGroupIdA, DataElementGroup.class.getSimpleName() ) );
         assertEquals( dataElementGroupB,
             idObjectManager.getObject( dataElementGroupIdB, DataElementGroup.class.getSimpleName() ) );
+    }
+
+    @Test
+    void testGetObjectByIdSchemeCode()
+    {
+        DataElement dataElementA = createDataElement( 'A' );
+        DataElement dataElementB = createDataElement( 'B' );
+        dataElementService.addDataElement( dataElementA );
+        dataElementService.addDataElement( dataElementB );
+        assertEquals( dataElementA, idObjectManager.getObject( DataElement.class, IdScheme.CODE, "DataElementCodeA" ) );
+        assertEquals( dataElementB, idObjectManager.getObject( DataElement.class, IdScheme.CODE, "DataElementCodeB" ) );
+        assertNull( idObjectManager.getObject( DataElement.class, IdScheme.CODE, "DataElementCodeC" ) );
+    }
+
+    @Test
+    void testGetObjectByIdSchemeAttribute()
+    {
+        DataElement dataElementA = createDataElement( 'A' );
+        DataElement dataElementB = createDataElement( 'B' );
+        dataElementService.addDataElement( dataElementA );
+        dataElementService.addDataElement( dataElementB );
+        attributeService.addAttributeValue( dataElementA, new AttributeValue( atA, "DEA" ) );
+        attributeService.addAttributeValue( dataElementB, new AttributeValue( atA, "DEB" ) );
+        assertEquals( dataElementA, idObjectManager.getObject( DataElement.class, IdScheme.from( atA ), "DEA" ) );
+        assertEquals( dataElementB, idObjectManager.getObject( DataElement.class, IdScheme.from( atA ), "DEB" ) );
+        assertNull( idObjectManager.getObject( DataElement.class, IdScheme.from( atA ), "DEC" ) );
     }
 
     @Test
@@ -629,7 +666,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetObjects()
+    void testGetObjectsByIdSchemeCode()
     {
         OrganisationUnit unit1 = createOrganisationUnit( 'A' );
         OrganisationUnit unit2 = createOrganisationUnit( 'B' );
@@ -646,7 +683,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetIdMapIdScheme()
+    void testGetIdMapIdSchemeCode()
     {
         DataElement dataElementA = createDataElement( 'A' );
         DataElement dataElementB = createDataElement( 'B' );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -170,6 +170,13 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
+    void testGetNonAttributeObjectByIdSchemeAttribute()
+    {
+        assertNull( idObjectManager.getObject(
+            DataElementOperand.class, IdScheme.from( atA ), "nOka5EbgNao.XNTq0nSrSlU" ) );
+    }
+
+    @Test
     void testLoad()
     {
         DataElement dataElementA = createDataElement( 'A' );
@@ -684,7 +691,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     }
 
     @Test
-    void testGetIdMapIdSchemeCode()
+    void testGetIdMapByIdSchemeCode()
     {
         DataElement dataElementA = createDataElement( 'A' );
         DataElement dataElementB = createDataElement( 'B' );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/common/IdentifiableObjectManagerTest.java
@@ -83,6 +83,7 @@ class IdentifiableObjectManagerTest extends TransactionalIntegrationTest
     @Autowired
     private SessionFactory sessionFactory;
 
+    @Autowired
     private AttributeService attributeService;
 
     @Autowired

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
@@ -50,6 +50,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.SerializationUtils;
+import org.hisp.dhis.attribute.Attribute;
+import org.hisp.dhis.attribute.AttributeService;
+import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.category.CategoryService;
 import org.hisp.dhis.common.BaseDimensionalItemObject;
@@ -59,6 +62,7 @@ import org.hisp.dhis.common.DimensionType;
 import org.hisp.dhis.common.DimensionalItemId;
 import org.hisp.dhis.common.DimensionalItemObject;
 import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.common.QueryModifiers;
 import org.hisp.dhis.common.ReportingRate;
@@ -101,6 +105,7 @@ import com.google.common.collect.Sets;
  */
 class DimensionServiceTest extends TransactionalIntegrationTest
 {
+    private Attribute atA;
 
     private DataElement deA;
 
@@ -116,7 +121,7 @@ class DimensionServiceTest extends TransactionalIntegrationTest
 
     private ProgramStage psA;
 
-    private TrackedEntityAttribute atA;
+    private TrackedEntityAttribute teaA;
 
     private ProgramIndicator piA;
 
@@ -199,6 +204,9 @@ class DimensionServiceTest extends TransactionalIntegrationTest
     private Map<DimensionalItemId, DimensionalItemObject> itemMap;
 
     @Autowired
+    private AttributeService attributeService;
+
+    @Autowired
     private DataElementService dataElementService;
 
     @Autowired
@@ -222,6 +230,11 @@ class DimensionServiceTest extends TransactionalIntegrationTest
     @Override
     public void setUpTest()
     {
+        atA = createAttribute( 'A' );
+        atA.setUnique( true );
+        atA.setDataElementAttribute( true );
+        atA.setDataSetAttribute( true );
+        attributeService.addAttribute( atA );
         deA = createDataElement( 'A' );
         deB = createDataElement( 'B' );
         deC = createDataElement( 'C' );
@@ -236,8 +249,8 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         idObjectManager.save( prA );
         psA = createProgramStage( 'A', 1 );
         idObjectManager.save( psA );
-        atA = createTrackedEntityAttribute( 'A' );
-        idObjectManager.save( atA );
+        teaA = createTrackedEntityAttribute( 'A' );
+        idObjectManager.save( teaA );
         piA = createProgramIndicator( 'A', prA, null, null );
         idObjectManager.save( piA );
         peA = createPeriod( "201201" );
@@ -292,6 +305,10 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         ouGroupSetA.getOrganisationUnitGroups().add( ouGroupB );
         ouGroupSetA.getOrganisationUnitGroups().add( ouGroupC );
         organisationUnitGroupService.updateOrganisationUnitGroupSet( ouGroupSetA );
+        attributeService.addAttributeValue( deA, new AttributeValue( atA, "DEA" ) );
+        attributeService.addAttributeValue( deB, new AttributeValue( atA, "DEB" ) );
+        attributeService.addAttributeValue( deC, new AttributeValue( atA, "DEC" ) );
+        attributeService.addAttributeValue( dsA, new AttributeValue( atA, "DSA" ) );
         queryModsA = QueryModifiers.builder().periodOffset( 10 ).build();
         queryModsB = QueryModifiers.builder().minDate( new Date() ).build();
         queryModsC = QueryModifiers.builder().maxDate( new Date() ).build();
@@ -301,7 +318,7 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         itemObjectD = new DataElementOperand( deA, cocA, cocA );
         itemObjectE = new ReportingRate( dsA );
         itemObjectF = new ProgramDataElementDimensionItem( prA, deA );
-        itemObjectG = new ProgramTrackedEntityAttributeDimensionItem( prA, atA );
+        itemObjectG = new ProgramTrackedEntityAttributeDimensionItem( prA, teaA );
         itemObjectH = piA;
         itemIdA = new DimensionalItemId( DATA_ELEMENT, deA.getUid() );
         itemIdB = new DimensionalItemId( DATA_ELEMENT_OPERAND, deA.getUid(), cocA.getUid() );
@@ -309,7 +326,7 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         itemIdD = new DimensionalItemId( DATA_ELEMENT_OPERAND, deA.getUid(), cocA.getUid(), cocA.getUid() );
         itemIdE = new DimensionalItemId( REPORTING_RATE, dsA.getUid(), ReportingRateMetric.REPORTING_RATE.name() );
         itemIdF = new DimensionalItemId( PROGRAM_DATA_ELEMENT, prA.getUid(), deA.getUid() );
-        itemIdG = new DimensionalItemId( PROGRAM_ATTRIBUTE, prA.getUid(), atA.getUid() );
+        itemIdG = new DimensionalItemId( PROGRAM_ATTRIBUTE, prA.getUid(), teaA.getUid() );
         itemIdH = new DimensionalItemId( PROGRAM_INDICATOR, piA.getUid() );
         itemIds = new HashSet<>();
         itemIds.add( itemIdA );
@@ -603,7 +620,7 @@ class DimensionServiceTest extends TransactionalIntegrationTest
     {
         String idA = deA.getUid();
         String idB = prA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + deA.getUid();
-        String idC = prA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + atA.getUid();
+        String idC = prA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + teaA.getUid();
         String idD = dsA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + ReportingRateMetric.REPORTING_RATE.name();
         String idE = dsA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + "UNKNOWN_METRIC";
         String idF = deA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + cocA.getUid();
@@ -616,7 +633,7 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         String idK = deA.getUid() + COMPOSITE_DIM_OBJECT_PLAIN_SEP + SYMBOL_WILDCARD + COMPOSITE_DIM_OBJECT_PLAIN_SEP
             + cocA.getUid();
         ProgramDataElementDimensionItem pdeA = new ProgramDataElementDimensionItem( prA, deA );
-        ProgramTrackedEntityAttributeDimensionItem ptaA = new ProgramTrackedEntityAttributeDimensionItem( prA, atA );
+        ProgramTrackedEntityAttributeDimensionItem ptaA = new ProgramTrackedEntityAttributeDimensionItem( prA, teaA );
         ReportingRate rrA = new ReportingRate( dsA, ReportingRateMetric.REPORTING_RATE );
         DataElementOperand deoA = new DataElementOperand( deA, cocA );
         DataElementOperand deoB = new DataElementOperand( deA, null );
@@ -643,6 +660,15 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         assertEquals( deoD, dimensionService.getDataDimensionalItemObject( idJ ) );
         assertNotNull( dimensionService.getDataDimensionalItemObject( idK ) );
         assertEquals( deoE, dimensionService.getDataDimensionalItemObject( idK ) );
+    }
+
+    @Test
+    void testGetDataDimensionalItemObjectWithAttributeIdScheme()
+    {
+        assertEquals( deA, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DEA" ) );
+        assertEquals( deB, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DEB" ) );
+        assertEquals( deC, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DEC" ) );
+        assertEquals( dsA, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DSA" ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dimension/DimensionServiceTest.java
@@ -668,7 +668,7 @@ class DimensionServiceTest extends TransactionalIntegrationTest
         assertEquals( deA, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DEA" ) );
         assertEquals( deB, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DEB" ) );
         assertEquals( deC, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DEC" ) );
-        assertEquals( dsA, dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DSA" ) );
+        assertNull( dimensionService.getDataDimensionalItemObject( IdScheme.from( atA ), "DSX" ) );
     }
 
     @Test

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/security/EnrollmentSecurityTest.java
@@ -415,8 +415,7 @@ class EnrollmentSecurityTest extends TransactionalIntegrationTest
         manager.updateNoAcl( organisationUnitB );
         en.setOrgUnit( av.getValue() );
         ImportOptions importOptions = new ImportOptions();
-        importOptions.getIdSchemes().setOrgUnitIdScheme( "ATTRIBUTE" );
-        importOptions.getIdSchemes().getOrgUnitIdScheme().setAttribute( "D1DDOl5hTsL" );
+        importOptions.getIdSchemes().setOrgUnitIdScheme( "ATTRIBUTE:D1DDOl5hTsL" );
         ImportSummary importSummary = enrollmentService.addEnrollment( en, importOptions );
         assertEquals( ImportStatus.ERROR, importSummary.getStatus() );
         assertEquals( "Program is not assigned to this Organisation Unit: " + av.getValue(),


### PR DESCRIPTION
This patch makes `IdentifiableObjectManager` not attempt to look up objects by attribute values (by an attribute based ID scheme) if the object entity does not support attributes/attribute values.

This behavior would crash the analytics engine, more specifically the `DimensionService` which would try to look up "data dimension objects" by looking up the various data dimension identities by identifier value, which would throw an exception for entities such as data element operand which do not support attributes.

One question is whether `IdentifiableObjectManager` should throw an exception in this cases, though I think returning null is acceptable and works best for this scenario.

### Automated testing

Added various unit tests.

### Manual testing

* Use attribute "KE Code" with UID `l1VmqIHKk6t`.
* Save an attribute value `KEANC1` for data element `ANC 1`.
* Make a an analytics API request using `dimension=dx:KEANC1` as dimension value and `inputIdScheme=ATTRIBUTE:l1VmqIHKk6t` for ID scheme.

```
http://localhost:9090/api/analytics.json?dimension=dx:KEANC1&dimension=pe:LAST_12_MONTHS
  &filter=ou:USER_ORGUNIT&inputIdScheme=ATTRIBUTE:l1VmqIHKk6t
```
