### PR TITLE
fix: Handle BindException [DHIS2-13928]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -80,6 +80,7 @@ import org.hisp.dhis.webapi.controller.exception.MetadataVersionException;
 import org.hisp.dhis.webapi.controller.exception.NotAuthenticatedException;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthenticationException;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenError;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.BadSqlGrammarException;
@@ -87,6 +88,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -187,33 +190,79 @@ public class CrudControllerAdvice
     @ResponseBody
     public WebMessage methodArgumentTypeMismatchException( MethodArgumentTypeMismatchException ex )
     {
-        if ( ex.getRequiredType() == null )
+        Class<?> requiredType = ex.getRequiredType();
+        if ( requiredType == null )
         {
-            return handleBadRequest( ex );
+            return badRequest( ex.getMessage() );
         }
 
-        if ( ex.getRequiredType().isEnum() )
+        return (requiredType.isEnum())
+            ? getEnumWebMessage( requiredType, ex.getValue(), ex.getName() )
+            : getWebMessage( ex.getValue(), requiredType.getSimpleName() );
+    }
+
+    @ExceptionHandler( TypeMismatchException.class )
+    @ResponseBody
+    public WebMessage handleTypeMismatchException( TypeMismatchException ex )
+    {
+        Class<?> requiredType = ex.getRequiredType();
+        if ( requiredType == null )
         {
-            String validValues = StringUtils
-                .join( Arrays.stream( ex.getRequiredType().getEnumConstants() ).map( Objects::toString )
-                    .collect( Collectors.toList() ), ", " );
-            String errorMessage = MessageFormat.format( "Value {0} is not a valid {1}. Valid values are: [{2}]",
-                ex.getValue(), ex.getName(), validValues );
-            return badRequest( errorMessage );
+            return badRequest( ex.getMessage() );
         }
-        return handleBadRequest( ex );
+
+        return (requiredType.isEnum())
+            ? getEnumWebMessage( requiredType, ex.getValue(), ex.getPropertyName() )
+            : getWebMessage( ex.getValue(), requiredType.getSimpleName() );
+    }
+
+    private WebMessage getEnumWebMessage( Class<?> requiredType, Object value, String field )
+    {
+        String validValues = StringUtils
+            .join( Arrays.stream( requiredType.getEnumConstants() ).map( Objects::toString )
+                .collect( Collectors.toList() ), ", " );
+        String errorMessage = MessageFormat.format( "Value {0} is not a valid {1}. Valid values are: [{2}]",
+            value, field, validValues );
+        return badRequest( errorMessage );
+    }
+
+    private WebMessage getWebMessage( Object value, String fieldType )
+    {
+        String errorMessage = MessageFormat.format( "Value {0} is not a valid {1}.",
+            value, fieldType );
+        return badRequest( errorMessage );
     }
 
     @ExceptionHandler( InvalidEnumValueException.class )
     @ResponseBody
     public WebMessage invalidEnumValueException( InvalidEnumValueException ex )
     {
-        String validValues = StringUtils
-            .join( Arrays.stream( ex.getEnumKlass().getEnumConstants() ).map( Objects::toString )
-                .collect( Collectors.toList() ), ", " );
-        String errorMessage = MessageFormat.format( "Value {0} is not a valid {1}. Valid values are: [{2}]",
-            ex.getInvalidValue(), ex.getFieldName(), validValues );
-        return badRequest( errorMessage );
+        return getEnumWebMessage( ex.getEnumKlass(), ex.getInvalidValue(), ex.getFieldName() );
+    }
+
+    /**
+     * A BindException wraps possible errors happened trying to bind all the
+     * request parameters to a binding object. Errors could be simple conversion
+     * failures (Trying to convert a 'TEXT' to an Integer ) or validation errors
+     * create by hibernate-validator framework. Currently, we are not using such
+     * framework hence only conversion errors can happen.
+     *
+     * Only first error is returned to the client in order to be consistent in
+     * the way BAD_REQUEST responses are displayed.
+     *
+     */
+    @ExceptionHandler( BindException.class )
+    @ResponseBody
+    public WebMessage handleBindException( BindException ex )
+    {
+        FieldError fieldError = ex.getFieldError();
+
+        if ( fieldError != null && fieldError.contains( TypeMismatchException.class ) )
+        {
+            return handleTypeMismatchException( fieldError.unwrap( TypeMismatchException.class ) );
+        }
+
+        return badRequest( ex.getMessage() );
     }
 
     @ExceptionHandler( Dhis2ClientException.class )

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SpringBindingTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SpringBindingTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.webapi.controller;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.hisp.dhis.dxf2.webmessage.WebMessageUtils.ok;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.hisp.dhis.dxf2.webmessage.WebMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+class SpringBindingTest
+{
+    private final static String ENDPOINT = "/binding";
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp()
+    {
+        mockMvc = MockMvcBuilders.standaloneSetup( new BindingController() )
+            .build();
+    }
+
+    @Test
+    void shouldReturnABadRequestWhenInvalidValueForEnumIsPassedAsParameter()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT )
+            .param( "simpleEnum", "INVALID" ) )
+            .andExpect( content().string( containsString( "Bad Request" ) ) )
+            .andExpect( content()
+                .string( containsString( "Value INVALID is not a valid simpleEnum. Valid values are: [YES, NO]" ) ) );
+    }
+
+    @Test
+    void shouldReturnABadRequestWhenInvalidValueForEnumInBindingObjectIsPassedAsParameter()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT + "/criteria" )
+            .param( "simpleEnumInCriteria", "INVALID" ) )
+            .andExpect( content().string( containsString( "Bad Request" ) ) )
+            .andExpect( content().string(
+                containsString( "Value INVALID is not a valid simpleEnumInCriteria. Valid values are: [YES, NO]" ) ) );
+    }
+
+    @Test
+    void shouldReturnABadRequestWhenInvalidValueForDoubleInBindingObjectIsPassedAsParameter()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT + "/criteria" )
+            .param( "doubleNumber", "INVALID" ) )
+            .andExpect( content().string( containsString( "Bad Request" ) ) )
+            .andExpect( content().string( containsString( "Value INVALID is not a valid Double." ) ) );
+    }
+
+    @Test
+    void shouldReturnABadRequestWhenInvalidValueForIntegerInBindingObjectIsPassedAsParameter()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT + "/criteria" )
+            .param( "integerNumber", "10.5" ) )
+            .andExpect( content().string( containsString( "Bad Request" ) ) )
+            .andExpect( content().string( containsString( "Value 10.5 is not a valid Integer." ) ) );
+    }
+
+    @Test
+    void shouldReturnABadRequestWhenInvalidValueForDateInBindingObjectIsPassedAsParameter()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT + "/criteria" )
+            .param( "date", "INVALID" ) )
+            .andExpect( content().string( containsString( "Bad Request" ) ) )
+            .andExpect( content().string( containsString( "Value INVALID is not a valid Date." ) ) );
+    }
+
+    @Test
+    void shouldReturnABadRequestWhenInvalidValueForBooleanInBindingObjectIsPassedAsParameter()
+        throws Exception
+    {
+        mockMvc.perform( get( ENDPOINT + "/criteria" )
+            .param( "booleanValue", "INVALID" ) )
+            .andExpect( content().string( containsString( "Bad Request" ) ) )
+            .andExpect( content().string( containsString( "Value INVALID is not a valid Boolean." ) ) );
+    }
+
+    @Controller
+    private class BindingController extends CrudControllerAdvice
+    {
+        @GetMapping( value = ENDPOINT )
+        public @ResponseBody WebMessage getValue( @RequestParam SimpleEnum simpleEnum )
+        {
+            return ok( simpleEnum.name() );
+        }
+
+        @GetMapping( value = ENDPOINT + "/criteria" )
+        public @ResponseBody WebMessage getValue( Criteria criteria )
+        {
+            return ok( criteria.toString() );
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    private class Criteria
+    {
+        private final SimpleEnum simpleEnumInCriteria;
+
+        private final Date date;
+
+        private final Double doubleNumber;
+
+        private final Integer integerNumber;
+
+        private final Boolean booleanValue;
+    }
+
+    private enum SimpleEnum
+    {
+        YES,
+        NO
+    }
+}


### PR DESCRIPTION
Handling `BindException` in `CrudControllerAdvice` and return a BAD_REQUEST if any request parameter conversion fails (in the specific a `TypeMismatchException` is thrown ).

`BindException` is also handling validation errors managed through `hibernate-validator` framework that is not currently used in DHIS2.

