### PR TITLE
feat: is( X in A, B, ... ) [DHIS2-14452]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -37,6 +37,7 @@ import static org.hisp.dhis.parser.expression.ExpressionItem.ITEM_GET_SQL;
 import static org.hisp.dhis.program.AnalyticsType.ENROLLMENT;
 import static org.hisp.dhis.program.DefaultProgramIndicatorService.PROGRAM_INDICATOR_ITEMS;
 import static org.hisp.dhis.program.variable.vEventCount.DEFAULT_COUNT_CONDITION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -177,6 +178,13 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
 
         relTypeA = new RelationshipType();
         relTypeA.setUid( "RelatnTypeA" );
+    }
+
+    @Test
+    void testIsIn()
+    {
+        assertEquals( "'A' in ('A','B','C')", test( "is('A' in 'A','B','C')" ) );
+        assertEquals( "1 in (1,2,3)", test( "is( 1 in 1, 2, 3 )" ) );
     }
 
     @Test

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/ParserUtils.java
@@ -39,6 +39,7 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.GEQ;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.GREATEST;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.GT;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IF;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IS;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IS_NOT_NULL;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.IS_NULL;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.LEAST;
@@ -67,6 +68,7 @@ import org.hisp.dhis.parser.expression.dataitem.ItemConstant;
 import org.hisp.dhis.parser.expression.function.FunctionFirstNonNull;
 import org.hisp.dhis.parser.expression.function.FunctionGreatest;
 import org.hisp.dhis.parser.expression.function.FunctionIf;
+import org.hisp.dhis.parser.expression.function.FunctionIs;
 import org.hisp.dhis.parser.expression.function.FunctionIsNotNull;
 import org.hisp.dhis.parser.expression.function.FunctionIsNull;
 import org.hisp.dhis.parser.expression.function.FunctionLeast;
@@ -144,6 +146,7 @@ public class ParserUtils
         .put( FIRST_NON_NULL, new FunctionFirstNonNull() )
         .put( GREATEST, new FunctionGreatest() )
         .put( IF, new FunctionIf() )
