### PR TITLE
feat: Add indicator style/icon object in metadata

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/common/MetadataItem.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.common;
 
+import static org.apache.commons.lang3.StringUtils.appendIfMissing;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -101,6 +103,11 @@ public class MetadataItem
     @JsonProperty
     private String expression;
 
+    @JsonProperty
+    private ObjectStyle style;
+
+    private transient String serverBaseUrl;
+
     // -------------------------------------------------------------------------
     // Constructors
     // -------------------------------------------------------------------------
@@ -120,6 +127,13 @@ public class MetadataItem
     public MetadataItem( String name, DimensionalItemObject dimensionalItemObject )
     {
         this.name = name;
+        setDataItem( dimensionalItemObject );
+    }
+
+    public MetadataItem( String name, String serverBaseUrl, DimensionalItemObject dimensionalItemObject )
+    {
+        this.name = name;
+        this.serverBaseUrl = serverBaseUrl;
         setDataItem( dimensionalItemObject );
     }
 
@@ -212,6 +226,15 @@ public class MetadataItem
             {
                 this.indicatorType = HibernateProxyUtils.unproxy( indicator.getIndicatorType() );
             }
+
+            if ( indicator.getStyle() != null )
+            {
+                // Override icon path.
+                ObjectStyle indicatorStyle = indicator.getStyle();
+                indicator.getStyle().setIcon( getFullIconUrl( indicatorStyle.getIcon() ) );
+
+                this.style = indicator.getStyle();
+            }
         }
         else if ( dimensionalItemObject instanceof ExpressionDimensionItem )
         {
@@ -219,6 +242,20 @@ public class MetadataItem
 
             this.expression = expressionDimensionItem.getExpression();
         }
+    }
+
+    /**
+     * It returns the full icon URL for the given icon name. The full URL is
+     * based on the Icons' API. See the controller
+     * {@link org.hisp.dhis.webapi.controller.IconController} for more details.
+     *
+     * @param iconName the icon name.
+     * @return the icon's full path.
+     */
+    private String getFullIconUrl( String iconName )
+    {
+        String absoluteUrl = appendIfMissing( serverBaseUrl, "/" );
+        return absoluteUrl + "api/icons/" + iconName + "/icon.svg";
     }
 
     private void setDataItem( DimensionalObject dimensionalObject )

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/DataQueryParams.java
@@ -520,6 +520,8 @@ public class DataQueryParams
      */
     protected transient boolean skipDataDimensionValidation = false;
 
+    protected transient String serverBaseUrl;
+
     protected String explainOrderId;
 
     // -------------------------------------------------------------------------
@@ -625,6 +627,7 @@ public class DataQueryParams
         params.skipDataDimensionValidation = this.skipDataDimensionValidation;
         params.userOrgUnitType = this.userOrgUnitType;
         params.explainOrderId = this.explainOrderId;
+        params.serverBaseUrl = this.serverBaseUrl;
 
         return params;
     }
@@ -2398,6 +2401,11 @@ public class DataQueryParams
         return apiVersion;
     }
 
+    public String getServerBaseUrl()
+    {
+        return serverBaseUrl;
+    }
+
     public Program getProgram()
     {
         return program;
@@ -3136,6 +3144,12 @@ public class DataQueryParams
         public Builder withValidationRules( List<? extends DimensionalItemObject> validationRules )
         {
             this.params.setDataDimensionOptions( DataDimensionItemType.VALIDATION_RULE, validationRules );
+            return this;
+        }
+
+        public Builder withServerBaseUrl( String serverBaseUrl )
+        {
+            params.serverBaseUrl = serverBaseUrl;
             return this;
         }
 

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/data/DefaultDataQueryService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.analytics.data;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.collections4.CollectionUtils.addIgnoreNull;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.Validate.notNull;
@@ -292,7 +293,7 @@ public class DefaultDataQueryService
 
                 if ( dimension != null && items != null )
                 {
-                    list.add( getDimension(
+                    addIgnoreNull( list, getDimension(
                         dimension, items, request.getRelativePeriodDate(), request.getDisplayProperty(),
                         userOrgUnits, false, firstNonNull( request.getInputIdScheme(), UID ) ) );
                 }

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/util/AnalyticsUtils.java
@@ -805,6 +805,7 @@ public class AnalyticsUtils
 
                     map.put( item.getDimensionItem(),
                         new MetadataItem( item.getDisplayProperty( params.getDisplayProperty() ),
+                            params.getServerBaseUrl(),
                             includeMetadataDetails ? item : null ) );
                 }
 
@@ -846,7 +847,6 @@ public class AnalyticsUtils
                 dimension.getDimensionItemKeywords().getKeywords()
                     .forEach( b -> map.putIfAbsent( b.getKey(), b.getMetadataItem() ) );
             }
-
         }
 
         Program program = params.getProgram();

--- a/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/MetadataItemTest.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/test/java/org/hisp/dhis/common/MetadataItemTest.java
@@ -29,12 +29,15 @@ package org.hisp.dhis.common;
 
 import static org.hisp.dhis.DhisConvenienceTest.createCategoryOptionCombo;
 import static org.hisp.dhis.DhisConvenienceTest.createDataElement;
