### PR TITLE
feat: add IdObjectDeletionHandler for users [DHIS2-13470]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectManager.java
@@ -82,6 +82,17 @@ public interface IdentifiableObjectManager
     Optional<? extends IdentifiableObject> find( @Nonnull String uid );
 
     /**
+     * Look up objects which have property createdBy or lastUpdatedBy linked to
+     * given {@link User}
+     *
+     * @param type the object class type.
+     * @param user the User which is linked to createdBy or lastUpdatedBy
+     *        property.
+     * @return The list of {@link IdentifiableObject} found
+     */
+    <T extends IdentifiableObject> List<T> findByUser( Class<T> type, @Nonnull User user );
+
+    /**
      * Lookup objects of a specific type by database ID.
      *
      * @param type the object class type.

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/IdentifiableObjectStore.java
@@ -431,4 +431,31 @@ public interface IdentifiableObjectStore<T>
      * Remove given UserGroup UID from all sharing records in database
      */
     void removeUserGroupFromSharing( @Nonnull String userGroupUID, @Nonnull String tableName );
+
+    /**
+     * Look up list objects which have property createdBy or lastUpdatedBy
+     * linked to given {@link User}
+     *
+     * @param user the {@link User} for filtering
+     * @return List of objects found.
+     */
+    List<T> findByUser( @Nonnull User user );
+
+    /**
+     * Look up list objects which have property lastUpdatedBy linked to given
+     * {@link User}
+     *
+     * @param user the {@link User} for filtering
+     * @return List of objects found.
+     */
+    List<T> findByLastUpdatedBy( @Nonnull User user );
+
+    /**
+     * Look up list objects which have property createdBy linked to given
+     * {@link User}
+     *
+     * @param user the {@link User} for filtering
+     * @return List of objects found.
+     */
+    List<T> findByCreatedBy( @Nonnull User user );
 }

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/BaseIdentifiableObject_.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/adapter/BaseIdentifiableObject_.java
@@ -37,6 +37,8 @@ public class BaseIdentifiableObject_
 {
     public static final String CREATED_BY = "createdBy";
 
+    public static final String LAST_UPDATED_BY = "lastUpdatedBy";
+
     public static final String TRANSLATIONS = "translations";
 
     public static final String SHARING = "sharing";

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryComboDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryComboDeletionHandler.java
@@ -29,26 +29,23 @@ package org.hisp.dhis.category;
 
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class CategoryComboDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class CategoryComboDeletionHandler extends IdObjectDeletionHandler<CategoryCombo>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     private final CategoryService categoryService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( Category.class, this::allowDeleteCategory );
         whenDeleting( CategoryOptionCombo.class, this::deleteCategoryOptionCombo );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.category;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Dang Duy Hieu
  */
 @Component
-@AllArgsConstructor
-public class CategoryDeletionHandler extends DeletionHandler
+public class CategoryDeletionHandler extends IdObjectDeletionHandler<Category>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( CategoryOption.class, this::deleteCategoryOption );
         whenDeleting( CategoryCombo.class, this::deleteCategoryCombo );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionComboDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionComboDeletionHandler.java
@@ -32,27 +32,25 @@ import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 import java.util.Iterator;
 import java.util.Map;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class CategoryOptionComboDeletionHandler extends JdbcDeletionHandler
+@RequiredArgsConstructor
+public class CategoryOptionComboDeletionHandler extends IdObjectDeletionHandler<CategoryOptionCombo>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( CategoryOptionCombo.class );
-
     private final CategoryService categoryService;
 
     // TODO expressionoptioncombo
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( CategoryOption.class, this::allowDeleteCategoryOption );
         whenVetoing( CategoryCombo.class, this::allowDeleteCategoryCombo );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionDeletionHandler.java
@@ -27,24 +27,18 @@
  */
 package org.hisp.dhis.category;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class CategoryOptionDeletionHandler extends DeletionHandler
+public class CategoryOptionDeletionHandler extends IdObjectDeletionHandler<CategoryOption>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Category.class, this::deleteCategory );
         whenDeleting( OrganisationUnit.class, this::deleteOrgUnit );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupDeletionHandler.java
@@ -27,23 +27,23 @@
  */
 package org.hisp.dhis.category;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class CategoryOptionGroupDeletionHandler
