### PR TITLE
feat: add validation for duplicate items in collection

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/feedback/ErrorCode.java
@@ -279,6 +279,7 @@ public enum ErrorCode
     E5004( "Id `{0}` for type `{1}` exists on more than 1 object in the payload, removing all but the first found" ),
     E5005( "Properties `{0}` in objects `{1}` must be unique within the payload" ),
     E5006( "Non-owner reference {0} on object {1} for association `{2}` disallowed for payload for ERRORS_NOT_OWNER" ),
+    E5007( "Duplicate reference {0} on object {1} for association `{2}`" ),
 
     /* Metadata import */
     E6000( "Program `{0}` has more than one program instance" ),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/objectbundle/validation/ReferencesCheck.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import org.hisp.dhis.common.EmbeddedObject;
 import org.hisp.dhis.common.IdentifiableObject;
+import org.hisp.dhis.commons.collection.CollectionUtils;
 import org.hisp.dhis.dxf2.metadata.AtomicMode;
 import org.hisp.dhis.dxf2.metadata.objectbundle.ObjectBundle;
 import org.hisp.dhis.feedback.ErrorCode;
@@ -190,6 +191,11 @@ public class ReferencesCheck implements ValidationCheck
                     objects.add( refObject );
                 }
             }
+
+            CollectionUtils.findDuplicates( refObjects )
+                .forEach( refObject -> preheatErrorReports.add( new PreheatErrorReport( identifier,
+                    ErrorCode.E5007, object, property, identifier.getIdentifiersWithName( refObject ),
+                    identifier.getIdentifiersWithName( object ), property.getName() ) ) );
         }
 
         ReflectionUtils.invokeMethod( object, property.getSetterMethod(), objects );

--- a/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
+++ b/dhis-2/dhis-support/dhis-support-commons/src/main/java/org/hisp/dhis/commons/collection/CollectionUtils.java
@@ -326,4 +326,31 @@ public class CollectionUtils
         return StreamSupport.stream( Spliterators.spliteratorUnknownSize( iterator,
             Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.IMMUTABLE ), false );
     }
+
+    /**
+     * Find duplicate item in given collection.
+     *
+     * @param collection the collection to be checked.
+     * @param <T> The object type of the collection item.
+     * @return Set of duplicate items.
+     */
+    public static <T> Set<T> findDuplicates( Collection<T> collection )
+    {
+        if ( CollectionUtils.isEmpty( collection ) )
+        {
+            return Set.of();
+        }
+        Set<T> duplicates = new HashSet<>();
+        Set<T> uniques = new HashSet<>();
+
+        for ( T t : collection )
+        {
+            if ( !uniques.add( t ) )
+            {
+                duplicates.add( t );
+            }
+        }
+
+        return duplicates;
+    }
 }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/metadata/MetadataImportServiceTest.java
@@ -1097,6 +1097,19 @@ class MetadataImportServiceTest extends TransactionalIntegrationTest
         assertEquals( createdByUser.getUid(), category.getCreatedBy().getUid() );
     }
 
