### PR TITLE
fix: OpenAPI server URL [DHIS2-14855]

### DIFF
--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -152,11 +152,25 @@ public class OpenApiController
                 : c;
     }
 
+    /**
+     * This has to work with 3 types of URLs
+     *
+     * <pre>
+     *     http://localhost/openapi.json
+     *     http://localhost:8080/api/openapi.json
+     *     https://play.dhis2.org/dev/api/openapi.json
+     * </pre>
+     *
+     * And any of the variants when it comes to the path the controller allows
+     * to query an OpenAPI document.
+     */
     private static String getServerUrl( HttpServletRequest request )
     {
         StringBuffer url = request.getRequestURL();
         String servletPath = request.getServletPath();
-        servletPath = servletPath.substring( servletPath.indexOf( "/api" ) );
-        return url.substring( 0, url.indexOf( "/api/" ) ) + servletPath;
+        servletPath = servletPath.substring( servletPath.indexOf( "/api" ) + 1 );
+        int apiStart = url.indexOf( "/api/" );
+        String root = apiStart < 0 ? url.substring( 0, url.indexOf( "/", 10 ) ) : url.substring( 0, apiStart );
+        return root + "/" + servletPath;
     }
 }

--- a/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
+++ b/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/openapi/OpenApiController.java
@@ -155,7 +155,8 @@ public class OpenApiController
     private static String getServerUrl( HttpServletRequest request )
     {
         StringBuffer url = request.getRequestURL();
-        String uri = request.getRequestURI();
-        return url.substring( 0, url.indexOf( uri ) ) + request.getServletPath();
+        String servletPath = request.getServletPath();
+        servletPath = servletPath.substring( servletPath.indexOf( "/api" ) );
+        return url.substring( 0, url.indexOf( "/api/" ) ) + servletPath;
     }
 }


### PR DESCRIPTION
Noticed this was not correct for play environments. So I thought about another way of extracting the path that should not fail independent of how the different path parts are defined. 

As this only fails on play the real test is that this works on play once it is deployed.