### PR TITLE
fix: expose SmsGateWayConfig uid as id [DHIS2-9249-39]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsGatewayConfig.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sms/config/SmsGatewayConfig.java
@@ -108,6 +108,12 @@ public abstract class SmsGatewayConfig
         this.isDefault = isDefault;
     }
 
+    @JsonProperty
+    public String getId()
+    {
+        return uid;
+    }
+
     public String getUid()
     {
         return uid;


### PR DESCRIPTION
## Summary

Exposes `SmsGatewayConfig.uid` as `id` also.

[DHIS2-9249](https://dhis2.atlassian.net/browse/DHIS2-9249)

[DHIS2-9249]: https://dhis2.atlassian.net/browse/DHIS2-9249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