### PR TITLE
ci: automate local jib builds for mac arm architecture [2.37]

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -9,41 +9,43 @@ concurrency:
 jobs:
   api-test:
     env:
-      CORE_IMAGE_NAME: "dhis2/core-dev:local"
-      PR_NUMBER: ${{ github.event.number }}
-      DOCKER_CHANNEL: "dhis2/core-pr"
-
+      CORE_IMAGE_NAME: "dhis2/core-pr:${{ github.event_name == 'pull_request' && github.event.number || 'local' }}"
+    
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'skip-api-tests')"
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: 8
           distribution: temurin
           cache: maven
-      - name: Build core image
-        run: |
-          mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f dhis-2/pom.xml -pl -dhis-web-embedded-jetty
-          mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f dhis-2/dhis-web/pom.xml
-          mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild -Djib.to.image=$CORE_IMAGE_NAME
 
       - name: Login to Docker Hub
-        if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
+        if: github.event_name == 'pull_request' # only login to Dockerhub on PRs where we want to publish
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DHIS2_BOT_DOCKER_HUB_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Publish docker image
-        if: "contains(github.event.pull_request.labels.*.name, 'publish-docker-image')"
+      - name: Build war
         run: |
-          docker tag $CORE_IMAGE_NAME $DOCKER_CHANNEL:$PR_NUMBER
-          docker push $DOCKER_CHANNEL:$PR_NUMBER
+          mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f dhis-2/pom.xml -pl -dhis-web-embedded-jetty
+          mvn clean install --threads 2C --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f dhis-2/dhis-web/pom.xml
+
+      - name: Build container image
+        run: |
+          if [ "${{github.event_name}}" = "pull_request" ]; then 
+            # on PRs: build and publish multi-arch images using Jib. Image is used for api tests in
+            # this workflow and can be pulled from Dockerhub by devs to run locally, ...
+            mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/dhis-web-portal/pom.xml jib:build -PjibBuild \
+                -Djib.to.image=$CORE_IMAGE_NAME -Djib.container.labels=DHIS2_BUILD_REVISION=${{github.event.pull_request.head.sha}},DHIS2_BUILD_BRANCH=${{github.head_ref}}
+          else
+            # only build image for running api tests in this workflow i.e. master, 2.39, ...
+            mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f ./dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild \
+                -Djib.to.image=$CORE_IMAGE_NAME
+          fi
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -44,12 +44,16 @@ repositories
 * development (branches master and the previous 3 supported major versions) [dhis2/core-dev](https://hub.docker.com/r/dhis2/core-dev/tags)
 * PRs labeled with `publish-docker-image` [dhis2/core-pr](https://hub.docker.com/r/dhis2/core-pr/tags)
 
-To run DHIS2 from latest master (as it is on GitHub) run
+* [`dhis2/core-dev`](https://hub.docker.com/r/dhis2/core-dev) - images of _the latest development_ DHIS2 versions - branches `master` (tagged as `latest`) and the previous 3 supported major versions. Image tags in this repository will be overwritten multiple times a day.
+
+* [`dhis2/core-canary`](https://hub.docker.com/r/dhis2/core-canary) - images of _the latest daily development_ DHIS2 versions. We tag the last `core-dev` images for the day and add an extra tag with a "yyyyMMdd"-formatted date, like `core-canary:latest-20230124`.
+
+* [`dhis2/core-pr`](https://hub.docker.com/r/dhis2/core-pr) - images of PRs.
+
+To run DHIS2 from latest `master` branch (as it is on GitHub) run:
 
 ```sh
-DHIS2_IMAGE=dhis2/core-dev:2.37 \
-DHIS2_DB_DUMP_URL=https://databases.dhis2.org/sierra-leone/2.37.8/dhis2-db-sierra-leone.sql.gz \
-  docker compose up
+DHIS2_IMAGE=dhis2/core-dev:latest docker compose up
 ```
 
 ### Local Image
@@ -87,14 +91,7 @@ The DHIS2 Docker image is built using
 to build DHIS2 and the web project first
 
 ```sh
-mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -f dhis-2/pom.xml -pl -dhis-web-embedded-jetty
-mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/pom.xml
-```
-
-Then build the Docker image
-
-```sh
-mvn -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/dhis-web-portal/pom.xml jib:dockerBuild
+./dhis-2/build-dev.sh
 ```
 
 Run the image using

--- a/dhis-2/build-dev.sh
+++ b/dhis-2/build-dev.sh
@@ -1,43 +1,36 @@
 #!/usr/bin/env bash
+# Builds DHIS2 war and Docker image for development use
 
-#
-## bash environment
-#
-
-if test "$BASH" = "" || "$BASH" -uc "a=();true \"\${a[@]}\"" 2>/dev/null; then
-    # Bash 4.4, Zsh
-    set -euo pipefail
-else
-    # Bash 4.3 and older chokes on empty arrays with set -u.
-    set -eo pipefail
-fi
-shopt -s nullglob globstar
-
-#
-## script environment
-#
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 D2CLUSTER="${1:-}"
 IMAGE=dhis2/core-dev
 TAG=local
+BUILD_REVISION=$(git --git-dir "$DIR/../.git" rev-parse HEAD)
+BUILD_BRANCH=$(git --git-dir "$DIR/../.git" branch --show-current)
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Choosing this approach over automatically activating a maven profile based on the architecture.
+# This is to not risk running both the jibBuild and jibBuildArmOnly profiles in our pipelines.
+# There might be ways like using https://maven.apache.org/enforcer/enforcer-rules/requireActiveProfile.html
+# to prevent that but they would require more work.
+ARCH=$(mvn help:system | grep "os\.arch")
+JIB_PROFILE=
+if [[ "$ARCH" == *arm64* || "$ARCH" == *aarch64* ]]; then
+  JIB_PROFILE="-P jibBuildArmOnly"
+fi
 
-print() {
-    echo -e "\033[1m$1\033[0m" 1>&2
-}
-
-print "Building dhis2-core and Docker image..."
+echo "Building dhis2-core and Docker image..."
 
 export MAVEN_OPTS="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25"
 mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f "${DIR}/pom.xml" -pl -dhis-web-embedded-jetty
 mvn clean install --threads 2C -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f "${DIR}/dhis-web/pom.xml"
-mvn -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f "${DIR}/dhis-web/dhis-web-portal/pom.xml" jib:dockerBuild
+mvn -DskipTests -Dmaven.test.skip=true -P jdk8,-default -f "${DIR}/dhis-web/dhis-web-portal/pom.xml" jib:dockerBuild $JIB_PROFILE \
+  -Djib.container.labels=DHIS2_BUILD_REVISION="${BUILD_REVISION}",DHIS2_BUILD_BRANCH="${BUILD_BRANCH}"
 
 if test -z "$D2CLUSTER"; then
-    print "No cluster name specified, skipping deploy"
+    echo "No cluster name specified, skipping deploy"
 else
-    print "Deploying to d2 cluster $D2CLUSTER..."
+    echo "Deploying to d2 cluster $D2CLUSTER..."
 
     d2 cluster up "$D2CLUSTER" --image $IMAGE:$TAG
     d2 cluster logs "$D2CLUSTER"

--- a/dhis-2/dhis-web/dhis-web-portal/pom.xml
+++ b/dhis-2/dhis-web/dhis-web-portal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -15,13 +15,13 @@
 
     <profiles>
         <profile>
+            <!-- used to build and push multi-architecture images -->
             <id>jibBuild</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>com.google.cloud.tools</groupId>
                         <artifactId>jib-maven-plugin</artifactId>
-                        <version>${jib.version}</version>
                         <configuration>
                             <from>
                                 <platforms>
@@ -40,10 +40,41 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- used to automatically build images for arm64 on Mac without users needing to configure Jib -->
+            <id>jibBuildArmOnly</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <configuration>
+                            <from>
+                                <platforms>
+                                    <platform>
+                                        <architecture>arm64</architecture>
+                                        <os>linux</os>
+                                    </platform>
+                                </platforms>
+                            </from>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
         <finalName>dhis</finalName>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.google.cloud.tools</groupId>
+                    <artifactId>jib-maven-plugin</artifactId>
+                    <version>${jib.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
@@ -126,7 +157,7 @@
 
     <properties>
         <rootDir>../../</rootDir>
-        <jib.version>3.3.0</jib.version>
+        <jib.version>3.3.1</jib.version>
         <jib.from.image>tomcat:9.0-jre11</jib.from.image>
         <jib.to.image>dhis2/core-dev:local</jib.to.image>
         <!-- uid=65534(nobody) gid=65534(nogroup) present in Tomcat image -->


### PR DESCRIPTION
backport of
* https://github.com/dhis2/dhis2-core/pull/12842
* https://github.com/dhis2/dhis2-core/pull/12870
* https://github.com/dhis2/dhis2-core/pull/12874
* update Jib to latest version

## Test Local Image

On a Mac with arm64 CPU architecture run

```sh
./dhis-2/build-dev.sh
docker inspect dhis2/core-dev:local -f "{{ .Architecture }}"
```

Output should be `arm64`.

You should then also be able to run this image using

```sh
docker compose up
```

## Test PR Image

Multi-arch images are built and pushed for every PR. An example for this PR [dhis2/core-pr:12877
](https://hub.docker.com/layers/dhis2/core-pr/12877/images/sha256-23630f6720e3877a3f8a67c4b6b2df3dbb16cc13eb52574d035d25d3cf7b7f6d?context=explore)

```sh
docker pull dhis2/core-pr:12877
docker inspect dhis2/core-pr:12877 -f "{{ .Architecture }}"
```

should show the architecture of your machine.