### PR TITLE
fix: Return meaningful error message for wrong enum value in parameter [DHIS2-14182]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
@@ -58,14 +58,6 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void testSyncPostJsonTrackerInvalidImportMode()
-    {
-        assertWebMessage( "Bad Request", 400, "ERROR",
-            "Value INVALID is not a valid importMode. Valid values are: [COMMIT, VALIDATE]",
-            POST( "/tracker?async=false&importMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
-    }
-
-    @Test
     void testAsyncPostJsonTracker()
     {
         assertWebMessage( "OK", 200, "OK", "Tracker job added",
@@ -78,13 +70,5 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
         assertWebMessage( "Internal Server Error", 500, "ERROR",
             "Invalid boolean value [INVALID]",
             POST( "/tracker?async=false&skipRuleEngine=INVALID", "{}" ).content( HttpStatus.INTERNAL_SERVER_ERROR ) );
-    }
-
-    @Test
-    void shouldReturnBadRequestWhenInvalidReportModeIsPassed()
-    {
-        assertWebMessage( "Bad Request", 400, "ERROR",
-            "Value INVALID is not a valid reportMode. Valid values are: [FULL, ERRORS, WARNINGS]",
-            GET( "/tracker/jobs/AAA/report?reportMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
@@ -61,8 +61,8 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     void testSyncPostJsonTrackerInvalidImportMode()
     {
         assertWebMessage( "Bad Request", 400, "ERROR",
-                "Value INVALID is not a valid importMode. Valid values are: [COMMIT, VALIDATE]",
-                POST( "/tracker?async=false&importMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
+            "Value INVALID is not a valid importMode. Valid values are: [COMMIT, VALIDATE]",
+            POST( "/tracker?async=false&importMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 
     @Test
@@ -76,15 +76,15 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     void shouldReturnInternalServerErrorWhenInvalidBooleanIsPassed()
     {
         assertWebMessage( "Internal Server Error", 500, "ERROR",
-                "Invalid boolean value [INVALID]",
-                POST( "/tracker?async=false&skipRuleEngine=INVALID", "{}" ).content( HttpStatus.INTERNAL_SERVER_ERROR ) );
+            "Invalid boolean value [INVALID]",
+            POST( "/tracker?async=false&skipRuleEngine=INVALID", "{}" ).content( HttpStatus.INTERNAL_SERVER_ERROR ) );
     }
 
     @Test
     void shouldReturnBadRequestWhenInvalidReportModeIsPassed()
     {
         assertWebMessage( "Bad Request", 400, "ERROR",
-                "Value INVALID is not a valid reportMode. Valid values are: [FULL, ERRORS, WARNINGS]",
-                GET( "/tracker/jobs/AAA/report?reportMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
+            "Value INVALID is not a valid reportMode. Valid values are: [FULL, ERRORS, WARNINGS]",
+            GET( "/tracker/jobs/AAA/report?reportMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
@@ -58,9 +58,33 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void testSyncPostJsonTrackerInvalidImportMode()
+    {
+        assertWebMessage( "Bad Request", 400, "ERROR",
+                "Value INVALID is not a valid importMode. Valid values are: [COMMIT, VALIDATE]",
+                POST( "/tracker?async=false&importMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
+    }
+
+    @Test
     void testAsyncPostJsonTracker()
     {
         assertWebMessage( "OK", 200, "OK", "Tracker job added",
             POST( "/tracker?async=true", "{}" ).content( HttpStatus.OK ) );
+    }
+
+    @Test
+    void shouldReturnInternalServerErrorWhenInvalidBooleanIsPassed()
+    {
+        assertWebMessage( "Internal Server Error", 500, "ERROR",
+                "Invalid boolean value [INVALID]",
+                POST( "/tracker?async=false&skipRuleEngine=INVALID", "{}" ).content( HttpStatus.INTERNAL_SERVER_ERROR ) );
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenInvalidReportModeIsPassed()
+    {
+        assertWebMessage( "Bad Request", 400, "ERROR",
+                "Value INVALID is not a valid reportMode. Valid values are: [FULL, ERRORS, WARNINGS]",
+                GET( "/tracker/jobs/AAA/report?reportMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
@@ -65,10 +65,10 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void shouldReturnInternalServerErrorWhenInvalidBooleanIsPassed()
+    void shouldReturnBadRequestWhenInvalidReportModeIsPassed()
     {
-        assertWebMessage( "Internal Server Error", 500, "ERROR",
-            "Invalid boolean value [INVALID]",
-            POST( "/tracker?async=false&skipRuleEngine=INVALID", "{}" ).content( HttpStatus.INTERNAL_SERVER_ERROR ) );
+        assertWebMessage( "Bad Request", 400, "ERROR",
+            "Value INVALID is not a valid reportMode. Valid values are: [FULL, ERRORS, WARNINGS]",
+            GET( "/tracker/jobs/AAA/report?reportMode=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -194,7 +194,7 @@ public class CrudControllerAdvice
     {
         if ( ex.getRequiredType() == null )
         {
-            return defaultExceptionHandler( ex );
+            return handleBadRequest( ex );
         }
 
         if ( ex.getRequiredType().isEnum() )
@@ -206,7 +206,7 @@ public class CrudControllerAdvice
                 ex.getValue(), ex.getName(), validValues );
             return badRequest( errorMessage );
         }
-        return defaultExceptionHandler( ex );
+        return handleBadRequest( ex );
     }
 
     @ExceptionHandler( InvalidEnumValueException.class )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -104,6 +104,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import io.github.classgraph.ClassGraph;
@@ -185,6 +186,22 @@ public class CrudControllerAdvice
     public WebMessage illegalQueryExceptionHandler( IllegalQueryException ex )
     {
         return conflict( ex.getMessage(), ex.getErrorCode() );
+    }
+
+    @ExceptionHandler( MethodArgumentTypeMismatchException.class )
+    @ResponseBody
+    public WebMessage methodArgumentTypeMismatchException( MethodArgumentTypeMismatchException ex )
+    {
+        if ( ex.getRequiredType().isEnum() )
+        {
+            String validValues = StringUtils
+                .join( Arrays.stream( ex.getRequiredType().getEnumConstants() ).map( Objects::toString )
+                    .collect( Collectors.toList() ), ", " );
+            String errorMessage = MessageFormat.format( "Value {0} is not a valid {1}. Valid values are: [{2}]",
+                ex.getValue(), ex.getName(), validValues );
+            return badRequest( errorMessage );
+        }
+        return defaultExceptionHandler( ex );
     }
 
     @ExceptionHandler( InvalidEnumValueException.class )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -192,6 +192,11 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage methodArgumentTypeMismatchException( MethodArgumentTypeMismatchException ex )
     {
+        if ( ex.getRequiredType() == null )
+        {
+            return defaultExceptionHandler( ex );
+        }
+
         if ( ex.getRequiredType().isEnum() )
         {
             String validValues = StringUtils

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportController.java
@@ -238,20 +238,16 @@ public class TrackerImportController
 
     @GetMapping( value = "/jobs/{uid}/report", produces = APPLICATION_JSON_VALUE )
     public ImportReport getJobReport( @PathVariable String uid,
-        @RequestParam( defaultValue = "errors", required = false ) String reportMode,
+        @RequestParam( defaultValue = "errors", required = false ) TrackerBundleReportMode reportMode,
         HttpServletResponse response )
         throws HttpStatusCodeException,
         NotFoundException
     {
-        TrackerBundleReportMode trackerBundleReportMode = TrackerBundleReportMode
-            .getTrackerBundleReportMode( reportMode );
-
         setNoStore( response );
 
         return Optional.ofNullable( notifier
             .getJobSummaryByJobId( JobType.TRACKER_IMPORT_JOB, uid ) )
-            .map( report -> trackerImportService.buildImportReport( (ImportReport) report,
-                trackerBundleReportMode ) )
+            .map( report -> trackerImportService.buildImportReport( (ImportReport) report, reportMode ) )
             .orElseThrow( () -> NotFoundException.notFoundUid( uid ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -61,6 +61,7 @@ import org.hisp.dhis.tracker.report.PersistenceReport;
 import org.hisp.dhis.tracker.report.Status;
 import org.hisp.dhis.tracker.report.TimingsStats;
 import org.hisp.dhis.tracker.report.ValidationReport;
+import org.hisp.dhis.webapi.controller.CrudControllerAdvice;
 import org.hisp.dhis.webapi.controller.exception.NotFoundException;
 import org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport;
 import org.hisp.dhis.webapi.controller.tracker.view.Event;
@@ -110,7 +111,9 @@ class TrackerImportControllerTest
         final TrackerImportController controller = new TrackerImportController( importStrategy, trackerImportService,
             csvEventService, new DefaultContextService(), notifier );
 
-        mockMvc = MockMvcBuilders.standaloneSetup( controller ).build();
+        mockMvc = MockMvcBuilders.standaloneSetup( controller )
+            .setControllerAdvice( new CrudControllerAdvice() )
+            .build();
     }
 
     @Test
@@ -370,7 +373,8 @@ class TrackerImportControllerTest
         mockMvc.perform( get( ENDPOINT + "/jobs/" + uid + "/report" )
             .content( "{}" )
             .contentType( MediaType.APPLICATION_JSON )
-            .accept( MediaType.APPLICATION_JSON ) ).andExpect( status().isNotFound() )
+            .accept( MediaType.APPLICATION_JSON ) )
+            .andExpect( status().isNotFound() )
             .andExpect( result -> assertTrue( result.getResolvedException() instanceof NotFoundException ) );
     }
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportControllerTest.java
@@ -374,7 +374,6 @@ class TrackerImportControllerTest
             .content( "{}" )
             .contentType( MediaType.APPLICATION_JSON )
             .accept( MediaType.APPLICATION_JSON ) )
-            .andExpect( status().isNotFound() )
             .andExpect( result -> assertTrue( result.getResolvedException() instanceof NotFoundException ) );
     }
 }


### PR DESCRIPTION
This PR is the first one in order to fix https://dhis2.atlassian.net/browse/DHIS2-14182
The issue was a wrong value of the `commitMode` parameter in the code (it is correct in the docs) so the user was trying to import and just run the validation, but the wrong value was discarded and the default to validate and commit was used instead.

The purpose here is to fix the wrong value and to add validation for all parameters in tracker importer.

First step to do so is to intercept `MethodArgumentTypeMismatchException`, that is thrown by Spring when a conversion from a String to a specific type in the parameters of an endpoint is not successful, and return a 400 (BAD_REQUEST) code.
For now I am only focusing on enums, perhaps we should then expand it to other types.