### PR TITLE
fix: Add due date filter in sql generation [DHIS2-14497]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/event/JdbcEventStore.java
@@ -1259,6 +1259,24 @@ public class JdbcEventStore implements EventStore
                 .append( " (pi.incidentdate >= :enrollmentOccurredAfter ) " );
         }
 
+        if ( params.getDueDateStart() != null )
+        {
+            mapSqlParameterSource.addValue( "startDueDate", params.getDueDateStart(), Types.TIMESTAMP );
+
+            fromBuilder
+                .append( hlp.whereAnd() )
+                .append( " (psi.duedate is not null and psi.duedate >= :startDueDate ) " );
+        }
+
+        if ( params.getDueDateEnd() != null )
+        {
+            mapSqlParameterSource.addValue( "endDueDate", params.getDueDateEnd(), Types.TIMESTAMP );
+
+            fromBuilder
+                .append( hlp.whereAnd() )
+                .append( " (psi.duedate is not null and psi.duedate <= :endDueDate ) " );
+        }
+
         if ( params.getFollowUp() != null )
         {
             fromBuilder.append( hlp.whereAnd() )

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/tracker/EventExporterTest.java
@@ -810,6 +810,54 @@ class EventExporterTest extends TrackerTest
         assertEquals( List.of( "nxP7UnKhomJ", "TvctPPhpD8z" ), enrollments );
     }
 
+    @Test
+    void shouldReturnNoEventsWhenParamStartDueDateLaterThanEventDueDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setDueDateStart( parseDate( "2021-02-28T13:05:00.000" ) );
+
+        List<String> events = eventsFunction.apply( params );
+
+        assertIsEmpty( events );
+    }
+
+    @Test
+    void shouldReturnEventsWhenParamStartDueDateEarlierThanEventsDueDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setDueDateStart( parseDate( "2018-02-28T13:05:00.000" ) );
+
+        List<String> events = eventsFunction.apply( params );
+
+        assertContainsOnly( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events );
+    }
+
+    @Test
+    void shouldReturnNoEventsWhenParamEndDueDateEarlierThanEventDueDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setDueDateEnd( parseDate( "2018-02-28T13:05:00.000" ) );
+
+        List<String> events = eventsFunction.apply( params );
+
+        assertIsEmpty( events );
+    }
+
+    @Test
+    void shouldReturnEventsWhenParamEndDueDateLaterThanEventsDueDate()
+    {
+        EventSearchParams params = new EventSearchParams();
+        params.setOrgUnit( orgUnit );
+        params.setDueDateEnd( parseDate( "2021-02-28T13:05:00.000" ) );
+
+        List<String> events = eventsFunction.apply( params );
+
+        assertContainsOnly( List.of( "D9PbzJY8bJM", "pTzf9KYMk72" ), events );
+    }
+
     private DataElement dataElement( String uid )
     {
         return dataElementService.getDataElement( uid );

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventCriteriaMapperTest.java
@@ -388,7 +388,7 @@ class TrackerEventCriteriaMapperTest
     }
 
     @Test
-    void testMappingEnrollmentOcurredAtDates()
+    void testMappingEnrollmentOccurredAtDates()
         throws BadRequestException,
         ForbiddenException
     {


### PR DESCRIPTION
In the new API we are not filtering by the fields _scheduledBefore_ or _scheduledAfter_, even though we should, based on [the documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/new-tracker.html#events-get-apitrackerevents).

This is a fix for https://dhis2.atlassian.net/browse/DHIS2-14497