### PR TITLE
feat: Predictor norm. dist. functions [DHIS2-14714] (#12994)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/expression/DefaultExpressionService.java
@@ -58,6 +58,8 @@ import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MAX_DATE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MEDIAN;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MIN;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.MIN_DATE;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NORM_DIST_CUM;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.NORM_DIST_DEN;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.N_BRACE;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ORGUNIT_ANCESTOR;
 import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ORGUNIT_DATASET;
@@ -138,6 +140,8 @@ import org.hisp.dhis.parser.expression.ExpressionState;
 import org.hisp.dhis.parser.expression.function.FunctionAggregationType;
 import org.hisp.dhis.parser.expression.function.FunctionMaxDate;
 import org.hisp.dhis.parser.expression.function.FunctionMinDate;
+import org.hisp.dhis.parser.expression.function.FunctionNormDistCum;
+import org.hisp.dhis.parser.expression.function.FunctionNormDistDen;
 import org.hisp.dhis.parser.expression.function.FunctionYearToDate;
 import org.hisp.dhis.parser.expression.function.PeriodOffset;
 import org.hisp.dhis.parser.expression.function.VectorAvg;
@@ -224,6 +228,8 @@ public class DefaultExpressionService
         .put( MEDIAN, new VectorMedian() )
         .put( MIN, new VectorMin() )
         .put( MIN_DATE, new FunctionMinDate() )
+        .put( NORM_DIST_CUM, new FunctionNormDistCum() )
+        .put( NORM_DIST_DEN, new FunctionNormDistDen() )
         .put( PERCENTILE_CONT, new VectorPercentileCont() )
         .put( STDDEV, new VectorStddevSamp() )
         .put( STDDEV_POP, new VectorStddevPop() )

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionNormDistAbstract.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionNormDistAbstract.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import static java.lang.Double.NaN;
+import static java.util.Collections.emptyList;
+import static org.hisp.dhis.antlr.AntlrParserUtils.castDouble;
+import static org.hisp.dhis.parser.expression.ParserUtils.DEFAULT_DOUBLE_VALUE;
+import static org.hisp.dhis.parser.expression.antlr.ExpressionParser.ExprContext;
+
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.hisp.dhis.parser.expression.CommonExpressionVisitor;
+import org.hisp.dhis.parser.expression.ExpressionItem;
+
+/**
+ * Parent class for normalized distribution functions.
+ *
+ * @author Jim Grace
+ */
+public abstract class FunctionNormDistAbstract
+    implements ExpressionItem
+{
+    private static final VectorStddevSamp vectorStddevSamp = new VectorStddevSamp();
+
+    private static final VectorAvg vectorAvg = new VectorAvg();
+
+    @Override
+    public Object getExpressionInfo( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        // Visit each argument
+        ctx.expr().forEach( visitor::visit );
+
+        // If we need to get the average and/or stddev of the first argument,
+        // then evaluate it also in the sample context so it will be sampled
+        if ( ctx.expr().size() < 3 )
+        {
+            visitor.visitSamples( ctx.expr( 0 ) );
+        }
+
+        return DEFAULT_DOUBLE_VALUE;
+    }
+
+    @Override
+    public Object evaluate( ExprContext ctx, CommonExpressionVisitor visitor )
+    {
+        ExprContext expr0 = ctx.expr( 0 );
+
+        Double x = visitor.castDoubleVisit( expr0 );
+
+        // If the second argument is specified, use it as the mean of the normal
+        // distribution. Otherwise, compute the mean of the first argument.
+        Double mean = (ctx.expr().size() > 1)
+            ? visitor.castDoubleVisit( ctx.expr( 1 ) )
+            : castDouble( vectorAvg.compute( expr0, visitor, emptyList() ) );
+
+        // If the third argument is specified, use it as the standard deviation
+        // of the normal distribution. Otherwise, compute the standard deviation
+        // of the first argument.
+        Double stddev = (ctx.expr().size() > 2)
+            ? visitor.castDoubleVisit( ctx.expr( 2 ) )
+            : castDouble( vectorStddevSamp.compute( expr0, visitor, emptyList() ) );
+
+        if ( stddev <= 0 )
+        {
+            return NaN; // stddev <=0 is not allowed, result is undefined
+        }
+
+        NormalDistribution dist = new NormalDistribution( mean, stddev );
+
+        return getDistributionValue( dist, x );
+    }
+
+    /**
+     * Returns the desired measure from the normal distribution. The measure
+     * desired is supplied by the subclass.
+     *
+     * @param dist The normal distribution
+     * @param x The value which to evaluate
+     * @return The desired result
+     */
+    protected abstract Double getDistributionValue( NormalDistribution dist, Double x );
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionNormDistCum.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionNormDistCum.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import org.apache.commons.math3.distribution.NormalDistribution;
+
+/**
+ * Finds the cumulative probability of a normal distribution.
+ *
+ * @author Jim Grace
+ */
+public class FunctionNormDistCum
+    extends FunctionNormDistAbstract
+{
+    @Override
+    protected Double getDistributionValue( NormalDistribution dist, Double x )
+    {
+        return dist.cumulativeProbability( x );
+    }
+}

--- a/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionNormDistDen.java
+++ b/dhis-2/dhis-support/dhis-support-expression-parser/src/main/java/org/hisp/dhis/parser/expression/function/FunctionNormDistDen.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2004-2022, University of Oslo
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * Neither the name of the HISP project nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package org.hisp.dhis.parser.expression.function;
+
+import org.apache.commons.math3.distribution.NormalDistribution;
+
+/**
+ * Finds the density of a normal distribution.
+ *
+ * @author Jim Grace
+ */
+public class FunctionNormDistDen
+    extends FunctionNormDistAbstract
+{
+    @Override
+    protected Double getDistributionValue( NormalDistribution dist, Double x )
+    {
+        return dist.density( x );
+    }
+}

--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -64,7 +64,7 @@
     <!-- *Dependencies* -->
 
     <!-- DHIS2 Rule Engine -->
-    <dhis2-rule-engine.version>2.0.45</dhis2-rule-engine.version>
+    <dhis2-rule-engine.version>2.0.47</dhis2-rule-engine.version>
 
     <!-- HISP Quick and Staxwax -->
     <dhis-hisp-quick.version>1.4.1</dhis-hisp-quick.version>
@@ -220,7 +220,7 @@
     <speedy-spotless-maven-plugin.version>0.1.3</speedy-spotless-maven-plugin.version>
     <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <jrebel-x-maven-plugin.version>1.1.10</jrebel-x-maven-plugin.version>
-    <dhis-antlr-expression-parser.version>1.0.30</dhis-antlr-expression-parser.version>
+    <dhis-antlr-expression-parser.version>1.0.33</dhis-antlr-expression-parser.version>
     <jai-imageio.version>1.1.1</jai-imageio.version>
     <gson.version>2.8.9</gson.version>
     <semver4j.version>3.1.0</semver4j.version>


### PR DESCRIPTION
**Note:** in [DHIS2-14714](https://dhis2.atlassian.net/browse/DHIS2-14714) Scott Russpatrick and Phil Donnelly have given special permission to backport this feature to 2.39.

* feat: Predictor norm. dist. functions [DHIS2-14714]

* fix: spotless

* fix: reference to DEFAULT_DOUBLE_VALUE

(cherry picked from commit 17f22b84ecc23ee33d99fc6dfc16d49c47131c2a)

[DHIS2-14714]: https://dhis2.atlassian.net/browse/DHIS2-14714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