### PR TITLE
feat: OpenAPI YAML generation

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiAnalyse.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/ApiAnalyse.java
@@ -337,7 +337,7 @@ final class ApiAnalyse
                 RequestBody a = p.getAnnotation( RequestBody.class );
                 Api.RequestBody requestBody = endpoint.getRequestBody()
                     .init( () -> new Api.RequestBody( p, a.required() ) );
-                Api.Schema type = analyseParamSchema( endpoint, p.getParameterizedType(), p.getType() );
+                Api.Schema type = analyseParamSchema( endpoint, p.getParameterizedType() );
                 consumes.forEach( mediaType -> requestBody.getConsumes().putIfAbsent( mediaType, type ) );
             }
             else if ( isParams( p ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Descriptions.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/Descriptions.java
@@ -155,7 +155,7 @@ final class Descriptions
                     else
                     {
                         // in CommonMark 2 spaces at the end mean new line
-                        value.append( line ).append( "  \\n" );
+                        value.append( line ).append( "  \n" );
                     }
                 }
             }
@@ -166,13 +166,13 @@ final class Descriptions
     private String trimText( String value )
     {
         String text = value;
-        while ( text.startsWith( "  \\n" ) )
+        while ( text.startsWith( "  \n" ) )
         {
-            text = text.substring( 4 );
+            text = text.substring( 3 );
         }
-        while ( text.endsWith( "  \\n" ) )
+        while ( text.endsWith( "  \n" ) )
         {
-            text = text.substring( 0, text.length() - 4 );
+            text = text.substring( 0, text.length() - 3 );
         }
         return text.trim();
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/JsonGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/JsonGenerator.java
@@ -27,11 +27,18 @@
  */
 package org.hisp.dhis.webapi.openapi;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
+
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
 
 /**
  * A utility to generate JSON based on simple {@link Runnable} callbacks for
@@ -43,13 +50,17 @@ import lombok.Value;
 public class JsonGenerator
 {
     @Value
+    @Builder( toBuilder = true )
     static class Format
     {
         public static final Format PRETTY_PRINT = new Format( true, true, true, true, true, "  " );
 
         public static final Format SMALL = new Format( false, false, false, false, false, "" );
 
-        boolean newLineAfterMember;
+        /**
+         * Item being an object member or an array element
+         */
+        boolean newLineBeforeItem;
 
         boolean newLineAfterObjectStart;
 
@@ -59,14 +70,80 @@ public class JsonGenerator
 
         boolean newLineBeforeArrayEnd;
 
-        String memberIndent;
+        /**
+         * 1 level of indent
+         */
+        String itemIndent;
     }
+
+    @Value
+    @Builder( toBuilder = true )
+    static class Language
+    {
+
+        public static final Language JSON = new Language(
+            "[", "", "]",
+            "{", ":", "}", ",",
+            "\"", "\"", JsonGenerator::escapeJsonString,
+            "\"", "\"", false, JsonGenerator::escapeJsonText,
+            UnaryOperator.identity() );
+
+        public static final Language YAML = new Language(
+            "", "- ", "",
+            "", ": ", "", "",
+            "", "", JsonGenerator::escapeYamlString,
+            "|-", "", true, JsonGenerator::escapeYamlText,
+            format -> format.toBuilder()
+                .itemIndent( "  " )
+                .newLineBeforeItem( true )
+                .newLineAfterArrayStart( false )
+                .newLineBeforeArrayEnd( false )
+                .newLineAfterObjectStart( false )
+                .newLineBeforeObjectEnd( false )
+                .build() );
+
+        String arrayStart;
+
+        String arrayItemStart;
+
+        String arrayEnd;
+
+        String objectStart;
+
+        String objectItemStart;
+
+        String objectEnd;
+
+        String itemSeparator;
+
+        String stringStart;
+
+        String stringEnd;
+
+        UnaryOperator<String> escapeString;
+
+        String textStart;
+
+        String textEnd;
+
+        boolean textIndent;
+
+        Function<String, List<String>> escapeText;
+
+        UnaryOperator<Format> adjustFormat;
+    }
+
+    private static final JsonStringEncoder JSON_ESCAPE_STRING = JsonStringEncoder.getInstance();
 
     private final StringBuilder out;
 
     private final Format format;
 
+    private final Language language;
+
     private String indent = "";
+
+    private boolean arrayItemLast = false;
 
     @Override
     public final String toString()
