### PR TITLE
fix: provide displayName for all data integrity checks [DHIS2-14770]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheck.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityCheck.java
@@ -58,6 +58,9 @@ public final class DataIntegrityCheck implements Serializable
     private final String name;
 
     @JsonProperty
+    private final String displayName;
+
+    @JsonProperty
     private final String section;
 
     @JsonProperty

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DataIntegrityYamlReader.java
@@ -115,6 +115,7 @@ class DataIntegrityYamlReader
 
                 adder.accept( DataIntegrityCheck.builder()
                     .name( trim( e.name ) )
+                    .displayName( trim( e.name ) )
                     .description( trim( e.description ) )
                     .introduction( trim( e.introduction ) )
                     .recommendation( trim( e.recommendation ) )

--- a/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
+++ b/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/dataintegrity/DefaultDataIntegrityService.java
@@ -518,6 +518,7 @@ public class DefaultDataIntegrityService
         String name = type.getName();
         checksByName.put( name, DataIntegrityCheck.builder()
             .name( name )
+            .displayName( name )
             .severity( DataIntegritySeverity.WARNING )
             .section( "Legacy" )
             .description( name.replace( '_', ' ' ) )


### PR DESCRIPTION
### Manual Testing
* open scheduler app
* add new job of type "data integrity"
* select "only selected checks"
* select one of the checks 
* safe

Verify that the app does not crash when opening the selection for checks