### PR TITLE
fix: tracker does not return fields in accordance with field filtering DHIS2-14783

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterParser.java
@@ -42,8 +42,8 @@ import org.apache.commons.lang3.StringUtils;
  * FieldFilterParser parses <a href=
  * "https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/metadata.html#webapi_metadata_field_filter">metadata
  * field filters</a>. For example <code>"dataSets[id,name]"</code> will result
- * in two {@link FieldPath}'s for <code>id</code> and <code>name</code> with
- * path <code>dataSet</code>.
+ * in three {@link FieldPath}'s for <code>id</code> and <code>name</code> with
+ * path <code>dataSet</code> and one for <code>dataSets</code>.
  *
  * @author Morten Olav Hansen
  */

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -132,30 +132,25 @@ public class FieldFilterService
     /**
      * Determines whether given path is included in the resulting ObjectNodes
      * after applying {@link #toObjectNode(Object, List)}. This obviously
-     * requires that the actual data contains such path.
+     * requires that the actual data contains such path when filtered.
      *
-     * FieldPath inclusion, exclusion as well as preset {@link FieldPreset.ALL}
-     * are taken into account.
+     * For example given a structure like
+     * <p>
+     * <code>{"event": "relationships": [] }</code>
+     * </p>
+     * and a
+     * <p>
+     * <code>filter="*,first[second[!third]]"</code>
+     * </p>
+     * <p>
+     * both paths<code>first</code> and <code>first.second</code> will result in
+     * true as they will be included in the filtered result. While
+     * <code>first.second.third</code> will result in false.
+     * </p>
      *
-     * // TODO: this does not yet support Attribute UIDs TODO: add examples with
-     * exclusion and preset all. Especially for the fact that with
-     * filter=FieldPreset.ALL you will get true for any path even if this field
-     * is not part of your objects schema.
-     *
-     * // TODO this example isn't good as I need to show given List<FieldPath>
-     * and path For example given data
-     *
-     * {"event": "relationships": [] }
-     *
-     * both paths
-     *
-     * <code>event</code> <code>event.relationships</code>
-     *
-     * will result in true as they will be included in the filtered result.
-     *
-     * @param rootClass
-     * @param filter
-     * @param path
+     * @param rootClass class the filter will be applied on
+     * @param filter field paths to be applied on the class
+     * @param path path to check for inclusion in the filter
      * @return
      */
     public boolean filterIncludes( Class<?> rootClass, List<FieldPath> filter, String path )

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -129,6 +129,53 @@ public class FieldFilterService
         return objectMapper;
     }
 
