### PR TITLE
fix: Return an error when parameter is null [TECH-1502]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/MvcTestConfig.java
@@ -48,7 +48,6 @@ import org.hisp.dhis.system.SystemService;
 import org.hisp.dhis.system.database.DatabaseInfo;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.UserSettingService;
-import org.hisp.dhis.webapi.controller.tracker.imports.StringToTrackerIdSchemeParamConverter;
 import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
 import org.hisp.dhis.webapi.mvc.DhisApiVersionHandlerMethodArgumentResolver;
@@ -285,7 +284,6 @@ public class MvcTestConfig implements WebMvcConfigurer
     public void addFormatters( FormatterRegistry registry )
     {
         registry.addConverter( new FieldPathConverter() );
-        registry.addConverter( new StringToTrackerIdSchemeParamConverter() );
     }
 
     @Bean

--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/TrackerImportControllerTest.java
@@ -55,17 +55,12 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     }
 
     @Test
-    void shouldReturnBadRequestWhenAllValidParametersAndEmptyIdSchemeArePassed()
+    void shouldReturnBadRequestWhenEmptyIdSchemeArePassed()
     {
-        assertWebMessage( "OK", 200, "OK", "Tracker job added",
-            POST( "/tracker?async=true&reportMode=FULL" +
-                "&importMode=VALIDATE" +
-                "&idScheme=" +
-                "&importStrategy=CREATE_AND_UPDATE" +
-                "&atomicMode=OBJECT" +
-                "&flushMode=AUTO" +
-                "&validationMode=FULL",
-                "{}" ).content( HttpStatus.OK ) );
+        assertWebMessage( "Bad Request", 400, "ERROR",
+            "idScheme cannot be empty. Valid values are: [UID, CODE, NAME, ATTRIBUTE:attributeUid]",
+            POST( "/tracker?async=false&idScheme=", "{}" )
+                .content( HttpStatus.BAD_REQUEST ) );
     }
 
     @Test