+import static org.hisp.dhis.DhisConvenienceTest.createIndicator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hisp.dhis.analytics.AggregationType;
 import org.hisp.dhis.category.CategoryOptionCombo;
 import org.hisp.dhis.dataelement.DataElement;
 import org.hisp.dhis.dataelement.DataElementOperand;
+import org.hisp.dhis.indicator.Indicator;
+import org.hisp.dhis.indicator.IndicatorType;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -72,5 +75,24 @@ class MetadataItemTest
         assertEquals( "MIA", miA.getName() );
         assertEquals( ValueType.BOOLEAN, miA.getValueType() );
         assertEquals( AggregationType.COUNT, miA.getAggregationType() );
+    }
+
+    @Test
+    void testIconUrlForIndicator()
+    {
+        String serverBaseUrl = "http://localhost:8080/dhis";
+
+        ObjectStyle style = new ObjectStyle();
+        style.setIcon( "icon-name" );
+
+        Indicator indicator = createIndicator( 'A', new IndicatorType() );
+        indicator.setStyle( style );
+
+        MetadataItem item = new MetadataItem( "any-name", serverBaseUrl, indicator );
+
+        assertEquals( "any-name", item.getName() );
+        assertEquals( serverBaseUrl, item.getServerBaseUrl() );
+        assertEquals( style.getIcon(), indicator.getStyle().getIcon() );
+        assertEquals( "http://localhost:8080/dhis/api/icons/icon-name/icon.svg", indicator.getStyle().getIcon() );
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
@@ -27,6 +27,7 @@
  */
 package org.hisp.dhis.webapi.controller;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hisp.dhis.common.DimensionalObjectUtils.getItemsFromParam;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_HTML_VALUE;
@@ -313,9 +314,13 @@ public class AnalyticsController
         HttpServletResponse response, boolean analyzeOnly )
     {
         DataQueryParams params = dataQueryService.getFromRequest( mapFromCriteria( criteria, apiVersion ) );
-        params = DataQueryParams.newBuilder( params )
-            .withServerBaseUrl( configurationProvider.getServerBaseUrl() )
-            .build();
+
+        if ( isNotBlank( configurationProvider.getServerBaseUrl() ) )
+        {
+            params = DataQueryParams.newBuilder( params )
+                .withServerBaseUrl( configurationProvider.getServerBaseUrl() )
+                .build();
+        }
 
         if ( analyzeOnly )
         {

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/AnalyticsController.java
@@ -49,6 +49,7 @@ import org.hisp.dhis.common.Grid;
 import org.hisp.dhis.common.OpenApi;
 import org.hisp.dhis.common.cache.CacheStrategy;
 import org.hisp.dhis.dxf2.datavalueset.DataValueSet;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.system.grid.GridUtils;
 import org.hisp.dhis.webapi.mvc.annotation.ApiVersion;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -82,6 +83,9 @@ public class AnalyticsController
 
     @Nonnull
     private final ContextUtils contextUtils;
+
+    @Nonnull
+    private final DhisConfigurationProvider configurationProvider;
 
     // -------------------------------------------------------------------------
     // Resources
@@ -309,6 +313,9 @@ public class AnalyticsController
         HttpServletResponse response, boolean analyzeOnly )
     {
         DataQueryParams params = dataQueryService.getFromRequest( mapFromCriteria( criteria, apiVersion ) );
+        params = DataQueryParams.newBuilder( params )
+            .withServerBaseUrl( configurationProvider.getServerBaseUrl() )
+            .build();
 
         if ( analyzeOnly )
         {

--- a/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
+++ b/dhis-2/dhis-web-api/src/test/java/org/hisp/dhis/webapi/controller/AnalyticsControllerTest.java
@@ -55,6 +55,7 @@ import org.hisp.dhis.common.GridHeader;
 import org.hisp.dhis.common.IdScheme;
 import org.hisp.dhis.common.IdentifiableObjectManager;
 import org.hisp.dhis.dataelement.DataElement;
+import org.hisp.dhis.external.conf.DhisConfigurationProvider;
 import org.hisp.dhis.system.grid.ListGrid;
 import org.hisp.dhis.user.UserSettingService;
 import org.hisp.dhis.webapi.utils.ContextUtils;
@@ -90,6 +91,9 @@ class AnalyticsControllerTest
     @Mock
     private DimensionService dimensionService;
 
+    @Mock
+    private DhisConfigurationProvider dhisConfigurationProvider;
+
     @BeforeEach
     public void setUp()
     {
@@ -101,7 +105,7 @@ class AnalyticsControllerTest
 
         // Controller under test
         AnalyticsController controller = new AnalyticsController( dataQueryService, analyticsService,
-            contextUtils );
+            contextUtils, dhisConfigurationProvider );
 
         mockMvc = MockMvcBuilders.standaloneSetup( controller ).build();
 


### PR DESCRIPTION
This change aims to provide the full icon path (URL) for indicators returned as part of the metadata objects in analytics responses.

It's a requirement needed by the frontend team, so they are able to display SVGs icons associated with the indicators selected by the user.

We trust that the property `server.base.url` is defined in `dhis.conf`, as we use `configurationProvider.getServerBaseUrl()`.
