### PR TITLE
ci: add labels for revision/branch when building locally

### DIFF
--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Builds DHIS2 war and Docker image for development use
 
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
 D2CLUSTER="${1:-}"
 IMAGE=dhis2/core-dev
 TAG=local
-
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+BUILD_REVISION=$(git --git-dir "$DIR/../.git" rev-parse HEAD)
+BUILD_BRANCH=$(git --git-dir "$DIR/../.git" branch --show-current)
 
 # Choosing this approach over automatically activating a maven profile based on the architecture.
 # This is to not risk running both the jibBuild and jibBuildArmOnly profiles in our pipelines.
@@ -19,12 +21,11 @@ fi
 
 echo "Building dhis2-core and Docker image..."
 
-print "Building dhis2-core and Docker image..."
-
 export MAVEN_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25"
 mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -f "${DIR}/pom.xml" -pl -dhis-web-embedded-jetty,-dhis-test-integration,-dhis-test-coverage
 mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -f "${DIR}/dhis-web/pom.xml"
-mvn -DskipTests -Dmaven.test.skip=true -f "${DIR}/dhis-web/dhis-web-portal/pom.xml" jib:dockerBuild $JIB_PROFILE
+mvn -DskipTests -Dmaven.test.skip=true -f "${DIR}/dhis-web/dhis-web-portal/pom.xml" jib:dockerBuild $JIB_PROFILE \
+  -Djib.container.labels=DHIS2_BUILD_REVISION="${BUILD_REVISION}",DHIS2_BUILD_BRANCH="${BUILD_BRANCH}"
 
 if test -z "$D2CLUSTER"; then
     echo "No cluster name specified, skipping deploy"


### PR DESCRIPTION
since images by default will get name dhis2/core-dev:local adding labels help identify where an image came from