### PR TITLE
ci: Remove timeout duration from slack message [skip ci]

### DIFF
--- a/jenkinsfiles/canary
+++ b/jenkinsfiles/canary
@@ -107,7 +107,7 @@ pipeline {
 
         aborted {
             script {
-                slack.sendTimedoutMessage(30)
+                slack.sendTimedoutMessage()
             }
         }
     }

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -241,7 +241,7 @@ pipeline {
 
         aborted {
             script {
-                slack.sendTimedoutMessage(30)
+                slack.sendTimedoutMessage()
             }
         }
     }

--- a/jenkinsfiles/eos
+++ b/jenkinsfiles/eos
@@ -52,7 +52,7 @@ pipeline {
 
         aborted {
             script {
-                slack.sendTimedoutMessage(30)
+                slack.sendTimedoutMessage()
             }
         }
     }

--- a/jenkinsfiles/stable
+++ b/jenkinsfiles/stable
@@ -142,7 +142,7 @@ pipeline {
 
         aborted {
             script {
-                slack.sendTimedoutMessage(30)
+                slack.sendTimedoutMessage()
             }
         }
     }


### PR DESCRIPTION
The overall pipeline timeout duration is 60m for the `stable` and `dev` pipelines and the timeout duration can vary based on multiple factors like inactivity (no new logs) for any of the stages/steps, as well as specific shorter timeouts like [here](https://github.com/dhis2/dhis2-core/blob/master/jenkinsfiles/dev#L219). 

i.e.  there are multiple factors that can change the final timeout duration and it's hard to predict, hence having a specific timeout duration in the message we send in Slack turns out to be inaccurate most of the time.