### PR TITLE
fix: Fix constant usage in rule engine [DHIS2-14154]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
+++ b/dhis-2/dhis-services/dhis-service-program-rule/src/main/java/org/hisp/dhis/programrule/engine/ProgramRuleEngine.java
@@ -230,7 +230,7 @@ public class ProgramRuleEngine
 
         Map<String, String> constantMap = constantService.getConstantMap().entrySet()
             .stream()
-            .collect( Collectors.toMap( Map.Entry::getKey, v -> v.getValue().toString() ) );
+            .collect( Collectors.toMap( Map.Entry::getKey, v -> Double.toString( v.getValue().getValue() ) ) );
 
         Map<String, List<String>> supplementaryData = supplementaryDataProvider.getSupplementaryData( programRules );
 


### PR DESCRIPTION
When fixes something in `dhis-service-program-rule` I try to just fix the issue and to create an integration test as we have a plan to refactor the whole module soon, so a coverage by integration tests will help to be confident on the refactor.

The issue here was that instead of the value of the constant we were putting in the constantMap the result of `toString` of Constant object.