@@ -88,7 +83,7 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     void shouldReturnBadRequestWhenInvalidIdSchemeIsPassed()
     {
         assertWebMessage( "Bad Request", 400, "ERROR",
-            "Value INVALID is not valid for parameter idScheme. It should be of type TrackerIdSchemeParam",
+            "Value INVALID is not valid for parameter idScheme. Valid values are: [UID, CODE, NAME, ATTRIBUTE:attributeUid]",
             POST( "/tracker?async=false&idScheme=INVALID", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 
@@ -96,7 +91,7 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     void shouldReturnBadRequestWhenInvalidAttributeIdSchemeIsPassed()
     {
         assertWebMessage( "Bad Request", 400, "ERROR",
-            "Value ATTRIBUTE:abc is not valid for parameter idScheme. It should be of type TrackerIdSchemeParam",
+            "Value ATTRIBUTE:abc is not valid for parameter idScheme. Valid values are: [UID, CODE, NAME, ATTRIBUTE:attributeUid]",
             POST( "/tracker?async=false&idScheme=ATTRIBUTE:abc", "{}" ).content( HttpStatus.BAD_REQUEST ) );
     }
 
@@ -104,7 +99,7 @@ class TrackerImportControllerTest extends DhisControllerConvenienceTest
     void shouldReturnBadRequestWhenInvalidFormatForAttributeIdSchemeIsPassed()
     {
         assertWebMessage( "Bad Request", 400, "ERROR",
-            "Value ATTRIBUTE:abcdefghilm:invalid is not valid for parameter idScheme. It should be of type TrackerIdSchemeParam",
+            "Value ATTRIBUTE:abcdefghilm:invalid is not valid for parameter idScheme. Valid values are: [UID, CODE, NAME, ATTRIBUTE:attributeUid]",
             POST( "/tracker?async=false&idScheme=ATTRIBUTE:abcdefghilm:invalid", "{}" )
                 .content( HttpStatus.BAD_REQUEST ) );
     }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -78,7 +78,7 @@ import org.hisp.dhis.webapi.controller.exception.MetadataImportConflictException
 import org.hisp.dhis.webapi.controller.exception.MetadataSyncException;
 import org.hisp.dhis.webapi.controller.exception.MetadataVersionException;
 import org.hisp.dhis.webapi.controller.exception.NotAuthenticatedException;
-import org.hisp.dhis.webapi.controller.tracker.imports.StringToTrackerIdSchemeParamConverter;
+import org.hisp.dhis.webapi.controller.tracker.imports.IdSchemeParamEditor;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthenticationException;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenError;
 import org.springframework.beans.TypeMismatchException;
@@ -134,7 +134,7 @@ public class CrudControllerAdvice
         binder.registerCustomEditor( Date.class, new FromTextPropertyEditor( DateUtils::parseDate ) );
         binder.registerCustomEditor( IdentifiableProperty.class, new FromTextPropertyEditor( String::toUpperCase ) );
         this.enumClasses.forEach( c -> binder.registerCustomEditor( c, new ConvertEnum( c ) ) );
-        binder.registerCustomEditor( TrackerIdSchemeParam.class, new StringToTrackerIdSchemeParamConverter() );
+        binder.registerCustomEditor( TrackerIdSchemeParam.class, new IdSchemeParamEditor() );
     }
 
     @ExceptionHandler( org.hisp.dhis.feedback.BadRequestException.class )
@@ -267,7 +267,7 @@ public class CrudControllerAdvice
 
     private String getNotValidValueMessage( Object value, String field )
     {
-        if ( value == null || "".equals( value ) )
+        if ( value == null || (value instanceof String && ((String) value).isEmpty()) )
         {
             return MessageFormat.format( "{0} cannot be empty.", field );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -72,11 +72,13 @@ import org.hisp.dhis.fieldfilter.FieldFilterException;
 import org.hisp.dhis.query.QueryException;
 import org.hisp.dhis.query.QueryParserException;
 import org.hisp.dhis.schema.SchemaPathException;
+import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.hisp.dhis.util.DateUtils;
 import org.hisp.dhis.webapi.controller.exception.MetadataImportConflictException;
 import org.hisp.dhis.webapi.controller.exception.MetadataSyncException;
 import org.hisp.dhis.webapi.controller.exception.MetadataVersionException;
 import org.hisp.dhis.webapi.controller.exception.NotAuthenticatedException;
+import org.hisp.dhis.webapi.controller.tracker.imports.StringToTrackerIdSchemeParamConverter;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenAuthenticationException;
 import org.hisp.dhis.webapi.security.apikey.ApiTokenError;
 import org.springframework.beans.TypeMismatchException;
@@ -132,6 +134,7 @@ public class CrudControllerAdvice
         binder.registerCustomEditor( Date.class, new FromTextPropertyEditor( DateUtils::parseDate ) );
         binder.registerCustomEditor( IdentifiableProperty.class, new FromTextPropertyEditor( String::toUpperCase ) );
         this.enumClasses.forEach( c -> binder.registerCustomEditor( c, new ConvertEnum( c ) ) );
+        binder.registerCustomEditor( TrackerIdSchemeParam.class, new StringToTrackerIdSchemeParamConverter() );
     }
 
     @ExceptionHandler( org.hisp.dhis.feedback.BadRequestException.class )
@@ -201,6 +204,14 @@ public class CrudControllerAdvice
         {
             customErrorMessage = getEnumErrorMessage( requiredType );
         }
+        else if ( requiredType.isPrimitive() )
+        {
+            customErrorMessage = getGenericFieldErrorMessage( requiredType.getSimpleName() );
+        }
+        else if ( ex.getCause() instanceof IllegalArgumentException )
+        {
+            customErrorMessage = ex.getCause().getMessage();
+        }
         else
         {
             customErrorMessage = getGenericFieldErrorMessage( requiredType.getSimpleName() );
@@ -225,6 +236,14 @@ public class CrudControllerAdvice
         {
             customErrorMessage = getEnumErrorMessage( requiredType );
         }
+        else if ( requiredType.isPrimitive() )
+        {
+            customErrorMessage = getGenericFieldErrorMessage( requiredType.getSimpleName() );
+        }
+        else if ( ex.getCause() instanceof IllegalArgumentException )
+        {
+            customErrorMessage = ex.getCause().getMessage();
+        }
         else
         {
             customErrorMessage = getGenericFieldErrorMessage( requiredType.getSimpleName() );
@@ -248,6 +267,10 @@ public class CrudControllerAdvice
 
     private String getNotValidValueMessage( Object value, String field )
     {
+        if ( value == null || "".equals( value ) )
+        {
+            return MessageFormat.format( "{0} cannot be empty.", field );
+        }
         return MessageFormat.format( "Value {0} is not valid for parameter {1}.", value, field );
     }
 
@@ -601,9 +624,15 @@ public class CrudControllerAdvice
         public void setAsText( String text )
             throws IllegalArgumentException
         {
-            Enum<T> enumValue = EnumUtils.getEnum( enumClass, text.toUpperCase() );
+            Enum<T> enumValue = EnumUtils.getEnumIgnoreCase( enumClass, text );
 
-            setValue( enumValue != null ? enumValue : text );
+            if ( enumValue == null )
+            {
+                throw new IllegalArgumentException(
+                    MessageFormat.format( " Cannot convert {0} to {1}", text, enumClass.toString() ) );
+            }
+
+            setValue( enumValue );
         }
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/CrudControllerAdvice.java
@@ -629,7 +629,7 @@ public class CrudControllerAdvice
             if ( enumValue == null )
             {
                 throw new IllegalArgumentException(
-                    MessageFormat.format( " Cannot convert {0} to {1}", text, enumClass.toString() ) );
+                    MessageFormat.format( " Cannot convert {0} to {1}", text, enumClass ) );
             }
 
             setValue( enumValue );

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/IdSchemeParamEditor.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/IdSchemeParamEditor.java
@@ -34,7 +34,7 @@ import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
 import org.springframework.util.StringUtils;
 
-public class StringToTrackerIdSchemeParamConverter extends PropertyEditorSupport
+public class IdSchemeParamEditor extends PropertyEditorSupport
 {
     private static final String VALID_VALUES = "Valid values are: [UID, CODE, NAME, ATTRIBUTE:attributeUid]";
 

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/StringToTrackerIdSchemeParamConverter.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/StringToTrackerIdSchemeParamConverter.java
@@ -27,22 +27,23 @@
  */
 package org.hisp.dhis.webapi.controller.tracker.imports;
 
+import java.beans.PropertyEditorSupport;
+
 import org.hisp.dhis.common.CodeGenerator;
 import org.hisp.dhis.tracker.TrackerIdScheme;
 import org.hisp.dhis.tracker.TrackerIdSchemeParam;
-import org.springframework.core.convert.converter.Converter;
 import org.springframework.util.StringUtils;
 
-public class StringToTrackerIdSchemeParamConverter implements Converter<String, TrackerIdSchemeParam>
+public class StringToTrackerIdSchemeParamConverter extends PropertyEditorSupport
 {
     private static final String VALID_VALUES = "Valid values are: [UID, CODE, NAME, ATTRIBUTE:attributeUid]";
 
     @Override
-    public TrackerIdSchemeParam convert( String source )
+    public void setAsText( String source )
     {
         if ( !StringUtils.hasText( source ) )
         {
-            return null;
+            throw new IllegalArgumentException( VALID_VALUES );
         }
 
         String[] splitParam = source.split( ":" );
@@ -72,13 +73,17 @@ public class StringToTrackerIdSchemeParamConverter implements Converter<String, 
         switch ( idScheme )
         {
         case UID:
-            return TrackerIdSchemeParam.UID;
+            setValue( TrackerIdSchemeParam.UID );
+            break;
         case NAME:
-            return TrackerIdSchemeParam.NAME;
+            setValue( TrackerIdSchemeParam.NAME );
+            break;
         case CODE:
-            return TrackerIdSchemeParam.CODE;
+            setValue( TrackerIdSchemeParam.CODE );
+            break;
         case ATTRIBUTE:
-            return TrackerIdSchemeParam.ofAttribute( attributeUid );
+            setValue( TrackerIdSchemeParam.ofAttribute( attributeUid ) );
+            break;
         default:
             throw new IllegalArgumentException( VALID_VALUES );
         }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsMapper.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/tracker/imports/TrackerImportParamsMapper.java
@@ -52,12 +52,7 @@ public class TrackerImportParamsMapper
         RequestParams request,
         Body params )
     {
-        // If user calls tracker import with empty idScheme /tracker?idScheme=
-        // then StringToTrackerIdSchemeParamConverter will
-        // return a null TrackerIdSchemeParam.
-        // In that case we are setting the defaultIdSchemeParam to UID
-        TrackerIdSchemeParam defaultIdSchemeParam = request.getIdScheme() == null ? TrackerIdSchemeParam.UID
-            : request.getIdScheme();
+        TrackerIdSchemeParam defaultIdSchemeParam = request.getIdScheme();
         TrackerIdSchemeParams idSchemeParams = TrackerIdSchemeParams.builder()
             .idScheme( defaultIdSchemeParam )
             .programIdScheme( getIdSchemeParam( request.getProgramIdScheme(), defaultIdSchemeParam ) )

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/security/config/WebMvcConfig.java
@@ -44,7 +44,6 @@ import org.hisp.dhis.node.DefaultNodeService;
 import org.hisp.dhis.node.NodeService;
 import org.hisp.dhis.user.CurrentUserService;
 import org.hisp.dhis.user.UserSettingService;
-import org.hisp.dhis.webapi.controller.tracker.imports.StringToTrackerIdSchemeParamConverter;
 import org.hisp.dhis.webapi.mvc.CurrentUserHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CurrentUserInfoHandlerMethodArgumentResolver;
 import org.hisp.dhis.webapi.mvc.CustomRequestMappingHandlerMapping;
@@ -224,7 +223,6 @@ public class WebMvcConfig extends DelegatingWebMvcConfiguration
     {
         registry.addConverter( new StringToOrderCriteriaListConverter() );
         registry.addConverter( new FieldPathConverter() );
-        registry.addConverter( new StringToTrackerIdSchemeParamConverter() );
     }
 
     @Primary

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SpringBindingTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/SpringBindingTest.java
@@ -34,8 +34,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Date;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import org.hisp.dhis.dxf2.webmessage.WebMessage;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +57,7 @@ class SpringBindingTest
     public void setUp()
     {
         mockMvc = MockMvcBuilders.standaloneSetup( new BindingController() )
+            .setControllerAdvice( new CrudControllerAdvice() )
             .build();
     }
 
@@ -92,7 +93,7 @@ class SpringBindingTest
             .param( "doubleNumber", "INVALID" ) )
             .andExpect( content().string( containsString( "Bad Request" ) ) )
             .andExpect( content().string( containsString(
-                "Value INVALID is not valid for parameter doubleNumber. It should be of type Double" ) ) );
+                "Value INVALID is not valid for parameter doubleNumber. It should be of type double" ) ) );
     }
 
     @Test
@@ -103,7 +104,7 @@ class SpringBindingTest
             .param( "integerNumber", "10.5" ) )
             .andExpect( content().string( containsString( "Bad Request" ) ) )
             .andExpect( content().string( containsString(
-                "Value 10.5 is not valid for parameter integerNumber. It should be of type Integer" ) ) );
+                "Value 10.5 is not valid for parameter integerNumber. For input string: \"10.5\"" ) ) );
     }
 
     @Test
