### PR TITLE
fix: TrackedEntities returning soft deleted events [ DHIS2-14562 ]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/importer/TrackerActions.java
+++ b/dhis-2/dhis-e2e-test/src/main/java/org/hisp/dhis/actions/tracker/importer/TrackerActions.java
@@ -134,6 +134,16 @@ public class TrackerActions
         return new TrackerApiResponse( this.get( "/enrollments/" + enrollmentId ) );
     }
 
+    public TrackerApiResponse getEnrollment( String enrollmentId, QueryParamsBuilder queryParamsBuilder )
+    {
+        return new TrackerApiResponse( this.get( "/enrollments/" + enrollmentId, queryParamsBuilder ) );
+    }
+
+    public TrackerApiResponse getEnrollments( QueryParamsBuilder queryParamsBuilder )
+    {
+        return new TrackerApiResponse( this.get( "/enrollments/", queryParamsBuilder ) );
+    }
+
     public TrackerApiResponse getEvent( String eventId )
     {
         return new TrackerApiResponse( this.get( "/events/" + eventId ) );

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/EnrollmentParams.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/EnrollmentParams.java
@@ -34,7 +34,7 @@ import lombok.With;
 @Value
 public class EnrollmentParams
 {
-    public static final EnrollmentParams TRUE = new EnrollmentParams( EnrollmentEventsParams.TRUE, true, true, true,
+    public static final EnrollmentParams TRUE = new EnrollmentParams( EnrollmentEventsParams.TRUE, true, true, false,
         false );
 
     public static final EnrollmentParams FALSE = new EnrollmentParams( EnrollmentEventsParams.FALSE, false, false,

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackedEntitiesSupportService.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.unauthorized;
-import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.TrackedEntityFieldsParamMapper.map;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,11 +78,10 @@ class TrackedEntitiesSupportService
     private final TrackedEntityTypeService trackedEntityTypeService;
 
     @SneakyThrows
-    public TrackedEntityInstance getTrackedEntityInstance( String id, String pr, List<String> fields )
+    public TrackedEntityInstance getTrackedEntityInstance( String id, String pr,
+        TrackedEntityInstanceParams trackedEntityInstanceParams )
     {
         User user = currentUserService.getCurrentUser();
-
-        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields );
 
         TrackedEntityInstance trackedEntityInstance = trackedEntityInstanceService.getTrackedEntityInstance( id,
             trackedEntityInstanceParams );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -93,7 +93,8 @@ public class TrackerEnrollmentsExportController
 
         List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollmentList;
 
-        EnrollmentParams enrollmentParams = map( fields );
+        EnrollmentParams enrollmentParams = map( fields )
+            .withIncludeDeleted( trackerEnrollmentCriteria.isIncludeDeleted() );
 
         if ( trackerEnrollmentCriteria.getEnrollment() == null )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -47,6 +47,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.common.DhisApiVersion;
 import org.hisp.dhis.common.OpenApi;
+import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
 import org.hisp.dhis.dxf2.events.event.csv.CsvEventService;
 import org.hisp.dhis.dxf2.events.trackedentity.TrackedEntityInstanceService;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
@@ -96,9 +97,12 @@ public class TrackerTrackedEntitiesExportController
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
+        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields )
+            .withIncludeDeleted( criteria.isIncludeDeleted() );
+
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
             .fromCollection( trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
-                map( fields ), false, false ) );
+                trackedEntityInstanceParams, false, false ) );
 
         PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
 
@@ -131,9 +135,12 @@ public class TrackerTrackedEntitiesExportController
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
+        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields )
+            .withIncludeDeleted( criteria.isIncludeDeleted() );
+
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
             .fromCollection( trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
-                map( fields ), false, false ) );
+                trackedEntityInstanceParams, false, false ) );
 
         OutputStream outputStream = response.getOutputStream();
 
@@ -167,8 +174,10 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( required = false ) String program,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
     {
+        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields );
+
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
-            trackedEntitiesSupportService.getTrackedEntityInstance( id, program, fields ) );
+            trackedEntitiesSupportService.getTrackedEntityInstance( id, program, trackedEntityInstanceParams ) );
         return ResponseEntity.ok( fieldFilterService.toObjectNode( trackedEntity, fields ) );
     }
 
@@ -180,8 +189,10 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
         throws IOException
     {
+        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields );
+
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
-            trackedEntitiesSupportService.getTrackedEntityInstance( id, program, fields ) );
+            trackedEntitiesSupportService.getTrackedEntityInstance( id, program, trackedEntityInstanceParams ) );
 
         OutputStream outputStream = response.getOutputStream();
         response.setContentType( CONTENT_TYPE_CSV );


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14562

After https://dhis2.atlassian.net/browse/DHIS2-12906?focusedCommentId=179404 we accidentally removed the `inlcludeDeleted` set from the web request to the params.
This issue fix and also add tests because there was no test coverage 