@@ -77,7 +154,7 @@ public class JsonGenerator
     final void addRootObject( Runnable addMembers )
     {
         addObjectMember( null, addMembers );
-        discardLastMemberComma( 0 );
+        discardLastMemberSeparator( 0 );
     }
 
     final void addObjectMember( String name, boolean condition, Runnable addMembers )
@@ -99,23 +176,23 @@ public class JsonGenerator
     final void addObjectMember( String name, Runnable addMembers )
     {
         appendMemberName( name );
-        out.append( "{" );
+        out.append( language.objectStart );
         if ( format.isNewLineAfterObjectStart() )
             out.append( '\n' );
         int length = out.length();
-        if ( format.isNewLineAfterMember() )
-            indent += format.getMemberIndent();
+        if ( format.isNewLineBeforeItem() )
+            indent += format.getItemIndent();
         appendItems( addMembers );
-        if ( format.isNewLineAfterMember() )
-            indent = indent.substring( 0, indent.length() - format.getMemberIndent().length() );
-        discardLastMemberComma( length );
+        if ( format.isNewLineBeforeItem() )
+            indent = indent.substring( 0, indent.length() - format.getItemIndent().length() );
+        discardLastMemberSeparator( length );
         if ( format.isNewLineBeforeObjectEnd() )
         {
             out.append( '\n' );
             appendMemberIndent();
         }
-        out.append( "}" );
-        appendMemberComma();
+        out.append( language.objectEnd );
+        appendMemberSeparator();
     }
 
     final void addArrayMember( String name, Collection<String> values )
@@ -134,19 +211,19 @@ public class JsonGenerator
     final void addArrayMember( String name, Runnable addElements )
     {
         appendMemberName( name );
-        out.append( '[' );
+        out.append( language.arrayStart );
         if ( format.isNewLineAfterArrayStart() )
             out.append( '\n' );
         int length = out.length();
         appendItems( addElements );
-        discardLastMemberComma( length );
+        discardLastMemberSeparator( length );
         if ( format.isNewLineBeforeArrayEnd() )
         {
             out.append( '\n' );
             appendMemberIndent();
         }
-        out.append( ']' );
-        appendMemberComma();
+        out.append( language.arrayEnd );
+        appendMemberSeparator();
     }
 
     final void addStringMember( String name, String value )
@@ -155,7 +232,17 @@ public class JsonGenerator
         {
             appendMemberName( name );
             appendString( value );
-            appendMemberComma();
+            appendMemberSeparator();
+        }
+    }
+
+    final void addStringMultilineMember( String name, String value )
+    {
+        if ( value != null )
+        {
+            appendMemberName( name );
+            appendStringMultiline( value );
+            appendMemberSeparator();
         }
     }
 
@@ -171,7 +258,7 @@ public class JsonGenerator
     {
         appendMemberName( name );
         out.append( value ? "true" : "false" );
-        appendMemberComma();
+        appendMemberSeparator();
     }
 
     final void addNumberMember( String name, Integer value )
@@ -186,7 +273,7 @@ public class JsonGenerator
     {
         appendMemberName( name );
         out.append( value );
-        appendMemberComma();
+        appendMemberSeparator();
     }
 
     private void appendItems( Runnable items )
@@ -201,37 +288,93 @@ public class JsonGenerator
     {
         return str == null
             ? out.append( "null" )
-            : out.append( '"' ).append( str.replace( "\"", "\\\"" ) ).append( '"' );
+            : out.append( language.stringStart ).append( language.escapeString.apply( str ) )
+                .append( language.stringEnd );
+    }
+
+    private void appendStringMultiline( String str )
+    {
+        if ( str == null )
+        {
+            out.append( "null" );
+            return;
+        }
+        out.append( language.textStart );
+        for ( String line : language.escapeText.apply( str ) )
+        {
+            if ( language.textIndent )
+                out.append( '\n' ).append( indent ).append( format.itemIndent );
+            out.append( line );
+        }
+        out.append( language.textEnd );
     }
 
     private void appendMemberName( String name )
     {
+        if ( name == null && out.length() == 0 )
+            return;
         appendMemberIndent();
         if ( name != null )
         {
-            appendString( name ).append( ':' );
+            arrayItemLast = false;
+            appendString( name ).append( language.objectItemStart );
+        }
+        else
+        {
+            arrayItemLast = !language.arrayItemStart.isEmpty();
+            out.append( language.arrayItemStart );
         }
     }
 
     private void appendMemberIndent()
     {
-        if ( format.isNewLineAfterMember() )
-            out.append( indent );
+        if ( !arrayItemLast && format.isNewLineBeforeItem() )
+            out.append( '\n' ).append( indent );
     }
 
