### PR TITLE
chore: remove unused href field from new tracker event export DHIS2-14828

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/export/TrackerEventsExportController.java
@@ -57,15 +57,12 @@ import org.hisp.dhis.dxf2.events.event.csv.CsvEventService;
 import org.hisp.dhis.feedback.BadRequestException;
 import org.hisp.dhis.feedback.ForbiddenException;
 import org.hisp.dhis.feedback.NotFoundException;
-import org.hisp.dhis.fieldfiltering.FieldFilterParams;
 import org.hisp.dhis.fieldfiltering.FieldFilterService;
 import org.hisp.dhis.fieldfiltering.FieldPath;
-import org.hisp.dhis.node.Preset;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.webapi.controller.event.webrequest.PagingWrapper;
 import org.hisp.dhis.webapi.controller.tracker.export.fieldsmapper.EventFieldsParamMapper;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
-import org.hisp.dhis.webapi.service.ContextService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
 import org.mapstruct.factory.Mappers;
 import org.springframework.http.HttpHeaders;
@@ -75,10 +72,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.Lists;
 
 @OpenApi.Tags( "tracker" )
 @RestController
@@ -97,9 +92,6 @@ public class TrackerEventsExportController
     private final EventService eventService;
 
     @Nonnull
-    private final ContextService contextService;
-
-    @Nonnull
     private final TrackerEventCriteriaMapper requestToSearchParams;
 
     @Nonnull
@@ -115,12 +107,11 @@ public class TrackerEventsExportController
 
     @GetMapping( produces = APPLICATION_JSON_VALUE )
     public PagingWrapper<ObjectNode> getEvents(
-        TrackerEventCriteria eventCriteria, HttpServletRequest request,
-        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<String> fields )
+        TrackerEventCriteria eventCriteria,
+        @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws BadRequestException,
         ForbiddenException
     {
-
         EventSearchParams eventSearchParams = requestToSearchParams.map( eventCriteria );
 
         if ( areAllEnrollmentsInvalid( eventCriteria, eventSearchParams ) )
@@ -130,11 +121,6 @@ public class TrackerEventsExportController
 
         Events events = eventService.getEvents( eventSearchParams );
 
-        if ( hasHref( fields, eventCriteria.getSkipEventId() ) )
-        {
-            events.getEvents().forEach( e -> e.setHref( getUri( e.getEvent(), request ) ) );
-        }
-
         PagingWrapper<ObjectNode> pagingWrapper = new PagingWrapper<>();
 
         if ( eventCriteria.isPagingRequest() )
@@ -143,11 +129,9 @@ public class TrackerEventsExportController
                 PagingWrapper.Pager.fromLegacy( eventCriteria, events.getPager() ) );
         }
 
-        FieldFilterParams<org.hisp.dhis.webapi.controller.tracker.view.Event> filterParams = FieldFilterParams
-            .of( EVENTS_MAPPER.fromCollection( events.getEvents() ), fields );
-        List<ObjectNode> objectNodes = fieldFilterService.toObjectNodes( filterParams );
+        List<ObjectNode> objectNodes = fieldFilterService
+            .toObjectNodes( EVENTS_MAPPER.fromCollection( events.getEvents() ), fields );
         return pagingWrapper.withInstances( objectNodes );
-
     }
 
     @GetMapping( produces = { CONTENT_TYPE_CSV, CONTENT_TYPE_CSV_GZIP, CONTENT_TYPE_TEXT_CSV } )
@@ -160,13 +144,6 @@ public class TrackerEventsExportController
         BadRequestException,
         ForbiddenException
     {
-        List<String> fields = Lists.newArrayList( contextService.getParameterValues( "fields" ) );
-
-        if ( fields.isEmpty() )
-        {
-            fields.addAll( Preset.ALL.getFields() );
-        }
-
         EventSearchParams eventSearchParams = requestToSearchParams.map( eventCriteria );
 
         if ( areAllEnrollmentsInvalid( eventCriteria, eventSearchParams ) )
@@ -175,11 +152,6 @@ public class TrackerEventsExportController
         }
 
         Events events = eventService.getEvents( eventSearchParams );
