### PR TITLE
refactor: Attribute flag columns as JSONB [DHIS2-14606]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
@@ -29,10 +29,12 @@ package org.hisp.dhis.attribute;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import org.hisp.dhis.category.Category;
 import org.hisp.dhis.category.CategoryOption;
@@ -256,6 +258,18 @@ public class Attribute
         {
             objectTypes.remove( type );
         }
+    }
+
+    @JsonIgnore
+    public Set<String> getObjectTypes()
+    {
+        return objectTypes.stream().map( ObjectType::name ).collect( toSet() );
+    }
+
+    public void setObjectTypes( Set<String> objectTypes )
+    {
+        this.objectTypes.clear();
+        objectTypes.forEach( name -> this.objectTypes.add( ObjectType.valueOf( name ) ) );
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/Attribute.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.attribute;
 
 import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -194,7 +195,7 @@ public class Attribute
 
     private ValueType valueType;
 
-    private final EnumSet<ObjectType> objectTypes = EnumSet.noneOf( ObjectType.class );
+    private EnumSet<ObjectType> objectTypes = EnumSet.noneOf( ObjectType.class );
 
     private boolean mandatory;
 
@@ -268,8 +269,8 @@ public class Attribute
 
     public void setObjectTypes( Set<String> objectTypes )
     {
-        this.objectTypes.clear();
-        objectTypes.forEach( name -> this.objectTypes.add( ObjectType.valueOf( name ) ) );
+        this.objectTypes = objectTypes.stream().map( ObjectType::valueOf )
+            .collect( toCollection( () -> EnumSet.noneOf( ObjectType.class ) ) );
     }
 
     @JsonProperty

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeService.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeService.java
@@ -38,8 +38,6 @@ import org.hisp.dhis.common.IdentifiableObject;
  */
 public interface AttributeService
 {
-    String ID = AttributeService.class.getName();
-
     // -------------------------------------------------------------------------
     // Attribute
     // -------------------------------------------------------------------------
@@ -103,12 +101,6 @@ public interface AttributeService
      * @return a set of all attributes.
      */
     List<Attribute> getAllAttributes();
-
-    List<Attribute> getAttributes( Class<?> klass );
-
-    List<Attribute> getMandatoryAttributes( Class<?> klass );
-
-    List<Attribute> getUniqueAttributes( Class<?> klass );
 
     // -------------------------------------------------------------------------
     // AttributeValue

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/attribute/AttributeStore.java
@@ -27,14 +27,7 @@
  */
 package org.hisp.dhis.attribute;
 
-import static java.util.Arrays.stream;
-
-import java.util.List;
-
-import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.common.IdentifiableObjectStore;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
@@ -42,35 +35,4 @@ import com.google.common.collect.ImmutableMap;
 public interface AttributeStore
     extends IdentifiableObjectStore<Attribute>
 {
-    String ID = AttributeStore.class.getName();
-
-    ImmutableMap<Class<?>, String> CLASS_ATTRIBUTE_MAP = stream( ObjectType.values() )
-        .collect( ImmutableMap.toImmutableMap( ObjectType::getType, ObjectType::getPropertyName ) );
-
-    /**
-     * Get all metadata attributes for a given class, returns empty list for
-     * un-supported types.
-     *
-     * @param klass Class to get metadata attributes for
-     * @return List of attributes for this class
-     */
-    List<Attribute> getAttributes( Class<?> klass );
-
-    /**
-     * Get all mandatory metadata attributes for a given class, returns empty
-     * list for un-supported types.
-     *
-     * @param klass Class to get metadata attributes for
-     * @return List of mandatory metadata attributes for this class
-     */
-    List<Attribute> getMandatoryAttributes( Class<?> klass );
-
-    /**
-     * Get all unique metadata attributes for a given class, returns empty list
-     * for un-supported types.
-     *
-     * @param klass Class to get metadata attributes for
-     * @return List of unique metadata attributes for this class
-     */
-    List<Attribute> getUniqueAttributes( Class<?> klass );
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/DefaultAttributeService.java
@@ -47,8 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
 @Service( "org.hisp.dhis.attribute.AttributeService" )
-public class DefaultAttributeService
-    implements AttributeService
+public class DefaultAttributeService implements AttributeService
 {
     private final Cache<Attribute> attributeCache;
 
@@ -129,27 +128,6 @@ public class DefaultAttributeService
     public List<Attribute> getAllAttributes()
     {
         return new ArrayList<>( attributeStore.getAll() );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public List<Attribute> getAttributes( Class<?> klass )
-    {
-        return new ArrayList<>( attributeStore.getAttributes( klass ) );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public List<Attribute> getMandatoryAttributes( Class<?> klass )
-    {
-        return new ArrayList<>( attributeStore.getMandatoryAttributes( klass ) );
-    }
-
-    @Override
-    @Transactional( readOnly = true )
-    public List<Attribute> getUniqueAttributes( Class<?> klass )
-    {
-        return new ArrayList<>( attributeStore.getUniqueAttributes( klass ) );
     }
 
     // -------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/hibernate/HibernateAttributeStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/attribute/hibernate/HibernateAttributeStore.java
@@ -27,11 +27,6 @@
  */
 package org.hisp.dhis.attribute.hibernate;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.persistence.criteria.CriteriaBuilder;
-
 import org.hibernate.SessionFactory;
 import org.hisp.dhis.attribute.Attribute;
 import org.hisp.dhis.attribute.AttributeStore;
@@ -57,49 +52,5 @@ public class HibernateAttributeStore
         CurrentUserService currentUserService, AclService aclService )
     {
         super( sessionFactory, jdbcTemplate, publisher, Attribute.class, currentUserService, aclService, true );
-    }
-
-    @Override
-    public List<Attribute> getAttributes( Class<?> klass )
-    {
-        if ( !CLASS_ATTRIBUTE_MAP.containsKey( klass ) )
-        {
-            return new ArrayList<>();
-        }
-
-        CriteriaBuilder builder = getCriteriaBuilder();
-
-        return getList( builder, newJpaParameters()
-            .addPredicate( root -> builder.equal( root.get( CLASS_ATTRIBUTE_MAP.get( klass ) ), true ) ) );
-    }
-
-    @Override
-    public List<Attribute> getMandatoryAttributes( Class<?> klass )
-    {
-        if ( !CLASS_ATTRIBUTE_MAP.containsKey( klass ) )
-        {
-            return new ArrayList<>();
-        }
-
-        CriteriaBuilder builder = getCriteriaBuilder();
-
-        return getList( builder, newJpaParameters()
-            .addPredicate( root -> builder.equal( root.get( CLASS_ATTRIBUTE_MAP.get( klass ) ), true ) )
-            .addPredicate( root -> builder.equal( root.get( "mandatory" ), true ) ) );
-    }
-
-    @Override
-    public List<Attribute> getUniqueAttributes( Class<?> klass )
-    {
-        if ( !CLASS_ATTRIBUTE_MAP.containsKey( klass ) )
-        {
-            return new ArrayList<>();
-        }
-
-        CriteriaBuilder builder = getCriteriaBuilder();
-
-        return getList( builder, newJpaParameters()
-            .addPredicate( root -> builder.equal( root.get( CLASS_ATTRIBUTE_MAP.get( klass ) ), true ) )
-            .addPredicate( root -> builder.equal( root.get( "unique" ), true ) ) );
     }
 }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -299,35 +299,25 @@ public class DefaultPreheatService implements PreheatService
         }
         for ( Class<? extends IdentifiableObject> klass : objects.keySet() )
         {
-            List<Attribute> mandatoryAttributes = attributesByObjectType.get( klass ).stream()
+            List<Attribute> mandatoryAttributes = attributesByObjectType.getOrDefault( klass, List.of() ).stream()
                 .filter( Attribute::isMandatory )
                 .collect( toUnmodifiableList() );
 
-            if ( !mandatoryAttributes.isEmpty() )
-            {
-                preheat.getMandatoryAttributes().put( klass, new HashSet<>() );
-            }
+            mandatoryAttributes.forEach( attribute -> preheat.getMandatoryAttributes()
+                .computeIfAbsent( klass, key -> new HashSet<>() ).add( attribute.getUid() ) );
 
-            mandatoryAttributes
-                .forEach( attribute -> preheat.getMandatoryAttributes().get( klass ).add( attribute.getUid() ) );
-
-            List<Attribute> uniqueAttributes = attributesByObjectType.get( klass ).stream()
+            List<Attribute> uniqueAttributes = attributesByObjectType.getOrDefault( klass, List.of() ).stream()
                 .filter( Attribute::isUnique )
                 .collect( toUnmodifiableList() );
 
-            if ( !uniqueAttributes.isEmpty() )
-            {
-                preheat.getUniqueAttributes().put( klass, new HashSet<>() );
-            }
-
-            uniqueAttributes
-                .forEach( attribute -> preheat.getUniqueAttributes().get( klass ).add( attribute.getUid() ) );
+            uniqueAttributes.forEach( attribute -> preheat.getUniqueAttributes()
+                .computeIfAbsent( klass, key -> new HashSet<>() ).add( attribute.getUid() ) );
 
             List<? extends IdentifiableObject> uniqueAttributeValues = manager.getAllByAttributes( klass,
                 uniqueAttributes );
             handleUniqueAttributeValues( klass, uniqueAttributeValues, preheat );
 
-            addAllClassesAttributes( klass, preheat, attributesByObjectType.get( klass ) );
+            addAllClassesAttributes( klass, preheat, attributesByObjectType.getOrDefault( klass, List.of() ) );
         }
 
         if ( objects.containsKey( Attribute.class ) )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/preheat/DefaultPreheatService.java
@@ -330,20 +330,14 @@ public class DefaultPreheatService implements PreheatService
 
                 if ( attribute.isMandatory() )
                 {
-                    attribute.getSupportedClasses().forEach( klass -> {
-                        if ( !preheat.getMandatoryAttributes().containsKey( klass ) )
-                            preheat.getMandatoryAttributes().put( klass, new HashSet<>() );
-                        preheat.getMandatoryAttributes().get( klass ).add( attribute.getUid() );
-                    } );
+                    attribute.getSupportedClasses().forEach( klass -> preheat.getMandatoryAttributes()
+                        .computeIfAbsent( klass, key -> new HashSet<>() ).add( attribute.getUid() ) );
                 }
 
                 if ( attribute.isUnique() )
                 {
-                    attribute.getSupportedClasses().forEach( klass -> {
-                        if ( !preheat.getUniqueAttributes().containsKey( klass ) )
-                            preheat.getUniqueAttributes().put( klass, new HashSet<>() );
-                        preheat.getUniqueAttributes().get( klass ).add( attribute.getUid() );
-                    } );
+                    attribute.getSupportedClasses().forEach( klass -> preheat.getUniqueAttributes()
+                        .computeIfAbsent( klass, key -> new HashSet<>() ).add( attribute.getUid() ) );
                 }
 
                 attribute.getSupportedClasses().forEach( klass -> preheat.addClassAttribute( klass, attribute ) );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/resources/org/hisp/dhis/attribute/hibernate/Attribute.hbm.xml
@@ -33,75 +33,7 @@
 
     <property name="unique" column="isunique" not-null="false" />
 
-    <property name="dataElementAttribute" not-null="true" />
-
-    <property name="dataElementGroupAttribute" not-null="false" />
-
-    <property name="indicatorAttribute" not-null="true" />
-
-    <property name="indicatorGroupAttribute" not-null="false" />
-
-    <property name="dataSetAttribute" not-null="false" />
-
-    <property name="organisationUnitAttribute" not-null="true" />
-
-    <property name="organisationUnitGroupAttribute" not-null="false" />
-
-    <property name="organisationUnitGroupSetAttribute" not-null="false" />
-
-    <property name="userAttribute" not-null="true" />
-
-    <property name="userGroupAttribute" not-null="false" />
-
-    <property name="programAttribute" not-null="false" />
-
-    <property name="programStageAttribute" not-null="false" />
-
-    <property name="trackedEntityTypeAttribute" not-null="false" />
-
-    <property name="trackedEntityAttributeAttribute" not-null="false" />
-
-    <property name="categoryOptionAttribute" not-null="false" />
-
-    <property name="categoryOptionGroupAttribute" not-null="false" />
-
-    <property name="documentAttribute" not-null="false" />
-
-    <property name="optionAttribute" not-null="false" />
-
-    <property name="optionSetAttribute" not-null="false" />
-
-    <property name="constantAttribute" not-null="false" />
-
-    <property name="legendSetAttribute" not-null="false" />
-
-    <property name="programIndicatorAttribute" not-null="false" />
-
-    <property name="sqlViewAttribute" not-null="false" />
-
-    <property name="sectionAttribute" not-null="false" />
-
-    <property name="categoryOptionComboAttribute" not-null="false" />
-
-    <property name="categoryOptionGroupSetAttribute" not-null="false"/>
-
-    <property name="dataElementGroupSetAttribute" not-null="false"/>
-
-    <property name="validationRuleAttribute" not-null="false"/>
-
-    <property name="validationRuleGroupAttribute" not-null="false"/>
-
-    <property name="categoryAttribute" not-null="false"/>
-
-    <property name="visualizationAttribute" not-null="true"/>
-
-    <property name="mapAttribute" not-null="true"/>
-
-    <property name="eventReportAttribute" not-null="true"/>
-
-    <property name="eventChartAttribute" not-null="true"/>
-
-    <property name="relationshipTypeAttribute" not-null="true"/>
+    <property name="objectTypes" column="objecttypes" not-null="true" type="jbSet" />
 
     <property name="sortOrder"/>
 

--- a/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_13__Attribute_flags_as_jsonb.sql
+++ b/dhis-2/dhis-support/dhis-support-db-migration/src/main/resources/org/hisp/dhis/db/migration/2.40/V2_40_13__Attribute_flags_as_jsonb.sql
@@ -1,0 +1,107 @@
+/* Converts numerous attribute boolean columns into a single jsonb column
+   with an array containing enum names of those columns that were true */
+
+/* create jsonb set column */
+alter table attribute add column if not exists objecttypes jsonb;
+
+/* make sure we have a function to create jsonb arrays without nulls */
+create or replace function jsonb_build_array_without_nulls(variadic anyarray)
+    returns jsonb language sql immutable as $$
+select jsonb_agg(elem)
+from unnest($1) as elem
+where elem is not null
+$$;
+
+/* Update is wrapped in a function so it only runs when flag columns still exist */
+create function update_object_type_columns_to_jsonb() returns void as
+$$
+begin
+    perform column_name from information_schema.columns where table_name= 'attribute' and column_name = 'dataelementattribute';
+    if found then
+        /* aggregate columns to new jsonb column (only true remains) */
+        update attribute set objecttypes = jsonb_build_array_without_nulls(
+                case when dataelementattribute = true then 'DATA_ELEMENT' end,
+                case when indicatorattribute = true then 'INDICATOR' end,
+                case when organisationunitattribute = true then 'ORGANISATION_UNIT' end,
+                case when userattribute = true then 'USER' end,
+                case when dataelementgroupattribute = true then 'DATA_ELEMENT_GROUP' end,
+                case when indicatorgroupattribute = true then 'INDICATOR_GROUP' end,
+                case when organisationunitgroupattribute = true then 'ORGANISATION_UNIT_GROUP' end,
+                case when usergroupattribute = true then 'USER_GROUP' end,
+                case when datasetattribute = true then 'DATA_SET' end,
+                case when organisationunitgroupsetattribute = true then 'ORGANISATION_UNIT_GROUP_SET' end,
+                case when programattribute = true then 'PROGRAM' end,
+                case when programstageattribute = true then 'PROGRAM_STAGE' end,
+                case when trackedentitytypeattribute = true then 'TRACKED_ENTITY_TYPE' end,
+                case when trackedentityattributeattribute = true then 'TRACKED_ENTITY_ATTRIBUTE' end,
+                case when categoryoptionattribute = true then 'CATEGORY_OPTION' end,
+                case when categoryoptiongroupattribute = true then 'CATEGORY_OPTION_GROUP' end,
+                case when documentattribute = true then 'DOCUMENT' end,
+                case when optionattribute = true then 'OPTION' end,
+                case when optionsetattribute = true then 'OPTION_SET' end,
+                case when constantattribute = true then 'CONSTANT' end,
+                case when legendsetattribute = true then 'LEGEND_SET' end,
+                case when programindicatorattribute = true then 'PROGRAM_INDICATOR' end,
+                case when sqlviewattribute = true then 'SQL_VIEW' end,
+                case when sectionattribute = true then 'SECTION' end,
+                case when categoryoptioncomboattribute = true then 'CATEGORY_OPTION_COMBO' end,
+                case when categoryoptiongroupsetattribute = true then 'CATEGORY_OPTION_GROUP_SET' end,
+                case when dataelementgroupsetattribute = true then 'DATA_ELEMENT_GROUP_SET' end,
+                case when validationruleattribute = true then 'VALIDATION_RULE' end,
+                case when validationrulegroupattribute = true then 'VALIDATION_RULE_GROUP' end,
+                case when categoryattribute = true then 'CATEGORY' end,
+                case when visualizationattribute = true then 'VISUALIZATION' end,
+                case when mapattribute = true then 'MAP' end,
+                case when eventreportattribute = true then 'EVENT_REPORT' end,
+                case when eventchartattribute = true then 'EVENT_CHART' end,
+                case when relationshiptypeattribute = true then 'RELATIONSHIP_TYPE' end
+            )
+        where 1=1;
+    end if;
+end;
+$$ language plpgsql;
+/* run the update*/
+select update_object_type_columns_to_jsonb();
+/* clean up the update function */
+drop function if exists update_object_type_columns_to_jsonb();
+
+/* make new column not null now that all have a jsonb value */
+alter table attribute alter column objecttypes set not null;
+
+/* drop all the flag columns*/
+alter table attribute
+    drop column if exists dataelementattribute,
+    drop column if exists indicatorattribute,
+    drop column if exists organisationunitattribute,
+    drop column if exists userattribute,
+    drop column if exists dataelementgroupattribute,
+    drop column if exists indicatorgroupattribute,
+    drop column if exists organisationunitgroupattribute,
+    drop column if exists usergroupattribute,
+    drop column if exists datasetattribute,
+    drop column if exists organisationunitgroupsetattribute,
+    drop column if exists programattribute,
+    drop column if exists programstageattribute,
+    drop column if exists trackedentitytypeattribute,
+    drop column if exists trackedentityattributeattribute,
+    drop column if exists categoryoptionattribute,
+    drop column if exists categoryoptiongroupattribute,
+    drop column if exists documentattribute,
+    drop column if exists optionattribute,
+    drop column if exists optionsetattribute,
+    drop column if exists constantattribute,
+    drop column if exists legendsetattribute,
+    drop column if exists programindicatorattribute,
+    drop column if exists sqlviewattribute,
+    drop column if exists sectionattribute,
+    drop column if exists categoryoptioncomboattribute,
+    drop column if exists categoryoptiongroupsetattribute,
+    drop column if exists dataelementgroupsetattribute,
+    drop column if exists validationruleattribute,
+    drop column if exists validationrulegroupattribute,
+    drop column if exists categoryattribute,
+    drop column if exists visualizationattribute,
+    drop column if exists mapattribute,
+    drop column if exists eventreportattribute,
+    drop column if exists eventchartattribute,
+    drop column if exists relationshiptypeattribute;

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
@@ -65,6 +65,8 @@ public class DhisPostgresDialect
             new StandardSQLFunction( JsonbFunctions.CHECK_USER_ACCESS, StandardBasicTypes.BOOLEAN ) );
         registerFunction( JsonbFunctions.REGEXP_SEARCH,
             new StandardSQLFunction( JsonbFunctions.REGEXP_SEARCH, StandardBasicTypes.BOOLEAN ) );
+        registerFunction( "jsonb_exists_any",
+            new StandardSQLFunction( "jsonb_exists_any", StandardBasicTypes.BOOLEAN ) );
         registerFunction( "array_agg",
             new StandardSQLFunction( "array_agg", StringArrayType.INSTANCE ) );
     }

--- a/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
+++ b/dhis-2/dhis-support/dhis-support-hibernate/src/main/java/org/hisp/dhis/hibernate/dialect/DhisPostgresDialect.java
@@ -65,8 +65,6 @@ public class DhisPostgresDialect
             new StandardSQLFunction( JsonbFunctions.CHECK_USER_ACCESS, StandardBasicTypes.BOOLEAN ) );
         registerFunction( JsonbFunctions.REGEXP_SEARCH,
             new StandardSQLFunction( JsonbFunctions.REGEXP_SEARCH, StandardBasicTypes.BOOLEAN ) );