-    private void appendMemberComma()
+    private void appendMemberSeparator()
     {
-        out.append( ',' );
-        if ( format.isNewLineAfterMember() )
-            out.append( '\n' );
+        arrayItemLast = false;
+        out.append( language.itemSeparator );
     }
 
-    private void discardLastMemberComma( int length )
+    private void discardLastMemberSeparator( int length )
     {
         if ( out.length() > length )
         {
-            int back = format.isNewLineAfterMember() ? 2 : 1;
-            out.setLength( out.length() - back ); // discard last ,
+            out.setLength( out.length() - language.itemSeparator.length() ); // discard last ,
         }
+    }
+
+    private static List<String> escapeJsonText( String unescaped )
+    {
+        return List.of( escapeJsonString( unescaped ) );
+    }
+
+    private static String escapeJsonString( String unescaped )
+    {
+        return new String( JSON_ESCAPE_STRING.quoteAsString( unescaped ) );
+    }
+
+    private static String escapeYamlString( String unescaped )
+    {
+        return unescaped;
+    }
+
+    private static List<String> escapeYamlText( String unescaped )
+    {
+        int start = 0;
+        int end = unescaped.indexOf( '\n' );
+        if ( end < 0 )
+            return List.of( unescaped );
+        List<String> lines = new ArrayList<>();
+        while ( end > 0 && end < unescaped.length() )
+        {
+            lines.add( unescaped.substring( start, end ) );
+            start = end + 1;
+            end = unescaped.indexOf( '\n', start );
+        }
+        lines.add( unescaped.substring( start ) );
+        return lines;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -39,7 +39,6 @@ import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -253,18 +252,36 @@ public class OpenApiGenerator extends JsonGenerator
         addSimpleType( JobParameters.class, schema -> schema.type( "object" ) );
     }
 
-    public static String generate( Api api )
+    public static String generateJson( Api api, String serverUrl )
     {
-        return generate( api, Format.PRETTY_PRINT, Configuration.DEFAULT );
+        return generateJson( api, Format.PRETTY_PRINT,
+            Configuration.DEFAULT.toBuilder().serverUrl( serverUrl ).build() );
     }
 
-    public static String generate( Api api, Format format, Configuration configuration )
+    public static String generateJson( Api api, Format format, Configuration configuration )
+    {
+        return generate( api, format, Language.JSON, configuration );
+    }
+
+    public static String generateYaml( Api api, String serverUrl )
+    {
+        return generateYaml( api, Format.PRETTY_PRINT,
+            Configuration.DEFAULT.toBuilder().serverUrl( serverUrl ).build() );
+    }
+
+    public static String generateYaml( Api api, Format format, Configuration configuration )
+    {
+        return generate( api, format, Language.YAML, configuration );
+    }
+
+    private static String generate( Api api, Format format, Language language, Configuration configuration )
     {
         int endpoints = 0;
         for ( Api.Controller c : api.getControllers() )
             endpoints += c.getEndpoints().size();
         int capacity = endpoints * 256 + api.getSchemas().size() * 512;
-        OpenApiGenerator gen = new OpenApiGenerator( api, format, configuration, new StringBuilder( capacity ) );
+        OpenApiGenerator gen = new OpenApiGenerator( api, language.getAdjustFormat().apply( format ), language,
+            configuration, new StringBuilder( capacity ) );
         gen.generateDocument();
         return gen.toString();
     }
@@ -275,9 +292,10 @@ public class OpenApiGenerator extends JsonGenerator
 
     private final Configuration configuration;
 