-    extends DeletionHandler
+    extends IdObjectDeletionHandler<CategoryOptionGroup>
 {
     private final CategoryService categoryService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( CategoryOption.class, this::deleteCategoryOption );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/category/CategoryOptionGroupSetDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.category;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Chau Thu Tran
  */
 @Component
-@AllArgsConstructor
-public class CategoryOptionGroupSetDeletionHandler extends DeletionHandler
+public class CategoryOptionGroupSetDeletionHandler extends IdObjectDeletionHandler<CategoryOptionGroupSet>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( CategoryOptionGroup.class, this::deleteCategoryOptionGroup );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/GenericAnalyticalObjectDeletionHandler.java
@@ -44,14 +44,14 @@ import org.hisp.dhis.organisationunit.OrganisationUnitGroupSet;
 import org.hisp.dhis.organisationunit.OrganisationUnitGroupSetDimension;
 import org.hisp.dhis.period.Period;
 import org.hisp.dhis.program.ProgramIndicator;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 
 /**
  * @author Lars Helge Overland
  */
 public abstract class GenericAnalyticalObjectDeletionHandler<T extends BaseAnalyticalObject, S extends AnalyticalObjectService<T>>
-    extends DeletionHandler
+    extends IdObjectDeletionHandler<T>
 {
 
     protected final DeletionVeto veto;
@@ -108,7 +108,7 @@ public abstract class GenericAnalyticalObjectDeletionHandler<T extends BaseAnaly
         {
             if ( analyticalObject.getPeriods().contains( period ) )
             {
-                return veto;
+                return VETO;
             }
         }
 

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/common/hibernate/HibernateIdentifiableObjectStore.java
@@ -874,6 +874,57 @@ public class HibernateIdentifiableObjectStore<T extends BaseIdentifiableObject>
     }
 
     /**
+     * Look up list objects which have property createdBy or lastUpdatedBy
+     * linked to given {@link User}
+     *
+     * @param user the {@link User} for filtering
+     * @return List of objects found.
+     */
+    @Override
+    public List<T> findByUser( @Nonnull User user )
+    {
+        CriteriaBuilder builder = getCriteriaBuilder();
+
+        return getListFromPartitions( builder, List.of( user ), 10000,
+            partition -> newJpaParameters()
+                .addPredicate( root -> builder.or( builder.equal( root.get( "createdBy" ), user ),
+                    builder.equal( root.get( "lastUpdatedBy" ), user ) ) ) );
+    }
+
+    /**
+     * Look up list objects which have property lastUpdatedBy linked to given
+     * {@link User}
+     *
+     * @param user the {@link User} for filtering
+     * @return List of objects found.
+     */
+    @Override
+    public List<T> findByLastUpdatedBy( @Nonnull User user )
+    {
+        CriteriaBuilder builder = getCriteriaBuilder();
+
+        return getListFromPartitions( builder, List.of( user ), 10000,
+            partition -> newJpaParameters()
+                .addPredicate( root -> builder.equal( root.get( "lastUpdatedBy" ), user ) ) );
+    }
+
+    /**
+     * Look up list objects which have property createdBy linked to given
+     * {@link User}
+     *
+     * @param user the {@link User} for filtering
+     * @return List of objects found.
+     */
+    @Override
+    public List<T> findByCreatedBy( @Nonnull User user )
+    {
+        CriteriaBuilder builder = getCriteriaBuilder();
+
+        return getListFromPartitions( builder, List.of( user ), 10000,
+            partition -> newJpaParameters().addPredicate( root -> builder.equal( root.get( "createdBy" ), user ) ) );
+    }
+
+    /**
      * Checks whether the given user has public access to the given identifiable
      * object.
      *

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevelDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalLevelDeletionHandler.java
@@ -31,19 +31,17 @@ import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionGroupSet;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Jim Grace
  */
 @Component
-public class DataApprovalLevelDeletionHandler extends JdbcDeletionHandler
+public class DataApprovalLevelDeletionHandler extends IdObjectDeletionHandler<DataApprovalLevel>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( DataApproval.class );
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( CategoryOptionGroupSet.class, this::allowDeleteCategoryOptionGroupSet );
         whenVetoing( DataApprovalWorkflow.class, this::allowDeleteDataApprovalWorkflow );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalWorkflowDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataapproval/DataApprovalWorkflowDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.dataapproval;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class DataApprovalWorkflowDeletionHandler extends DeletionHandler
+public class DataApprovalWorkflowDeletionHandler extends IdObjectDeletionHandler<DataApprovalWorkflow>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( DataApprovalLevel.class, this::deleteDataApprovalLevel );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementDeletionHandler.java
@@ -32,34 +32,29 @@ import static org.hisp.dhis.category.CategoryCombo.DEFAULT_CATEGORY_COMBO_NAME;
 import java.util.Iterator;
 import java.util.Map;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.dataset.DataSetElement;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.option.OptionSet;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class DataElementDeletionHandler extends JdbcDeletionHandler
+@RequiredArgsConstructor
+public class DataElementDeletionHandler extends IdObjectDeletionHandler<DataElement>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( DataElement.class );
-
-    private final IdentifiableObjectManager idObjectManager;
-
     private final CategoryService categoryService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( CategoryCombo.class, this::deleteCategoryCombo );
         whenDeleting( DataSet.class, this::deleteDataSet );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupDeletionHandler.java
@@ -29,8 +29,7 @@ package org.hisp.dhis.dataelement;
 
 import lombok.AllArgsConstructor;
 
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,12 +37,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @AllArgsConstructor
-public class DataElementGroupDeletionHandler extends DeletionHandler
+public class DataElementGroupDeletionHandler extends IdObjectDeletionHandler<DataElementGroup>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( DataElement.class, this::deleteDataElement );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementGroupSetDeletionHandler.java
@@ -29,8 +29,7 @@ package org.hisp.dhis.dataelement;
 
 import lombok.AllArgsConstructor;
 
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -38,12 +37,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @AllArgsConstructor
-public class DataElementGroupSetDeletionHandler extends DeletionHandler
+public class DataElementGroupSetDeletionHandler extends IdObjectDeletionHandler<DataElementGroupSet>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( DataElementGroup.class, this::deleteDataElementGroup );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementOperandDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataelement/DataElementOperandDeletionHandler.java
@@ -31,19 +31,17 @@ import java.util.Map;
 
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Jim Grace
  */
 @Component
-public class DataElementOperandDeletionHandler extends JdbcDeletionHandler
+public class DataElementOperandDeletionHandler extends IdObjectDeletionHandler<DataElementOperand>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( DataElementOperand.class );
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( CategoryOptionCombo.class, this::allowDeleteCategoryOptionCombo );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/DataSetDeletionHandler.java
@@ -33,35 +33,32 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataapproval.DataApprovalWorkflow;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.indicator.Indicator;
 import org.hisp.dhis.legend.LegendSet;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class DataSetDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class DataSetDeletionHandler extends IdObjectDeletionHandler<DataSet>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     private final DataSetService dataSetService;
 
     private final CategoryService categoryService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( DataElement.class, this::deleteDataElement );
         whenDeleting( Indicator.class, this::deleteIndicator );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/SectionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/dataset/SectionDeletionHandler.java
@@ -32,7 +32,7 @@ import java.util.Iterator;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,14 +40,14 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class SectionDeletionHandler extends DeletionHandler
+public class SectionDeletionHandler extends IdObjectDeletionHandler<Section>
 {
     private final SectionService sectionService;
 
     private final SectionStore sectionStore;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( DataElement.class, this::deleteDataElement );
         whenDeleting( DataSet.class, this::deleteDataSet );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventchart/EventChartDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventchart/EventChartDeletionHandler.java
@@ -54,7 +54,7 @@ public class EventChartDeletionHandler
     }
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         // generic
         whenDeleting( Period.class, this::deletePeriod );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventreport/EventReportDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventreport/EventReportDeletionHandler.java
@@ -54,7 +54,7 @@ public class EventReportDeletionHandler
     }
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         // generic
         whenDeleting( Period.class, this::deletePeriod );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/eventvisualization/EventVisualizationDeletionHandler.java
