### PR TITLE
fix: (PI) Return null instead of NaN [DHIS2-14704] (#12944)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/event/data/AbstractJdbcEventAnalyticsManager.java
@@ -417,17 +417,7 @@ public abstract class AbstractJdbcEventAnalyticsManager
                     getAnalyticsType(), params.getEarliestStartDate(), params.getLatestEndDate() );
             }
 
-            if ( queryItem.getValueType() == ValueType.NUMBER )
-            {
-                return ColumnAndAlias.ofColumnAndAlias(
-                    coalesceAsDoubleNan( programIndicatorSubquery ),
-                    asClause );
-            }
-            else
-            {
-                return ColumnAndAlias.ofColumnAndAlias( programIndicatorSubquery, asClause );
-            }
-
+            return ColumnAndAlias.ofColumnAndAlias( programIndicatorSubquery, asClause );
         }
         else if ( ValueType.COORDINATE == queryItem.getValueType() )
         {
@@ -449,18 +439,13 @@ public abstract class AbstractJdbcEventAnalyticsManager
             ColumnAndAlias columnAndAlias = getColumnAndAlias( queryItem, isAggregated, queryItem.getItemName() );
 
             return ColumnAndAlias.ofColumnAndAlias(
-                coalesceAsDoubleNan( columnAndAlias.getColumn() ),
+                columnAndAlias.getColumn(),
                 defaultIfNull( columnAndAlias.getAlias(), queryItem.getItemName() ) );
         }
         else
         {
             return getColumnAndAlias( queryItem, isGroupByClause, "" );
         }
-    }
-
-    protected String coalesceAsDoubleNan( String column )
-    {
-        return "coalesce(" + column + ", double precision 'NaN')";
     }
 
     private ColumnAndAlias getColumnAndAlias( QueryItem queryItem, boolean isGroupByClause, String aliasIfMissing )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/test/java/org/hisp/dhis/analytics/event/data/EnrollmentAnalyticsManagerTest.java
@@ -198,7 +198,7 @@ class EnrollmentAnalyticsManagerTest extends
 
         if ( valueType == ValueType.NUMBER )
         {
-            subSelect = "coalesce(" + subSelect + ", double precision 'NaN') as \"fWIAEtYVEGk\"";
+            subSelect = subSelect + " as \"fWIAEtYVEGk\"";
         }
         String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect + "  from " + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) " + "and ps = '"
@@ -262,8 +262,8 @@ class EnrollmentAnalyticsManagerTest extends
             + programA.getUid() + ".pi = ax.pi and \"fWIAEtYVEGk\" is not null and ps = '"
             + programStage.getUid() + "' order by executiondate desc limit 1 )";
 
-        String expected = "ax.\"monthly\",ax.\"ou\"," + "coalesce(" + subSelect
-            + ", double precision 'NaN') as \"fWIAEtYVEGk\"" + "  from "
+        String expected = "ax.\"monthly\",ax.\"ou\"," + subSelect
+            + " as \"fWIAEtYVEGk\"" + "  from "
             + getTable( programA.getUid() )
             + " as ax where ax.\"monthly\" in ('2000Q1') and (uidlevel1 = 'ouabcdefghA' ) "
             + "and ps = '" + programStage.getUid() + "' and " + subSelect + " > '10' limit 10001";
@@ -380,7 +380,7 @@ class EnrollmentAnalyticsManagerTest extends
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "ax.\"monthly\",ax.\"ou\",coalesce((SELECT avg (" + piSubquery + ") FROM analytics_event_"
+        String expected = "ax.\"monthly\",ax.\"ou\",(SELECT avg (" + piSubquery + ") FROM analytics_event_"
             + programA.getUid().toLowerCase() + " as subax WHERE  "
             + "subax.tei in (select tei.uid from trackedentityinstance tei " +
             "LEFT JOIN relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid  " +
@@ -389,7 +389,7 @@ class EnrollmentAnalyticsManagerTest extends
             "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid " +
             "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid " +
             "WHERE rty.relationshiptypeid = " + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
+            + " AND tei.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
             + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel1 = 'ouabcdefghA' ) limit 101";
@@ -421,7 +421,7 @@ class EnrollmentAnalyticsManagerTest extends
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "ax.\"monthly\",ax.\"ou\",coalesce((SELECT avg (" + piSubquery + ") FROM analytics_event_"
+        String expected = "ax.\"monthly\",ax.\"ou\",(SELECT avg (" + piSubquery + ") FROM analytics_event_"
             + programA.getUid().toLowerCase() + " as subax WHERE "
             + " subax.tei in (select tei.uid from trackedentityinstance tei LEFT JOIN relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid  "
             +
@@ -430,7 +430,7 @@ class EnrollmentAnalyticsManagerTest extends
             "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid " +
             "LEFT JOIN programinstance pi on pi.programinstanceid = ri2.programinstanceid WHERE rty.relationshiptypeid "
             +
-            "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi )), double precision 'NaN')" + " as \""
+            "= " + relationshipTypeA.getId() + " AND pi.uid = ax.pi ))" + " as \""
             + programIndicatorA.getUid() + "\"  "
             + "from analytics_enrollment_" + programA.getUid()
             + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel1 = 'ouabcdefghA' ) limit 101";
@@ -492,7 +492,7 @@ class EnrollmentAnalyticsManagerTest extends
 
         verify( jdbcTemplate ).queryForRowSet( sql.capture() );
 
-        String expected = "ax.\"monthly\",ax.\"ou\",coalesce((SELECT avg (" + piSubquery + ") FROM analytics_event_"
+        String expected = "ax.\"monthly\",ax.\"ou\",(SELECT avg (" + piSubquery + ") FROM analytics_event_"
             + programB.getUid().toLowerCase() + " as subax WHERE  "
             + "subax.tei in (select tei.uid from trackedentityinstance tei " +
             "LEFT JOIN relationshipitem ri on tei.trackedentityinstanceid = ri.trackedentityinstanceid  " +
@@ -501,7 +501,7 @@ class EnrollmentAnalyticsManagerTest extends
             "LEFT JOIN relationshiptype rty on rty.relationshiptypeid = r.relationshiptypeid " +
             "LEFT JOIN trackedentityinstance tei on tei.trackedentityinstanceid = ri2.trackedentityinstanceid " +
             "WHERE rty.relationshiptypeid = " + relationshipTypeA.getId()
-            + " AND tei.uid = ax.tei )), double precision 'NaN') as \""
+            + " AND tei.uid = ax.tei )) as \""
             + programIndicatorA.getUid()
             + "\"  " + "from analytics_enrollment_" + programA.getUid()
             + " as ax where enrollmentdate >= '2015-01-01' and enrollmentdate < '2017-04-09' and (uidlevel1 = 'ouabcdefghA' ) limit 101";


### PR DESCRIPTION
**[Backporting from 2.40/master]**

When a PI expression results in 'NaN', filters like `is not null`, `greater than`, etc. do not work correctly.
It happens because currently, the filter is compared against 'NaN' value, which always evaluates true for such kinds of filters.

In analytics queries, null and 'NaN' values are always replaced by empty at response time.