+    /**
+     * Determines whether given path is included in the resulting ObjectNodes
+     * after applying {@link #toObjectNode(Object, List)}. This obviously
+     * requires that the actual data contains such path.
+     *
+     * FieldPath inclusion, exclusion as well as preset {@link FieldPreset.ALL}
+     * are taken into account.
+     *
+     * // TODO: this does not yet support Attribute UIDs TODO: add examples with
+     * exclusion and preset all. Especially for the fact that with
+     * filter=FieldPreset.ALL you will get true for any path even if this field
+     * is not part of your objects schema.
+     *
+     * // TODO this example isn't good as I need to show given List<FieldPath>
+     * and path For example given data
+     *
+     * {"event": "relationships": [] }
+     *
+     * both paths
+     *
+     * <code>event</code> <code>event.relationships</code>
+     *
+     * will result in true as they will be included in the filtered result.
+     *
+     * @param rootClass
+     * @param filter
+     * @param path
+     * @return
+     */
+    public boolean filterIncludes( Class<?> rootClass, List<FieldPath> filter, String path )
+    {
+        List<FieldPath> expandedFilter = fieldPathHelper.apply( filter, rootClass );
+
+        for ( FieldPath f : expandedFilter )
+        {
+            if ( f.toFullPath().equals( path ) )
+            {
+                if ( f.isExclude() )
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static class IgnoreJsonSerializerRefinementAnnotationInspector extends JacksonAnnotationIntrospector
     {
         /**

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -166,10 +166,6 @@ public class FieldFilterService
         {
             if ( f.toFullPath().equals( path ) )
             {
-                if ( f.isExclude() )
-                {
-                    return false;
-                }
                 return true;
             }
         }

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -62,11 +62,13 @@ public class FieldPathHelper
 {
     private final SchemaService schemaService;
 
-    public void apply( List<FieldPath> fieldPaths, Class<?> rootKlass )
+    public List<FieldPath> apply( List<FieldPath> fieldPaths, Class<?> rootKlass )
     {
-        if ( rootKlass == null || fieldPaths.isEmpty() )
+        List<FieldPath> result = new ArrayList<>();
+
+        if ( fieldPaths.isEmpty() || rootKlass == null )
         {
-            return;
+            return result;
         }
 
         List<FieldPath> presets = fieldPaths.stream().filter( FieldPath::isPreset ).collect( Collectors.toList() );
@@ -93,6 +95,8 @@ public class FieldPathHelper
 
         fieldPaths.clear();
         fieldPaths.addAll( fieldPathMap.values() );
+
+        return result;
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -33,8 +33,10 @@ import static java.util.function.Predicate.not;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -303,10 +305,24 @@ public class FieldPathHelper
 
     private void applyExclusions( List<FieldPath> exclusions, Map<String, FieldPath> fieldPathMap )
     {
+        Set<String> excludedPaths = new HashSet<>();
         for ( FieldPath exclusion : exclusions )
         {
-            fieldPathMap.remove( exclusion.toFullPath() );
+            // TODO(ivo): would it break other code if we exclude all children? A child will not be included in the JSON
+            // if its parent is explicitly excluded
+            // before:
+            //             fieldPathMap.remove( exclusion.toFullPath() );
+            excludedPaths.add( exclusion.toFullPath() );
+
+            for ( String path : fieldPathMap.keySet() )
+            {
+                if ( path.startsWith( exclusion.toFullPath() ) )
+                {
+                    excludedPaths.add( path );
+                }
+            }
         }
+        fieldPathMap.keySet().removeAll( excludedPaths );
     }
 
     // ----------------------------------------------------------------------------------------------------------------

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -32,7 +32,6 @@ import static java.util.function.Predicate.not;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -70,7 +69,7 @@ public class FieldPathHelper
     {
         if ( fieldPaths.isEmpty() || rootKlass == null )
         {
-            return Collections.emptyList();
+            return List.of();
         }
 
         Map<String, FieldPath> fieldPathMap = fieldPaths.stream()

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -308,10 +308,6 @@ public class FieldPathHelper
         Set<String> excludedPaths = new HashSet<>();
         for ( FieldPath exclusion : exclusions )
         {
-            // TODO(ivo): would it break other code if we exclude all children? A child will not be included in the JSON
-            // if its parent is explicitly excluded
-            // before:
-            //             fieldPathMap.remove( exclusion.toFullPath() );
             excludedPaths.add( exclusion.toFullPath() );
 
             for ( String path : fieldPathMap.keySet() )

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -32,6 +32,7 @@ import static java.util.function.Predicate.not;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -67,11 +68,9 @@ public class FieldPathHelper
 
     public List<FieldPath> apply( List<FieldPath> fieldPaths, Class<?> rootKlass )
     {
-        List<FieldPath> result = new ArrayList<>();
-
         if ( fieldPaths.isEmpty() || rootKlass == null )
         {
-            return result;
+            return Collections.emptyList();
         }
 
         Map<String, FieldPath> fieldPathMap = getFieldPathMap( fieldPaths );
@@ -92,9 +91,7 @@ public class FieldPathHelper
         List<FieldPath> exclusions = fieldPaths.stream().filter( FieldPath::isExclude ).collect( Collectors.toList() );
         applyExclusions( exclusions, fieldPathMap );
 
-        result.addAll( fieldPathMap.values() );
-
-        return result;
+        return new ArrayList<>( fieldPathMap.values() );
     }
 
     /**

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -302,6 +302,11 @@ public class FieldPathHelper
         }
     }
 
+    /**
+     * Returns included field paths. Included paths are not explicitly excluded
+     * (full-path matches exclusion) and not indirectly excluded via a parent
+     * field path.
+     */
     private void applyExclusions( List<FieldPath> exclusions, Map<String, FieldPath> fieldPathMap )
     {
         Set<String> excludedPaths = new HashSet<>();

--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldPathHelper.java
@@ -73,7 +73,10 @@ public class FieldPathHelper
             return Collections.emptyList();
         }
 
-        Map<String, FieldPath> fieldPathMap = getFieldPathMap( fieldPaths );
+        Map<String, FieldPath> fieldPathMap = fieldPaths.stream()
+            .filter( not( FieldPath::isPreset ).and( not( FieldPath::isExclude ) ) )
+            .collect( Collectors.toMap( FieldPath::toFullPath, Function.identity() ) );
+
         applyProperties( fieldPathMap.values(), rootKlass );
 
         List<FieldPath> presets = fieldPaths.stream().filter( FieldPath::isPreset ).collect( Collectors.toList() );
@@ -197,8 +200,7 @@ public class FieldPathHelper
      *        populated.
      * @param rootKlass the root class type of the entity.
      */
-    public void applyPresets( List<FieldPath> presets, Map<String, FieldPath> fieldPathMap,
-        Class<?> rootKlass )
+    public void applyPresets( List<FieldPath> presets, Map<String, FieldPath> fieldPathMap, Class<?> rootKlass )
     {
         List<FieldPath> fieldPaths = new ArrayList<>();
 
@@ -383,13 +385,6 @@ public class FieldPathHelper
         fieldPath.setProperty( property );
 
         return fieldPath;
-    }
-
-    private Map<String, FieldPath> getFieldPathMap( List<FieldPath> fieldPaths )
-    {
-        return fieldPaths.stream()
-            .filter( not( FieldPath::isPreset ).and( not( FieldPath::isExclude ) ) )
-            .collect( Collectors.toMap( FieldPath::toFullPath, Function.identity() ) );
     }
 
     private Schema getSchemaByPath( List<String> paths, Class<?> klass )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
@@ -56,7 +56,7 @@ class FieldFilterServiceTest extends DhisControllerConvenienceTest
     FieldPathHelper fieldPathHelper;
 
     @Test
-    void shouldIncludePathGivenFilterContainsPresetAll()
+    void shouldIncludeAllPathsGivenFilterContainsPresetAll()
     {
         Root root = new Root( new First( new Second( new Third() ) ) );
         List<FieldPath> filter = FieldFilterParser.parse( "*" );
@@ -89,7 +89,9 @@ class FieldFilterServiceTest extends DhisControllerConvenienceTest
 
         assertAll( "filterIncludes should match what's included in the filtered JSON",
             () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
-            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ) );
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second.third" ) ) );
     }
 
     @Test
@@ -115,27 +117,8 @@ class FieldFilterServiceTest extends DhisControllerConvenienceTest
         assertAll( "filterIncludes should match what's included in the filtered JSON",
             () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
             () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
-            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first.second" ),
             () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) ),
             () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second.third" ) ) );
-    }
-
-    @Test
-    void REMOVE_WHEN_DONE_DEBUGGING_PLAYGROUND()
-    {
-        assertFalse( fieldFilterService.filterIncludes( Root.class, FieldFilterParser.parse( "!first,first[second]" ),
-            "first.second" ) );
-    }
-
-    @Test
-    void shouldExcludePathGivenFilterContainsExplicitExclusionOfPathDespiteExplicitInclusionOfPath()
-    {
-        Root root = new Root( new First( new Second( new Third() ) ) );
-        List<FieldPath> filter = FieldFilterParser.parse( "first,!first" );
-
-        assertAll( "filterIncludes should match what's included in the filtered JSON",
-            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
-            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ) );
     }
 
     void assertJSONIncludes( ObjectNode json, String path )

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2004-2023, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import lombok.Data;
+
+import org.hisp.dhis.fieldfiltering.FieldFilterParser;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
+import org.hisp.dhis.fieldfiltering.FieldPath;
+import org.hisp.dhis.fieldfiltering.FieldPathHelper;
+import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class FieldFilterServiceTest extends DhisControllerConvenienceTest
+{
+
+    @Autowired
+    FieldFilterService fieldFilterService;
+
+    @Autowired
+    FieldPathHelper fieldPathHelper;
+
+    @Test
+    void shouldIncludePathGivenFilterContainsPresetAll()
+    {
+        Root root = new Root( new First( new Second( new Third() ) ) );
+        List<FieldPath> filter = FieldFilterParser.parse( "*" );
+
+        assertAll( "filterIncludes should match what's included in the filtered JSON",
+            () -> assertJSONIncludes( fieldFilterService.toObjectNode( root, filter ), "first.second.third" ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first.second.third" ) ) );
+    }
+
+    @Test
+    void shouldIncludeChildPathsGivenFilterContainsParent()
+    {
+        Root root = new Root( new First( new Second( new Third() ) ) );
+        List<FieldPath> filter = FieldFilterParser.parse( "first" );
+
+        assertAll( "filterIncludes should match what's included in the filtered JSON",
+            () -> assertJSONIncludes( fieldFilterService.toObjectNode( root, filter ), "first.second.third" ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first.second.third" ) ) );
+    }
+
+    @Test
+    void shouldExcludePathGivenFilterContainsExplicitExclusionOfPathDespitePresetAll()
+    {
+        Root root = new Root( new First( new Second( new Third() ) ) );
+        List<FieldPath> filter = FieldFilterParser.parse( "*,first[second[!third]]" );
+
+        assertAll( "filterIncludes should match what's included in the filtered JSON",
+            () -> assertJSONIncludes( fieldFilterService.toObjectNode( root, filter ), "first.second" ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
+            () -> assertTrue( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) ),
+            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first.second.third" ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second.third" ) ) );
+    }
+
+    @Test
+    void shouldExcludeChildPathGivenFilterContainsExclusionOfAParentDespiteDirectParentBeingIncluded()
+    {
+        Root root = new Root( new First( new Second( new Third() ) ) );
+        List<FieldPath> filter = FieldFilterParser.parse( "!first,first[second]" );
+
+        assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) );
+
+        assertAll( "filterIncludes should match what's included in the filtered JSON",
+            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
+            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first.second" ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second.third" ) ) );
+    }
+
+    @Test
+    void test()
+    {
+        assertFalse(
+            fieldFilterService.filterIncludes( Root.class, FieldFilterParser.parse( "!first,first" ), "first" ) );
+        assertFalse( fieldFilterService.filterIncludes( Root.class, FieldFilterParser.parse( "!first,first[second]" ),
+            "first.second" ) );
+    }
+
+    @Test
+    void shouldExcludePathGivenFilterContainsExplicitExclusionOfPathDespiteExplicitInclusionOfPath()
+    {
+        Root root = new Root( new First( new Second( new Third() ) ) );
+        List<FieldPath> filter = FieldFilterParser.parse( "first,!first" );
+
+        assertAll( "filterIncludes should match what's included in the filtered JSON",
+            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ) );
+    }
+
+    void assertJSONIncludes( ObjectNode json, String path )
+    {
+        String jsonPtr = toJSONPointer( path );
+        assertFalse( json.at( jsonPtr ).isMissingNode(),
+            () -> String.format( "Path '%s' (JSON ptr '%s') not found in JSON %s", path, jsonPtr, json ) );
+    }
+
+    void assertJSONExcludes( ObjectNode json, String path )
+    {
+        String jsonPtr = toJSONPointer( path );
+        assertTrue( json.at( jsonPtr ).isMissingNode(),
+            () -> String.format( "Path '%s' (JSON ptr '%s') found in JSON %s", path, jsonPtr, json ) );
+    }
+
+    private static String toJSONPointer( String path )
+    {
+        return "/" + path.replace( ".", "/" );
+    }
+
+    /**
+     * Sample classes used to build nested JSON we can filter using the
+     * {@link FieldFilterService}.
+     */
+    @Data
+    private static class Root
+    {
+        @JsonProperty
+        private final First first;
+
+    }
+
+    @Data
+    private static class First
+    {
+        @JsonProperty
+        private final Second second;
+    }
+
+    @Data
+    private static class Second
+    {
+        @JsonProperty
+        private final Third third;
+    }
+
+    @Data
+    private static class Third
+    {
+        @JsonProperty
+        private final String value = "3";
+    }
+}

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/FieldFilterServiceTest.java
@@ -82,6 +82,17 @@ class FieldFilterServiceTest extends DhisControllerConvenienceTest
     }
 
     @Test
