### PR TITLE
fix: Org unit descendant check using path property [TECH-1511]

### DIFF
--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -613,7 +613,7 @@ public class OrganisationUnit
      * ancestor org units.
      *
      * @param ancestors the collection of ancestor org units.
-     * @return true if his org unit is a descendant of the ancestors.
+     * @return true if this org unit is a descendant of the ancestors.
      */
     public boolean isDescendant( Collection<OrganisationUnit> ancestors )
     {

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -621,9 +621,7 @@ public class OrganisationUnit
             return false;
         }
 
-        Set<String> ancestorUids = IdentifiableObjectUtils.getUidsAsSet( ancestors );
-
-        return ancestorUids.stream()
+        return IdentifiableObjectUtils.getUidsAsSet( ancestors ).stream()
             .anyMatch( uid -> path.contains( uid ) );
     }
 

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -622,7 +622,7 @@ public class OrganisationUnit
         }
 
         return IdentifiableObjectUtils.getUidsAsSet( ancestors ).stream()
-            .anyMatch( uid -> path.contains( uid ) );
+            .anyMatch( uid -> StringUtils.contains( path, uid ) );
     }
 
     public Set<OrganisationUnit> getChildrenThisIfEmpty()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -27,6 +27,8 @@
  */
 package org.hisp.dhis.organisationunit;
 
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -603,6 +605,26 @@ public class OrganisationUnit
         this.parent = newParent;
 
         newParent.getChildren().add( this );
+    }
+
+    /**
+     * Indicates whether this org unit is a descendant of any of the given
+     * ancestor org units.
+     *
+     * @param ancestors the collection of ancestor org units.
+     * @return true if his org unit is a descendant of the ancestors.
+     */
+    public boolean isDescendant( Collection<OrganisationUnit> ancestors )
+    {
+        if ( isEmpty( ancestors ) )
+        {
+            return false;
+        }
+
+        Set<String> ancestorUids = IdentifiableObjectUtils.getUidsAsSet( ancestors );
+
+        return ancestorUids.stream()
+            .anyMatch( uid -> path.contains( uid ) );
     }
 
     public Set<OrganisationUnit> getChildrenThisIfEmpty()

--- a/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
+++ b/dhis-2/dhis-api/src/main/java/org/hisp/dhis/organisationunit/OrganisationUnit.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -621,7 +622,9 @@ public class OrganisationUnit
             return false;
         }
 
-        return IdentifiableObjectUtils.getUidsAsSet( ancestors ).stream()
+        return ancestors.stream()
+            .filter( Objects::nonNull )
+            .map( OrganisationUnit::getUid )
             .anyMatch( uid -> StringUtils.contains( path, uid ) );
     }
 

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitTest.java
@@ -168,6 +168,7 @@ class OrganisationUnitTest
 
         assertTrue( unitC.isDescendant( Set.of( unitB ) ) );
         assertTrue( unitC.isDescendant( Set.of( unitA ) ) );
+        assertTrue( unitB.isDescendant( Set.of( unitB ) ) );
         assertTrue( unitC.isDescendant( Set.of( unitA, unitD ) ) );
         assertTrue( unitB.isDescendant( Set.of( unitA ) ) );
         assertTrue( unitB.isDescendant( Set.of( unitA, unitD ) ) );

--- a/dhis-2/dhis-api/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitTest.java
+++ b/dhis-2/dhis-api/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitTest.java
@@ -29,11 +29,14 @@ package org.hisp.dhis.organisationunit;
 
 import static org.hisp.dhis.organisationunit.FeatureType.MULTI_POLYGON;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.geotools.geojson.geom.GeometryJSON;
 import org.hisp.dhis.common.coordinate.CoordinateUtils;
@@ -98,10 +101,10 @@ class OrganisationUnitTest
         unitB = new OrganisationUnit( "OrgUnitB" );
         unitC = new OrganisationUnit( "OrgUnitC" );
         unitD = new OrganisationUnit( "OrgUnitD" );
-        unitA.setUid( "uidA" );
-        unitB.setUid( "uidB" );
-        unitC.setUid( "uidC" );
-        unitD.setUid( "uidD" );
+        unitA.setUid( "e8iHpRVptzA" );
+        unitB.setUid( "e8iHpRVptzB" );
+        unitC.setUid( "e8iHpRVptzC" );
+        unitD.setUid( "e8iHpRVptzD" );
     }
 
     @Test
@@ -145,8 +148,33 @@ class OrganisationUnitTest
         unitD.setParent( unitC );
         unitC.setParent( unitB );
         unitB.setParent( unitA );
-        String expected = "/uidA/uidB/uidC/uidD";
+        String expected = "/e8iHpRVptzA/e8iHpRVptzB/e8iHpRVptzC/e8iHpRVptzD";
         assertEquals( expected, unitD.getPath() );
+    }
+
+    @Test
+    void testIsDescendant()
+    {
+        unitB.setParent( unitA );
+        unitC.setParent( unitB );
+        unitD.setParent( unitA );
+
+        // Set path property directly to emulate persistence layer
+
+        unitA.getPath();
+        unitB.getPath();
+        unitC.getPath();
+        unitD.getPath();
+
+        assertTrue( unitC.isDescendant( Set.of( unitB ) ) );
+        assertTrue( unitC.isDescendant( Set.of( unitA ) ) );
+        assertTrue( unitC.isDescendant( Set.of( unitA, unitD ) ) );
+        assertTrue( unitB.isDescendant( Set.of( unitA ) ) );
+        assertTrue( unitB.isDescendant( Set.of( unitA, unitD ) ) );
+
+        assertFalse( unitC.isDescendant( Set.of( unitD ) ) );
+        assertFalse( unitB.isDescendant( Set.of( unitD ) ) );
+        assertFalse( unitB.isDescendant( Set.of( unitC ) ) );
     }
 
     @Test