@@ -54,7 +54,7 @@ public class EventVisualizationDeletionHandler
     }
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         // generic
         whenDeleting( Period.class, this::deletePeriod );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorDeletionHandler.java
@@ -35,7 +35,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryOptionCombo;
@@ -43,23 +43,23 @@ import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.expression.ExpressionService;
 import org.hisp.dhis.legend.LegendSet;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class IndicatorDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class IndicatorDeletionHandler extends IdObjectDeletionHandler<Indicator>
 {
     private final IndicatorService indicatorService;
 
     private final ExpressionService expressionService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( IndicatorType.class, this::allowDeleteIndicatorType );
         whenDeleting( IndicatorGroup.class, this::deleteIndicatorGroup );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.indicator;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class IndicatorGroupDeletionHandler extends DeletionHandler
+public class IndicatorGroupDeletionHandler extends IdObjectDeletionHandler<IndicatorGroup>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Indicator.class, this::deleteIndicator );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/indicator/IndicatorGroupSetDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.indicator;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class IndicatorGroupSetDeletionHandler extends DeletionHandler
+public class IndicatorGroupSetDeletionHandler extends IdObjectDeletionHandler<IndicatorGroup>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( IndicatorGroup.class, this::deleteIndicatorGroup );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/legend/LegendSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/legend/LegendSetDeletionHandler.java
@@ -27,22 +27,22 @@
  */
 package org.hisp.dhis.legend;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class LegendSetDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class LegendSetDeletionHandler extends IdObjectDeletionHandler<LegendSet>
 {
     private final LegendSetService legendSetService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Legend.class, this::deleteLegend );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/MapViewDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/mapping/MapViewDeletionHandler.java