+    void shouldExcludePathAsExclusionOverrulesInclusion()
+    {
+        Root root = new Root( new First( new Second( new Third() ) ) );
+        List<FieldPath> filter = FieldFilterParser.parse( "!first,first" );
+
+        assertAll( "filterIncludes should match what's included in the filtered JSON",
+            () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
+            () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ) );
+    }
+
+    @Test
     void shouldExcludePathGivenFilterContainsExplicitExclusionOfPathDespitePresetAll()
     {
         Root root = new Root( new First( new Second( new Third() ) ) );
@@ -101,8 +112,6 @@ class FieldFilterServiceTest extends DhisControllerConvenienceTest
         Root root = new Root( new First( new Second( new Third() ) ) );
         List<FieldPath> filter = FieldFilterParser.parse( "!first,first[second]" );
 
-        assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first.second" ) );
-
         assertAll( "filterIncludes should match what's included in the filtered JSON",
             () -> assertJSONExcludes( fieldFilterService.toObjectNode( root, filter ), "first" ),
             () -> assertFalse( fieldFilterService.filterIncludes( Root.class, filter, "first" ) ),
@@ -112,10 +121,8 @@ class FieldFilterServiceTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void test()
+    void REMOVE_WHEN_DONE_DEBUGGING_PLAYGROUND()
     {
-        assertFalse(
-            fieldFilterService.filterIncludes( Root.class, FieldFilterParser.parse( "!first,first" ), "first" ) );
         assertFalse( fieldFilterService.filterIncludes( Root.class, FieldFilterParser.parse( "!first,first[second]" ),
             "first.second" ) );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsMapperTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsMapperTest.java
@@ -48,11 +48,9 @@ class EnrollmentFieldsMapperTest extends DhisControllerConvenienceTest
     static Stream<Arguments> getEnrollmentParamsMultipleCases()
     {
         return Stream.of(
-            // TODO(ivo): this is a potential bug :( while the parser does parse this into FieldPath(name=all, path=[], exclude=true, preset=true, transformers=[], fullPath=null)
-            // if you make requests using it to a metadata API you'll get the same result whether its an inclusion or exclusion
-            // try: curl --silent -u admin:district -H 'content-type: application/json' 'https://play.dhis2.org/2.39.1/api/organisationUnits?page=1&pageSize=1&fields=!*' | jq .organisationUnits
-            // so the FieldFilterService.apply differs from implementation and assumption of what it would do
-            arguments( "!*", true, true, true ), // expected value are false on master
+            // This value does not make sense as it means exclude all.
+            // We initially assumed field filtering would exclude all fields but is does not. Keeping this test as a reminder of its behavior.
+            arguments( "!*", true, true, true ),
             arguments( "*", true, true, true ),
             arguments( "*,!relationships", true, true, false ),
             arguments( "*,!attributes", false, true, true ),

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsMapperTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsMapperTest.java
@@ -43,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 class EventFieldsMapperTest extends DhisControllerConvenienceTest
 {
     @Autowired
-    EventFieldsParamMapper eventFieldsParamMapper;
+    EventFieldsParamMapper mapper;
 
     static Stream<Arguments> getEventParamsMultipleCases()
     {
@@ -66,7 +66,7 @@ class EventFieldsMapperTest extends DhisControllerConvenienceTest
     @ParameterizedTest
     void getEventParamsMultipleCases( String fields, boolean expectRelationships )
     {
-        EventParams params = eventFieldsParamMapper.map( FieldFilterParser.parse( fields ) );
+        EventParams params = mapper.map( FieldFilterParser.parse( fields ) );
 
         assertEquals( expectRelationships, params.isIncludeRelationships() );
     }

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsMapperTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsMapperTest.java
@@ -48,10 +48,8 @@ class EventFieldsMapperTest extends DhisControllerConvenienceTest
     static Stream<Arguments> getEventParamsMultipleCases()
     {
         return Stream.of(
-            // TODO(ivo): this is a potential bug :( while the parser does parse this into FieldPath(name=all, path=[], exclude=true, preset=true, transformers=[], fullPath=null)
-            // if you make requests using it to a metadata API you'll get the same result whether its an inclusion or exclusion
-            // try: curl --silent -u admin:district -H 'content-type: application/json' 'https://play.dhis2.org/2.39.1/api/organisationUnits?page=1&pageSize=1&fields=!*' | jq .organisationUnits
-            // so the FieldFilterService.apply differs from implementation and assumption of what it would do
+            // This value does not make sense as it means exclude all.
+            // We initially assumed field filtering would exclude all fields but is does not. Keeping this test as a reminder of its behavior.
             arguments( "!*", true ), // expected value is false on master
             arguments( "*", true ),
             arguments( "relationships", true ),

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/TrackedEntityFieldsParamMapperTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/TrackedEntityFieldsParamMapperTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class TrackedEntityFieldsParamMapperTest extends DhisControllerConvenienceTest
@@ -48,34 +49,13 @@ class TrackedEntityFieldsParamMapperTest extends DhisControllerConvenienceTest
     @Autowired
     TrackedEntityFieldsParamMapper mapper;
 
-    @Test
-    void mapWithStar()
+    @ParameterizedTest
+    @ValueSource( strings = { "*", "!*" } )
+    void mapWithStar( String fields )
     {
-        TrackedEntityInstanceParams params = map( "*" );
-
-        assertTrue( params.isIncludeRelationships() );
-        assertTrue( params.isIncludeEnrollments() );
-        assertTrue( params.getTeiEnrollmentParams().isIncludeEvents() );
-        assertTrue( params.isIncludeProgramOwners() );
-    }
-
-    @Test
-    void mapWithPresetAll()
-    {
-        TrackedEntityInstanceParams params = map( ":all" );
-
-        assertTrue( params.isIncludeRelationships() );
-        assertTrue( params.isIncludeEnrollments() );
-        assertTrue( params.getTeiEnrollmentParams().isIncludeEvents() );
-        assertTrue( params.isIncludeProgramOwners() );
-    }
-
-    @Test
-    void mapWithAllExcluded()
-    {
-        // This value does not make sense as it means exclude all.
+        // This value "!*" does not make sense as it means exclude all.
         // We initially assumed field filtering would exclude all fields but is does not. Keeping this test as a reminder of its behavior.
-        TrackedEntityInstanceParams params = map( "!*" );
+        TrackedEntityInstanceParams params = map( fields );
 
         assertTrue( params.isIncludeRelationships() );
         assertTrue( params.isIncludeEnrollments() );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -82,7 +82,7 @@ public class TrackerEnrollmentsExportController
 
     private final FieldFilterService fieldFilterService;
 
-    private final EnrollmentFieldsParamMapper enrollmentFieldsParamMapper;
+    private final EnrollmentFieldsParamMapper fieldsMapper;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     PagingWrapper<ObjectNode> getInstances(
@@ -95,7 +95,7 @@ public class TrackerEnrollmentsExportController
 
         List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollmentList;
 
-        EnrollmentParams enrollmentParams = enrollmentFieldsParamMapper.map( fields )
+        EnrollmentParams enrollmentParams = fieldsMapper.map( fields )
             .withIncludeDeleted( trackerEnrollmentCriteria.isIncludeDeleted() );
 
         if ( trackerEnrollmentCriteria.getEnrollment() == null )
@@ -134,7 +134,7 @@ public class TrackerEnrollmentsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException
     {
-        EnrollmentParams enrollmentParams = enrollmentFieldsParamMapper.map( fields );
+        EnrollmentParams enrollmentParams = fieldsMapper.map( fields );
 
         Enrollment enrollment = ENROLLMENT_MAPPER
             .from( enrollmentService.getEnrollment( id, enrollmentParams ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEnrollmentsExportController.java
@@ -28,15 +28,12 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
-import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.EnrollmentFieldsParamMapper.map;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
 
 import lombok.RequiredArgsConstructor;
 
@@ -53,6 +50,7 @@ import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.program.ProgramInstanceQueryParams;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.EnrollmentFieldsParamMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.mapstruct.factory.Mappers;
@@ -78,14 +76,13 @@ public class TrackerEnrollmentsExportController
 
     private static final EnrollmentMapper ENROLLMENT_MAPPER = Mappers.getMapper( EnrollmentMapper.class );
 
-    @Nonnull
     private final TrackerEnrollmentCriteriaMapper enrollmentCriteriaMapper;
 
-    @Nonnull
     private final EnrollmentService enrollmentService;
 
-    @Nonnull
     private final FieldFilterService fieldFilterService;
+
+    private final EnrollmentFieldsParamMapper enrollmentFieldsParamMapper;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     PagingWrapper<ObjectNode> getInstances(
@@ -98,7 +95,7 @@ public class TrackerEnrollmentsExportController
 
         List<org.hisp.dhis.dxf2.events.enrollment.Enrollment> enrollmentList;
 
-        EnrollmentParams enrollmentParams = map( fields )
+        EnrollmentParams enrollmentParams = enrollmentFieldsParamMapper.map( fields )
             .withIncludeDeleted( trackerEnrollmentCriteria.isIncludeDeleted() );
 
         if ( trackerEnrollmentCriteria.getEnrollment() == null )
@@ -137,7 +134,7 @@ public class TrackerEnrollmentsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException
     {
-        EnrollmentParams enrollmentParams = map( fields );
+        EnrollmentParams enrollmentParams = enrollmentFieldsParamMapper.map( fields );
 
         Enrollment enrollment = ENROLLMENT_MAPPER
             .from( enrollmentService.getEnrollment( id, enrollmentParams ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
-import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.EventFieldsParamMapper.map;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_GZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_TEXT_CSV;
@@ -64,6 +63,7 @@ import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.node.Preset;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.EventFieldsParamMapper;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -110,6 +110,8 @@ public class TrackerEventsExportController
 
     @Nonnull
     private final FieldFilterService fieldFilterService;
+
+    private final EventFieldsParamMapper eventFieldsParamMapper;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     public PagingWrapper<ObjectNode> getEvents(
@@ -234,7 +236,7 @@ public class TrackerEventsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException
     {
-        EventParams eventParams = map( fields );
+        EventParams eventParams = eventFieldsParamMapper.map( fields );
         Event event = eventService.getEvent( programStageInstanceService.getProgramStageInstance( uid ),
             eventParams );
         if ( event == null )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -111,7 +111,7 @@ public class TrackerEventsExportController
     @Nonnull
     private final FieldFilterService fieldFilterService;
 
-    private final EventFieldsParamMapper eventFieldsParamMapper;
+    private final EventFieldsParamMapper eventsMapper;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     public PagingWrapper<ObjectNode> getEvents(
@@ -236,7 +236,7 @@ public class TrackerEventsExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException
     {
-        EventParams eventParams = eventFieldsParamMapper.map( fields );
+        EventParams eventParams = eventsMapper.map( fields );
         Event event = eventService.getEvent( programStageInstanceService.getProgramStageInstance( uid ),
             eventParams );
         if ( event == null )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -101,7 +101,7 @@ public class TrackerTrackedEntitiesExportController
     @Nonnull
     private final CsvEventService<TrackedEntity> csvEventService;
 
-    private final TrackedEntityFieldsParamMapper trackedEntityFieldsParamMapper;
+    private final TrackedEntityFieldsParamMapper fieldsMapper;
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     PagingWrapper<ObjectNode> getInstances( TrackerTrackedEntityCriteria criteria,
@@ -111,7 +111,7 @@ public class TrackerTrackedEntitiesExportController
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields,
+        TrackedEntityInstanceParams trackedEntityInstanceParams = fieldsMapper.map( fields,
             criteria.isIncludeDeleted() );
 
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
@@ -152,7 +152,7 @@ public class TrackerTrackedEntitiesExportController
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
         // TODO the filtering does not apply to CSV. Why are we using the mapper here?
-        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields,
+        TrackedEntityInstanceParams trackedEntityInstanceParams = fieldsMapper.map( fields,
             criteria.isIncludeDeleted() );
 
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
@@ -191,7 +191,7 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( required = false ) String program,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
     {
-        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields );
+        TrackedEntityInstanceParams trackedEntityInstanceParams = fieldsMapper.map( fields );
 
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
             trackedEntitiesSupportService.getTrackedEntityInstance( id, program, trackedEntityInstanceParams ) );
@@ -206,7 +206,7 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws IOException
     {
-        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields );
+        TrackedEntityInstanceParams trackedEntityInstanceParams = fieldsMapper.map( fields );
 
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
             trackedEntitiesSupportService.getTrackedEntityInstance( id, program, trackedEntityInstanceParams ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -28,7 +28,6 @@
 package org.hisp.dhis.webapi.controller.tracker.export;
 
 import static org.hisp.dhis.webapi.controller.tracker.TrackerControllerSupport.RESOURCE_PATH;
-import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.TrackedEntityFieldsParamMapper.map;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_GZIP;
 import static org.hisp.dhis.webapi.utils.ContextUtils.CONTENT_TYPE_CSV_ZIP;
@@ -59,6 +58,7 @@ import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.trackedentity.TrackedEntityInstanceQueryParams;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
+import org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.TrackedEntityFieldsParamMapper;
 import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -101,17 +101,18 @@ public class TrackerTrackedEntitiesExportController
     @Nonnull
     private final CsvEventService<TrackedEntity> csvEventService;
 
+    private final TrackedEntityFieldsParamMapper trackedEntityFieldsParamMapper;
+
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     PagingWrapper<ObjectNode> getInstances( TrackerTrackedEntityCriteria criteria,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws BadRequestException,
         ForbiddenException
     {
-
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields )
-            .withIncludeDeleted( criteria.isIncludeDeleted() );
+        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields,
+            criteria.isIncludeDeleted() );
 
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
             .fromCollection( trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
@@ -150,8 +151,9 @@ public class TrackerTrackedEntitiesExportController
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields )
-            .withIncludeDeleted( criteria.isIncludeDeleted() );
+        // TODO the filtering does not apply to CSV. Why are we using the mapper here?
+        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields,
+            criteria.isIncludeDeleted() );
 
         List<TrackedEntity> trackedEntityInstances = TRACKED_ENTITY_MAPPER
             .fromCollection( trackedEntityInstanceService.getTrackedEntityInstances( queryParams,
@@ -189,7 +191,7 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( required = false ) String program,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
     {
-        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields );
+        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields );
 
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
             trackedEntitiesSupportService.getTrackedEntityInstance( id, program, trackedEntityInstanceParams ) );
@@ -204,7 +206,7 @@ public class TrackerTrackedEntitiesExportController
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws IOException
     {
-        TrackedEntityInstanceParams trackedEntityInstanceParams = map( fields );
+        TrackedEntityInstanceParams trackedEntityInstanceParams = trackedEntityFieldsParamMapper.map( fields );
 
         TrackedEntity trackedEntity = TRACKED_ENTITY_MAPPER.from(
             trackedEntitiesSupportService.getTrackedEntityInstance( id, program, trackedEntityInstanceParams ) );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerTrackedEntitiesExportController.java
@@ -151,7 +151,6 @@ public class TrackerTrackedEntitiesExportController
     {
         TrackedEntityInstanceQueryParams queryParams = criteriaMapper.map( criteria );
 
-        // TODO the filtering does not apply to CSV. Why are we using the mapper here?
         TrackedEntityInstanceParams trackedEntityInstanceParams = fieldsMapper.map( fields,
             criteria.isIncludeDeleted() );
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsParamMapper.java
@@ -35,25 +35,31 @@ import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.Fields
 import java.util.List;
 import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.dxf2.events.EnrollmentParams;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
+import org.hisp.dhis.tracker.domain.Enrollment;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class EnrollmentFieldsParamMapper
 {
-    private EnrollmentFieldsParamMapper()
-    {
-    }
+    private final FieldFilterService fieldFilterService;
 
-    public static EnrollmentParams map( List<FieldPath> fields )
+    public EnrollmentParams map( List<FieldPath> fields )
     {
         Map<String, FieldPath> roots = rootFields( fields );
         EnrollmentParams params = initUsingAllOrNoFields( roots );
-
-        params = withFieldRelationships( roots, params );
-        params = withFieldEvents( roots, params );
-        params = withFieldAttributes( roots, params );
-
+        params = params.withIncludeRelationships(
+            fieldFilterService.filterIncludes( Enrollment.class, fields, FIELD_RELATIONSHIPS ) );
+        params = params
+            .withIncludeEvents( fieldFilterService.filterIncludes( Enrollment.class, fields, FIELD_EVENTS ) );
+        params = params
+            .withIncludeAttributes( fieldFilterService.filterIncludes( Enrollment.class, fields, FIELD_ATTRIBUTES ) );
         return params;
     }
 
@@ -69,30 +75,5 @@ public class EnrollmentFieldsParamMapper
             }
         }
         return params;
-    }
-
-    private static EnrollmentParams withFieldRelationships( Map<String, FieldPath> roots,
-        EnrollmentParams params )
-    {
-        return roots.containsKey( FIELD_RELATIONSHIPS )
-            ? params.withIncludeRelationships( !roots.get( FIELD_RELATIONSHIPS ).isExclude() )
-            : params;
-    }
-
-    private static EnrollmentParams withFieldEvents(
-        Map<String, FieldPath> roots,
-        EnrollmentParams params )
-    {
-        return roots.containsKey( FIELD_EVENTS )
-            ? params.withIncludeEvents( !roots.get( FIELD_EVENTS ).isExclude() )
-            : params;
-    }
-
-    private static EnrollmentParams withFieldAttributes( Map<String, FieldPath> roots,
-        EnrollmentParams params )
-    {
-        return roots.containsKey( FIELD_ATTRIBUTES )
-            ? params.withIncludeAttributes( !roots.get( FIELD_ATTRIBUTES ).isExclude() )
-            : params;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EnrollmentFieldsParamMapper.java
@@ -41,7 +41,7 @@ import org.hisp.dhis.dxf2.events.EnrollmentParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
-import org.hisp.dhis.tracker.domain.Enrollment;
+import org.hisp.dhis.webapi.controller.tracker.view.Enrollment;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsParamMapper.java
@@ -50,7 +50,6 @@ public class EventFieldsParamMapper
 
     public EventParams map( List<FieldPath> fields )
     {
-        // TODO we could create a type FieldPaths wrapping List<FieldPath> to answer questions like containsPreset(ALL)
         Map<String, FieldPath> roots = rootFields( fields );
         EventParams params = initUsingAllOrNoFields( roots );
         return params

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsParamMapper.java
@@ -33,24 +33,28 @@ import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.Fields
 import java.util.List;
 import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
+
 import org.hisp.dhis.dxf2.events.EventParams;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
+import org.hisp.dhis.tracker.domain.Event;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class EventFieldsParamMapper
 {
-    private EventFieldsParamMapper()
-    {
-    }
+    private final FieldFilterService fieldFilterService;
 
-    public static EventParams map( List<FieldPath> fields )
+    public EventParams map( List<FieldPath> fields )
     {
+        // TODO we could create a type FieldPaths wrapping List<FieldPath> to answer questions like containsPreset(ALL)
         Map<String, FieldPath> roots = rootFields( fields );
         EventParams params = initUsingAllOrNoFields( roots );
-
-        params = withFieldRelationships( roots, params );
-
-        return params;
+        return params
+            .withIncludeRelationships( fieldFilterService.filterIncludes( Event.class, fields, FIELD_RELATIONSHIPS ) );
     }
 
     private static EventParams initUsingAllOrNoFields( Map<String, FieldPath> roots )
@@ -65,13 +69,5 @@ public class EventFieldsParamMapper
             }
         }
         return params;
-    }
-
-    private static EventParams withFieldRelationships( Map<String, FieldPath> roots,
-        EventParams params )
-    {
-        return roots.containsKey( FIELD_RELATIONSHIPS )
-            ? params.withIncludeRelationships( !roots.get( FIELD_RELATIONSHIPS ).isExclude() )
-            : params;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/EventFieldsParamMapper.java
@@ -39,7 +39,7 @@ import org.hisp.dhis.dxf2.events.EventParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
-import org.hisp.dhis.tracker.domain.Event;
+import org.hisp.dhis.webapi.controller.tracker.view.Event;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/TrackedEntityFieldsParamMapper.java
@@ -59,8 +59,6 @@ public class TrackedEntityFieldsParamMapper
 
     public TrackedEntityInstanceParams map( List<FieldPath> fields )
     {
-        // TODO should includeDeleted by false when a controller does not pass it in?
-        // TODO what about dataSynchronizationQuery? When should it be true, when false? Who sets this?
         return map( fields, false );
     }
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/TrackedEntityFieldsParamMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/fieldsmapper/TrackedEntityFieldsParamMapper.java
@@ -28,45 +28,69 @@
 package org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper;
 
 import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.FieldsParamMapper.FIELD_ATTRIBUTES;
-import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.FieldsParamMapper.FIELD_EVENTS;
 import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.FieldsParamMapper.FIELD_RELATIONSHIPS;
 import static org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.FieldsParamMapper.rootFields;
 
 import java.util.List;
 import java.util.Map;
 
+import lombok.RequiredArgsConstructor;
+
+import org.hisp.dhis.dxf2.events.EnrollmentEventsParams;
+import org.hisp.dhis.dxf2.events.EnrollmentParams;
+import org.hisp.dhis.dxf2.events.EventParams;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceEnrollmentParams;
 import org.hisp.dhis.dxf2.events.TrackedEntityInstanceParams;
+import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
 import org.hisp.dhis.fieldfiltering.FieldPreset;
+import org.hisp.dhis.webapi.controller.tracker.view.TrackedEntity;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class TrackedEntityFieldsParamMapper
 {
-    private TrackedEntityFieldsParamMapper()
-    {
-    }
+    private final FieldFilterService fieldFilterService;
 
     private static final String FIELD_PROGRAM_OWNERS = "programOwners";
 
     private static final String FIELD_ENROLLMENTS = "enrollments";
 
-    public static TrackedEntityInstanceParams map( List<FieldPath> fields )
+    public TrackedEntityInstanceParams map( List<FieldPath> fields )
+    {
+        // TODO should includeDeleted by false when a controller does not pass it in?
+        // TODO what about dataSynchronizationQuery? When should it be true, when false? Who sets this?
+        return map( fields, false );
+    }
+
+    public TrackedEntityInstanceParams map( List<FieldPath> fields, boolean includeDeleted )
     {
         Map<String, FieldPath> roots = rootFields( fields );
 
         TrackedEntityInstanceParams params = initUsingAllOrNoFields( roots );
+        params = params.withIncludeRelationships(
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_RELATIONSHIPS ) );
+        params = params.withIncludeProgramOwners(
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_PROGRAM_OWNERS ) );
+        params = params.withIncludeAttributes(
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_ATTRIBUTES ) );
 
-        params = withFieldRelationships( roots, params );
-        params = withFieldProgramOwners( roots, params );
-        params = withFieldAttributes( roots, params );
-
-        params = initNestedEnrollmentProperties( roots, params );
-
-        params = withFieldEnrollmentsAndEvents( fields, roots, params );
-        params = withFieldEnrollmentAndAttributes( fields, roots, params );
-        params = withFieldEnrollmentAndRelationships( fields, roots, params );
-        params = withFieldEventsAndRelationships( fields, roots, params );
-
+        EventParams eventParams = new EventParams(
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.events.relationships" ) );
+        EnrollmentEventsParams enrollmentEventsParams = new EnrollmentEventsParams(
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.events" ),
+            eventParams );
+        EnrollmentParams enrollmentParams = new EnrollmentParams(
+            enrollmentEventsParams,
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.relationships" ),
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, "enrollments.attributes" ),
+            includeDeleted,
+            false );
+        TrackedEntityInstanceEnrollmentParams teiEnrollmentParams = new TrackedEntityInstanceEnrollmentParams(
+            fieldFilterService.filterIncludes( TrackedEntity.class, fields, FIELD_ENROLLMENTS ),
+            enrollmentParams );
+        params = params.withTeiEnrollmentParams( teiEnrollmentParams );
         return params;
     }
 
@@ -83,162 +107,5 @@ public class TrackedEntityFieldsParamMapper
             }
         }
         return params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldRelationships( Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        return roots.containsKey( FIELD_RELATIONSHIPS )
-            ? params.withIncludeRelationships( !roots.get( FIELD_RELATIONSHIPS ).isExclude() )
-            : params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldAttributes( Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        return roots.containsKey( FIELD_ATTRIBUTES )
-            ? params.withIncludeAttributes( !roots.get( FIELD_ATTRIBUTES ).isExclude() )
-            : params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldProgramOwners( Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        return roots.containsKey( FIELD_PROGRAM_OWNERS )
-            ? params.withIncludeProgramOwners( !roots.get( FIELD_PROGRAM_OWNERS ).isExclude() )
-            : params;
-    }
-
-    private static TrackedEntityInstanceParams initNestedEnrollmentProperties( Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        if ( roots.containsKey( FIELD_ENROLLMENTS ) )
-        {
-            FieldPath p = roots.get( FIELD_ENROLLMENTS );
-            params = params.withTeiEnrollmentParams( !p.isExclude() ? TrackedEntityInstanceEnrollmentParams.TRUE
-                : TrackedEntityInstanceEnrollmentParams.FALSE );
-        }
-        return params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldEnrollmentsAndEvents( List<FieldPath> fieldPaths,
-        Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        FieldPath events = fieldPathByNestedField( fieldPaths, FIELD_EVENTS, List.of( FIELD_ENROLLMENTS ) );
-
-        if ( events == null )
-        {
-            return params;
-        }
-
-        if ( events.isExclude() )
-        {
-            return params.withTeiEnrollmentParams(
-                params.getTeiEnrollmentParams().withIncludeEvents( false ) );
-        }
-        // since exclusion takes precedence if "!enrollments" we do not need to
-        // check the events field value
-        if ( roots.containsKey( FIELD_ENROLLMENTS ) && !roots.get( FIELD_ENROLLMENTS ).isExclude() )
-        {
-            return params.withTeiEnrollmentParams(
-                params.getTeiEnrollmentParams().withIncludeEvents( !events.isExclude() ) );
-        }
-        return params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldEnrollmentAndAttributes( List<FieldPath> fieldPaths,
-        Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        FieldPath attribute = fieldPathByNestedField( fieldPaths, FIELD_ATTRIBUTES,
-            List.of( FIELD_ENROLLMENTS ) );
-
-        if ( attribute == null )
-        {
-            return params;
-        }
-
-        if ( attribute.isExclude() )
-        {
-            return params.withTeiEnrollmentParams(
-                params.getTeiEnrollmentParams().withIncludeAttributes( false ) );
-        }
-        // since exclusion takes precedence if "!enrollments" we do not need to
-        // check the attributes field value
-        if ( roots.containsKey( FIELD_ENROLLMENTS ) && !roots.get( FIELD_ENROLLMENTS ).isExclude() )
-        {
-            return params
-                .withTeiEnrollmentParams(
-                    params.getTeiEnrollmentParams().withIncludeAttributes( !attribute.isExclude() ) );
-        }
-        return params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldEnrollmentAndRelationships( List<FieldPath> fieldPaths,
-        Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        FieldPath relationship = fieldPathByNestedField( fieldPaths, FIELD_RELATIONSHIPS,
-            List.of( FIELD_ENROLLMENTS ) );
-
-        if ( relationship == null )
-        {
-            return params;
-        }
-
-        if ( relationship.isExclude() )
-        {
-            return params.withEnrollmentParams(
-                params.getEnrollmentParams().withIncludeRelationships( false ) );
-        }
-        // since exclusion takes precedence if "!enrollments" we do not need to
-        // check the relationship field value
-        if ( roots.containsKey( FIELD_ENROLLMENTS ) && !roots.get( FIELD_ENROLLMENTS ).isExclude() )
-        {
-            return params.withEnrollmentParams(
-                params.getEnrollmentParams().withIncludeRelationships( !relationship.isExclude() ) );
-        }
-        return params;
-    }
-
-    private static TrackedEntityInstanceParams withFieldEventsAndRelationships( List<FieldPath> fieldPaths,
-        Map<String, FieldPath> roots,
-        TrackedEntityInstanceParams params )
-    {
-        FieldPath relationship = fieldPathByNestedField( fieldPaths, FIELD_RELATIONSHIPS,
-            List.of( FIELD_ENROLLMENTS, FIELD_EVENTS ) );
-
-        if ( relationship == null )
-        {
-            return params;
-        }
-
-        if ( relationship.isExclude() )
-        {
-            return params.withEventParams( params.getEventParams().withIncludeRelationships( false ) );
-        }
-        // since exclusion takes precedence if "!enrollments" we do not need to
-        // check the relationship field value
-        if ( roots.containsKey( FIELD_ENROLLMENTS ) && !roots.get( FIELD_ENROLLMENTS ).isExclude() )
-        {
-            return params
-                .withEventParams( params.getEventParams().withIncludeRelationships( !relationship.isExclude() ) );
-        }
-        return params;
-    }
-
-    private static FieldPath fieldPathByNestedField( List<FieldPath> fieldPaths, String nestedField,
-        List<String> fieldToMatch )
-    {
-        return fieldPaths.stream().filter( fp -> isNestedField( fp, nestedField, fieldToMatch ) && fp.isExclude() )
-            .findFirst()
-            .orElse( null );
-    }
-
-    private static boolean isNestedField( FieldPath fieldPath, String field, List<String> fieldToMatch )
-    {
-        return !fieldPath.isRoot() && field.equals( fieldPath.getName() )
-            && fieldPath.getPath().equals( fieldToMatch );
     }
 }


### PR DESCRIPTION
* Add `FieldFilterService.filterIncludes(Class rootClass, List<FieldPath> filter, String path)` to answer the question "is path `x.y.z` included in given `filter`". Reusing the same logic that determines which fields are included when applying the filter.
* Don't mutate the `fields` parameter passed to the FieldFilterService. It's surprising and error prone if the argument is reused.
* Adapt tracker controllers to use `filterIncludes`