### PR TITLE
feat: Add outputIdScheme parameter to source data endpoints [DHIS2-14061]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -150,6 +150,7 @@ public class AggregateDataExchangeService
      * identifier.
      *
      * @param uid the {@link AggregateDataExchange} identifier.
+     * @param params the {@link SourceDataQueryParams}.
      * @return the source data for the analytics data exchange.
      */
     public List<Grid> getSourceData( String uid, SourceDataQueryParams params )
@@ -165,6 +166,7 @@ public class AggregateDataExchangeService
      * the given identifier.
      *
      * @param uid the {@link AggregateDataExchange} identifier.
+     * @param params the {@link SourceDataQueryParams}.
      * @return the source data value sets for the analytics data exchange.
      */
     public List<DataValueSet> getSourceDataValueSets( String uid, SourceDataQueryParams params )

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeService.java
@@ -43,6 +43,7 @@ import javax.annotation.Nonnull;
 
 import lombok.RequiredArgsConstructor;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.hisp.dhis.analytics.AnalyticsService;
 import org.hisp.dhis.analytics.DataQueryParams;
 import org.hisp.dhis.analytics.DataQueryService;
@@ -151,12 +152,12 @@ public class AggregateDataExchangeService
      * @param uid the {@link AggregateDataExchange} identifier.
      * @return the source data for the analytics data exchange.
      */
-    public List<Grid> getSourceData( String uid )
+    public List<Grid> getSourceData( String uid, SourceDataQueryParams params )
     {
         AggregateDataExchange exchange = aggregateDataExchangeStore.loadByUid( uid );
 
         return mapToList( exchange.getSource().getRequests(),
-            request -> analyticsService.getAggregatedDataValues( toDataQueryParams( request ) ) );
+            request -> analyticsService.getAggregatedDataValues( toDataQueryParams( request, params ) ) );
     }
 
     /**
@@ -166,12 +167,12 @@ public class AggregateDataExchangeService
      * @param uid the {@link AggregateDataExchange} identifier.
      * @return the source data value sets for the analytics data exchange.
      */
-    public List<DataValueSet> getSourceDataValueSets( String uid )
+    public List<DataValueSet> getSourceDataValueSets( String uid, SourceDataQueryParams params )
     {
         AggregateDataExchange exchange = aggregateDataExchangeStore.loadByUid( uid );
 
         return mapToList( exchange.getSource().getRequests(),
-            request -> analyticsService.getAggregatedDataValueSet( toDataQueryParams( request ) ) );
+            request -> analyticsService.getAggregatedDataValueSet( toDataQueryParams( request, params ) ) );
     }
 
     /**
@@ -187,7 +188,8 @@ public class AggregateDataExchangeService
     {
         try
         {
-            DataValueSet dataValueSet = analyticsService.getAggregatedDataValueSet( toDataQueryParams( request ) );
+            DataValueSet dataValueSet = analyticsService
+                .getAggregatedDataValueSet( toDataQueryParams( request, new SourceDataQueryParams() ) );
 
             return exchange.getTarget().getType() == TargetType.INTERNAL ? pushToInternal( exchange, dataValueSet )
                 : pushToExternal( exchange, dataValueSet );
@@ -272,14 +274,17 @@ public class AggregateDataExchangeService
      * {@link SourceRequest}.
      *
      * @param request the {@link SourceRequest}.
+     * @param params the {@link SourceDataQueryParams}.
      * @return the {@link DataQueryParams}.
      */
-    DataQueryParams toDataQueryParams( SourceRequest request )
+    DataQueryParams toDataQueryParams( SourceRequest request, SourceDataQueryParams params )
     {
+        String queryOutputIdScheme = params.getOutputIdScheme();
+
         IdScheme inputIdScheme = toIdSchemeOrDefault( request.getInputIdScheme() );
-        IdScheme outputDataElementIdScheme = toIdScheme( request.getOutputDataElementIdScheme() );
-        IdScheme outputOrgUnitIdScheme = toIdScheme( request.getOutputOrgUnitIdScheme() );
-        IdScheme outputIdScheme = toIdScheme( request.getOutputIdScheme() );
+        IdScheme outputDataElementIdScheme = toIdScheme( queryOutputIdScheme, request.getOutputDataElementIdScheme() );
+        IdScheme outputOrgUnitIdScheme = toIdScheme( queryOutputIdScheme, request.getOutputOrgUnitIdScheme() );
+        IdScheme outputIdScheme = toIdScheme( queryOutputIdScheme, request.getOutputIdScheme() );
 
         List<DimensionalObject> filters = mapToList(
             request.getFilters(), f -> toDimensionalObject( f, inputIdScheme ) );
@@ -323,14 +328,17 @@ public class AggregateDataExchangeService
     }
 
     /**
-     * Returns the {@link IdScheme} based on the given ID scheme string, or null
-     * if the given ID scheme string is null.
+     * Returns the {@link IdScheme} based on the given ID scheme strings. The
+     * first non-null value will be used. Returns null if all of the given ID
+     * scheme strings are null.
      *
-     * @param idScheme the ID scheme string.
-     * @return the given ID scheme, or null if null.
+     * @param idSchemes the ID scheme strings.
+     * @return the given ID scheme, or null.
      */
