### PR TITLE
fix: Make dependabot ignore ANTLR parser and rule engine dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,12 @@ updates:
       - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
         versions:
           - ">= 3.0"
+      - dependency-name: "org.hisp.dhis.parser:*" # Antlr parser must be upgraded manually due to circular dependency with rule engine
+        versions:
+          - ">= 1.0"
+      - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
+        versions:
+          - ">= 2.0"
   # 2.39
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -99,6 +105,12 @@ updates:
       - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
         versions:
           - ">= 3.0"
+      - dependency-name: "org.hisp.dhis.parser:*" # Antlr parser must be upgraded manually due to circular dependency with rule engine
+        versions:
+          - ">= 1.0"
+      - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
+        versions:
+          - ">= 2.0"
     target-branch: "2.39"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.38
@@ -152,6 +164,12 @@ updates:
       - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
         versions:
           - ">= 3.0"
+      - dependency-name: "org.hisp.dhis.parser:*" # Antlr parser must be upgraded manually due to circular dependency with rule engine
+        versions:
+          - ">= 1.0"
+      - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
+        versions:
+          - ">= 2.0"
     target-branch: "2.38"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources
   # 2.37
@@ -208,5 +226,11 @@ updates:
       - dependency-name: "org.springframework.ldap:*" # Spring ldap 3.x requires Spring 6 (see above)
         versions:
           - ">= 3.0"
+      - dependency-name: "org.hisp.dhis.parser:*" # Antlr parser must be upgraded manually due to circular dependency with rule engine
+        versions:
+          - ">= 1.0"
+      - dependency-name: "org.hisp.dhis.rules:*" # Rule engine must be upgraded manually due to circular dependency with ANTLR parser
+        versions:
+          - ">= 2.0"
     target-branch: "2.37"
     open-pull-requests-limit: 1 # only initially so we do not take away too many CI resources


### PR DESCRIPTION
Rule engine library and ANTLR parser library must be upgraded together in core because both core and rule engine depend on ANTLR parser and because of ANTLR architecture they must use the exact same version.
Hopefully we will get rid of this weird dependency chain soon.
For now, it doesn't make sense for dependabot try to upgrade these dependencies as it will never succeed