### PR TITLE
ci: only use jib:build on PRs from non-forks (#12890) [2.37]

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -22,8 +22,10 @@ jobs:
           distribution: temurin
           cache: maven
 
+      # we only want to publish to Dockerhub on PRs
+      # PRs from forks cannot access secrets so such PRs cannot publish Docker images
       - name: Login to Docker Hub
-        if: github.event_name == 'pull_request' # only login to Dockerhub on PRs where we want to publish
+        if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}
@@ -36,8 +38,8 @@ jobs:
 
       - name: Build container image
         run: |
-          if [ "${{github.event_name}}" = "pull_request" ]; then 
-            # on PRs: build and publish multi-arch images using Jib. Image is used for api tests in
+          if [ "${{github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork}}" = "true" ]; then
+            # on PRs (of non-forks): build and publish multi-arch images using Jib. Image is used for api tests in
             # this workflow and can be pulled from Dockerhub by devs to run locally, ...
             mvn --batch-mode --no-transfer-progress -DskipTests -Dmaven.test.skip=true -f dhis-2/dhis-web/dhis-web-portal/pom.xml jib:build -PjibBuild \
                 -Djib.to.image=$CORE_IMAGE_NAME -Djib.container.labels=DHIS2_BUILD_REVISION=${{github.event.pull_request.head.sha}},DHIS2_BUILD_BRANCH=${{github.head_ref}}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ repositories
 
 * [`dhis2/core-canary`](https://hub.docker.com/r/dhis2/core-canary) - images of _the latest daily development_ DHIS2 versions. We tag the last `core-dev` images for the day and add an extra tag with a "yyyyMMdd"-formatted date, like `core-canary:latest-20230124`.
 
-* [`dhis2/core-pr`](https://hub.docker.com/r/dhis2/core-pr) - images of PRs.
+* [`dhis2/core-pr`](https://hub.docker.com/r/dhis2/core-pr) - images of PRs made from
+  https://github.com/dhis2/dhis2-core/ and not from forks. As forks do not have access to our
+  organizations/repos secrets.
 
 To run DHIS2 from latest `master` branch (as it is on GitHub) run:
 


### PR DESCRIPTION
backport of https://github.com/dhis2/dhis2-core/pull/12890