### PR TITLE
feat: Use rule engine version using expression parser [TECH-1491]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/pom.xml
+++ b/dhis-2/dhis-services/dhis-service-core/pom.xml
@@ -198,10 +198,6 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>

--- a/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/pom.xml
@@ -35,10 +35,6 @@
 
     <!-- Application -->
     <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
     </dependency>

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineDescriptionTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/programrule/engine/ProgramRuleEngineDescriptionTest.java
@@ -43,6 +43,7 @@ import org.hisp.dhis.programrule.ProgramRuleService;
 import org.hisp.dhis.programrule.ProgramRuleVariable;
 import org.hisp.dhis.programrule.ProgramRuleVariableService;
 import org.hisp.dhis.programrule.ProgramRuleVariableSourceType;
+import org.hisp.dhis.rules.models.RuleEngineValidationException;
 import org.hisp.dhis.rules.models.RuleValidationResult;
 import org.hisp.dhis.test.integration.SingleSetupIntegrationTestBase;
 import org.hisp.dhis.trackedentity.TrackedEntityAttribute;
@@ -75,7 +76,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
     private String incorrectConditionTextDE = "#{Program_Rule_Variable_Text_DE} == 'text_de' +";
 
     private String extractDataMatrixValueExpression = "d2:extractDataMatrixValue('serial number'," +
-        " ']d201084700069915412110081996195256\u001D10DXB2005\u001D17220228') > 0";
+        " ']d201084700069915412110081996195256\u001D10DXB2005\u001D17220228') == 'some text'";
 
     private String conditionNumericDE = "#{Program_Rule_Variable_Numeric_DE} == 14";
 
