### PR TITLE
fix: category constraints are now added if needed [DHIS2-14241]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/CategorySecurityUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/CategorySecurityUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.security;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.program.Program;
+
+@NoArgsConstructor( access = AccessLevel.PRIVATE )
+public class CategorySecurityUtils
+{
+    /**
+     * Returns the categories the user is constrained to. If the user is super
+     * user, an empty set is returned. If the user is not super user, the
+     * categories of the program category combo are returned if present.
+     *
+     * @param params the data query parameters.
+     * @return the categories the user is constrained to.
+     */
+    static Collection<Category> getCategoriesWithoutRestrictions( DataQueryParams params )
+    {
+        return Optional.of( params )
+            .map( DataQueryParams::getProgram )
+            .map( Program::getCategoryCombo )
+            .map( CategoryCombo::getCategories )
+            .orElse( Collections.emptyList() )
+            .stream()
+            /*
+             * If the user has selected a category option, we do not want to
+             * apply any constraints
+             */
+            .filter( category -> !hasUserSelectedCategoryOption( category, params ) )
+            .collect( Collectors.toList() );
+    }
+
+    /**
+     * Returns true if the user has selected a category option for the given
+     * category.
+     *
+     * @param category the category
+     * @param params the data query parameters.
+     * @return true if the user has selected a category option for the given
+     *         category.
+     */
+    private static boolean hasUserSelectedCategoryOption( Category category, DataQueryParams params )
+    {
+        Stream<DimensionalObject> dimensionalObjects = Stream.concat(
+            params.getDimensions().stream(),
+            params.getFilters().stream() );
+
+        return dimensionalObjects
+            .anyMatch( dimensionalObject -> hasUserConstraints( dimensionalObject, category ) );
+    }
+
+    /**
+     * Returns true if the given dimensionalObject contains any constraint on
+     * the given Category
+     *
+     * @param dimensionalObject the dimensional object
+     * @param category the category
+     * @return true if the given dimensionalObject contains any constraint on
+     *         the given Category
+     */
+    private static boolean hasUserConstraints( DimensionalObject dimensionalObject, Category category )
+    {
+        return dimensionalObject.getDimensionType() == DimensionType.CATEGORY &&
+            dimensionalObject.getUid().equals( category.getUid() ) &&
+            !dimensionalObject.getItems().isEmpty();
+    }
+}

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -28,13 +28,18 @@
 package org.hisp.dhis.analytics.security;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.Collections.emptyList;
+import static org.hisp.dhis.analytics.security.CategorySecurityUtils.getCategoriesWithoutRestrictions;
 import static org.hisp.dhis.analytics.util.AnalyticsUtils.throwIllegalQueryEx;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -42,6 +47,7 @@ import org.hisp.dhis.analytics.AnalyticsSecurityManager;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.QueryParamsBuilder;
 import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.category.Category;
 import org.hisp.dhis.common.BaseDimensionalObject;
 import org.hisp.dhis.common.DimensionService;
 import org.hisp.dhis.common.DimensionType;
@@ -346,12 +352,25 @@ public class DefaultAnalyticsSecurityManager
         // Check if current user has dimension constraints
         // ---------------------------------------------------------------------
 
-        if ( params == null || user == null || !user.hasDimensionConstraints() )
+        if ( params == null || user == null )
         {
             return;
         }
 