@@ -59,7 +59,7 @@ public class MapViewDeletionHandler
     }
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         // generic
         whenDeleting( Indicator.class, this::deleteIndicator );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/MessageConversationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/message/MessageConversationDeletionHandler.java
@@ -27,7 +27,7 @@
  */
 package org.hisp.dhis.message;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.user.User;
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Component;
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class MessageConversationDeletionHandler extends DeletionHandler
 {
     private final MessageService messageService;

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/OptionGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/option/OptionGroupDeletionHandler.java
@@ -29,22 +29,20 @@ package org.hisp.dhis.option;
 
 import java.util.List;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.hisp.dhis.system.deletion.DeletionHandler;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 @Component
-@AllArgsConstructor
-public class OptionGroupDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class OptionGroupDeletionHandler extends IdObjectDeletionHandler<OptionGroup>
 {
-    @Autowired
-    private OptionGroupStore optionGroupStore;
+    private final OptionGroupStore optionGroupStore;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Option.class, this::deleteOption );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitDeletionHandler.java
@@ -30,14 +30,11 @@ package org.hisp.dhis.organisationunit;
 import static java.util.stream.Collectors.joining;
 import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 
-import lombok.AllArgsConstructor;
-
 import org.hisp.dhis.common.BaseIdentifiableObject;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.hisp.dhis.user.User;
 import org.springframework.stereotype.Component;
 
@@ -45,13 +42,10 @@ import org.springframework.stereotype.Component;
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class OrganisationUnitDeletionHandler extends DeletionHandler
+public class OrganisationUnitDeletionHandler extends IdObjectDeletionHandler<OrganisationUnit>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( DataSet.class, this::deleteDataSet );
         whenDeleting( User.class, this::deleteUser );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.organisationunit;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class OrganisationUnitGroupDeletionHandler extends DeletionHandler
+public class OrganisationUnitGroupDeletionHandler extends IdObjectDeletionHandler<OrganisationUnitGroup>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( OrganisationUnit.class, this::deleteOrganisationUnit );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupSetDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnitGroupSetDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.organisationunit;
 
-import lombok.AllArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class OrganisationUnitGroupSetDeletionHandler extends DeletionHandler
+public class OrganisationUnitGroupSetDeletionHandler extends IdObjectDeletionHandler<OrganisationUnitGroup>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( OrganisationUnitGroup.class, this::deleteOrganisationUnitGroup );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/predictor/PredictorGroupDeletionHandler.java
@@ -27,23 +27,17 @@
  */
 package org.hisp.dhis.predictor;
 
-import lombok.RequiredArgsConstructor;
-
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Jim Grace
  */
 @Component
-@RequiredArgsConstructor
-public class PredictorGroupDeletionHandler extends DeletionHandler
+public class PredictorGroupDeletionHandler extends IdObjectDeletionHandler<PredictorGroup>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Predictor.class, this::deletePredictor );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramDeletionHandler.java
@@ -38,11 +38,10 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.category.CategoryCombo;
 import org.hisp.dhis.category.CategoryService;
-import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
 import org.hisp.dhis.user.UserRole;
@@ -53,18 +52,14 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramDeletionHandler extends DeletionHandler
+public class ProgramDeletionHandler extends IdObjectDeletionHandler<Program>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( Program.class );
-
     private final ProgramService programService;
-
-    private final IdentifiableObjectManager idObjectManager;
 
     private final CategoryService categoryService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( CategoryCombo.class, this::deleteCategoryCombo );
         whenDeleting( OrganisationUnit.class, this::deleteOrganisationUnit );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorDeletionHandler.java
@@ -30,22 +30,22 @@ package org.hisp.dhis.program;
 import java.util.Collection;
 import java.util.HashSet;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Chau Thu Tran
  */
 @Component
