### PR TITLE
fix: allow attribute UID in fields param for all overloaded methods

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -216,6 +216,7 @@ public class FieldFilterService
             applyAttributeValuesAttribute( object, fieldPaths, isSkipSharing );
 
             ObjectNode objectNode = objectMapper.valueToTree( object );
+            applyAttributeValueFields( object, objectNode, fieldPaths );
             applyTransformers( objectNode, null, "", fieldTransformers );
 
             objectNodes.add( objectNode );


### PR DESCRIPTION
During https://github.com/dhis2/dhis2-core/pull/10790 (https://dhis2.atlassian.net/browse/DHIS2-13158) we added the ability to pass an attribute UID in the `fields` query parameter. There are multiple overloaded methods in `FieldFilterService` to achieve that only one of which was changed.