### PR TITLE
fix: Remove hibernate validator dependency [DHIS2-13928]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiToken.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/security/apikey/ApiToken.java
@@ -36,6 +36,7 @@ import org.hisp.dhis.common.MetadataObject;
 import org.hisp.dhis.schema.PropertyType;
 import org.hisp.dhis.schema.annotation.Property;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -63,9 +64,7 @@ public class ApiToken extends BaseIdentifiableObject implements MetadataObject
 
     private List<ApiTokenAttribute> attributes = new ArrayList<>();
 
-    @JsonProperty
-    @JacksonXmlProperty( namespace = DxfNamespaces.DXF_2_0 )
-    @Property( PropertyType.TEXT )
+    @JsonIgnore
     public String getKey()
     {
         return key;

--- a/dhis-2/dhis-support/dhis-support-system/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-system/pom.xml
@@ -144,10 +144,6 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api-test/pom.xml
+++ b/dhis-2/dhis-web-api-test/pom.xml
@@ -275,11 +275,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityGroupSizeUserGroupsControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/dataintegrity/DataIntegrityGroupSizeUserGroupsControllerTest.java
@@ -99,6 +99,7 @@ class DataIntegrityGroupSizeUserGroupsControllerTest extends AbstractDataIntegri
         user.setCode( "Code" + uniquePart );
         user.setFirstName( FIRST_NAME + uniquePart );
         user.setSurname( SURNAME + uniquePart );
+        user.setUsername( "username" + uniquePart );
         return user;
     }
 

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/security/JwtBearerTokenTest.java
@@ -27,9 +27,9 @@
  */
 package org.hisp.dhis.webapi.security;
 
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.hisp.dhis.web.WebClient.JwtTokenHeader;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import java.util.Properties;

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -267,10 +267,6 @@
       <artifactId>javacsv</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>

--- a/dhis-2/dhis-web-api/pom.xml
+++ b/dhis-2/dhis-web-api/pom.xml
@@ -397,11 +397,6 @@
       <artifactId>poi</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -155,7 +155,7 @@ public class MapController
         Map newMap = deserializeJsonEntity( request );
         newMap.setUid( uid );
 
