### PR TITLE
fix: Createdbyuserinfo and lastupdatedbyuserinfo jsonb fields in programinstance are all blank (Old Tracker Capture)

### DIFF
--- a/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
+++ b/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/events/enrollment/AbstractEnrollmentService.java
@@ -91,6 +91,7 @@ import org.hisp.dhis.program.ProgramStageInstance;
 import org.hisp.dhis.program.ProgramStageInstanceService;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramTrackedEntityAttribute;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.program.notification.event.ProgramEnrollmentNotificationEvent;
 import org.hisp.dhis.programrule.engine.EnrollmentEvaluationEvent;
 import org.hisp.dhis.programrule.engine.TrackerEnrollmentWebHookEvent;
@@ -605,6 +606,8 @@ public abstract class AbstractEnrollmentService
             programInstance.setEndDate( date );
         }
 
+        programInstance.setCreatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
+
         programInstanceService.addProgramInstance( programInstance, importOptions.getUser() );
 
         importSummary = validateProgramInstance( program, programInstance, enrollment, importSummary );
@@ -1001,6 +1004,8 @@ public abstract class AbstractEnrollmentService
 
         updateAttributeValues( enrollment, importOptions );
         updateDateFields( enrollment, programInstance );
+
+        programInstance.setLastUpdatedByUserInfo( UserInfoSnapshot.from( importOptions.getUser() ) );
 
         programInstanceService.updateProgramInstance( programInstance, importOptions.getUser() );
         teiService.updateTrackedEntityInstance( programInstance.getEntityInstance(), importOptions.getUser() );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EnrollmentImportTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/dxf2/events/EnrollmentImportTest.java
@@ -30,7 +30,6 @@ package org.hisp.dhis.dxf2.events;
 import static org.hisp.dhis.user.UserRole.AUTHORITY_ALL;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -48,6 +47,7 @@ import org.hisp.dhis.program.Program;
 import org.hisp.dhis.program.ProgramInstance;
 import org.hisp.dhis.program.ProgramStatus;
 import org.hisp.dhis.program.ProgramType;
+import org.hisp.dhis.program.UserInfoSnapshot;
 import org.hisp.dhis.test.integration.TransactionalIntegrationTest;
 import org.hisp.dhis.trackedentity.TrackedEntityInstance;
 import org.hisp.dhis.trackedentity.TrackedEntityType;
@@ -122,7 +122,7 @@ class EnrollmentImportTest extends TransactionalIntegrationTest
     {
         String enrollmentUid = CodeGenerator.generateUid();
 
-        Enrollment enrollment = createEnrollment( organisationUnitA.getUid(), program.getUid(),
+        Enrollment enrollment = enrollment( organisationUnitA.getUid(), program.getUid(),
             trackedEntityInstance.getUid() );
         enrollment.setEnrollment( enrollmentUid );
 
@@ -131,7 +131,7 @@ class EnrollmentImportTest extends TransactionalIntegrationTest
             null );
 
         assertAll( () -> assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() ),
-            () -> assertNotNull(
+            () -> assertEquals( UserInfoSnapshot.from( user ),
                 enrollmentService.getEnrollment( enrollmentUid, EnrollmentParams.FALSE )
                     .getCreatedByUserInfo() ) );
     }
@@ -139,7 +139,7 @@ class EnrollmentImportTest extends TransactionalIntegrationTest
     @Test
     void shouldSetUpdatedByUserInfoWhenUpdateEnrollments()
     {
-        Enrollment enrollment = createEnrollment( organisationUnitA.getUid(), program.getUid(),
+        Enrollment enrollment = enrollment( organisationUnitA.getUid(), program.getUid(),
             trackedEntityInstance.getUid() );
         enrollment.setEnrollment( programInstance.getUid() );
 
@@ -148,12 +148,12 @@ class EnrollmentImportTest extends TransactionalIntegrationTest
             true );
 
         assertAll( () -> assertEquals( ImportStatus.SUCCESS, importSummaries.getStatus() ),
-            () -> assertNotNull(
+            () -> assertEquals( UserInfoSnapshot.from( user ),
                 enrollmentService.getEnrollment( programInstance.getUid(), EnrollmentParams.FALSE )
                     .getLastUpdatedByUserInfo() ) );
     }
 
-    private Enrollment createEnrollment( String orgUnit, String program, String trackedEntity )
+    private Enrollment enrollment( String orgUnit, String program, String trackedEntity )
     {
         Enrollment enrollment = new Enrollment();
         enrollment.setOrgUnit( orgUnit );


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-14524

Populate `createdbyuserinfo` and `lastupdatedbyuserinfo` when creating and updating enrollments in the old tracker.
