### PR TITLE
ci: add Jenkins build status to GitHub commit [skip ci]

### DIFF
--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -204,7 +204,7 @@ pipeline {
                     if (env.GIT_BRANCH == 'master') {
                         withCredentials([usernamePassword(credentialsId: 'dhis2-im-bot', passwordVariable: 'PASSWORD', usernameVariable: 'USER_EMAIL')]) {
                             dir('im-db-manager') {
-                                sparseCheckout('https://github.com/dhis2-sre/im-database-manager', 'master', '/scripts')
+                                git.sparseCheckout('https://github.com/dhis2-sre/im-database-manager', 'master', '/scripts')
 
                                 dir('scripts') {
                                     env.DATABASE_ID = sh(
@@ -218,7 +218,7 @@ pipeline {
                             }
 
                             dir('im-manager') {
-                                sparseCheckout('https://github.com/dhis2-sre/im-manager', 'master', '/scripts')
+                                git.sparseCheckout('https://github.com/dhis2-sre/im-manager', 'master', '/scripts')
 
                                 dir('scripts') {
                                     echo 'Creating DHIS2 instance on IM...'

--- a/jenkinsfiles/dev
+++ b/jenkinsfiles/dev
@@ -35,6 +35,10 @@ pipeline {
                 implementIoBuildStarted(buildJob: true, buildName: "${STAGE_NAME}")
                 echo 'Building DHIS2 ...'
                 script {
+                    env.DHIS2_COMMIT_SHA = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+                    env.DHIS2_REPO_URL = sh(returnStdout: true, script: 'git config remote.origin.url').trim()
+                    git.setCommitStatus("${env.DHIS2_COMMIT_SHA}", "${env.DHIS2_REPO_URL}")
+
                     withMaven(options: [artifactsPublisher(disabled: true)]) {
                         sh 'mvn -X -T 4 --batch-mode --no-transfer-progress clean install -f dhis-2/pom.xml -P -default --update-snapshots -pl -dhis-web-embedded-jetty,-dhis-test-coverage'
                         sh 'mvn -X -T 4 --batch-mode --no-transfer-progress install -f dhis-2/dhis-web/pom.xml -P -default --update-snapshots'
@@ -234,6 +238,10 @@ pipeline {
     post {
         always {
             archiveArtifacts artifacts: '**/target/surefire-reports/TEST-*.xml'
+
+            script {
+                git.setCommitStatus("${env.DHIS2_COMMIT_SHA}", "${env.DHIS2_REPO_URL}")
+            }
         }
 
         failure {


### PR DESCRIPTION
Add Jenkins builds status to GitHub commit status (and Checks).

Tested with Pending, Succeeded and Failed statuses.
![image](https://user-images.githubusercontent.com/8098421/221576849-2d190d52-b4bb-4c38-a987-31f8eecef3b0.png)
![image](https://user-images.githubusercontent.com/8098421/221576862-85829ce5-074a-458a-ad32-f00b0d8954c6.png)
![image](https://user-images.githubusercontent.com/8098421/221576877-5f637735-fe29-4371-abd2-3ddf562e8835.png)
