### PR TITLE
perf: remove unnecessary attributeValue handler in FieldFilterService

### DIFF
--- a/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
+++ b/dhis-2/dhis-services/dhis-service-node/src/main/java/org/hisp/dhis/fieldfilter/DefaultFieldFilterService.java
@@ -387,12 +387,6 @@ public class DefaultFieldFilterService implements FieldFilterService
             ((BaseIdentifiableObject) object).setAccess( access );
         }
 
-        if ( fieldMap.containsKey( "attribute" ) && AttributeValue.class.isAssignableFrom( object.getClass() ) )
-        {
-            AttributeValue attributeValue = (AttributeValue) object;
-            attributeValue.setAttribute( attributeService.getAttribute( attributeValue.getAttribute().getUid() ) );
-        }
-
         if ( Sharing.class.isAssignableFrom( object.getClass() ) )
         {
             Sharing sharing = (Sharing) object;


### PR DESCRIPTION
### Issue
- This issue related to the old `DefaultFieldFilterService` so its only applied to 2.38 and older versions.
- An api request with `attributeValues` in fields filter will take a long time to load.
```
api/optionSets.json?fields=id,displayName,options[id,displayName,code,attributeValues]&paging=false
```
- There is a special handler for `attributeValues` in `DefaultFieldFilterService` which help to load `Attribute` entity from database/cache if the api request needs any other properties of `Attribute` beside UID. 
- Although all `Attribute` are cached and no database query is made, the call to `attributeService.getAttribute( attributeId )` still taking time.
- After debugging, I found out that there is another method doing the same thing `handleJsonbObjectProperties`.  This method will only be invoked if the api request includes `Attribute.name` or other properties.

### Fix
- Remove the redundant `attributeValues` handler.
- After the fix, the query time is reduced from 22s to 4s.

### Test
- Added a test to make sure api request for `Attribute.name` like below still works properly.

```
api/optionSets.json?fields=id,displayName,options[id,displayName,code,attributeValues[value,attribute[id,name]]&paging=false
```

Screenshot tested with Laos DB
<img width="995" alt="Screen Shot 2023-02-17 at 1 04 07 AM" src="https://user-images.githubusercontent.com/766102/219455898-ae414fa7-ac0b-435f-903c-b2503932ac82.png">

