### PR TITLE
feat: Gist API attributeValues as simple key-value map [DHIS2-14696]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/DefaultGistService.java
@@ -105,8 +105,7 @@ public class DefaultGistService
         GistBuilder queryBuilder = createFetchBuilder( query, context, access, this );
         List<Object[]> rows = fetchWithParameters( query, queryBuilder,
             getSession().createQuery( queryBuilder.buildFetchHQL(), Object[].class ) );
-        queryBuilder.transform( rows );
-        return rows;
+        return queryBuilder.transform( rows );
     }
 
     @Override

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/gist/GistLogic.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.gist;
 
+import org.hisp.dhis.attribute.AttributeValue;
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.gist.GistQuery.Comparison;
 import org.hisp.dhis.gist.GistQuery.Filter;
@@ -112,6 +113,11 @@ final class GistLogic
     static boolean isAccessProperty( Property p )
     {
         return "access".equals( p.key() ) && p.getKlass() == Access.class;
+    }
+
+    static boolean isAttributeValuesProperty( Property p )
+    {
+        return "attributeValues".equals( p.key() ) && p.getItemKlass() == AttributeValue.class;
     }
 
     static boolean isCollectionSizeFilter( Filter filter, Property property )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/GistAttributeControllerTest.java
@@ -31,12 +31,19 @@ import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.jsontree.JsonArray;
+import org.hisp.dhis.jsontree.JsonList;
+import org.hisp.dhis.jsontree.JsonMap;
 import org.hisp.dhis.jsontree.JsonObject;
+import org.hisp.dhis.jsontree.JsonString;
+import org.hisp.dhis.jsontree.JsonValue;
 import org.hisp.dhis.web.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,6 +78,47 @@ class GistAttributeControllerTest extends AbstractGistControllerTest
         attrId = postNewAttribute( "extra", ValueType.TEXT, Attribute.ObjectType.USER_GROUP );
         group1Id = postNewUserGroupWithAttributeValue( "G1", attrId, "extra-value" );
         group2Id = postNewUserGroupWithAttributeValue( "G2", attrId, "different" );
+    }
+
+    @Test
+    void testAttributeValues_SingleObjectOnlyField()
+    {
+        assertMapEquals( Map.of( attrId, "extra-value" ),
+            GET( "/userGroups/{id}/gist?fields=attributeValues", group1Id ).content().asMap( JsonString.class ) );
+    }
+
+    @Test
+    void testAttributeValues_SingleObjectProperty()
+    {
+        assertMapEquals( Map.of( attrId, "extra-value" ),
+            GET( "/userGroups/{id}/attributeValues/gist", group1Id ).content().asMap( JsonString.class ) );
+    }
+
+    @Test
+    void testAttributeValues_SingleObjectOneOfManyFields()
+    {
+        assertMapEquals( Map.of( attrId, "extra-value" ),
+            GET( "/userGroups/{id}/gist?fields=id,name,attributeValues&headless=true", group1Id )
+                .content().getMap( "attributeValues", JsonString.class ) );
+    }
+
+    @Test
+    void testAttributeValues_ListOnlyField()
+    {
+        assertListOfMapEquals( List.of( Map.of( attrId, "extra-value" ), Map.of( attrId, "different" ) ),
+            GET( "/userGroups/gist?fields=attributeValues&headless=true&order=name" ).content()
+                .asList( JsonMap.class ) );
+    }
+
+    @Test
+    void testAttributeValues_ListOneOfManyFields()
+    {
+        JsonArray list = GET( "/userGroups/gist?fields=id,name,attributeValues&headless=true&order=name" ).content();
+        assertEquals( 2, list.size() );
+        assertMapEquals( Map.of( attrId, "extra-value" ),
+            list.getObject( 0 ).getMap( "attributeValues", JsonString.class ) );
+        assertMapEquals( Map.of( attrId, "different" ),
+            list.getObject( 1 ).getMap( "attributeValues", JsonString.class ) );
     }
 
     @Test
@@ -176,5 +224,30 @@ class GistAttributeControllerTest extends AbstractGistControllerTest
     {
         return assertStatus( HttpStatus.CREATED, POST( "/attributes", "{" + "'name':'" + name + "', "
             + "'valueType':'" + valueType.name() + "', " + "'" + objectType.getPropertyName() + "':true}" ) );
+    }
+
+    private static void assertListOfMapEquals( List<Map<String, String>> expected, JsonList<?> actual )
+    {
+        assertEquals( expected.size(), actual.size() );
+        int i = 0;
+        for ( JsonValue e : actual )
+        {
+            assertMapEquals( expected.get( i++ ), e.asMap( JsonString.class ) );
+        }
+    }
+
+    private static void assertMapEquals( Map<String, String> expected, JsonMap<JsonString> actual )
+    {
+        assertEquals( expected, toMap( actual ) );
+    }
+
+    private static Map<String, String> toMap( JsonMap<JsonString> actual )
+    {
+        Map<String, String> res = new HashMap<>();
+        for ( String key : actual.keys() )
+        {
+            res.put( key, actual.get( key ).string() );
+        }
+        return res;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AbstractGistReadOnlyController.java
@@ -168,7 +168,7 @@ public abstract class AbstractGistReadOnlyController<T extends PrimaryKeyObject>
             throw new BadRequestException( "No such property: " + property );
         }
 
-        if ( !objProperty.isCollection() )
+        if ( !objProperty.isCollection() || !PrimaryKeyObject.class.isAssignableFrom( objProperty.getItemKlass() ) )
         {
             return gistToJsonObjectResponse( uid, createGistQuery( params, getEntityClass(), GistAutoType.L )
                 .withFilter( new Filter( "id", Comparison.EQ, uid ) )


### PR DESCRIPTION
### Summary
For Gist API the `attributeValues` set of attribute values is transformed to a simple key-value map, where key is the attribute ID, value the attribute value.

### Automatic Testing
New test scenarios were added to test list and object gist with single property as well as multi-property listing.

### Manual Testing 
Try for example...

* `/api/organisationUnits/gist?fields=attributeValues`
* `/api/organisationUnits/gist?fields=id,name,attributeValues`
* `/api/organisationUnits/{uid}/attributeValues/gist` 
* `/api/organisationUnits/{uid}/gist?fields=attributeValues`
* `/api/organisationUnits/{uid}/gist?fields=id,name,attributeValues`

Check the attribute values are shown as key-value map. Best tested with objects that actually have attribute values.