### PR TITLE
feat: Add Icon into Visualization [DHIS2-14691]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Icon.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Icon.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static org.hisp.dhis.common.DxfNamespaces.DXF_2_0;
+
+import java.io.Serializable;
+
+import lombok.Data;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+/**
+ * Representation of an icon object that can be used by clients to manage and
+ * show/hide icons.
+ *
+ * We should allow only one Icon per type.
+ *
+ * @author maikel arabori
+ */
+@Data
+public class Icon implements Serializable
+{
+    public enum IconType
+    {
+        DATA_ITEM;
+    }
+
+    /**
+     * Flag to show or hide the icon. False by default.
+     */
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
+    private boolean show;
+
+    /**
+     * The type of this icon.
+     */
+    @JsonProperty
+    @JacksonXmlProperty( namespace = DXF_2_0 )
+    private IconType type;
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+            return true;
+
+        if ( o == null || getClass() != o.getClass() )
+            return false;
+
+        Icon icon = (Icon) o;
+
+        return new EqualsBuilder().append( type, icon.type ).isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder( 17, 37 ).append( type ).toHashCode();
+    }
+}

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Icon.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Icon.java
@@ -56,13 +56,6 @@ public class Icon implements Serializable
     }
 
     /**
-     * Flag to show or hide the icon. False by default.
-     */
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DXF_2_0 )
-    private boolean show;
-
-    /**
      * The type of this icon.
      */
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/visualization/Visualization.java
@@ -52,9 +52,11 @@ import static org.hisp.dhis.visualization.VisualizationType.PIVOT_TABLE;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.hisp.dhis.analytics.NumberType;
 import org.hisp.dhis.category.CategoryCombo;
@@ -85,6 +87,7 @@ import org.hisp.dhis.period.Period;
 import org.hisp.dhis.schema.annotation.PropertyRange;
 import org.hisp.dhis.translation.Translatable;
 import org.hisp.dhis.user.User;
+import org.hisp.dhis.visualization.Icon.IconType;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -233,6 +236,12 @@ public class Visualization
      * bars.
      */
     private String colorSet;
+
+    /**
+     * The collection of {@link Icon} objects associated. Should be unique for
+     * each {@link IconType}.
+     */
+    private Set<Icon> icons = new HashSet<>();
 
     // -------------------------------------------------------------------------
     // Display items for graphics/charts
@@ -736,6 +745,19 @@ public class Visualization
     public void setOptionalAxes( List<Axis> optionalAxes )
     {
         this.optionalAxes = optionalAxes;
+    }
+
+    @JsonProperty( "icons" )
+    @JacksonXmlElementWrapper( localName = "icons", namespace = DXF_2_0 )
+    @JacksonXmlProperty( localName = "icons", namespace = DXF_2_0 )
+    public Set<Icon> getIcons()
+    {
+        return icons;
+    }
+
+    public void setIcons( Set<Icon> icons )
+    {
+        this.icons = icons;
     }
 
     @JsonProperty( "legend" )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/visualization/hibernate/Visualization.hbm.xml
@@ -222,6 +222,8 @@
 
     <property name="axes" type="jbAxes"/>
 
+    <property name="icons" type="jbIcons"/>
+
     <component name="legendDefinitions" class="org.hisp.dhis.visualization.LegendDefinitions">
       <property name="legendDisplayStyle" length="40">
         <type name="org.hibernate.type.EnumType">

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_12__Add_icon_column_to_visualization.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_12__Add_icon_column_to_visualization.sql
@@ -1,0 +1,2 @@
+-- DHIS2-14691
+alter table visualization add column if not exists icons jsonb default '{}'::jsonb;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/resources/org/hisp/dhis/usertype/UserTypes.hbm.xml
@@ -37,6 +37,10 @@
     <param name="clazz">org.hisp.dhis.visualization.AxisV2</param>
   </typedef>
 
+  <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonSetBinaryType" name="jbIcons">
+    <param name="clazz">org.hisp.dhis.visualization.Icon</param>
+  </typedef>
+
   <typedef class="org.hisp.dhis.hibernate.jsonb.type.JsonBinaryType" name="jbSeriesKey">
     <param name="clazz">org.hisp.dhis.visualization.SeriesKey</param>
   </typedef>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/visualization/DefaultVisualizationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/visualization/DefaultVisualizationServiceTest.java
@@ -50,7 +50,6 @@ class DefaultVisualizationServiceTest extends TransactionalIntegrationTest
     {
         // Given
         Icon icon = new Icon();
-        icon.setShow( true );
         icon.setType( DATA_ITEM );
 
         Visualization aVisWithIcons = createVisualization( "any" );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/visualization/DefaultVisualizationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/visualization/DefaultVisualizationServiceTest.java
@@ -40,7 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 /**
  * Tests for {@link DefaultVisualizationService}.
  */
-public class DefaultVisualizationServiceTest extends TransactionalIntegrationTest
+class DefaultVisualizationServiceTest extends TransactionalIntegrationTest
 {
     @Autowired
     private VisualizationService visualizationService;

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/visualization/DefaultVisualizationServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/visualization/DefaultVisualizationServiceTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.visualization;
+
+import static org.hisp.dhis.visualization.Icon.IconType.DATA_ITEM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+import java.util.Set;
+
+import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests for {@link DefaultVisualizationService}.
+ */
+public class DefaultVisualizationServiceTest extends TransactionalIntegrationTest
+{
+    @Autowired
+    private VisualizationService visualizationService;
+
+    @Test
+    void testPostWithIconsObject()
+    {
+        // Given
+        Icon icon = new Icon();
+        icon.setShow( true );
+        icon.setType( DATA_ITEM );
+
+        Visualization aVisWithIcons = createVisualization( "any" );
+        aVisWithIcons.setIcons( Set.of( icon ) );
+
+        // When
+        long uid = visualizationService.save( aVisWithIcons );
+
+        // Then
+        Visualization saved = visualizationService.getVisualization( uid );
+        assertIterableEquals( Set.of( icon ), saved.getIcons() );
+        assertEquals( "any", saved.getName() );
+    }
+
+    private Visualization createVisualization( String name )
+    {
+        Visualization visualization = createVisualization( 'X' );
+        visualization.setName( name );
+        return visualization;
+    }
+}


### PR DESCRIPTION
Adds a new Icon object into the Visualization.

Note that Visualization can have multiple Icon objects, but should not have icons of the same type.
This is the reason for using a Set. It will avoid duplicates and at the same time express it explicitly.