+    @Test
+    void testImportDuplicates()
+        throws IOException
+    {
+        Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata = renderService.fromMetadata(
+            new ClassPathResource( "dxf2/duplicate_categories.json" ).getInputStream(), RenderFormat.JSON );
+        MetadataImportParams params = createParams( ImportStrategy.CREATE, metadata );
+        ImportReport report = importService.importMetadata( params );
+        assertEquals( Status.ERROR, report.getStatus() );
+        assertTrue( report.hasErrorReport( errorReport -> errorReport.getMessage().equals(
+            "Duplicate reference [XJGLlMAMCcn] (Category) on object Gender [faV8QvLgIwB] (CategoryCombo) for association `category`" ) ) );
+    }
+
     private MetadataImportParams createParams( ImportStrategy importStrategy,
         Map<Class<? extends IdentifiableObject>, List<IdentifiableObject>> metadata )
     {

--- a/dhis-2/dhis-test-integration/src/test/resources/dxf2/duplicate_categories.json
+++ b/dhis-2/dhis-test-integration/src/test/resources/dxf2/duplicate_categories.json
@@ -1,0 +1,127 @@
+{
+  "categoryCombos": [
+    {
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      },
+      "categories": [
+        {
+          "id": "XJGLlMAMCcn"
+        },
+        {
+          "id": "XJGLlMAMCcn"
+        }
+      ],
+      "name": "Gender",
+      "skipTotal": false,
+      "dataDimensionType": "DISAGGREGATION",
+      "id": "faV8QvLgIwB"
+    }
+  ],
+  "organisationUnits": [
+    {
+      "lastUpdated": "2016-03-08T07:27:17.772+0000",
+      "name": "Country",
+      "created": "2016-03-08T07:27:17.757+0000",
+      "uuid": "d981e7c4-3c72-4e0d-8995-078f16830473",
+      "shortName": "Country",
+      "description": "",
+      "id": "x3gVvpbVgqy",
+      "attributeValues": [ ],
+      "path": "/x3gVvpbVgqy",
+      "featureType": "NONE",
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "openingDate": "2016-03-08"
+    }
+  ],
+  "categoryOptions": [
+    {
+      "id": "JYiFOMKa25J",
+      "userGroupAccesses": [ ],
+      "attributeValues": [ ],
+      "shortName": "Female",
+      "name": "Female",
+      "created": "2016-03-08T07:28:50.372+0000",
+      "lastUpdated": "2016-03-08T07:28:50.374+0000",
+      "organisationUnits": [ ],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      }
+    },
+    {
+      "shortName": "Male",
+      "userGroupAccesses": [ ],
+      "id": "tdaMRD34m8o",
+      "attributeValues": [ ],
+      "lastUpdated": "2016-03-08T07:28:44.217+0000",
+      "name": "Male",
+      "created": "2016-03-08T07:28:44.214+0000",
+      "organisationUnits": [ ],
+      "user": {
+        "id": "T12jeH7KPzk"
+      },
+      "sharing": {
+        "public": "rw------",
+        "external": false
+      }
+    }
+  ],
+  "categories": [
+    {
+      "categoryOptions": [
+        {
+          "id": "JYiFOMKa25J"
+        },
+        {
+          "id": "tdaMRD34m8o"
+        },
+        {
+          "id": "tdaMRD34m8o"
+        }
+      ],
+      "name": "Gender",
+      "shortName": "Gender",
+      "dataDimension": true,
+      "dataDimensionType": "DISAGGREGATION",
+      "userGroupAccesses": [],
+      "id": "XJGLlMAMCcn"
+    }
+  ],
+  "categoryOptionCombos": [
+    {
+      "categoryOptions": [
+        {
+          "id": "JYiFOMKa25J"
+        },
+        {
+          "id": "JYiFOMKa25J"
+        }
+      ],
+      "categoryCombo": {
+        "id": "faV8QvLgIwB"
+      },
+      "id": "J5uZylXMmbB",
+      "ignoreApproval": false,
+      "lastUpdated": "2016-03-08T07:29:15.715+0000",
+      "name": "Female",
+      "created": "2016-03-08T07:29:15.714+0000"
+    }
+  ],
+  "organisationUnitLevels": [
+    {
+      "id": "JEMRBUHgpqN",
+      "name": "Level 1",
+      "created": "2016-03-08T07:27:22.448+0000",
+      "level": 1,
+      "lastUpdated": "2016-03-08T07:27:22.449+0000"
+    }
+  ],
+  "date": "2016-03-08T07:34:13.552+0000"
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-10313
- This PR add a preheat validation for duplicate items in a reference collection. 
- For testing, import `Category` with duplicate `CategoryOption`. The import report will contain ` ErrorCode.E5007`
```
"categories": [
    {
      "categoryOptions": [
        {
          "id": "JYiFOMKa25J"
        },
        {
          "id": "tdaMRD34m8o"
        },
        {
          "id": "tdaMRD34m8o"
        }
      ],
      "name": "Gender",
      "shortName": "Gender",
      "dataDimension": true,
      "dataDimensionType": "DISAGGREGATION",
      "userGroupAccesses": [],
      "id": "XJGLlMAMCcn"
    }
  ],
```