-    private OpenApiGenerator( Api api, Format format, Configuration configuration, StringBuilder out )
+    private OpenApiGenerator( Api api, Format format, Language language, Configuration configuration,
+        StringBuilder out )
     {
-        super( out, format );
+        super( out, format, language );
         this.api = api;
         this.configuration = configuration;
         checkConfiguration( configuration );
@@ -323,23 +341,24 @@ public class OpenApiGenerator extends JsonGenerator
             } );
             addArrayMember( "tags", api.getTags().values(), tag -> addObjectMember( null, () -> {
                 addStringMember( "name", tag.getName() );
-                addStringMember( "description", tag.getDescription().orElse( configuration.missingDescription ) );
+                addStringMultilineMember( "description",
+                    tag.getDescription().orElse( configuration.missingDescription ) );
                 addObjectMember( "externalDocs", tag.getExternalDocsUrl().isPresent(), () -> {
                     addStringMember( "url", tag.getExternalDocsUrl().getValue() );
-                    addStringMember( "description", tag.getExternalDocsDescription().getValue() );
+                    addStringMultilineMember( "description", tag.getExternalDocsDescription().getValue() );
                 } );
             } ) );
             addArrayMember( "servers",
                 () -> addObjectMember( null, () -> addStringMember( "url", configuration.serverUrl ) ) );
+            addArrayMember( "security",
+                () -> addObjectMember( null, () -> addArrayMember( "basicAuth",
+                    () -> addArrayMember( null, List.of() ) ) ) );
             addObjectMember( "paths", this::generatePaths );
             addObjectMember( "components", () -> {
                 addObjectMember( "securitySchemes", this::generateSecuritySchemes );
                 addObjectMember( "schemas", this::generateSchemas );
                 addObjectMember( "parameters", this::generateParameters );
             } );
-            addArrayMember( "security",
-                () -> addObjectMember( null, () -> addArrayMember( "basicAuth",
-                    () -> addArrayMember( null, Collections.emptyList() ) ) ) );
         } );
         log.info( format( "OpenAPI document generated for %d controllers with %d named schemas",
             api.getControllers().size(), api.getSchemas().size() ) );
