### PR TITLE
fix: (PI) NaN values always returned in spite of filter [DHIS2-14704]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -435,7 +435,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
 
     protected String coalesceAsDoubleNan( String column )
     {
-        return "coalesce(" + column + ", double precision 'NaN')";
+        return "nullif(coalesce(" + column + "), double precision 'NaN')";
     }
 
     private ColumnAndAlias getColumnAndAlias( QueryItem queryItem, boolean isGroupByClause, String aliasIfMissing )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -195,7 +195,7 @@ class EnrollmentAnalyticsManagerTest extends
 
         if ( valueType == ValueType.NUMBER )
         {
-            subSelect = "coalesce(" + subSelect + ", double precision 'NaN') as \"fWIAEtYVEGk\"";
+            subSelect = "nullif(coalesce(" + subSelect + "), double precision 'NaN') as \"fWIAEtYVEGk\"";
         }
         String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect + "  from " + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) " + "and ps = '"
@@ -258,8 +258,8 @@ class EnrollmentAnalyticsManagerTest extends
             + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid() + "' order by executiondate desc limit 1 )";
 
-        String expected = "ax.\"monthly\",ax.\"ou\"," + "coalesce(" + subSelect
-            + ", double precision 'NaN') as \"fWIAEtYVEGk\"" + "  from "
+        String expected = "ax.\"monthly\",ax.\"ou\"," + "nullif(coalesce(" + subSelect
+            + "), double precision 'NaN') as \"fWIAEtYVEGk\"" + "  from "
             + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and (ax.\"uidlevel1\" = 'ouabcdefghA' ) "
             + "and ps = '" + programStage.getUid() + "' and " + subSelect + " > '10' limit 10001";
@@ -376,7 +376,8 @@ class EnrollmentAnalyticsManagerTest extends
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "ax.\"monthly\",ax.\"ou\",coalesce((SELECT avg (" + piSubquery + ") FROM analytics_event_"
+        String expected = "ax.\"monthly\",ax.\"ou\",nullif(coalesce((SELECT avg (" + piSubquery
+            + ") FROM analytics_event_"
             + programA.getUid().toLowerCase() + " as subax WHERE  "
             + "subax.tei in (select tei.uid from trackedentityinstance tei " +
             "LEFT JOIN relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid  " +
@@ -385,7 +386,7 @@ class EnrollmentAnalyticsManagerTest extends
             "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid " +
             "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid " +
             "WHERE rty.relationshiptypeid = " + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
+            + " AND tei.uid = ax.tei ))), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
             + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
@@ -418,7 +419,8 @@ class EnrollmentAnalyticsManagerTest extends
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "ax.\"monthly\",ax.\"ou\",coalesce((SELECT avg (" + piSubquery + ") FROM analytics_event_"
+        String expected = "ax.\"monthly\",ax.\"ou\",nullif(coalesce((SELECT avg (" + piSubquery
+            + ") FROM analytics_event_"
             + programA.getUid().toLowerCase() + " as subax WHERE "
             + " subax.tei in (select tei.uid from trackedentityinstance tei LEFT JOIN relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid  "
             +
@@ -427,7 +429,7 @@ class EnrollmentAnalyticsManagerTest extends
             "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid " +
             "LEFT JOIN programinstance pi on pi.programinstanceid = ri2.programinstanceid WHERE rty.relationshiptypeid "
             +
-            "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi )), double precision 'NaN')" + " as \""
+            "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi ))), double precision 'NaN')" + " as \""
             + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
             + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";
@@ -490,7 +492,8 @@ class EnrollmentAnalyticsManagerTest extends
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "ax.\"monthly\",ax.\"ou\",coalesce((SELECT avg (" + piSubquery + ") FROM analytics_event_"
+        String expected = "ax.\"monthly\",ax.\"ou\",nullif(coalesce((SELECT avg (" + piSubquery
+            + ") FROM analytics_event_"
             + programB.getUid().toLowerCase() + " as subax WHERE  "
             + "subax.tei in (select tei.uid from trackedentityinstance tei " +
             "LEFT JOIN relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid  " +
@@ -499,7 +502,7 @@ class EnrollmentAnalyticsManagerTest extends
             "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid " +
             "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid " +
             "WHERE rty.relationshiptypeid = " + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
+            + " AND tei.uid = ax.tei ))), double precision 'NaN') as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
             + " as ax where (enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09')and (ax.\"uidlevel1\" = 'ouabcdefghA' ) limit 101";


### PR DESCRIPTION
When a PI expression results in 'NaN', filters like `is not null`, `greater than`, etc. do not work correctly.
It happens because currently, the filter is compared against 'NaN' value, which always evaluates true for such kinds of filters.
In analytics queries, the final value displayed for 'NaN' is always empty, which also gives the wrong impression from the client's perspective.

This fix will use the `nullif` function to make those filters work as expected, turning 'NaN' into `null`.