-        mergeService.merge( new MergeParams<>( newMap, map )
+        mergeService.merge( new MergeParams<>( map, newMap )
             .setMergeMode( params.getMergeMode() )
             .setSkipSharing( params.isSkipSharing() )
             .setSkipTranslation( params.isSkipTranslation() ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/ApiTokenController.java
@@ -91,19 +91,6 @@ public class ApiTokenController extends AbstractCrudController<ApiToken>
     }
 
     @Override
-    protected void postProcessResponseEntity( ApiToken entity, WebOptions options, Map<String, String> parameters )
-    {
-        entity.setKey( null );
-    }
-
-    @Override
-    protected void postProcessResponseEntities( List<ApiToken> entityList, WebOptions options,
-        Map<String, String> parameters )
-    {
-        entityList.forEach( t -> t.setKey( null ) );
-    }
-
-    @Override
     public void partialUpdateObject( String pvUid, Map<String, String> rpParameters,
         @CurrentUser User currentUser, HttpServletRequest request )
     {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataSetValueQueryParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataSetValueQueryParams.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.webapi.webdomain.datavalue;
 
-import javax.validation.constraints.NotBlank;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,7 +55,6 @@ import org.hisp.dhis.webapi.openapi.SchemaGenerators.UID;
 @AllArgsConstructor( access = AccessLevel.PRIVATE )
 public class DataSetValueQueryParams
 {
-    @NotBlank
     @OpenApi.Property( { UID.class, DataElement.class } )
     private String ds;
 
@@ -67,11 +64,9 @@ public class DataSetValueQueryParams
     @OpenApi.Property( { UID.class, CategoryOption.class } )
     private String cp;
 
-    @NotBlank
     @OpenApi.Property( Period.class )
     private String pe;
 
-    @NotBlank
     @OpenApi.Property( { UID.class, OrganisationUnit.class } )
     private String ou;
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueQueryParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/DataValueQueryParams.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.webapi.webdomain.datavalue;
 
-import javax.validation.constraints.NotBlank;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -58,15 +56,12 @@ import org.hisp.dhis.webapi.openapi.SchemaGenerators.UID;
 @AllArgsConstructor( access = AccessLevel.PRIVATE )
 public class DataValueQueryParams
 {
-    @NotBlank
     @OpenApi.Property( { UID.class, DataElement.class } )
     private String de;
 
-    @NotBlank
     @OpenApi.Property( { Period.class } )
     private String pe;
 
-    @NotBlank
     @OpenApi.Property( { UID.class, OrganisationUnit.class } )
     private String ou;
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/MinMaxValueQueryParams.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/webdomain/datavalue/MinMaxValueQueryParams.java
@@ -27,8 +27,6 @@
  */
 package org.hisp.dhis.webapi.webdomain.datavalue;
 
-import javax.validation.constraints.NotBlank;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -55,15 +53,12 @@ import org.hisp.dhis.webapi.openapi.SchemaGenerators.UID;
 @AllArgsConstructor( access = AccessLevel.PRIVATE )
 public class MinMaxValueQueryParams
 {
-    @NotBlank
     @OpenApi.Property( { UID.class, DataElement.class } )
     private String de;
 
-    @NotBlank
     @OpenApi.Property( { UID.class, OrganisationUnit.class } )
     private String ou;
 
-    @NotBlank
     @OpenApi.Property( { UID.class, CategoryOptionCombo.class } )
     private String co;
 }

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/dataitem/ResponseHandlerTest.java
@@ -37,7 +37,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGE_SIZE;
 import static org.hisp.dhis.webapi.webdomain.WebOptions.PAGING;
@@ -131,7 +130,7 @@ class ResponseHandlerTest
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
-        final Set<Class<? extends BaseIdentifiableObject>> anyTargetEntities = asSet( Indicator.class,
+        final Set<Class<? extends BaseIdentifiableObject>> anyTargetEntities = Set.of( Indicator.class,
             DataSet.class );
         final Set<String> anyFilters = newHashSet( "any" );
         final User anyUser = new User();
@@ -154,7 +153,7 @@ class ResponseHandlerTest
     {
         // Given
         final RootNode anyRootNode = new RootNode( "any" );
-        final Set<Class<? extends BaseIdentifiableObject>> anyTargetEntities = asSet( Indicator.class,
+        final Set<Class<? extends BaseIdentifiableObject>> anyTargetEntities = Set.of( Indicator.class,
             DataSet.class );
         final Set<String> anyFilters = newHashSet( "any" );
         final User anyUser = new User();

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -166,7 +166,6 @@
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
     <joda-time.version>2.12.2</joda-time.version>
     <cron-utils.version>9.2.0</cron-utils.version>
-    <validation-api.version>2.0.1.Final</validation-api.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
@@ -831,7 +830,6 @@
                 <RestrictImports>
                   <reason>Use javax.annotation.Nonnull and javax.annotation.CheckForNull instead</reason>
                   <bannedImports>
-                    <bannedImport>javax.validation.constraints.NotNull</bannedImport>
                     <bannedImport>lombok.NonNull</bannedImport>
                   </bannedImports>
                 </RestrictImports>
@@ -2379,12 +2377,6 @@
         <groupId>org.mapstruct</groupId>
         <artifactId>mapstruct</artifactId>
         <version>${mapstruct.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>javax.validation</groupId>
-        <artifactId>validation-api</artifactId>
-        <version>${validation-api.version}</version>
       </dependency>
 
     </dependencies>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -167,7 +167,6 @@
     <joda-time.version>2.12.2</joda-time.version>
     <cron-utils.version>9.2.0</cron-utils.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
-    <hibernate-validator.version>6.2.0.Final</hibernate-validator.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
@@ -688,7 +687,6 @@
               <ignoredUnusedDeclaredDependency>commons-fileupload:commons-fileupload</ignoredUnusedDeclaredDependency>
               <!-- Removing makes some tests fail -->
               <ignoredUnusedDeclaredDependency>io.netty:netty-all</ignoredUnusedDeclaredDependency>
-              <ignoredUnusedDeclaredDependency>org.hibernate.validator:hibernate-validator</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.cache2k:cache2k-core</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.springframework.security:spring-security-aspects</ignoredUnusedDeclaredDependency>
               <ignoredUnusedDeclaredDependency>org.apache.jclouds.api:filesystem</ignoredUnusedDeclaredDependency>
@@ -1619,17 +1617,6 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-spatial</artifactId>
         <version>${hibernate.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate.validator</groupId>
-        <artifactId>hibernate-validator</artifactId>
-        <version>${hibernate-validator.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>jakarta.validation</groupId>
-            <artifactId>jakarta.validation-api</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>


### PR DESCRIPTION
`hibernate-validator` dependency was not really used in the system so it was removed. By consequence also `validation-api` can be removed.

Some tests needed to be fixed as having `hibernate-validator` in the classpath was hiding some errors. I didn't investigate in depth why, but some `not-null` values were set to null and tests were not working properly.