+        .put( IS, new FunctionIs() )
         .put( IS_NOT_NULL, new FunctionIsNotNull() )
         .put( IS_NULL, new FunctionIsNull() )
         .put( LEAST, new FunctionLeast() )

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionIs.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionIs.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import static java.util.stream.Collectors.toList;
+import static org.hisp.dhis.antlr.AntlrParserUtils.compare;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import java.util.List;
+
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+
+/**
+ * Function is
+ *
+ * @author Jim Grace
+ */
+public class FunctionIs
+    implements ExpressionItem
+{
+    @Override
+    public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        Object arg0 = visitor.visit( ctx.expr( 0 ) );
+
+        for ( int i = 1; i < ctx.expr().size(); i++ )
+        {
+            Object argN = visitor.visit( ctx.expr( i ) );
+
+            if ( compare( arg0, argN ) == 0 )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Object evaluateAllPaths( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        List<Object> values = ctx.expr().stream()
+            .map( visitor::visit )
+            .collect( toList() );
+
+        Object arg0 = values.get( 0 );
+
+        for ( int i = 1; i < values.size(); i++ )
+        {
+            Object argN = values.get( i );
+
+            if ( compare( arg0, argN ) == 0 )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public Object getSql( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        List<String> args = ctx.expr().stream()
+            .map( visitor::castStringVisit )
+            .collect( toList() );
+
+        String arg0 = args.get( 0 );
+
+        String others = String.join( ",", args.subList( 1, args.size() ) );
+
+        return arg0 + " in (" + others + ")";
+    }
+}

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/expression/ExpressionServiceTest.java
@@ -44,10 +44,12 @@ import static org.hisp.dhis.expression.MissingValueStrategy.SKIP_IF_ALL_VALUES_M
 import static org.hisp.dhis.expression.MissingValueStrategy.SKIP_IF_ANY_VALUE_MISSING;
 import static org.hisp.dhis.expression.ParseType.INDICATOR_EXPRESSION;
 import static org.hisp.dhis.expression.ParseType.PREDICTOR_EXPRESSION;
+import static org.hisp.dhis.expression.ParseType.PREDICTOR_SKIP_TEST;
 import static org.hisp.dhis.expression.ParseType.VALIDATION_RULE_EXPRESSION;
 import static org.hisp.dhis.util.DateUtils.parseDate;
 import static org.hisp.dhis.utils.Assertions.assertMapEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -566,6 +568,17 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
     }
 
     /**
+     * Evaluates a test expression that returns a boolean.
+     *
+     * @param expr expression to evaluate
+     * @return the expression value: true or false
+     */
+    private boolean evalBoolean( String expr )
+    {
+        return Boolean.valueOf( eval( expr, PREDICTOR_SKIP_TEST, NEVER_SKIP, BOOLEAN, null ) );
+    }
+
+    /**
      * Evaluates an indicator expression with a valueMap.
      */
     private String evalIndicator( String expr, Map<DimensionalItemObject, Object> valueMap )
@@ -887,19 +900,19 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
     @Test
     void testLogarithms()
     {
-        assertEquals( evalDouble( "log(50)" ), DELTA, 3.912023005428146 );
-        assertEquals( evalDouble( "log(2.718281828459045)" ), DELTA, 1 );
+        assertEquals( 3.912023005428146, evalDouble( "log(50)" ), DELTA );
+        assertEquals( 1, evalDouble( "log(2.718281828459045)" ), DELTA );
         assertEquals( "-Infinity", eval( "log(0)" ) );
         assertEquals( "NaN", eval( "log(-1)" ) );
-        assertEquals( evalDouble( "log(50,3)" ), DELTA, 3.5608767950073115 );
-        assertEquals( evalDouble( "log(8,2)" ), DELTA, 3 );
+        assertEquals( 3.5608767950073115, evalDouble( "log(50,3)" ), DELTA );
+        assertEquals( 3, evalDouble( "log(8,2)" ), DELTA );
         assertEquals( "-Infinity", eval( "log(0,3)" ) );
         assertEquals( "NaN", eval( "log(-1,3)" ) );
         assertEquals( "0", eval( "log(50,0)" ) );
         assertEquals( "NaN", eval( "log(50,-3)" ) );
         assertEquals( "NaN", eval( "log(-50,-3)" ) );
-        assertEquals( evalDouble( "log10(50)" ), DELTA, 1.6989700043360187 );
-        assertEquals( evalDouble( "log10(1000)" ), DELTA, 3 );
+        assertEquals( 1.6989700043360187, evalDouble( "log10(50)" ), DELTA );
+        assertEquals( 3, evalDouble( "log10(1000)" ), DELTA );
         assertEquals( "-Infinity", eval( "log10(0)" ) );
         assertEquals( "NaN", eval( "log10(-1)" ) );
     }
@@ -921,6 +934,11 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
         assertEquals( "1", eval( "if(2 >= 1, 1, 0)" ) );
         assertEquals( "null DeA DeE", eval( "if( #{dataElemenA} > #{dataElemenE}, 1, 0)" ) );
         assertEquals( "null DeA DeE", eval( "if( #{dataElemenE} < #{dataElemenA}, 1, 0)" ) );
+    }
+
+    @Test
+    void testComparisonPrecidence()
+    {
         // Comparison precedence is after Add, Subtract
         assertEquals( "0", eval( "if(5 < 2 + 3, 1, 0)" ) );
         assertEquals( "0", eval( "if(5 > 2 + 3, 1, 0)" ) );
@@ -1064,7 +1082,7 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
-    public void testRemoveZeros()
+    void testRemoveZeros()
     {
         assertEquals( "null", eval( "removeZeros( 0 )" ) );
         assertEquals( "null", eval( "removeZeros( 10 - 2 * 5 )" ) );
@@ -1239,6 +1257,20 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
+    void testIsIn()
+    {
+        assertTrue( evalBoolean( "is('A' in 'A','B','C')" ) );
+        assertTrue( evalBoolean( "is('B' in 'A','B','C')" ) );
+        assertTrue( evalBoolean( "is('C' in 'A','B','C')" ) );
+        assertFalse( evalBoolean( "is('D' in 'A','B','C')" ) );
+
+        assertTrue( evalBoolean( "is( 1 in 1, 2, 3 )" ) );
+        assertTrue( evalBoolean( "is( 2 in 1, 2, 3 )" ) );
+        assertTrue( evalBoolean( "is( 3 in 1, 2, '3' )" ) );
+        assertFalse( evalBoolean( "is( 4 in 1, 2, 3 )" ) );
+    }
+
+    @Test
     void testMissingValueStrategy()
     {
         assertEquals( "3 DeA", eval( "#{dataElemenA}", SKIP_IF_ANY_VALUE_MISSING ) );
@@ -1326,6 +1358,8 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
         assertEquals( "if(orgUnit.ancestor(OuA,OuB),1,0)",
             desc( "if(orgUnit.ancestor(OrgUnitUidA,OrgUnitUidB),1,0)" ) );
         assertEquals( "if(orgUnit.group(OugA,OugB),1,0)", desc( "if(orgUnit.group(orgUnitGrpA,orgUnitGrpB),1,0)" ) );
+        assertEquals( "if(is(DeA in DeB,DeC,DeD),1,0)",
+            desc( "if(is(#{dataElemenA} in #{dataElemenB},#{dataElemenC},#{dataElemenD}),1,0)" ) );
     }
 
     @Test
@@ -1428,20 +1462,20 @@ class ExpressionServiceTest extends SingleSetupIntegrationTestBase
             .getIndicatorDimensionalItemMap( indicators );
         IndicatorValue value = expressionService.getIndicatorValueObject( indicatorA, singletonList( period ),
             itemMap, defaultValueMap, null );
-        assertEquals( value.getNumeratorValue(), DELTA, 2.5 );
-        assertEquals( value.getDenominatorValue(), DELTA, 5.0 );
-        assertEquals( value.getFactor(), DELTA, 100.0 );
-        assertEquals( value.getMultiplier(), DELTA, 100 );
-        assertEquals( value.getDivisor(), DELTA, 1 );
-        assertEquals( value.getValue(), DELTA, 50.0 );
+        assertEquals( 2.5, value.getNumeratorValue(), DELTA );
+        assertEquals( 5.0, value.getDenominatorValue(), DELTA );
+        assertEquals( 100.0, value.getFactor(), DELTA );
+        assertEquals( 100, value.getMultiplier(), DELTA );
+        assertEquals( 1, value.getDivisor(), DELTA );
+        assertEquals( 50.0, value.getValue(), DELTA );
         value = expressionService.getIndicatorValueObject( indicatorB, singletonList( period ),
             itemMap, defaultValueMap, null );
-        assertEquals( value.getNumeratorValue(), DELTA, 20.0 );
-        assertEquals( value.getDenominatorValue(), DELTA, 5.0 );
-        assertEquals( value.getFactor(), DELTA, 36500.0 );
-        assertEquals( value.getMultiplier(), DELTA, 36500 );
-        assertEquals( value.getDivisor(), DELTA, 1 );
-        assertEquals( value.getValue(), DELTA, 146000.0 );
+        assertEquals( 20.0, value.getNumeratorValue(), DELTA );
+        assertEquals( 5.0, value.getDenominatorValue(), DELTA );
+        assertEquals( 36500.0, value.getFactor(), DELTA );
+        assertEquals( 36500, value.getMultiplier(), DELTA );
+        assertEquals( 1, value.getDivisor(), DELTA );
+        assertEquals( 146000.0, value.getValue(), DELTA );
     }
 
     @Test

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -64,7 +64,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>2.0.45</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.0.46</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.1</dhis-hisp-quick.version>
@@ -220,7 +220,7 @@
     <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.10</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.30</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.32</dhis-antlr-expression-parser.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.8.9</gson.version>
     <semver4j.version>3.1.0</semver4j.version>


### PR DESCRIPTION
See [DHIS2-14452](https://dhis2.atlassian.net/browse/DHIS2-14452), especially [this comment](https://dhis2.atlassian.net/browse/DHIS2-14452?focusedCommentId=180081). This implements the syntax:

`is(X in 'A', 'B', ..., 'Z')`

which is equivalent to the following SQL logic (and in fact is translated into this for program indicators):

`X in ('A', 'B', ..., 'Z')`

[DHIS2-14452]: https://dhis2.atlassian.net/browse/DHIS2-14452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