### PR TITLE
fix: allow attribute UID in fields param for all FieldFilterService methods DHIS2-14735

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.fieldfiltering;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -191,6 +192,14 @@ public class FieldFilterService
             return objectNodes;
         }
 
+        toObjectNodes( objects, fieldPaths, user, isSkipSharing, objectNodes::add );
+
+        return objectNodes;
+    }
+
+    private <T> void toObjectNodes( List<T> objects, List<FieldPath> fieldPaths, User user,
+        boolean isSkipSharing, Consumer<ObjectNode> consumer )
+    {
         if ( user == null )
         {
             user = currentUserService.getCurrentUser();
@@ -219,10 +228,8 @@ public class FieldFilterService
             applyAttributeValueFields( object, objectNode, fieldPaths );
             applyTransformers( objectNode, null, "", fieldTransformers );
 
-            objectNodes.add( objectNode );
+            consumer.accept( objectNode );
         }
-
-        return objectNodes;
     }
 
     /**
@@ -230,7 +237,8 @@ public class FieldFilterService
      *
      * @param params Filter params to apply
      * @param generator Pre-created json generator
-     * @throws IOException
+     * @throws IOException if there is either an underlying I/O problem or
+     *         encoding issue on writing to the generator
      */
     public void toObjectNodesStream( FieldFilterParams<?> params, JsonGenerator generator )
         throws IOException
@@ -239,38 +247,24 @@ public class FieldFilterService
         {
             return;
         }
-
-        if ( params.getUser() == null )
-        {
-            params.setUser( currentUserService.getCurrentUser() );
-        }
-
         List<FieldPath> fieldPaths = FieldFilterParser.parse( params.getFilters() );
 
-        // In case we get a proxied object in we can't just use o.getClass(), we
-        // need to figure out the real class name by using HibernateProxyUtils.
-        Object firstObject = params.getObjects().iterator().next();
-        fieldPathHelper.apply( fieldPaths, HibernateProxyUtils.getRealClass( firstObject ) );
-
-        SimpleFilterProvider filterProvider = getSimpleFilterProvider( fieldPaths, params.isSkipSharing() );
-
-        // only set filter provider on a local copy so that we don't affect
-        // other object mappers (running across other threads)
-        ObjectMapper objectMapper = jsonMapper.copy().setFilterProvider( filterProvider );
-
-        Map<String, List<FieldTransformer>> fieldTransformers = getTransformers( fieldPaths );
-
-        for ( Object object : params.getObjects() )
+        try
         {
-            applyAccess( object, fieldPaths, params.isSkipSharing(), params.getUser() );
-            applySharingDisplayNames( object, fieldPaths, params.isSkipSharing() );
-            applyAttributeValuesAttribute( object, fieldPaths, params.isSkipSharing() );
-
-            ObjectNode objectNode = objectMapper.valueToTree( object );
-            applyAttributeValueFields( object, objectNode, fieldPaths );
-            applyTransformers( objectNode, null, "", fieldTransformers );
-
-            generator.writeObject( objectNode );
+            toObjectNodes( params.getObjects(), fieldPaths, params.getUser(), params.isSkipSharing(), n -> {
+                try
+                {
+                    generator.writeObject( n );
+                }
+                catch ( IOException e )
+                {
+                    throw new UncheckedIOException( e );
+                }
+            } );
+        }
+        catch ( UncheckedIOException e )
+        {
+            throw e.getCause();
         }
     }
 

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -216,6 +216,7 @@ public class FieldFilterService
             applyAttributeValuesAttribute( object, fieldPaths, isSkipSharing );
 
             ObjectNode objectNode = objectMapper.valueToTree( object );
+            applyAttributeValueFields( object, objectNode, fieldPaths );
             applyTransformers( objectNode, null, "", fieldTransformers );
 
             objectNodes.add( objectNode );


### PR DESCRIPTION
During https://github.com/dhis2/dhis2-core/pull/10790 (https://dhis2.atlassian.net/browse/DHIS2-13158) we added the ability to pass an attribute UID in the `fields` query parameter. There are multiple methods in `FieldFilterService` to achieve that only one of which was changed.