@@ -365,7 +384,8 @@ public class OpenApiGenerator extends JsonGenerator
             tags.add( "synthetic" );
         addObjectMember( method.name().toLowerCase(), () -> {
             addBooleanMember( "deprecated", endpoint.getDeprecated() );
-            addStringMember( "description", endpoint.getDescription().orElse( configuration.missingDescription ) );
+            addStringMultilineMember( "description",
+                endpoint.getDescription().orElse( configuration.missingDescription ) );
             addStringMember( "operationId", getUniqueOperationId( endpoint ) );
             addArrayMember( "tags", tags );
             addArrayMember( "parameters", endpoint.getParameters().values(), this::generateParameter );
@@ -402,7 +422,8 @@ public class OpenApiGenerator extends JsonGenerator
         addObjectMember( name, () -> {
             addStringMember( "name", parameter.getName() );
             addStringMember( "in", parameter.getIn().name().toLowerCase() );
-            addStringMember( "description", parameter.getDescription().orElse( configuration.missingDescription ) );
+            addStringMultilineMember( "description",
+                parameter.getDescription().orElse( configuration.missingDescription ) );
             addBooleanMember( "required", parameter.isRequired() );
             addObjectMember( "schema", () -> generateSchemaOrRef( parameter.getType() ) );
         } );
@@ -420,10 +441,11 @@ public class OpenApiGenerator extends JsonGenerator
     private void generateResponse( Api.Response response )
     {
         addObjectMember( String.valueOf( response.getStatus().value() ), () -> {
-            addStringMember( "description", response.getDescription().orElse( configuration.missingDescription ) );
+            addStringMultilineMember( "description",
+                response.getDescription().orElse( configuration.missingDescription ) );
             addObjectMember( "headers", response.getHeaders().values(),
                 header -> addObjectMember( header.getName(), () -> {
-                    addStringMember( "description", header.getDescription() );
+                    addStringMultilineMember( "description", header.getDescription() );
                     addObjectMember( "schema", () -> generateSchema( header.getType() ) );
                 } ) );
             boolean hasContent = !response.getContent().isEmpty() && response.getStatus() != HttpStatus.NO_CONTENT;
@@ -524,8 +546,8 @@ public class OpenApiGenerator extends JsonGenerator
         }
         if ( schemaType == Api.Schema.Type.UNKNOWN )
         {
-            addStringMember( "description",
-                "The exact type is unknown.  \\n(Java type was: `" + schema.getSource().getTypeName() + "`)" );
+            addStringMultilineMember( "description",
+                "The exact type is unknown.  \n(Java type was: `" + schema.getSource().getTypeName() + "`)" );
             return;
         }
         if ( schemaType == Api.Schema.Type.ONE_OF )
@@ -565,7 +587,7 @@ public class OpenApiGenerator extends JsonGenerator
                 addObjectMember( "additionalProperties",
                     () -> generateSchemaOrRef( schema.getProperties().get( 1 ).getType() ) );
                 if ( schema.getProperties().get( 0 ).getType().getRawType() != String.class )
-                    addStringMember( "description",
+                    addStringMultilineMember( "description",
                         "keys are " + schema.getProperties().get( 0 ).getType().getRawType() );
                 return;
             }
@@ -575,7 +597,7 @@ public class OpenApiGenerator extends JsonGenerator
         }
         else
         {
-            addStringMember( "description", "The actual type is unknown.  \\n(Java type was: `" + type + "`)" );
+            addStringMultilineMember( "description", "The actual type is unknown.  \n(Java type was: `" + type + "`)" );
             if ( type != Object.class )
             {
                 log.warn( schema + " " + schema.getSource() );
@@ -607,7 +629,7 @@ public class OpenApiGenerator extends JsonGenerator
         addStringMember( "type", "object" );
         addArrayMember( "required", List.of( "id" ) );
         addObjectMember( "properties", () -> addObjectMember( "id", () -> generateUidSchema( schema ) ) );
-        addTypeDescriptionMember( schema.getSource(), "A UID reference to a %s  \\n(Java name `%s`)" );
+        addTypeDescriptionMember( schema.getSource(), "A UID reference to a %s  \n(Java name `%s`)" );
     }
 
     private void generateUidSchema( Api.Schema schema )
@@ -617,10 +639,10 @@ public class OpenApiGenerator extends JsonGenerator
         addStringMember( "pattern", "^[0-9a-zA-Z]{11}$" );
         addNumberMember( "minLength", 11 );
         addNumberMember( "maxLength", 11 );
-        addStringMember( "example", generateUid( schema.getRawType() ) );
+        addStringMultilineMember( "example", generateUid( schema.getRawType() ) );
         if ( schema.getType() == Api.Schema.Type.UID )
         {
-            addTypeDescriptionMember( schema.getSource(), "A UID for an %s object  \\n(Java name `%s`)" );
+            addTypeDescriptionMember( schema.getSource(), "A UID for an %s object  \n(Java name `%s`)" );
         }
     }
 
@@ -629,7 +651,7 @@ public class OpenApiGenerator extends JsonGenerator
         String name = type == BaseIdentifiableObject.class || type == IdentifiableObject.class
             ? "any type of object"
             : getUniqueSchemaName( (Class<?>) type );
-        addStringMember( "description", String.format( template, name, type.getTypeName() ) );
+        addStringMultilineMember( "description", String.format( template, name, type.getTypeName() ) );
     }
 
     /*

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiGenerator.java
@@ -431,7 +431,8 @@ public class OpenApiGenerator extends JsonGenerator
 
     private void generateRequestBody( Api.RequestBody requestBody )
     {
-        addStringMember( "description", requestBody.getDescription().orElse( configuration.missingDescription ) );
+        addStringMultilineMember( "description",
+            requestBody.getDescription().orElse( configuration.missingDescription ) );
         addBooleanMember( "required", requestBody.isRequired() );
         addObjectMember( "content",
             () -> requestBody.getConsumes().forEach( ( key, value ) -> addObjectMember( key.toString(),


### PR DESCRIPTION
### Summary
* adds YAML support for OpenAPI spec.
* the `serverUrls` returned by the generated spec will use the same base URL as the server request used to generate
* the escaping of newlines is no longer done in `Descriptions` as JSON and YAML do them differently
* multi-line strings are handled differently to better support JSON and YAML differences

### Endpoints
Also adds new endpoints to make it easier to get a spec for a particular path:

    /api/{path}/openapi.json
    /api/{path}/openapi.yaml

For example to get a spec on the `/users` endpoint this becomes

    /api/users/openapi.json
    /api/users/openapi.yaml

Consequently to get a spec of all paths the endpoint is

    /api/openapi.json
    /api/openapi.yaml

The `/openapi` endpoints continue to provide explicit path and tag filter capability

    /api/openapi/openapi.json?tag=metadata
    /api/openapi/openapi.yaml?tag=metadata

### Manual Testing
Generating grouped JSON and YAML files and importing them in stoplight to see if errors are reported.
