### PR TITLE
fix: signature changes to FieldFilterService DHIS2-13731

### DIFF
--- a/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/EventHookListener.java
+++ b/dhis-2/dhis-services/dhis-service-event-hook/src/main/java/org/hisp/dhis/eventhook/EventHookListener.java
@@ -89,8 +89,7 @@ public class EventHookListener
 
                     for ( Object object : ((Collection<?>) event.getObject()) )
                     {
-                        objects.add( fieldFilterService.toObjectNode( object,
-                            List.of( eventHook.getSource().getFields() ) ) );
+                        objects.add( fieldFilterService.toObjectNode( object, eventHook.getSource().getFields() ) );
                     }
 
                     event = event.withObject( objects );
@@ -98,7 +97,7 @@ public class EventHookListener
                 else
                 {
                     ObjectNode objectNode = fieldFilterService.toObjectNode( event.getObject(),
-                        List.of( eventHook.getSource().getFields() ) );
+                        eventHook.getSource().getFields() );
                     event = event.withObject( objectNode );
                 }
 


### PR DESCRIPTION
PR https://github.com/dhis2/dhis2-core/pull/12419
Introduced 2 calls to the FieldFilterService using the old signature.

PR https://github.com/dhis2/dhis2-core/pull/12936
Introduced signature changes to the FieldFilterService.

The PRs were merged in the above order. Each PR passed the checks as both were based on a commit having the old signature. Compilation failed after the merge as the first PR still relied on the old signature.