-
-        if ( hasHref( fields, eventCriteria.getSkipEventId() ) )
-        {
-            events.getEvents().forEach( e -> e.setHref( getUri( e.getEvent(), request ) ) );
-        }
 
         OutputStream outputStream = response.getOutputStream();
         response.setContentType( CONTENT_TYPE_CSV );
@@ -202,37 +174,9 @@ public class TrackerEventsExportController
             CollectionUtils.isEmpty( eventSearchParams.getProgramInstances() );
     }
 
-    private String getUri( String eventUid, HttpServletRequest request )
-    {
-        return UriComponentsBuilder.fromUriString( ContextUtils.getRootPath( request ) )
-            .pathSegment( RESOURCE_PATH, EVENTS, eventUid )
-            .build()
-            .toString();
-    }
-
-    protected boolean hasHref( List<String> fields, Boolean skipEventId )
-    {
-        return (skipEventId == null || !skipEventId) && fieldsContainsHref( fields );
-    }
-
-    private boolean fieldsContainsHref( List<String> fields )
-    {
-        for ( String field : fields )
-        {
-            // For now assume href/access if * or preset is requested
-            if ( field.contains( "href" ) || field.equals( "*" ) || field.startsWith( ":" ) )
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     @GetMapping( "{uid}" )
     public ResponseEntity<ObjectNode> getEvent(
         @PathVariable String uid,
-        HttpServletRequest request,
         @RequestParam( defaultValue = DEFAULT_FIELDS_PARAM ) List<FieldPath> fields )
         throws NotFoundException
     {
@@ -244,7 +188,6 @@ public class TrackerEventsExportController
             throw new NotFoundException( Event.class, uid );
         }
 
-        event.setHref( getUri( uid, request ) );
         return ResponseEntity
             .ok( fieldFilterService.toObjectNode( EVENTS_MAPPER.from( event ), fields ) );
     }


### PR DESCRIPTION
it was added when /tracker/event was added in

https://github.com/dhis2/dhis2-core/pull/7103

According to Giuseppe he only added it because it was part of the old tracker event endpoint for GET. No other GET endpoint in old and new tracker exposes this field.

'href' was returned on GET if fields query parameter contained value 'href' or '*'. In new tracker 'href' is only returned on GET /tracker/events until 2.36 after which it did not work anymore. So far no one has reported an issue.

## Sample

```
curl --silent -u admin:district 'https://play.dhis2.org/2.36.13.2/api/tracker/events/Eo8tmGwDoLM?orgUnit=DiszpKrYNg8&program=WSGAb5XwJ3Y&fields=*' | jq .
{
  "href": "https://play.dhis2.org/2.36.13.2/api/tracker/events/Eo8tmGwDoLM",
  "event": "Eo8tmGwDoLM",
  "status": "SCHEDULE",
  "program": "WSGAb5XwJ3Y",
  "programStage": "PUZaKR0Jh2k",
  "enrollment": "yeAHmGoijmS",
  "enrollmentStatus": "ACTIVE",
  "orgUnit": "DiszpKrYNg8",
  "orgUnitName": "Ngelehun CHC",
  "trackedEntity": "B7sl37PwJlI",
  "relationships": [],
  "scheduledAt": "2023-01-31T00:00:00.000",
  "storedBy": "system",
  "followup": false,
  "deleted": false,
  "createdAt": "2018-01-20T11:18:15.601",
  "createdAtClient": "2017-01-20T11:18:15.601",
  "updatedAt": "2018-01-20T11:18:29.500",
  "attributeOptionCombo": "HllvX50cXC0",
  "attributeCategoryOptions": "xYerKDKCefk",
  "dataValues": [],
  "notes": []
}
```