-        Set<DimensionalObject> dimensionConstraints = user.getDimensionConstraints();
+        // Categories the user is constrained to
+        Collection<Category> categories = currentUserService.currentUserIsSuper() ? emptyList()
+            : getCategoriesWithoutRestrictions( params );
+
+        // union of user and category constraints
+        Set<DimensionalObject> dimensionConstraints = Stream.concat(
+            user.getDimensionConstraints().stream(),
+            categories.stream() )
+            .collect( Collectors.toSet() );
+
+        if ( dimensionConstraints.isEmpty() ) // if no constraints
+        {
+            return; // nothing to do - no filters added to query
+        }
 
         for ( DimensionalObject dimension : dimensionConstraints )
         {

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/CategorySecurityUtilsTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/security/CategorySecurityUtilsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.analytics.security;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hisp.dhis.analytics.security.CategorySecurityUtils.getCategoriesWithoutRestrictions;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.hisp.dhis.analytics.DataQueryParams;
+import org.hisp.dhis.analytics.event.EventQueryParams;
+import org.hisp.dhis.category.Category;
+import org.hisp.dhis.category.CategoryCombo;
+import org.hisp.dhis.common.BaseIdentifiableObject;
+import org.hisp.dhis.common.DimensionType;
+import org.hisp.dhis.common.DimensionalItemObject;
+import org.hisp.dhis.common.DimensionalObject;
+import org.hisp.dhis.program.Program;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A test for {@link CategorySecurityUtils} This class is a test for the method
+ * {@link CategorySecurityUtils#getCategoriesWithoutRestrictions(DataQueryParams)}
+ * which is used to get the categories that are not restricted by the user.
+ */
+class CategorySecurityUtilsTest
+{
+
+    @Test
+    void testCategoryOptionsConstraints()
+    {
+        runTest(
+            // categories in Program -> categoryCombo -> categories
+            List.of( "cat1", "cat2", "cat3" ),
+            // Dimensions with flag if they have items
+            List.of(
+                // has items
+                Pair.of( "cat1", true ),
+                // has no items
+                Pair.of( "cat2", false ) ),
+            // only categories not specified or without items should be returned
+            List.of( "cat2", "cat3" ) );
+
+    }
+
+    @Test
+    void testCategoryOptionsNoConstraints()
+    {
+        List<String> allCategories = List.of( "cat1", "cat2", "cat3" );
+        runTest(
+            // categories in Program -> categoryCombo -> categories
+            allCategories,
+            // when no dimensions/filters
+            Collections.emptyList(),
+            // all categories should be returned
+            allCategories );
+    }
+
+    /**
+     * The actual test implementation. It mocks the objects needed for the test
+     * and runs the test.
+     *
+     * @param categoryUids the categories in the Program -> categoryCombo ->
+     *        categories
+     * @param dimensionsWithFlag the dimensions with flag if they have items
+     * @param expected the expected result
+     */
+    private void runTest( List<String> categoryUids, List<Pair<String, Boolean>> dimensionsWithFlag,
+        List<String> expected )
+    {
+        List<Category> categories = categoryUids.stream()
+            .map( this::mockCategory )
+            .collect( Collectors.toList() );
+
+        CategoryCombo categoryCombo = mock( CategoryCombo.class );
+        when( categoryCombo.getCategories() ).thenReturn( categories );
+
+        Program program = mock( Program.class );
+        when( program.getCategoryCombo() ).thenReturn( categoryCombo );
+
+        EventQueryParams.Builder paramBuilder = new EventQueryParams.Builder().withProgram( program );
+
+        dimensionsWithFlag.stream()
+            .map( dimWithFlag -> mockDimension(
+                dimWithFlag.getLeft(),
+                dimWithFlag.getRight() ) )
+            .forEach( paramBuilder::addDimension );
+
+        EventQueryParams params = paramBuilder.build();
+
+        // the actual tested method
+        List<String> actual = getCategoriesWithoutRestrictions( params )
+            .stream()
+            .map( BaseIdentifiableObject::getUid )
+            .collect( Collectors.toList() );
+
+        assertThat( expected, containsInAnyOrder( actual.toArray() ) );
+        assertThat( actual, hasSize( expected.size() ) );
+    }
+
+    private DimensionalObject mockDimension( String dim, boolean withItem )
+    {
+        DimensionalObject dimension = mock( DimensionalObject.class );
+        when( dimension.getDimensionType() ).thenReturn( DimensionType.CATEGORY );
+        when( dimension.getUid() ).thenReturn( dim );
+        when( dimension.getDimension() ).thenReturn( dim );
+        if ( withItem )
+        {
+            when( dimension.getItems() )
+                .thenReturn(
+                    singletonList( mockDimensionalItemObject() ) );
+        }
+        return dimension;
+    }
+
+    private DimensionalItemObject mockDimensionalItemObject()
+    {
+        return mock( DimensionalItemObject.class );
+    }
+
+    private Category mockCategory( String uid )
+    {
+        Category category = mock( Category.class );
+        when( category.getUid() ).thenReturn( uid );
+        return category;
+    }
+}


### PR DESCRIPTION
### can only be merged once the release and control team has approved it

Categories on which to execute `getCanReadDimensionItems` should always be added when user is not superuser and no dimensionItems are present on them.