### PR TITLE
fix: Prevent NPE when saving Interpretation [DHIS2-14858]

### DIFF
--- a/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
+++ b/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/interpretation/DefaultInterpretationService.java
@@ -28,6 +28,7 @@
 package org.hisp.dhis.interpretation;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -311,12 +312,17 @@ public class DefaultInterpretationService
         if ( interpretableObjectSchema.isSubscribable() )
         {
             SubscribableObject object = (SubscribableObject) interpretableObject;
-            Set<User> subscribers = new HashSet<>( userService.getUsers( object.getSubscribers() ) );
-            subscribers.remove( currentUserService.getCurrentUser() );
+            Set<String> subscribersUid = object.getSubscribers();
 
-            if ( !subscribers.isEmpty() )
+            if ( isNotEmpty( subscribersUid ) )
             {
-                sendNotificationMessage( subscribers, interpretation, comment, notificationType );
+                Set<User> subscribers = new HashSet<>( userService.getUsers( subscribersUid ) );
+                subscribers.remove( currentUserService.getCurrentUser() );
+
+                if ( !subscribers.isEmpty() )
+                {
+                    sendNotificationMessage( subscribers, interpretation, comment, notificationType );
+                }
             }
         }
     }


### PR DESCRIPTION
**[Backport from master/2.40]**

In some cases, `object.getSubscribers()` may return null. This was causing an NPE.
It could be related to a manual change in the DB or some scripts. Independent of that, the code should treat it in the same way as we treat empty sets, and avoid NPE.