-    IdScheme toIdScheme( String idScheme )
+    IdScheme toIdScheme( String... idSchemes )
     {
+        String idScheme = ObjectUtils.firstNonNull( idSchemes );
+
         return idScheme != null ? IdScheme.from( idScheme ) : null;
     }
 

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/SourceDataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/SourceDataQueryParams.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.dataexchange.aggregate;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors( chain = true )
+@ToString
+@NoArgsConstructor
+public class SourceDataQueryParams
+{
+    private String outputIdScheme;
+}

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/SourceDataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/main/java/org/hisp/dhis/dataexchange/aggregate/SourceDataQueryParams.java
@@ -30,13 +30,11 @@ package org.hisp.dhis.dataexchange.aggregate;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 import lombok.experimental.Accessors;
 
 @Getter
 @Setter
 @Accessors( chain = true )
-@ToString
 @NoArgsConstructor
 public class SourceDataQueryParams
 {

--- a/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
+++ b/dhis-2/dhis-services/dhis-service-data-exchange/src/test/java/org/hisp/dhis/dataexchange/aggregate/AggregateDataExchangeServiceTest.java
@@ -159,12 +159,21 @@ class AggregateDataExchangeServiceTest
             .setOutputOrgUnitIdScheme( IdScheme.CODE.name() )
             .setOutputIdScheme( IdScheme.CODE.name() );
 
-        DataQueryParams query = service.toDataQueryParams( sourceRequest );
+        DataQueryParams query = service.toDataQueryParams( sourceRequest, new SourceDataQueryParams() );
 
         assertTrue( query.hasDimension( DimensionalObject.DATA_X_DIM_ID ) );
         assertTrue( query.hasDimension( DimensionalObject.PERIOD_DIM_ID ) );
         assertTrue( query.hasDimension( DimensionalObject.ORGUNIT_DIM_ID ) );
         assertEquals( IdScheme.UID, query.getOutputDataElementIdScheme() );
+        assertEquals( IdScheme.CODE, query.getOutputOrgUnitIdScheme() );
+        assertEquals( IdScheme.CODE, query.getOutputIdScheme() );
+
+        SourceDataQueryParams params = new SourceDataQueryParams()
+            .setOutputIdScheme( IdScheme.CODE.name() );
+
+        query = service.toDataQueryParams( sourceRequest, params );
+
+        assertEquals( IdScheme.CODE, query.getOutputDataElementIdScheme() );
         assertEquals( IdScheme.CODE, query.getOutputOrgUnitIdScheme() );
         assertEquals( IdScheme.CODE, query.getOutputIdScheme() );
     }
@@ -217,10 +226,16 @@ class AggregateDataExchangeServiceTest
     @Test
     void testToIdScheme()
     {
+        String undefined = null;
+
         assertEquals( IdScheme.CODE, service.toIdScheme( "code" ) );
         assertEquals( IdScheme.UID, service.toIdScheme( "UID" ) );
         assertEquals( IdScheme.UID, service.toIdScheme( "uid" ) );
-        assertNull( service.toIdScheme( null ) );
+        assertEquals( IdScheme.UID, service.toIdScheme( "uid" ) );
+        assertEquals( IdScheme.UID, service.toIdScheme( undefined, "uid" ) );
+        assertEquals( IdScheme.UID, service.toIdScheme( undefined, undefined, "uid" ) );
+        assertNull( service.toIdScheme( undefined ) );
+        assertNull( service.toIdScheme( undefined, undefined ) );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AggregateDataExchangeController.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchange;
 import org.hisp.dhis.dataexchange.aggregate.AggregateDataExchangeService;
+import org.hisp.dhis.dataexchange.aggregate.SourceDataQueryParams;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
 import org.hisp.dhis.dxf2.importsummary.ImportSummaries;
 import org.hisp.dhis.scheduling.NoopJobProgress;
@@ -79,15 +80,15 @@ public class AggregateDataExchangeController
 
     @GetMapping( "/{uid}/sourceData" )
     @ResponseStatus( value = HttpStatus.OK )
-    public List<Grid> getSourceData( @PathVariable String uid )
+    public List<Grid> getSourceData( @PathVariable String uid, SourceDataQueryParams params )
     {
-        return service.getSourceData( uid );
+        return service.getSourceData( uid, params );
     }
 
     @GetMapping( "/{uid}/sourceDataValueSets" )
     @ResponseStatus( value = HttpStatus.OK )
-    public List<DataValueSet> getSourceDataValueSets( @PathVariable String uid )
+    public List<DataValueSet> getSourceDataValueSets( @PathVariable String uid, SourceDataQueryParams params )
     {
-        return service.getSourceDataValueSets( uid );
+        return service.getSourceDataValueSets( uid, params );
     }
 }


### PR DESCRIPTION
Adds an `outputIdScheme` parameter to source data endpoints, to allow clients/apps to override the output ID scheme.

This is needed by the data exchange app to render the data preview correctly by matching the data to the metadata.