### PR TITLE
fix: Remove list wrapper in field filter service [DHIS2-14743]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-field-filtering/src/main/java/org/hisp/dhis/fieldfiltering/FieldFilterService.java
@@ -149,7 +149,7 @@ public class FieldFilterService
     public <T> ObjectNode toObjectNode( T object, String filters )
     {
         List<FieldPath> fieldPaths = FieldFilterParser.parse( filters );
-        return toObjectNode( List.of( object ), fieldPaths );
+        return toObjectNode( object, fieldPaths );
     }
 
     public <T> ObjectNode toObjectNode( T object, List<FieldPath> filters )


### PR DESCRIPTION
Removes unnecessary and invalid List wrapper for object argument in `FieldFilterService`. This wrapper lead to Jackson throwing an exception stating that  `class com.fasterxml.jackson.databind.node.ArrayNode cannot be cast to class com.fasterxml.jackson.databind.node.ObjectNode`.