--- a/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
+++ b/dhis-2/dhis-services/dhis-service-analytics/src/main/java/org/hisp/dhis/analytics/security/DefaultAnalyticsSecurityManager.java
@@ -61,7 +61,6 @@ import org.hisp.dhis.dataapproval.DataApprovalLevel;
 import org.hisp.dhis.dataapproval.DataApprovalLevelService;
 import org.hisp.dhis.feedback.ErrorCode;
 import org.hisp.dhis.organisationunit.OrganisationUnit;
-import org.hisp.dhis.organisationunit.OrganisationUnitService;
 import org.hisp.dhis.security.acl.AclService;
 import org.hisp.dhis.setting.SystemSettingManager;
 import org.hisp.dhis.user.CurrentUserService;
@@ -88,8 +87,6 @@ public class DefaultAnalyticsSecurityManager
     private final AclService aclService;
 
     private final CurrentUserService currentUserService;
-
-    private final OrganisationUnitService organisationUnitService;
 
     // -------------------------------------------------------------------------
     // AnalyticsSecurityManager implementation
@@ -127,9 +124,9 @@ public class DefaultAnalyticsSecurityManager
 
         for ( OrganisationUnit queryOrgUnit : queryOrgUnits )
         {
-            boolean notDescendant = !organisationUnitService.isDescendant( queryOrgUnit, viewOrgUnits );
+            boolean descendant = queryOrgUnit.isDescendant( viewOrgUnits );
 
-            if ( notDescendant )
+            if ( !descendant )
             {
                 throwIllegalQueryEx( ErrorCode.E7120, user.getUsername(), queryOrgUnit.getUid() );
             }

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/AnalyticsSecurityManagerTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/analytics/security/AnalyticsSecurityManagerTest.java
@@ -68,7 +68,6 @@ import com.google.common.collect.Sets;
  */
 class AnalyticsSecurityManagerTest extends TransactionalIntegrationTest
 {
-
     @Autowired
     private AnalyticsSecurityManager securityManager;
 
@@ -139,6 +138,7 @@ class AnalyticsSecurityManagerTest extends TransactionalIntegrationTest
         organisationUnitService.addOrganisationUnit( ouC );
         organisationUnitService.addOrganisationUnit( ouD );
         organisationUnitService.addOrganisationUnit( ouE );
+        organisationUnitService.addOrganisationUnit( ouF );
         userOrgUnits = Sets.newHashSet( ouB, ouC );
         User user = createUserWithAuth( "A", "F_VIEW_EVENT_ANALYTICS" );
         user.setOrganisationUnits( userOrgUnits );

--- a/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitServiceTest.java
+++ b/dhis-2/dhis-test-integration/src/test/java/org/hisp/dhis/organisationunit/OrganisationUnitServiceTest.java
@@ -520,6 +520,27 @@ class OrganisationUnitServiceTest extends SingleSetupIntegrationTestBase
     }
 
     @Test
+    void testIsDescendantOrgUnit()
+    {
+        OrganisationUnit ouA = createOrganisationUnit( 'A' );
+        organisationUnitService.addOrganisationUnit( ouA );
+        OrganisationUnit ouB = createOrganisationUnit( 'B', ouA );
+        ouA.getChildren().add( ouB );
+        organisationUnitService.addOrganisationUnit( ouB );
+        OrganisationUnit ouC = createOrganisationUnit( 'C', ouB );
+        ouB.getChildren().add( ouC );
+        organisationUnitService.addOrganisationUnit( ouC );
+        OrganisationUnit ouD = createOrganisationUnit( 'D' );
+        organisationUnitService.addOrganisationUnit( ouD );
+        assertTrue( ouA.isDescendant( Set.of( ouA ) ) );
+        assertTrue( ouB.isDescendant( Set.of( ouA ) ) );
+        assertTrue( ouC.isDescendant( Set.of( ouA, ouD ) ) );
+        assertTrue( ouB.isDescendant( Set.of( ouA, ouC ) ) );
+        assertFalse( ouB.isDescendant( Set.of( ouC ) ) );
+        assertFalse( ouD.isDescendant( Set.of( ouA ) ) );
+    }
+
+    @Test
     void testIsDescendantObject()
     {
         OrganisationUnit unit1 = createOrganisationUnit( '1' );


### PR DESCRIPTION
Introduces a faster way of performing the org unit "is descendant" check, and applies it to the analytics security manager. Instead of performing the check in a transactional method which fetches the org unit from the database, the check is done locally to the org unit by comparing the org unit ancestor `path` property directly with the ancestor identifiers. This saves a transaction and database lookup per check. In particular for maps and pivot tables with hundreds or thousands of org units, this yields a huge performance benefit.

The performance improvement only applies for users which do not have the `ALL` authority and do have at least one data view org unit.

YourKit CPU profiling:

![analytics-is-descendant](https://user-images.githubusercontent.com/908206/221999277-e12bd787-7f1c-4ae1-8b2a-e7dcbb37e8aa.png)