-        registerFunction( "jsonb_exists_any",
-            new StandardSQLFunction( "jsonb_exists_any", StandardBasicTypes.BOOLEAN ) );
         registerFunction( "array_agg",
             new StandardSQLFunction( "array_agg", StringArrayType.INSTANCE ) );
     }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/attribute/AttributeStoreTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/attribute/AttributeStoreTest.java
@@ -34,59 +34,13 @@ import org.hisp.dhis.common.ValueType;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.indicator.IndicatorGroup;
-import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Morten Olav Hansen <mortenoh@gmail.com>
  */
-class AttributeStoreTest extends TransactionalIntegrationTest
+class AttributeStoreTest
 {
-
-    @Autowired
-    private AttributeStore attributeStore;
-
-    private Attribute atA;
-
-    private Attribute atB;
-
-    @Override
-    protected void setUpTest()
-    {
-        atA = new Attribute();
-        atA.setName( "attribute_simple" );
-        atA.setValueType( ValueType.TEXT );
-        atA.setIndicatorAttribute( true );
-        atA.setDataElementAttribute( true );
-        atB = new Attribute();
-        atB.setName( "attribute_with_options" );
-        atB.setValueType( ValueType.TEXT );
-        atB.setOrganisationUnitAttribute( true );
-        atB.setDataElementAttribute( true );
-        attributeStore.save( atA );
-        attributeStore.save( atB );
-    }
-
-    @Test
-    void testGetDataElementAttributes()
-    {
-        assertEquals( 2, attributeStore.getAttributes( DataElement.class ).size() );
-    }
-
-    @Test
-    void testGetIndicatorAttributes()
-    {
-        assertEquals( 1, attributeStore.getAttributes( Indicator.class ).size() );
-    }
-
-    @Test
-    void testGetOrganisationUnitAttributes()
-    {
-        assertEquals( 1, attributeStore.getAttributes( OrganisationUnit.class ).size() );
-    }
-
     @Test
     void testGetSupportedClasses()
     {
@@ -100,25 +54,5 @@ class AttributeStoreTest extends TransactionalIntegrationTest
         assertEquals( 2, attribute.getSupportedClasses().size() );
         assertTrue( attribute.getSupportedClasses().contains( Indicator.class ) );
         assertTrue( attribute.getSupportedClasses().contains( IndicatorGroup.class ) );
-    }
-
-    @Test
-    void testGetMandatoryAttributes()
-    {
-        Attribute attribute = new Attribute( "AttributeName", ValueType.TEXT );
-        attribute.setDataElementAttribute( true );
-        attribute.setMandatory( true );
-        attributeStore.save( attribute );
-        assertEquals( 1, attributeStore.getMandatoryAttributes( DataElement.class ).size() );
-    }
-
-    @Test
-    void testGetUniqueAttributes()
-    {
-        Attribute attribute = new Attribute( "AttributeName", ValueType.TEXT );
-        attribute.setDataElementAttribute( true );
-        attribute.setUnique( true );
-        attributeStore.save( attribute );
-        assertEquals( 1, attributeStore.getUniqueAttributes( DataElement.class ).size() );
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AttributeControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/AttributeControllerTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.hisp.dhis.attribute.Attribute.ObjectType;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
-import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.hisp.dhis.webapi.DhisControllerIntegrationTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
  *
  * @author Jan Bernitt
  */
-class AttributeControllerTest extends DhisControllerConvenienceTest
+class AttributeControllerTest extends DhisControllerIntegrationTest
 {
 
     /**


### PR DESCRIPTION
### Summary
Replaces all boolean attribute flag columns with a single JSONB column that holds a set (array) of the `enum` names representing those former columns that were `true`.

Note that the getter/setter had to use `Set<String>` when directly mapped from `jsonb` column type without a custom mapper. 

### Preheat
The preheat was using dedicated methods to get attribute lists per target object class. One request for any, one for mandatory and one for unique attributes associated with a particular object types. So a preheat with _N_ object types would do `N * 3` DB requests. Instead we now do a single request for all attributes independent of number of object types imported (preheated). 

### Automatic Testing
A test already existed testing each attribute type. It was just changed to be a postgres integration controller test to test full circle.

### Manual Testing
* create an attribute
* edit the object types it can be used with and select a single one
* add a attribute value to one of the target object types

Do the above for each of the possible object types.