### PR TITLE
ci: log to STDOUT only in docker-compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,10 @@ services:
       - 127.0.0.1:9010:9010 # JMX port (for example for VisualVM)
     volumes:
       - ./docker/dhis.conf:/opt/dhis2/dhis.conf:ro
+      - ./docker/log4j2.xml:/opt/dhis2/log4j2.xml:ro
     environment:
       JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8081 \
+              -Dlog4j2.configurationFile=/opt/dhis2/log4j2.xml
               -Dcom.sun.management.jmxremote \
               -Dcom.sun.management.jmxremote.port=9010 \
               -Dcom.sun.management.jmxremote.local.only=false \

--- a/docker/log4j2.xml
+++ b/docker/log4j2.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="10">
+    <!-- Stream logs:
+            docker compose logs -f web
+         Stream logs of a particuar package only:
+            docker compose logs -f web | grep org.hisp.dhis.monitoring.metrics
+         Show timestamps:
+            docker compose logs -t -f web
+    -->
+    <Properties>
+        <Property name="layout">%-5level %c [%t] %msg%n</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${layout}" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <!--
+            This config logs events
+
+            for Loggers declared in packages prefixed with "org.hisp.dhis" i.e. "org.hisp.dhis.security"
+            from level INFO to more severe (WARN, ERROR, ...)
+
+            any Logger declared in a package not prefixed with "org.hisp.dhis" and
+            without a Logger config defined here will log from level WARN to more severe.
+
+            Adapt this config as you see fit.
+
+            Please check https://logging.apache.org/log4j/2.x/manual/configuration.html
+        -->
+        <Logger name="org.hisp.dhis" level="INFO" additivity="true"/>
+
+        <Root level="WARN">
+            <AppenderRef ref="console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
as is standard in containerized environments. Logs can easily be streamed from STDOUT. Logs can be redirected to files if needed.

Simplified the log layout to make them easier to read and parse. Timestamps can be obtained by adding a flag to the docker CLI if needed. The pattern allows streaming logs of a particular package. This was previously achieved by logging into different files.

We already made this change to the `d2` CLI. See https://github.com/dhis2/docker-compose/pull/26

## Examples

```sh
docker compose logs -f web | grep org.hisp.dhis.security.AuthenticationLoggerListener
core-web-1  | INFO  org.hisp.dhis.security.AuthenticationLoggerListener [http-nio-8080-exec-6] Authentication event: AuthenticationSuccessEvent; username: admin; ip: 172.22.0.1; sessionId: dab6a453992db34347e8ee51ecb091de553fb4424deecf167bd52c2c27bc46f0
core-web-1  | INFO  org.hisp.dhis.security.AuthenticationLoggerListener [http-nio-8080-exec-1] Authentication event: LogoutSuccessEvent; username: admin; ip: 172.22.0.1; sessionId: dab6a453992db34347e8ee51ecb091de553fb4424deecf167bd52c2c27bc46f0
```

```sh
docker compose logs -t -f web | grep org.hisp.dhis.monitoring.metrics
core-web-1  | 2023-02-03T06:16:29.295444544Z INFO  org.hisp.dhis.monitoring.metrics.MetricsEnabler [main] Monitoring metric for key monitoring.uptime.enabled is disabled
core-web-1  | 2023-02-03T06:16:29.296331816Z INFO  org.hisp.dhis.monitoring.metrics.MetricsEnabler [main] Monitoring metric for key monitoring.hibernate.enabled is disabled
core-web-1  | 2023-02-03T06:16:29.297277610Z INFO  org.hisp.dhis.monitoring.metrics.MetricsEnabler [main] Monitoring metric for key monitoring.cpu.enabled is disabled
core-web-1  | 2023-02-03T06:16:29.298958798Z INFO  org.hisp.dhis.monitoring.metrics.MetricsEnabler [main] Monitoring metric for key monitoring.dbpool.enabled is disabled
core-web-1  | 2023-02-03T06:16:29.299960567Z INFO  org.hisp.dhis.monitoring.metrics.MetricsEnabler [main] Monitoring metric for key monitoring.jvm.enabled is disabled
core-web-1  | 2023-02-03T06:16:29.536630273Z INFO  org.hisp.dhis.monitoring.metrics.MetricsEnabler [main] Monitoring metric for key monitoring.api.enabled is disabled
```