### PR TITLE
perf: Speed expressions via I18n cache [TECH-1504] (#12913)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -156,6 +156,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -756,7 +757,7 @@ public class DefaultExpressionService
             .idObjectManager( idObjectManager )
             .dimensionService( dimensionService )
             .statementBuilder( statementBuilder )
-            .i18n( i18nManager.getI18n() )
+            .i18nSupplier( Suppliers.memoize( i18nManager::getI18n ) )
             .constantMap( getConstantMap() )
             .itemMap( PARSE_TYPE_EXPRESSION_ITEMS.get( params.getParseType() ) )
             .itemMethod( itemMethod )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/DefaultProgramIndicatorService.java
@@ -123,6 +123,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -508,7 +509,7 @@ public class DefaultProgramIndicatorService
             .programIndicatorService( this )
             .programStageService( programStageService )
             .statementBuilder( statementBuilder )
-            .i18n( i18nManager.getI18n() )
+            .i18nSupplier( Suppliers.memoize( i18nManager::getI18n ) )
             .constantMap( expressionService.getConstantMap() )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )

--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/ProgramVariableItem.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/program/variable/ProgramVariableItem.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.*;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.V_ZERO_POS_VALUE_COUNT;
 
 import org.hisp.dhis.antlr.ParserExceptionWithoutContext;
+import org.hisp.dhis.i18n.I18n;
 import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
 import org.hisp.dhis.program.ProgramExpressionItem;
 
@@ -74,7 +75,9 @@ public class ProgramVariableItem
     @Override
     public Object getDescription( ExprContext ctx, CommonExpressionVisitor visitor )
     {
-        String variableName = visitor.getI18n().getString( ctx.programVariable().getText() );
+        I18n i18n = visitor.getI18nSupplier().get();
+
+        String variableName = i18n.getString( ctx.programVariable().getText() );
 
         visitor.getItemDescriptions().put( ctx.getText(), variableName );
 

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorFunctionsTest.java
@@ -673,7 +673,7 @@ class ProgramSqlGeneratorFunctionsTest extends DhisConvenienceTest
             .programIndicatorService( programIndicatorService )
             .programStageService( programStageService )
             .statementBuilder( statementBuilder )
-            .i18n( new I18n( null, null ) )
+            .i18nSupplier( () -> new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )
             .params( params )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorItemsTest.java
@@ -252,7 +252,7 @@ class ProgramSqlGeneratorItemsTest extends DhisConvenienceTest
             .programIndicatorService( programIndicatorService )
             .programStageService( programStageService )
             .statementBuilder( statementBuilder )
-            .i18n( new I18n( null, null ) )
+            .i18nSupplier( () -> new I18n( null, null ) )
             .constantMap( constantMap )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( itemMethod )

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/program/ProgramSqlGeneratorVariablesTest.java
@@ -88,6 +88,9 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
     @Mock
     private DimensionService dimensionService;
 
+    @Mock
+    private I18n i18n;
+
     private StatementBuilder statementBuilder;
 
     private CommonExpressionVisitor subject;
@@ -322,7 +325,7 @@ class ProgramSqlGeneratorVariablesTest extends DhisConvenienceTest
             .programIndicatorService( programIndicatorService )
             .programStageService( programStageService )
             .statementBuilder( statementBuilder )
-            .i18n( new I18n( null, null ) )
+            .i18nSupplier( () -> new I18n( null, null ) )
             .itemMap( PROGRAM_INDICATOR_ITEMS )
             .itemMethod( ITEM_GET_SQL )
             .params( params )

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/CommonExpressionVisitor.java
@@ -31,6 +31,7 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -76,7 +77,13 @@ public class CommonExpressionVisitor
 
     private StatementBuilder statementBuilder;
 
-    private I18n i18n;
+    /**
+     * A {@link Supplier} object that can return a {@link I18n} instance when
+     * needed. This is done because retrieving a {@link I18n} instance can be
+     * expensive and is not needed for most parsing operations. When it is
+     * needed, however, this can provide it.
+     */
+    private Supplier<I18n> i18nSupplier;
 
     /**
      * Map of constant values to use in evaluating the expression.

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/program/ProgramIndicatorServiceVariableTest.java
@@ -111,6 +111,11 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase
         return programIndicatorService.getAnalyticsSql( expression, NUMERIC, piB, startDate, endDate );
     }
 
+    private Object describe( String expression )
+    {
+        return programIndicatorService.getExpressionDescription( expression );
+    }
+
     // -------------------------------------------------------------------------
     // Program variables tests (in alphabetical order)
     // -------------------------------------------------------------------------
@@ -303,5 +308,15 @@ class ProgramIndicatorServiceVariableTest extends IntegrationTestBase
         assertEquals(
             "coalesce(\"TEAttribute\",'') + nullif(cast((case when \"TEAttribute\" >= 0 then 1 else 0 end) as double),0)",
             getSqlEnrollment( "A{TEAttribute} + V{zero_pos_value_count}" ) );
+    }
+
+    // -------------------------------------------------------------------------
+    // Get description
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testOrgUnitCountDescription()
+    {
+        assertEquals( "Organisation unit count", describe( "V{org_unit_count}" ) );
     }
 }


### PR DESCRIPTION
* perf: Speed expressions via I18n cache [TECH-1504]

* fix: fix other tests

* refactor: Use Guava Suppliers.memoize [TECH-1504]

* fix: Remove test i18nManager.getI18n()

(cherry picked from commit f2973278d4b28441c54ebb48989993275c48dc42)

[TECH-1504]: https://dhis2.atlassian.net/browse/TECH-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECH-1504]: https://dhis2.atlassian.net/browse/TECH-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