### PR TITLE
fix: Remove unnecessary logic in 2.37 [DHIS2-13981] [2.37]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceServiceTest.java
@@ -531,7 +531,7 @@ public class TrackedEntityInstanceServiceTest
         TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
         params.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
         params.setOrders(
-            Collections.singletonList(
+            Arrays.asList(
                 OrderParam.builder().field( filtH.getUid() ).direction( OrderParam.SortDirection.ASC ).build() ) );
         params.setAttributes( Collections.singletonList( new QueryItem( filtH ) ) );
 
@@ -569,54 +569,6 @@ public class TrackedEntityInstanceServiceTest
 
         assertEquals( Arrays.asList( entityInstanceB1.getId(), entityInstanceA1.getId(), entityInstanceD1.getId(),
             entityInstanceC1.getId() ), teiIdList );
-    }
-
-    @Test
-    public void shouldSortEntitiesByAttributeDescendingWhenAttributeDescendingProvided()
-    {
-        TrackedEntityAttribute tea = createTrackedEntityAttribute();
-
-        addEntityInstances();
-
-        createTrackedEntityInstanceAttribute( entityInstanceA1, tea, "A" );
-        createTrackedEntityInstanceAttribute( entityInstanceB1, tea, "D" );
-        createTrackedEntityInstanceAttribute( entityInstanceC1, tea, "C" );
-        createTrackedEntityInstanceAttribute( entityInstanceD1, tea, "B" );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-        params.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
-        params.setOrders(
-            Collections.singletonList(
-                OrderParam.builder().field( tea.getUid() ).direction( OrderParam.SortDirection.DESC ).build() ) );
-
-        List<Long> teiIdList = entityInstanceService.getTrackedEntityInstanceIds( params, true, true );
-
-        assertEquals( Arrays.asList( entityInstanceB1.getId(), entityInstanceC1.getId(), entityInstanceD1.getId(),
-            entityInstanceA1.getId() ), teiIdList );
-    }
-
-    @Test
-    public void shouldSortEntitiesByAttributeAscendingWhenAttributeAscendingProvided()
-    {
-        TrackedEntityAttribute tea = createTrackedEntityAttribute();
-
-        addEntityInstances();
-
-        createTrackedEntityInstanceAttribute( entityInstanceA1, tea, "A" );
-        createTrackedEntityInstanceAttribute( entityInstanceB1, tea, "D" );
-        createTrackedEntityInstanceAttribute( entityInstanceC1, tea, "C" );
-        createTrackedEntityInstanceAttribute( entityInstanceD1, tea, "B" );
-
-        TrackedEntityInstanceQueryParams params = new TrackedEntityInstanceQueryParams();
-        params.setOrganisationUnits( Sets.newHashSet( organisationUnit ) );
-        params.setOrders(
-            Collections.singletonList(
-                OrderParam.builder().field( tea.getUid() ).direction( OrderParam.SortDirection.ASC ).build() ) );
-
-        List<Long> teiIdList = entityInstanceService.getTrackedEntityInstanceIds( params, true, true );
-
-        assertEquals( Arrays.asList( entityInstanceA1.getId(), entityInstanceD1.getId(), entityInstanceC1.getId(),
-            entityInstanceB1.getId() ), teiIdList );
     }
 
     private void addEnrollment( TrackedEntityInstance entityInstance, Date enrollmentDate, char programStage )
@@ -662,25 +614,5 @@ public class TrackedEntityInstanceServiceTest
         trackedEntityAttributeValue.setEntityInstance( entityInstance );
         trackedEntityAttributeValue.setValue( attributeValue );
         attributeValueService.addTrackedEntityAttributeValue( trackedEntityAttributeValue );
-    }
-
-    private TrackedEntityAttribute createTrackedEntityAttribute()
-    {
-        TrackedEntityAttribute tea = createTrackedEntityAttribute( 'X' );
-        attributeService.addTrackedEntityAttribute( tea );
-
-        return tea;
-    }
-
-    private void createTrackedEntityInstanceAttribute( TrackedEntityInstance trackedEntityInstance,
-        TrackedEntityAttribute attribute, String value )
-    {
-        TrackedEntityAttributeValue trackedEntityAttributeValueA1 = new TrackedEntityAttributeValue();
-
-        trackedEntityAttributeValueA1.setAttribute( attribute );
-        trackedEntityAttributeValueA1.setEntityInstance( trackedEntityInstance );
-        trackedEntityAttributeValueA1.setValue( value );
-
-        attributeValueService.addTrackedEntityAttributeValue( trackedEntityAttributeValueA1 );
     }
 }


### PR DESCRIPTION
The order by field is not needed by the tracker client in 2.37, this commit is to remove the changes I did and leave it as it was before I started working on it.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-13981