### PR TITLE
fix: Fetch nested event notes in trackedEntityInstance endpoint [DHIS2-11731]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/DefaultEventStore.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/trackedentity/store/DefaultEventStore.java
@@ -65,12 +65,12 @@ public class DefaultEventStore
         "from programstageinstance psi " +
         "where psi.programstageinstanceid in (:ids)";
 
-    private static final String GET_NOTES_SQL = "select pi.uid as key, tec.uid, tec.commenttext, " +
+    private static final String GET_NOTES_SQL = "select psi.uid as key, tec.uid, tec.commenttext, " +
         "tec.creator, tec.created " +
         "from trackedentitycomment tec " +
         "join programstageinstancecomments psic " +
         "on tec.trackedentitycommentid = psic.trackedentitycommentid " +
-        "join programinstance pi on psic.programstageinstanceid = pi.programinstanceid " +
+        "join programstageinstance psi on psic.programstageinstanceid = psi.programstageinstanceid " +
         "where psic.programstageinstanceid in (:ids)";
 
     private static final String ACL_FILTER_SQL = "CASE WHEN p.type = 'WITH_REGISTRATION' THEN " +

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/TrackerTest.java
@@ -63,6 +63,7 @@ import org.hisp.dhis.dxf2.events.enrollment.EnrollmentService;
 import org.hisp.dhis.dxf2.events.enrollment.EnrollmentStatus;
 import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.dxf2.events.event.EventService;
+import org.hisp.dhis.dxf2.events.event.Note;
 import org.hisp.dhis.dxf2.importsummary.ImportSummary;
 import org.hisp.dhis.event.EventStatus;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
@@ -344,6 +345,7 @@ public abstract class TrackerTest extends IntegrationTestBase
                 event1.setLastUpdatedAtClient( now );
                 event1.setCompletedDate( now );
                 event1.setCompletedBy( "[Unknown]" );
+                event1.setNotes( createEventNotes() );
                 eventList.add( event1 );
             }
             enrollment.setEvents( eventList );
@@ -405,5 +407,20 @@ public abstract class TrackerTest extends IntegrationTestBase
         group
             .setAuthorities( new HashSet<>( Arrays.asList( "z1", UserRole.AUTHORITY_ALL ) ) );
         user.setUserRoles( Sets.newHashSet( group ) );
+    }
+
+    private List<Note> createEventNotes()
+    {
+        List<Note> notes = new ArrayList<>();
+
+        for ( int i = 1; i < 3; i++ )
+        {
+            Note e = new Note();
+            e.setNote( "Event note: " + i );
+            e.setValue( "Event note: " + i );
+            notes.add( e );
+        }
+
+        return notes;
     }
 }

--- a/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/test/java/org/hisp/dhis/dxf2/events/aggregates/TrackedEntityInstanceAggregateTest.java
@@ -396,6 +396,32 @@ class TrackedEntityInstanceAggregateTest extends TrackerTest
     }
 
     @Test
+    void testFetchTrackedEntityInstancesWithEventNotes()
+    {
+        doInTransaction( this::persistTrackedEntityInstanceWithEnrollmentAndEvents );
+        TrackedEntityInstanceQueryParams queryParams = new TrackedEntityInstanceQueryParams();
+        queryParams.setOrganisationUnits( Sets.newHashSet( organisationUnitA ) );
+        queryParams.setTrackedEntityType( trackedEntityTypeA );
+        queryParams.setIncludeAllAttributes( true );
+        TrackedEntityInstanceParams params = new TrackedEntityInstanceParams( false, true, true, false, false, false );
+        final List<TrackedEntityInstance> trackedEntityInstances = trackedEntityInstanceService
+            .getTrackedEntityInstances( queryParams, params, false, false );
+
+        assertThat( trackedEntityInstances, hasSize( 1 ) );
+        assertThat( trackedEntityInstances.get( 0 ).getEnrollments(), hasSize( 1 ) );
+        assertThat( trackedEntityInstances.get( 0 ).getEnrollments().get( 0 ).getEvents(), hasSize( 5 ) );
+
+        List<Event> events = trackedEntityInstances.get( 0 ).getEnrollments().get( 0 ).getEvents();
+
+        assertThat( events.get( 0 ).getNotes(), hasSize( 2 ) );
+        assertThat( events.get( 1 ).getNotes(), hasSize( 2 ) );
+        assertThat( events.get( 2 ).getNotes(), hasSize( 2 ) );
+        assertThat( events.get( 3 ).getNotes(), hasSize( 2 ) );
+        assertThat( events.get( 4 ).getNotes(), hasSize( 2 ) );
+
+    }
+
+    @Test
     void testFetchTrackedEntityInstancesWithoutEvents()
     {
         doInTransaction( () -> {


### PR DESCRIPTION
backport [[DHIS2-11731]](https://dhis2.atlassian.net/browse/DHIS2-11731)

[DHIS2-11731]: https://dhis2.atlassian.net/browse/DHIS2-11731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