-@AllArgsConstructor
-public class ProgramIndicatorDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class ProgramIndicatorDeletionHandler extends IdObjectDeletionHandler<ProgramIndicator>
 {
     private final ProgramIndicatorService programIndicatorService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Program.class, this::deleteProgram );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorGroupDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramIndicatorGroupDeletionHandler.java
@@ -29,7 +29,7 @@ package org.hisp.dhis.program;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -37,12 +37,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramIndicatorGroupDeletionHandler extends DeletionHandler
+public class ProgramIndicatorGroupDeletionHandler extends IdObjectDeletionHandler<ProgramIndicatorGroup>
 {
     private final ProgramIndicatorService programIndicatorService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( ProgramIndicator.class, this::deleteProgramIndicator );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramInstanceDeletionHandler.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.springframework.stereotype.Component;
 
@@ -45,14 +45,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramInstanceDeletionHandler extends JdbcDeletionHandler
+public class ProgramInstanceDeletionHandler extends IdObjectDeletionHandler<ProgramInstance>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( ProgramInstance.class );
-
     private final ProgramInstanceService programInstanceService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( TrackedEntityInstance.class, this::deleteTrackedEntityInstance );
         whenVetoing( Program.class, this::allowDeleteProgram );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramNotificationInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramNotificationInstanceDeletionHandler.java
@@ -36,8 +36,8 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.program.notification.ProgramNotificationInstance;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceParam;
 import org.hisp.dhis.program.notification.ProgramNotificationInstanceService;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -46,14 +46,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class ProgramNotificationInstanceDeletionHandler extends DeletionHandler
+public class ProgramNotificationInstanceDeletionHandler extends IdObjectDeletionHandler<ProgramNotificationInstance>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( ProgramNotificationInstance.class );
-
     private final ProgramNotificationInstanceService programNotificationInstanceService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( ProgramInstance.class, this::deleteProgramInstance );
         whenDeleting( ProgramStageInstance.class, this::deleteProgramStageInstance );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDataElementDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDataElementDeletionHandler.java
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementDomain;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,12 +42,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramStageDataElementDeletionHandler extends DeletionHandler
+public class ProgramStageDataElementDeletionHandler extends IdObjectDeletionHandler<ProgramStageDataElement>
 {
     private final ProgramStageDataElementService programStageDataElementService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( ProgramStage.class, this::deleteProgramStage );
         whenDeleting( DataElement.class, this::deleteDataElement );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageDeletionHandler.java
@@ -36,7 +36,7 @@ import lombok.RequiredArgsConstructor;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataentryform.DataEntryForm;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -44,14 +44,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramStageDeletionHandler extends JdbcDeletionHandler
+public class ProgramStageDeletionHandler extends IdObjectDeletionHandler<ProgramStage>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( ProgramStage.class );
-
     private final ProgramStageService programStageService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Program.class, this::deleteProgram );
         whenDeleting( DataEntryForm.class, this::deleteDataEntryForm );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageInstanceDeletionHandler.java
@@ -33,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -41,14 +41,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramStageInstanceDeletionHandler extends JdbcDeletionHandler
+public class ProgramStageInstanceDeletionHandler extends IdObjectDeletionHandler<ProgramStageInstance>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( ProgramStageInstance.class );
-
     private final ProgramStageInstanceService programStageInstanceService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( ProgramStage.class, this::allowDeleteProgramStage );
         whenDeleting( ProgramInstance.class, this::deleteProgramInstance );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageSectionDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/ProgramStageSectionDeletionHandler.java
@@ -33,8 +33,7 @@ import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.common.IdentifiableObjectManager;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,14 +41,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class ProgramStageSectionDeletionHandler extends DeletionHandler
+public class ProgramStageSectionDeletionHandler extends IdObjectDeletionHandler<ProgramStageSection>
 {
-    private final IdentifiableObjectManager idObjectManager;
-
     private final ProgramStageSectionService programStageSectionService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( ProgramIndicator.class, this::deleteProgramIndicator );
         whenDeleting( ProgramStage.class, this::deleteProgramStage );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipTypeDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/relationship/RelationshipTypeDeletionHandler.java
@@ -29,23 +29,23 @@ package org.hisp.dhis.relationship;
 
 import java.util.Objects;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.Program;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Enrico Colasante
  */
 @Component
-@AllArgsConstructor
-public class RelationshipTypeDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class RelationshipTypeDeletionHandler extends IdObjectDeletionHandler<RelationshipType>
 {
     private final RelationshipTypeService relationshipTypeService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( Program.class, this::deleteProgram );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/SMSCommandDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/sms/command/SMSCommandDeletionHandler.java
@@ -32,8 +32,8 @@ import static org.hisp.dhis.system.deletion.DeletionVeto.ACCEPT;
 import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.dataset.DataSet;
-import org.hisp.dhis.system.deletion.DeletionHandler;
 import org.hisp.dhis.system.deletion.DeletionVeto;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
@@ -41,14 +41,12 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
-public class SMSCommandDeletionHandler extends DeletionHandler
+public class SMSCommandDeletionHandler extends IdObjectDeletionHandler<SMSCommand>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( SMSCommand.class );
-
     private final SMSCommandService smsCommandService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( DataSet.class, this::allowDeleteDataSet );
     }

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentity/TrackedEntityInstanceDeletionHandler.java
@@ -31,19 +31,17 @@ import java.util.Map;
 
 import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.system.deletion.DeletionVeto;
-import org.hisp.dhis.system.deletion.JdbcDeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Chau Thu Tran
  */
 @Component
-public class TrackedEntityInstanceDeletionHandler extends JdbcDeletionHandler
+public class TrackedEntityInstanceDeletionHandler extends IdObjectDeletionHandler<TrackedEntityInstance>
 {
-    private static final DeletionVeto VETO = new DeletionVeto( TrackedEntityInstance.class );
-
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenVetoing( OrganisationUnit.class, this::allowDeleteOrganisationUnit );
         whenVetoing( TrackedEntityType.class, this::allowDeleteTrackedEntityType );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/trackedentitycomment/TrackedEntityCommentDeletionHandler.java
@@ -31,18 +31,18 @@ import lombok.RequiredArgsConstructor;
 
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStageInstance;
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 
 /**
  * @author Abyot Asalefew Gizaw <abyota@gmail.com>
  */
 @RequiredArgsConstructor
-public class TrackedEntityCommentDeletionHandler extends DeletionHandler
+public class TrackedEntityCommentDeletionHandler extends IdObjectDeletionHandler<TrackedEntityComment>
 {
     private final TrackedEntityCommentService commentService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( ProgramInstance.class, this::deleteProgramInstance );
         whenDeleting( ProgramStageInstance.class, this::deleteProgramStageInstance );

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/user/UserRoleDeletionHandler.java
@@ -29,22 +29,22 @@ package org.hisp.dhis.user;
 
 import java.util.HashSet;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
-import org.hisp.dhis.system.deletion.DeletionHandler;
+import org.hisp.dhis.system.deletion.IdObjectDeletionHandler;
 import org.springframework.stereotype.Component;
 
 /**
  * @author Lars Helge Overland
  */
 @Component
-@AllArgsConstructor
-public class UserRoleDeletionHandler extends DeletionHandler
+@RequiredArgsConstructor
+public class UserRoleDeletionHandler extends IdObjectDeletionHandler<UserRole>
 {
     private final UserService userService;
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         whenDeleting( User.class, this::deleteUser );
     }

--- a/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/visualization/VisualizationDeletionHandler.java
+++ b/dhis-2/dhis-services/dhis-service-reporting/src/main/java/org/hisp/dhis/visualization/VisualizationDeletionHandler.java
@@ -58,7 +58,7 @@ public class VisualizationDeletionHandler
     }
 
     @Override
-    protected void register()
+    protected void registerHandler()
     {
         // generic
         whenDeleting( Indicator.class, this::deleteIndicator );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dashboard/DashboardItemDeletionHandlerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dashboard/DashboardItemDeletionHandlerTest.java
@@ -186,8 +186,8 @@ class DashboardItemDeletionHandlerTest extends TransactionalIntegrationTest
     @Test
     void testDeleteUser()
     {
-        User userA = makeUser( "A" );
-        User userB = makeUser( "B" );
+        User userA = makeUser( "X" );
+        User userB = makeUser( "Y" );
         userService.addUser( userA );
         userService.addUser( userB );
         dashboardItem.getUsers().add( userA );


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-13470
- When deleting a User the `IdObjectDeletionHandler` will check if that User is  linked to any IdentifiableObject  of all Metadata object types. 
- The look up query use property `createdBy` and `lastUpdatedBy`. However, not all objects which extends `BaseIdentifiableObject` have both properties. So we need to use the schema to check before execute the loop up query.
- Added test in `UserServiceTest`

#### Manual testing
1. Create a new UserA, login with that user and create a DataElement. 
2. Login with system user and delete UserA
3. Expected: error is shown with message indicating UserA is linked to a DataElement.