### PR TITLE
fix: Check if dueDate param is null [DHIS2-14736]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -2101,12 +2101,9 @@ public class JdbcEventStore implements EventStore
             .addValue( "programInstanceId", programStageInstance.getProgramInstance().getId() )
             .addValue( "programstageid", programStageInstance.getProgramStage()
                 .getId() )
-            .addValue( DUE_DATE.getColumnName(), new Timestamp( programStageInstance.getDueDate()
-                .getTime() ) )
+            .addValue( DUE_DATE.getColumnName(), JdbcEventSupport.toTimestamp( programStageInstance.getDueDate() ) )
             .addValue( EXECUTION_DATE.getColumnName(),
-                (programStageInstance.getExecutionDate() != null
-                    ? new Timestamp( programStageInstance.getExecutionDate().getTime() )
-                    : null) )
+                JdbcEventSupport.toTimestamp( programStageInstance.getExecutionDate() ) )
             .addValue( "organisationunitid", programStageInstance.getOrganisationUnit().getId() )
             .addValue( STATUS.getColumnName(), programStageInstance.getStatus().toString() )
             .addValue( COMPLETEDDATE.getColumnName(),

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -248,7 +248,7 @@ public class EventManager
             catch ( Exception e )
             {
                 handleFailure( workContext, importSummaries, events, IMPORT_ERROR_STRING, UPDATE );
-                log.error( "Failed to update events: " + e );
+                log.error( "Failed to update events: ", e );
             }
 
             final List<String> eventPersistenceFailedUids = importSummaries.getImportSummaries().stream()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/importer/EventManager.java
@@ -248,6 +248,7 @@ public class EventManager
             catch ( Exception e )
             {
                 handleFailure( workContext, importSummaries, events, IMPORT_ERROR_STRING, UPDATE );
+                log.error( "Failed to update events: " + e );
             }
 
             final List<String> eventPersistenceFailedUids = importSummaries.getImportSummaries().stream()

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/event/JdbcEventStoreTest.java
@@ -29,6 +29,7 @@ package org.hisp.dhis.dxf2.events.event;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hisp.dhis.utils.Assertions.assertNotEmpty;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
@@ -40,11 +41,17 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dxf2.events.report.EventRow;
 import org.hisp.dhis.dxf2.events.trackedentity.store.EventStore;
+import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.jdbc.statementbuilder.PostgreSQLStatementBuilder;
+import org.hisp.dhis.organisationunit.OrganisationUnit;
 import org.hisp.dhis.organisationunit.OrganisationUnitStore;
+import org.hisp.dhis.program.ProgramInstance;
+import org.hisp.dhis.program.ProgramStage;
+import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.user.CurrentUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,6 +132,21 @@ class JdbcEventStoreTest
         List<EventRow> rows = subject.getEventRows( eventSearchParams, null );
         assertThat( rows, hasSize( 1 ) );
         verify( rowSet, times( 4 ) ).getString( "psi_eventdatavalues" );
+    }
+
+    @Test
+    void shouldUpdateEventsWhenDateFieldsAreNotSet()
+    {
+        List<ProgramStageInstance> programStageInstances = new ArrayList<>();
+        ProgramStageInstance psi = new ProgramStageInstance( new ProgramInstance(), new ProgramStage(),
+            new OrganisationUnit() );
+        psi.setStatus( EventStatus.ACTIVE );
+        psi.setAttributeOptionCombo( new CategoryOptionCombo() );
+        programStageInstances.add( psi );
+
+        List<ProgramStageInstance> instances = subject.updateEvents( programStageInstances );
+
+        assertNotEmpty( instances );
     }
 
     private void mockRowSet()


### PR DESCRIPTION
There's an issue when updating events if the dueDate is not set in the payload. For some legacy reason we assumed it would always be set, in this PR we aim to solve this by checking if it's null first.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-14736