### PR TITLE
fix: Maps API not persisting on PUT [DHIS2-14851]

### DIFF
--- a/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
+++ b/dhis-2/dhis-web-api-test/src/test/java/org/hisp/dhis/webapi/controller/MapControllerTest.java
@@ -45,12 +45,23 @@ import org.junit.jupiter.api.Test;
  */
 class MapControllerTest extends DhisControllerConvenienceTest
 {
-
     @Test
     void testPutJsonObject()
     {
         String mapId = assertStatus( HttpStatus.CREATED, POST( "/maps/", "{'name':'My map'}" ) );
-        assertStatus( HttpStatus.NO_CONTENT, PUT( "/maps/" + mapId, "{'name':'My updated map'}" ) );
+
+        JsonResponse map = GET( "/maps/{uid}", mapId ).content();
+
+        // The default merge method is REPLACE, so we must set the mandatory attributes from the created object.
+        String mandatoryProperties = "'lastUpdated':'" + map.get( "lastUpdated" ).node().value() + "', 'created':'"
+            + map.get( "created" ).node().value() + "'";
+
+        assertStatus( HttpStatus.NO_CONTENT,
+            PUT( "/maps/" + mapId, "{'name':'My updated map'," + mandatoryProperties + "}" ) );
+
+        map = GET( "/maps/{uid}", mapId ).content();
+
+        assertEquals( "My updated map", map.get( "name" ).node().value() );
     }
 
     @Test

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/mapping/MapController.java
@@ -155,7 +155,7 @@ public class MapController
         Map newMap = deserializeJsonEntity( request );
         newMap.setUid( uid );
 
-        mergeService.merge( new MergeParams<>( map, newMap )
+        mergeService.merge( new MergeParams<>( newMap, map )
             .setMergeMode( params.getMergeMode() )
             .setSkipSharing( params.isSkipSharing() )
             .setSkipTranslation( params.isSkipTranslation() ) );


### PR DESCRIPTION
In the Maps application, when we try to save (`PUT`) an existing Map, we don’t get any error back, but the Map changes are not saved.

That was caused by a small bug in the maps controller. This PR will invert the arguments in `mergeService.merge`  to use the correct objects at `merging` time and also fix the associated test.

For steps to reproduce and test it, please see: https://dhis2.atlassian.net/browse/DHIS2-14851