### PR TITLE
feat: datastore access in metadata [DHIS2-14595]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
@@ -271,8 +271,6 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest
     {
         assertStatus( HttpStatus.CREATED, POST( "/dataStore/pets/cat", "{}" ) );
 
-        switchToNewUser( "guest" );
-
         JsonDatastoreValue metaData = GET( "/dataStore/pets/cat/metaData" ).content().as( JsonDatastoreValue.class );
         assertEquals( "pets", metaData.getNamespace() );
         assertEquals( "cat", metaData.getKey() );

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DatastoreControllerTest.java
@@ -46,6 +46,7 @@ import org.hisp.dhis.datastore.DatastoreEntry;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection;
 import org.hisp.dhis.datastore.DatastoreNamespaceProtection.ProtectionType;
 import org.hisp.dhis.datastore.DatastoreService;
+import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
 import org.hisp.dhis.web.HttpStatus.Series;
 import org.hisp.dhis.webapi.DhisControllerConvenienceTest;
@@ -60,7 +61,6 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 class DatastoreControllerTest extends DhisControllerConvenienceTest
 {
-
     /**
      * Only used directly to setup namespace protection as this is by intention
      * not possible using the REST API.
@@ -270,10 +270,16 @@ class DatastoreControllerTest extends DhisControllerConvenienceTest
     void testGetKeyJsonValueMetaData()
     {
         assertStatus( HttpStatus.CREATED, POST( "/dataStore/pets/cat", "{}" ) );
+
+        switchToNewUser( "guest" );
+
         JsonDatastoreValue metaData = GET( "/dataStore/pets/cat/metaData" ).content().as( JsonDatastoreValue.class );
         assertEquals( "pets", metaData.getNamespace() );
         assertEquals( "cat", metaData.getKey() );
         assertTrue( metaData.getValue().isUndefined(), "metadata should not contain the value" );
+        JsonObject access = metaData.getObject( "access" );
+        assertTrue( access.isObject() );
+        assertTrue( access.has( "manage", "write", "read", "update", "delete" ) );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/DatastoreController.java
@@ -36,6 +36,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 import org.apache.commons.beanutils.BeanUtils;
@@ -58,6 +59,9 @@ import org.hisp.dhis.datastore.DatastoreService;
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.hisp.dhis.dxf2.webmessage.WebMessageUtils;
 import org.hisp.dhis.feedback.NotFoundException;
+import org.hisp.dhis.security.acl.AclService;
+import org.hisp.dhis.user.CurrentUser;
+import org.hisp.dhis.user.User;
 import org.hisp.dhis.webapi.JsonWriter;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.springframework.http.HttpStatus;
@@ -83,10 +87,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Controller
 @RequestMapping( "/dataStore" )
 @ApiVersion( { DhisApiVersion.DEFAULT, DhisApiVersion.ALL } )
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class DatastoreController
 {
     private final DatastoreService service;
+
+    private final AclService aclService;
 
     private final ObjectMapper jsonMapper;
 
@@ -258,8 +264,10 @@ public class DatastoreController
     @GetMapping( value = "/{namespace}/{key}/metaData", produces = APPLICATION_JSON_VALUE )
     public @ResponseBody DatastoreEntry getKeyJsonValueMetaData( @PathVariable String namespace,
         @PathVariable String key,
-        HttpServletResponse response )
-        throws Exception
+        @CurrentUser User currentUser )
+        throws NotFoundException,
+        InvocationTargetException,
+        IllegalAccessException
     {
         DatastoreEntry entry = getExistingEntry( namespace, key );
 
@@ -268,6 +276,7 @@ public class DatastoreController
         metaData.setValue( null );
         metaData.setJbPlainValue( null );
         metaData.setEncryptedValue( null );
+        metaData.setAccess( aclService.getAccess( entry, currentUser ) );
         return metaData;
     }
 


### PR DESCRIPTION
### Summary
Adds the `Access` information for the current user to the `metaData` information of a datastore entry.

### Automatic Testing
An existing test was extended to check for presence of the access information.

### Manual Testing
* create a datastore entry
* check `/api/dataStore/{ns}/{key}/metaData` 
* look for the `access` in the response object
* check with different users for different sharing setting of the tested datastore entry that the user's authorities is reflected