@@ -205,7 +206,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
     {
         RuleValidationResult result = validateRuleCondition( programRuleTextAtt.getCondition(), program );
         assertNotNull( result );
-        assertEquals( "AttributeA == 'text_att' || Current date", result.getDescription() );
+        assertEquals( "AttributeA == 'text_att' || d2:hasValue(Current date)", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -215,7 +216,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
         RuleValidationResult result = validateRuleCondition( "#{prv1}+#{prv2}>0", program );
 
         assertNotNull( result );
-        assertEquals( "prv1+prv2>0", result.getDescription() );
+        assertEquals( "prv1 + prv2 > 0", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -224,7 +225,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
     {
         RuleValidationResult result = validateRuleCondition( programRuleWithD2HasValue.getCondition(), program );
         assertNotNull( result );
-        assertEquals( "AttributeA", result.getDescription() );
+        assertEquals( "d2:hasValue(AttributeA)", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -234,7 +235,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
         programRuleWithD2HasValue.setCondition( conditionWithD2HasValue2 );
         RuleValidationResult result = validateRuleCondition( programRuleWithD2HasValue.getCondition(), program );
         assertNotNull( result );
-        assertEquals( "AttributeA", result.getDescription() );
+        assertEquals( "d2:hasValue(AttributeA)", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -243,7 +244,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
     {
         RuleValidationResult result = validateRuleCondition( programRuleNumericAtt.getCondition(), program );
         assertNotNull( result );
-        assertEquals( "AttributeB == 12 || Current date", result.getDescription() );
+        assertEquals( "AttributeB == 12 || d2:hasValue(Current date)", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -252,7 +253,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
     {
         RuleValidationResult result = validateRuleCondition( conditionNumericAttWithOR, program );
         assertNotNull( result );
-        assertEquals( "AttributeB == 12 or Current date", result.getDescription() );
+        assertEquals( "AttributeB == 12 or d2:hasValue(Current date)", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -260,8 +261,8 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
     void testProgramRuleWithNumericTrackedEntityAttributeWithAnd()
     {
         RuleValidationResult result = validateRuleCondition( conditionNumericAttWithAND, program );
-        assertNotNull( result );
-        assertEquals( "AttributeB == 12 and Current date", result.getDescription() );
+        assertNotNull( result );    // new environment variable must be added in this map
+        assertEquals( "AttributeB == 12 and d2:hasValue(Current date)", result.getDescription() );
         assertTrue( result.isValid() );
     }
 
@@ -307,7 +308,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
         RuleValidationResult result = validateRuleCondition( "1 > 2 +", program );
         assertNotNull( result );
         assertFalse( result.isValid() );
-        assertThat( result.getException(), instanceOf( IllegalStateException.class ) );
+        assertThat( result.getException(), instanceOf( RuleEngineValidationException.class ) );
     }
 
     @Test
@@ -316,7 +317,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
         RuleValidationResult result = validateRuleCondition( incorrectConditionTextDE, program );
         assertNotNull( result );
         assertFalse( result.isValid() );
-        assertThat( result.getException(), instanceOf( IllegalStateException.class ) );
+        assertThat( result.getException(), instanceOf( RuleEngineValidationException.class ) );
     }
 
     @Test
@@ -333,12 +334,12 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
         RuleValidationResult result = programRuleEngineNew.getDataExpressionDescription( "1 + 2 +", program );
         assertNotNull( result );
         assertFalse( result.isValid() );
-        assertThat( result.getException(), instanceOf( IllegalStateException.class ) );
+        assertThat( result.getException(), instanceOf( RuleEngineValidationException.class ) );
         result = programRuleEngineNew
             .getDataExpressionDescription( "d2:daysBetween(V{completed_date},V{current_date}) > 0 )", program );
         assertNotNull( result );
         assertFalse( result.isValid() );
-        assertThat( result.getException(), instanceOf( IllegalStateException.class ) );
+        assertThat( result.getException(), instanceOf( RuleEngineValidationException.class ) );
         result = programRuleEngineNew.getDataExpressionDescription( conditionWithD2DaysBetween, program );
         assertNotNull( result );
         assertTrue( result.isValid() );
@@ -350,7 +351,7 @@ class ProgramRuleEngineDescriptionTest extends SingleSetupIntegrationTestBase
         result = programRuleEngineNew.getDataExpressionDescription( programRuleNumericAtt.getCondition(), program );
         assertNotNull( result );
         assertTrue( result.isValid() );
-        assertEquals( "AttributeB == 12 || Current date", result.getDescription() );
+        assertEquals( "AttributeB == 12 || d2:hasValue(Current date)", result.getDescription() );
         result = programRuleEngineNew.getDataExpressionDescription( "'2020-12-12'", program );
         assertNotNull( result );
         assertTrue( result.isValid() );

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -64,7 +64,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>2.1.2</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.1.3-SNAPSHOT</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.1</dhis-hisp-quick.version>

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -64,7 +64,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>2.0.47</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.1.2</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.1</dhis-hisp-quick.version>
@@ -133,7 +133,6 @@
     <htmllexer.version>2.1</htmllexer.version>
     <poi.version>5.2.3</poi.version>
     <itext.version>2.1.7</itext.version>
-    <antlr.version>4.9.3</antlr.version>
 
     <!-- GIS -->
     <batik-transcoder.version>1.16</batik-transcoder.version>
@@ -711,6 +710,7 @@
               <ignoredUnusedDeclaredDependency>org.hisp.dhis:dhis-web-apps</ignoredUnusedDeclaredDependency>
             </ignoredUnusedDeclaredDependencies>
             <ignoredUsedUndeclaredDependencies>
+              <ignoredUsedUndeclaredDependency>org.antlr:antlr4-runtime</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>org.junit.jupiter:junit-jupiter-api</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>io.micrometer:micrometer-core</ignoredUsedUndeclaredDependency>
               <ignoredUsedUndeclaredDependency>io.prometheus:simpleclient</ignoredUsedUndeclaredDependency>
@@ -1050,10 +1050,6 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.hisp.dhis.parser</groupId>
-            <artifactId>dhis-antlr-expression-parser</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -1723,13 +1719,6 @@
         <groupId>org.apache.jclouds.provider</groupId>
         <artifactId>aws-s3</artifactId>
         <version>${jclouds.version}</version>
-      </dependency>
-
-      <!-- ExpressionParser -->
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-runtime</artifactId>
-        <version>${antlr.version}</version>
       </dependency>
 
       <!-- Reporting -->

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -64,7 +64,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>2.1.3-SNAPSHOT</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.1.3</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.1</dhis-hisp-quick.version>


### PR DESCRIPTION
Use new version of rule engine library that is not using ANTLR parser anymore.
Now ANTLR library is only used by `dhis-antlr-expression-parser` so we do not need to declare it as a dependency.