### PR TITLE
ci: don't login to Dockerhub master api tests

### DIFF
--- a/.github/workflows/run-api-tests.yml
+++ b/.github/workflows/run-api-tests.yml
@@ -31,7 +31,7 @@ jobs:
           cache: maven
 
       - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_PUSH }}
+        if: ${{ env.DOCKERHUB_PUSH == 'true' }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DHIS2_BOT_DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
DOCKERHUB_PUSH env contains a string 'false' which is considered truthy by JS I assume JS is powering the action underneath. So true && 'false' resulted in 'false' in the if of the step. Since 'false' is truthy we did log in