@@ -114,7 +115,7 @@ class SpringBindingTest
             .param( "date", "INVALID" ) )
             .andExpect( content().string( containsString( "Bad Request" ) ) )
             .andExpect( content().string(
-                containsString( "Value INVALID is not valid for parameter date. It should be of type Date" ) ) );
+                containsString( "Value INVALID is not valid for parameter date. Invalid format: \"INVALID\"" ) ) );
     }
 
     @Test
@@ -125,7 +126,7 @@ class SpringBindingTest
             .param( "booleanValue", "INVALID" ) )
             .andExpect( content().string( containsString( "Bad Request" ) ) )
             .andExpect( content().string( containsString(
-                "Value INVALID is not valid for parameter booleanValue. It should be of type Boolean" ) ) );
+                "Value INVALID is not valid for parameter booleanValue. Invalid boolean value [INVALID]" ) ) );
     }
 
     @Controller
@@ -144,19 +145,19 @@ class SpringBindingTest
         }
     }
 
-    @AllArgsConstructor
-    @Getter
+    @NoArgsConstructor
+    @Data
     private class Criteria
     {
-        private final SimpleEnum simpleEnumInCriteria;
+        private SimpleEnum simpleEnumInCriteria;
 
-        private final Date date;
+        private Date date;
 
-        private final Double doubleNumber;
+        private double doubleNumber;
 
-        private final Integer integerNumber;
+        private Integer integerNumber;
 
-        private final Boolean booleanValue;
+        private Boolean booleanValue;
     }
 
     private enum SimpleEnum


### PR DESCRIPTION
Convert parameters of type `TrackerIdSchemeParam` using a `PropertyEditor` instead of a `Converter`.
What I understood looking at Spring code is that when parsing parameters Spring will first try to use a `PropertyEditor` that is specific for the MVC layer and it make sense for us to throw an exception if the parameter is null.
Before we were using a `Converter` that is a global object used by Spring and even though in our case was not used anywhere else than the MVC layer, it was conceptually wrong to raise an exception for null values.

On the same logic, I changed the `PropertyEditor` for Enums to raise an exception if the value is empty.

When parsing the paramter Spring will try to use the `PropertyEditor` and it will catch an `IllegalArgumentException` or `ConversionException` and wrap it in a `TypeMismatchException` that we are already handling in `CrudControllerAdvice`

We may need to agree on naming conventions for this part, I didn't put a lot of thoughts in it yet