### PR TITLE
fix: Return events if explicit fields are provided [DHIS2-14720]

### DIFF
--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/acl/TrackedEntityInstanceAclReadTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/acl/TrackedEntityInstanceAclReadTests.java
@@ -50,6 +50,7 @@ import org.hisp.dhis.helpers.QueryParamsBuilder;
 import org.hisp.dhis.helpers.models.User;
 import org.hisp.dhis.tracker.TrackerApiTest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -243,6 +244,35 @@ public class TrackedEntityInstanceAclReadTests
         json.getAsJsonArray( "trackedEntityInstances" ).iterator()
             .forEachRemaining( ( teiJson ) -> assertTrackedEntityInstance( user, teiJson.getAsJsonObject() ) );
 
+    }
+
+    @Test
+    void shouldReturnEventsWhenExplicitFieldsAreProvided()
+    {
+        User user = users.stream().findFirst().orElseThrow( () -> new RuntimeException( "User UID not found for test" ) );
+        new LoginActions().loginAsUser( user.getUsername(), user.getPassword() );
+
+        QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
+        queryParamsBuilder.addAll( "trackedEntityInstance=VROP0n2v145", "fields=enrollments[events[dueDate]]" );
+
+        ApiResponse response = teiActions.get( "/", queryParamsBuilder );
+
+        response.validate().statusCode( 200 );
+        response.validate().body( "trackedEntityInstances", Matchers.not( Matchers.emptyArray() ) );
+
+        JsonObject tei = response.getBody().getAsJsonArray("trackedEntityInstances").get(0).getAsJsonObject();
+        assertTrue( tei.has( "enrollments" ) );
+
+        JsonArray enrollmentsArray = tei.getAsJsonArray( "enrollments" );
+        assertEquals(1, enrollmentsArray.size());
+        assertTrue(enrollmentsArray.get(0).getAsJsonObject().has("events"));
+
+        JsonArray eventsArray = enrollmentsArray.get(0).getAsJsonObject().getAsJsonArray("events");
+        assertEquals(2, eventsArray.size());
+        assertTrue(eventsArray.get(0).getAsJsonObject().has("dueDate"));
+        assertEquals("2020-04-24T00:00:00.000", eventsArray.get(0).getAsJsonObject().get("dueDate").getAsString());
+        assertTrue(eventsArray.get(1).getAsJsonObject().has("dueDate"));
+        assertEquals("2020-04-24T00:00:00.000", eventsArray.get(1).getAsJsonObject().get("dueDate").getAsString());
     }
 
     /* Helper methods */

--- a/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/acl/TrackedEntityInstanceAclReadTests.java
+++ b/dhis-2/dhis-e2e-test/src/test/java/org/hisp/dhis/tracker/acl/TrackedEntityInstanceAclReadTests.java
@@ -249,7 +249,8 @@ public class TrackedEntityInstanceAclReadTests
     @Test
     void shouldReturnEventsWhenExplicitFieldsAreProvided()
     {
-        User user = users.stream().findFirst().orElseThrow( () -> new RuntimeException( "User UID not found for test" ) );
+        User user = users.stream().findFirst()
+            .orElseThrow( () -> new RuntimeException( "User UID not found for test" ) );
         new LoginActions().loginAsUser( user.getUsername(), user.getPassword() );
 
         QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
@@ -260,19 +261,21 @@ public class TrackedEntityInstanceAclReadTests
         response.validate().statusCode( 200 );
         response.validate().body( "trackedEntityInstances", Matchers.not( Matchers.emptyArray() ) );
 
-        JsonObject tei = response.getBody().getAsJsonArray("trackedEntityInstances").get(0).getAsJsonObject();
+        JsonObject tei = response.getBody().getAsJsonArray( "trackedEntityInstances" ).get( 0 ).getAsJsonObject();
         assertTrue( tei.has( "enrollments" ) );
 
         JsonArray enrollmentsArray = tei.getAsJsonArray( "enrollments" );
-        assertEquals(1, enrollmentsArray.size());
-        assertTrue(enrollmentsArray.get(0).getAsJsonObject().has("events"));
+        assertEquals( 1, enrollmentsArray.size() );
+        assertTrue( enrollmentsArray.get( 0 ).getAsJsonObject().has( "events" ) );
 
-        JsonArray eventsArray = enrollmentsArray.get(0).getAsJsonObject().getAsJsonArray("events");
-        assertEquals(2, eventsArray.size());
-        assertTrue(eventsArray.get(0).getAsJsonObject().has("dueDate"));
-        assertEquals("2020-04-24T00:00:00.000", eventsArray.get(0).getAsJsonObject().get("dueDate").getAsString());
-        assertTrue(eventsArray.get(1).getAsJsonObject().has("dueDate"));
-        assertEquals("2020-04-24T00:00:00.000", eventsArray.get(1).getAsJsonObject().get("dueDate").getAsString());
+        JsonArray eventsArray = enrollmentsArray.get( 0 ).getAsJsonObject().getAsJsonArray( "events" );
+        assertEquals( 2, eventsArray.size() );
+        assertTrue( eventsArray.get( 0 ).getAsJsonObject().has( "dueDate" ) );
+        assertEquals( "2020-04-24T00:00:00.000",
+            eventsArray.get( 0 ).getAsJsonObject().get( "dueDate" ).getAsString() );
+        assertTrue( eventsArray.get( 1 ).getAsJsonObject().has( "dueDate" ) );
+        assertEquals( "2020-04-24T00:00:00.000",
+            eventsArray.get( 1 ).getAsJsonObject().get( "dueDate" ).getAsString() );
     }
 
     /* Helper methods */

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/event/TrackedEntityInstanceController.java
@@ -572,7 +572,7 @@ public class TrackedEntityInstanceController
 
         if ( joined.contains( "events" ) )
         {
-            params.withTeiEnrollmentParams(
+            params = params.withTeiEnrollmentParams(
                 params.getTeiEnrollmentParams().withIncludeEvents( true ) );
         }
 


### PR DESCRIPTION
Fix to return events in case explicit fields are provided, like `fields=enrollments[events[dueDate]]`

https://dhis2.atlassian.net/browse/DHIS2-14720