### PR TITLE
fix: delete compulsoryDataElementOperand when updating DataSet

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/DataSetControllerTest.java
@@ -27,10 +27,13 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.hisp.dhis.web.WebClient.Body;
 import static org.hisp.dhis.web.WebClientUtils.assertStatus;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.dataset.DataSet;
 import org.hisp.dhis.jsontree.JsonArray;
 import org.hisp.dhis.jsontree.JsonObject;
 import org.hisp.dhis.web.HttpStatus;
@@ -100,5 +103,36 @@ class DataSetControllerTest extends DhisControllerConvenienceTest
         assertEquals( HttpStatus.OK, res.status() );
         assertEquals( "attachment; filename=metadata.json", res.header( "Content-Disposition" ) );
         assertEquals( "application/json", res.header( "Content-Type" ) );
+    }
+
+    /**
+     * When updating DataSet, compulsoryDataElementOperand should be deleted if
+     * the referenced DataElement is removed from the DataSet.
+     */
+    @Test
+    void testRemoveDataElement()
+    {
+        DataElement deA = createDataElement( 'A' );
+        deA.setUid( "cYeuwXTCPkU" );
+        DataElement deB = createDataElement( 'B' );
+        deB.setUid( "fbfJHSPpUQD" );
+        manager.save( deA );
+        manager.save( deB );
+
+        String dataSetId = assertStatus( HttpStatus.CREATED,
+            POST( "/dataSets/", Body( "dataset/dataset_with_compulsoryDataElementOperand.json" ) ) );
+
+        DataSet dataSet = manager.get( DataSet.class, dataSetId );
+
+        assertEquals( 1, dataSet.getCompulsoryDataElementOperands().size() );
+
+        assertStatus( HttpStatus.OK,
+            PUT( "/dataSets/{id}", dataSetId,
+                Body( "dataset/dataset_with_compulsoryDataElementOperand_update.json" ) ) );
+
+        dataSet = manager.get( DataSet.class, dataSetId );
+
+        assertEquals( 0, dataSet.getCompulsoryDataElementOperands().size() );
+
     }
 }

--- a/dhis-2/dhis-web-api-test/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand.json
+++ b/dhis-2/dhis-web-api-test/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand.json
@@ -1,0 +1,53 @@
+{
+  "validCompleteOnly": false,
+  "skipOffline": false,
+  "compulsoryFieldsCompleteOnly": false,
+  "id": "Tl0gpmhQOmr",
+  "sharing": {
+    "external": false,
+    "users": {},
+    "userGroups": {},
+    "public": "rw------"
+  },
+  "timelyDays": 15,
+  "name": "test1",
+  "dataElementDecoration": false,
+  "notifyCompletingUser": false,
+  "noValueRequiresComment": false,
+  "fieldCombinationRequired": false,
+  "renderHorizontally": false,
+  "renderAsTabs": false,
+  "mobile": false,
+  "openPeriodsAfterCoEndDate": 0,
+  "periodType": "Monthly",
+  "openFuturePeriods": 0,
+  "expiryDays": 0,
+  "categoryCombo": {
+    "id": "bjDvmb4bfuf"
+  },
+  "lastUpdatedBy": {
+    "id": "GOLswS44mh8"
+  },
+  "dataSetElements": [
+    {
+      "dataElement": {
+        "id": "cYeuwXTCPkU"
+      }
+    },
+    {
+      "dataElement": {
+        "id": "fbfJHSPpUQD"
+      }
+    }
+  ],
+  "compulsoryDataElementOperands": [
+    {
+      "dataElement": {
+        "id": "fbfJHSPpUQD"
+      },
+      "categoryOptionCombo": {
+        "id": "pq2XI5kz2BY"
+      }
+    }
+  ]
+}

--- a/dhis-2/dhis-web-api-test/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand_update.json
+++ b/dhis-2/dhis-web-api-test/src/test/resources/dataset/dataset_with_compulsoryDataElementOperand_update.json
@@ -1,0 +1,48 @@
+{
+  "validCompleteOnly": false,
+  "skipOffline": false,
+  "compulsoryFieldsCompleteOnly": false,
+  "id": "Tl0gpmhQOmr",
+  "sharing": {
+    "external": false,
+    "users": {},
+    "userGroups": {},
+    "public": "rw------"
+  },
+  "timelyDays": 15,
+  "name": "test1",
+  "dataElementDecoration": false,
+  "notifyCompletingUser": false,
+  "noValueRequiresComment": false,
+  "fieldCombinationRequired": false,
+  "renderHorizontally": false,
+  "renderAsTabs": false,
+  "mobile": false,
+  "openPeriodsAfterCoEndDate": 0,
+  "periodType": "Monthly",
+  "openFuturePeriods": 0,
+  "expiryDays": 0,
+  "categoryCombo": {
+    "id": "bjDvmb4bfuf"
+  },
+  "lastUpdatedBy": {
+    "id": "GOLswS44mh8"
+  },
+  "dataSetElements": [
+    {
+      "dataElement": {
+        "id": "cYeuwXTCPkU"
+      }
+    }
+  ],
+  "compulsoryDataElementOperands": [
+    {
+      "dataElement": {
+        "id": "fbfJHSPpUQD"
+      },
+      "categoryOptionCombo": {
+        "id": "pq2XI5kz2BY"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-12189
- When updating DataSet, compulsoryDataElementOperand should be deleted if the referenced DataElement is removed from the DataSet.

#### Testing 
1. Create two aggregate DEs (test1, test2)
2. Add the two DEs to a new data set
3. Tick the box "Complete allowed only if compulsory fields are filled" 
4. Make one of the DEs mandatory (test2)
5. Unassign a Data Element from the data set – the one that was mandatory (test2)

Expected: The Dataset **should not** have any compulsoryDataElementOperand left. Can check by browsing `api/dataSet/{id}` 