### PR TITLE
chore: deploy instance with TTL set to 10 years (approx.) [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -194,6 +194,7 @@ pipeline {
                 IMAGE_PULL_POLICY = "Always"
                 FLYWAY_MIGRATE_OUT_OF_ORDER = "true"
                 FLYWAY_REPAIR_BEFORE_MIGRATION = "true"
+                INSTANCE_TTL = "315360000"
             }
             steps {
                 script {


### PR DESCRIPTION
The default TTL of an instance deployed using the instance manager is 48 hours. This PR will deploy an instance with a TTL of 10 years thus preventing the instance from being garbage collected soon than that